### PR TITLE
feat: add MCP client discovery across 17 clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,12 @@ Pre-built binaries for Linux, macOS, and Windows are available on the [Releases 
 ## Quick Start
 
 ```bash
+# Auto-discover and scan all MCP configs on your machine
+aguara scan --auto
+
+# Discover which MCP clients are configured (no scanning)
+aguara discover
+
 # Scan a skills directory
 aguara scan .claude/skills/
 
@@ -64,9 +70,10 @@ aguara scan .claude/skills/ --ci
 ## Usage
 
 ```
-aguara scan <path> [flags]
+aguara scan [path] [flags]
 
 Flags:
+      --auto                  Auto-discover and scan all MCP client configs
       --severity string       Minimum severity to report: critical, high, medium, low, info (default "info")
       --format string         Output format: terminal, json, sarif, markdown (default "terminal")
   -o, --output string         Output file path (default: stdout)
@@ -79,6 +86,21 @@ Flags:
       --changed               Only scan git-changed files
   -v, --verbose               Show rule descriptions for critical and high findings
   -h, --help                  Help
+```
+
+### MCP Client Discovery
+
+Aguara can auto-detect MCP configurations across **17 clients**: Claude Desktop, Cursor, VS Code, Cline, Windsurf, OpenClaw, OpenCode, Zed, Amp, Gemini CLI, Copilot CLI, Amazon Q, Claude Code, Roo Code, Kilo Code, BoltAI, and JetBrains.
+
+```bash
+# List all detected MCP configs
+aguara discover
+
+# JSON output
+aguara discover --format json
+
+# Discover + scan in one command
+aguara scan --auto
 ```
 
 ### CI Integration
@@ -201,6 +223,12 @@ result, err := aguara.Scan(ctx, "./skills/")
 // Scan inline content (no disk I/O)
 result, err := aguara.ScanContent(ctx, content, "skill.md")
 
+// Discover all MCP client configs on the machine
+discovered, err := aguara.Discover()
+for _, client := range discovered.Clients {
+    fmt.Printf("%s: %d servers\n", client.Client, len(client.Servers))
+}
+
 // List rules, optionally filtered
 rules := aguara.ListRules(aguara.WithCategory("prompt-injection"))
 
@@ -213,8 +241,9 @@ Options: `WithMinSeverity()`, `WithDisabledRules()`, `WithCustomRules()`, `WithR
 ## Architecture
 
 ```
-aguara.go              Public API: Scan, ScanContent, ListRules, ExplainRule
+aguara.go              Public API: Scan, ScanContent, Discover, ListRules, ExplainRule
 options.go             Functional options for the public API
+discover/              MCP client discovery: 17 clients, config parsers, auto-detection
 cmd/aguara/            CLI entry point (Cobra)
 internal/
   engine/

--- a/aguara.go
+++ b/aguara.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/garagon/aguara/discover"
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pattern"
 	"github.com/garagon/aguara/internal/engine/toxicflow"
@@ -36,6 +37,18 @@ const (
 	SeverityHigh     = types.SeverityHigh
 	SeverityCritical = types.SeverityCritical
 )
+
+// Re-export discover types so consumers don't need a separate import.
+type (
+	DiscoverResult   = discover.Result
+	DiscoveredServer = discover.MCPServer
+	DiscoveredClient = discover.ClientResult
+)
+
+// Discover finds all MCP client configurations on the local machine.
+func Discover() (*DiscoverResult, error) {
+	return discover.Scan()
+}
 
 // RuleOverride allows changing the severity of a rule or disabling it.
 type RuleOverride struct {

--- a/cmd/aguara/commands/discover.go
+++ b/cmd/aguara/commands/discover.go
@@ -1,0 +1,40 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/garagon/aguara/discover"
+)
+
+var discoverCmd = &cobra.Command{
+	Use:   "discover",
+	Short: "Discover MCP client configurations on this machine",
+	Long:  `Scans well-known paths for 17 MCP client applications and lists their configured servers.`,
+	Args:  cobra.NoArgs,
+	RunE:  runDiscover,
+}
+
+func init() {
+	rootCmd.AddCommand(discoverCmd)
+}
+
+func runDiscover(cmd *cobra.Command, args []string) error {
+	result, err := discover.Scan()
+	if err != nil {
+		return fmt.Errorf("discovery failed: %w", err)
+	}
+
+	switch flagFormat {
+	case "json":
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	default:
+		fmt.Print(discover.FormatTree(result))
+		return nil
+	}
+}

--- a/discover/discover.go
+++ b/discover/discover.go
@@ -1,0 +1,181 @@
+package discover
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MCPServer represents a discovered MCP server from a client config.
+type MCPServer struct {
+	Name    string            `json:"name"`
+	Command string            `json:"command"`
+	Args    []string          `json:"args"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// ClientResult holds the discovered MCP servers for a single client.
+type ClientResult struct {
+	Client  string      `json:"client"`
+	Path    string      `json:"path"`
+	Servers []MCPServer `json:"servers"`
+}
+
+// Result holds the full discovery output.
+type Result struct {
+	Clients []ClientResult `json:"clients"`
+}
+
+// TotalServers returns the total number of MCP servers found.
+func (r *Result) TotalServers() int {
+	n := 0
+	for _, c := range r.Clients {
+		n += len(c.Servers)
+	}
+	return n
+}
+
+// TotalClients returns the number of clients that have at least one server.
+func (r *Result) TotalClients() int {
+	n := 0
+	for _, c := range r.Clients {
+		if len(c.Servers) > 0 {
+			n++
+		}
+	}
+	return n
+}
+
+// AllServers returns a flat list of all discovered servers with their client name.
+func (r *Result) AllServers() []struct {
+	Client string
+	Server MCPServer
+} {
+	var all []struct {
+		Client string
+		Server MCPServer
+	}
+	for _, c := range r.Clients {
+		for _, s := range c.Servers {
+			all = append(all, struct {
+				Client string
+				Server MCPServer
+			}{Client: c.Client, Server: s})
+		}
+	}
+	return all
+}
+
+// Scan checks all known MCP client config paths and extracts server definitions.
+func Scan() (*Result, error) {
+	result := &Result{}
+
+	for _, client := range KnownClients() {
+		for _, path := range client.Paths {
+			var servers []MCPServer
+			var err error
+
+			switch {
+			case client.Name == "openclaw":
+				cr, oerr := scanOpenClawConfig(path)
+				if oerr != nil {
+					continue
+				}
+				if len(cr.Servers) > 0 {
+					result.Clients = append(result.Clients, *cr)
+				}
+				continue
+			case client.ConfigKey == "opencode":
+				servers, err = parseOpenCodeConfig(path)
+			case client.ConfigKey == "claude-code":
+				servers, err = parseClaudeCodeConfig(path)
+			default:
+				servers, err = parseConfigWithKey(path, client.ConfigKey)
+			}
+
+			if err != nil {
+				continue
+			}
+			if len(servers) > 0 {
+				result.Clients = append(result.Clients, ClientResult{
+					Client:  client.Name,
+					Path:    path,
+					Servers: servers,
+				})
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// FormatTree returns a human-readable tree of discovered MCP servers.
+func FormatTree(result *Result) string {
+	if len(result.Clients) == 0 {
+		return "No MCP configurations found.\n\nChecked paths for: Claude Desktop, Cursor, VS Code, Cline, Windsurf, OpenClaw, " +
+			"OpenCode, Zed, Amp, Gemini CLI, Copilot CLI, Amazon Q, Claude Code, Roo Code, Kilo Code, BoltAI, JetBrains"
+	}
+
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "Found %d MCP configuration(s):\n\n", result.TotalClients())
+
+	for _, cr := range result.Clients {
+		fmt.Fprintf(&b, "  %s  %s\n", clientDisplayName(cr.Client), cr.Path)
+		for i, srv := range cr.Servers {
+			prefix := "├──"
+			if i == len(cr.Servers)-1 {
+				prefix = "└──"
+			}
+			cmdStr := srv.Command
+			if len(srv.Args) > 0 {
+				cmdStr += " " + strings.Join(srv.Args, " ")
+			}
+			fmt.Fprintf(&b, "    %s %-20s %s\n", prefix, srv.Name, cmdStr)
+		}
+		b.WriteString("\n")
+	}
+
+	fmt.Fprintf(&b, "Total: %d MCP servers across %d clients\n", result.TotalServers(), result.TotalClients())
+	return b.String()
+}
+
+func clientDisplayName(name string) string {
+	switch name {
+	case "claude-desktop":
+		return "Claude Desktop"
+	case "cursor":
+		return "Cursor"
+	case "vscode":
+		return "VS Code"
+	case "cline":
+		return "Cline"
+	case "windsurf":
+		return "Windsurf"
+	case "openclaw":
+		return "OpenClaw"
+	case "opencode":
+		return "OpenCode"
+	case "zed":
+		return "Zed"
+	case "amp":
+		return "Amp"
+	case "gemini-cli":
+		return "Gemini CLI"
+	case "copilot-cli":
+		return "Copilot CLI"
+	case "amazon-q":
+		return "Amazon Q"
+	case "claude-code":
+		return "Claude Code"
+	case "roo-code":
+		return "Roo Code"
+	case "kilo-code":
+		return "Kilo Code"
+	case "boltai":
+		return "BoltAI"
+	case "jetbrains":
+		return "JetBrains"
+	default:
+		return name
+	}
+}

--- a/discover/discover_test.go
+++ b/discover/discover_test.go
@@ -1,0 +1,584 @@
+package discover
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeTestConfig(t *testing.T, dir, filename string, servers map[string]mcpServerJSON) string {
+	t.Helper()
+	cfg := mcpConfigJSON{MCPServers: servers}
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, filename)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeOpenClawConfig(t *testing.T, dir string, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, "openclaw.json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// --- parseConfigWithKey tests ---
+
+func TestParseConfigFile(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestConfig(t, dir, "mcp.json", map[string]mcpServerJSON{
+		"filesystem": {Command: "npx", Args: []string{"-y", "@mcp/server-filesystem", "/data"}},
+		"database":   {Command: "node", Args: []string{"./db-server.js"}, Env: map[string]string{"DB_URL": "postgres://localhost"}},
+	})
+
+	servers, err := parseConfigWithKey(path, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 2 {
+		t.Fatalf("got %d servers, want 2", len(servers))
+	}
+
+	found := map[string]bool{}
+	for _, s := range servers {
+		found[s.Name] = true
+		if s.Name == "filesystem" {
+			if s.Command != "npx" {
+				t.Errorf("filesystem command = %q, want npx", s.Command)
+			}
+		}
+		if s.Name == "database" {
+			if s.Env["DB_URL"] != "postgres://localhost" {
+				t.Errorf("database env = %v", s.Env)
+			}
+		}
+	}
+	if !found["filesystem"] || !found["database"] {
+		t.Error("missing expected servers")
+	}
+}
+
+func TestParseConfigFile_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.json")
+	_ = os.WriteFile(path, []byte("not json"), 0o644)
+
+	_, err := parseConfigWithKey(path, "")
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestParseConfigFile_NoFile(t *testing.T) {
+	_, err := parseConfigWithKey("/nonexistent/path.json", "")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestParseConfigWithKey_ServersKey(t *testing.T) {
+	dir := t.TempDir()
+	config := map[string]any{
+		"servers": map[string]mcpServerJSON{
+			"my-tool": {Command: "node", Args: []string{"server.js"}},
+		},
+	}
+	data, _ := json.MarshalIndent(config, "", "  ")
+	path := filepath.Join(dir, "mcp.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseConfigWithKey(path, "servers")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("got %d servers, want 1", len(servers))
+	}
+	if servers[0].Name != "my-tool" {
+		t.Errorf("name = %q, want my-tool", servers[0].Name)
+	}
+	if servers[0].Command != "node" {
+		t.Errorf("command = %q, want node", servers[0].Command)
+	}
+}
+
+func TestParseConfigWithKey_ServersKeyFallbackToMCPServers(t *testing.T) {
+	dir := t.TempDir()
+	config := map[string]any{
+		"mcpServers": map[string]mcpServerJSON{
+			"fallback-tool": {Command: "python", Args: []string{"serve.py"}},
+		},
+	}
+	data, _ := json.MarshalIndent(config, "", "  ")
+	path := filepath.Join(dir, "mcp.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseConfigWithKey(path, "servers")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("got %d servers, want 1", len(servers))
+	}
+	if servers[0].Name != "fallback-tool" {
+		t.Errorf("name = %q, want fallback-tool", servers[0].Name)
+	}
+}
+
+func TestParseConfigWithKey_EmptyKeyDefaultsToMCPServers(t *testing.T) {
+	dir := t.TempDir()
+	path := writeTestConfig(t, dir, "mcp.json", map[string]mcpServerJSON{
+		"test-srv": {Command: "test"},
+	})
+
+	servers, err := parseConfigWithKey(path, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("got %d servers, want 1", len(servers))
+	}
+	if servers[0].Name != "test-srv" {
+		t.Errorf("name = %q, want test-srv", servers[0].Name)
+	}
+}
+
+// --- parseOpenCodeConfig tests ---
+
+func TestParseOpenCodeConfig(t *testing.T) {
+	dir := t.TempDir()
+	config := map[string]any{
+		"mcp": map[string]any{
+			"my-server": map[string]any{
+				"command":     []string{"npx", "-y", "@mcp/server"},
+				"environment": map[string]string{"API_KEY": "secret"},
+			},
+			"simple": map[string]any{
+				"command": []string{"mcp-tool"},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(config, "", "  ")
+	path := filepath.Join(dir, "opencode.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseOpenCodeConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 2 {
+		t.Fatalf("got %d servers, want 2", len(servers))
+	}
+
+	found := map[string]MCPServer{}
+	for _, s := range servers {
+		found[s.Name] = s
+	}
+
+	srv := found["my-server"]
+	if srv.Command != "npx" {
+		t.Errorf("my-server command = %q, want npx", srv.Command)
+	}
+	if len(srv.Args) != 2 || srv.Args[0] != "-y" || srv.Args[1] != "@mcp/server" {
+		t.Errorf("my-server args = %v, want [-y @mcp/server]", srv.Args)
+	}
+	if srv.Env["API_KEY"] != "secret" {
+		t.Errorf("my-server env = %v", srv.Env)
+	}
+
+	simple := found["simple"]
+	if simple.Command != "mcp-tool" {
+		t.Errorf("simple command = %q, want mcp-tool", simple.Command)
+	}
+	if len(simple.Args) != 0 {
+		t.Errorf("simple args = %v, want empty", simple.Args)
+	}
+}
+
+func TestParseOpenCodeConfig_NoMCPKey(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte(`{"theme": "dark"}`)
+	path := filepath.Join(dir, "opencode.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseOpenCodeConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 0 {
+		t.Errorf("got %d servers, want 0", len(servers))
+	}
+}
+
+// --- parseClaudeCodeConfig tests ---
+
+func TestParseClaudeCodeConfig(t *testing.T) {
+	dir := t.TempDir()
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			"global-srv": map[string]any{
+				"command": "npx",
+				"args":    []string{"@mcp/global"},
+			},
+		},
+		"projects": map[string]any{
+			"/home/user/project-a": map[string]any{
+				"mcpServers": map[string]any{
+					"project-srv": map[string]any{
+						"command": "node",
+						"args":    []string{"local.js"},
+					},
+				},
+			},
+			"/home/user/project-b": map[string]any{
+				"mcpServers": map[string]any{
+					"global-srv": map[string]any{
+						"command": "npx",
+						"args":    []string{"@mcp/global"},
+					},
+					"another-srv": map[string]any{
+						"command": "python",
+						"args":    []string{"serve.py"},
+					},
+				},
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(config, "", "  ")
+	path := filepath.Join(dir, ".claude.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseClaudeCodeConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have 3 unique servers: global-srv, project-srv, another-srv
+	// global-srv appears in both top-level and project-b but should be deduped
+	if len(servers) != 3 {
+		t.Fatalf("got %d servers, want 3 (deduped)", len(servers))
+	}
+
+	found := map[string]bool{}
+	for _, s := range servers {
+		found[s.Name] = true
+	}
+	for _, name := range []string{"global-srv", "project-srv", "another-srv"} {
+		if !found[name] {
+			t.Errorf("missing server %q", name)
+		}
+	}
+}
+
+func TestParseClaudeCodeConfig_TopLevelOnly(t *testing.T) {
+	dir := t.TempDir()
+	config := map[string]any{
+		"mcpServers": map[string]any{
+			"only-srv": map[string]any{
+				"command": "echo",
+			},
+		},
+	}
+	data, _ := json.MarshalIndent(config, "", "  ")
+	path := filepath.Join(dir, ".claude.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseClaudeCodeConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 1 {
+		t.Fatalf("got %d servers, want 1", len(servers))
+	}
+	if servers[0].Name != "only-srv" {
+		t.Errorf("name = %q, want only-srv", servers[0].Name)
+	}
+}
+
+func TestParseClaudeCodeConfig_NoServers(t *testing.T) {
+	dir := t.TempDir()
+	data := []byte(`{"theme": "dark"}`)
+	path := filepath.Join(dir, ".claude.json")
+	_ = os.WriteFile(path, data, 0o644)
+
+	servers, err := parseClaudeCodeConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(servers) != 0 {
+		t.Errorf("got %d servers, want 0", len(servers))
+	}
+}
+
+// --- OpenClaw tests ---
+
+func TestScanOpenClawConfig_Valid(t *testing.T) {
+	dir := t.TempDir()
+	path := writeOpenClawConfig(t, dir, `{
+		"gateway": {"port": 18789, "bind": "127.0.0.1"},
+		"agents": {
+			"assistant": {"sandbox": true},
+			"coder": {"sandbox": false}
+		},
+		"tools": {"profile": "standard", "allow": ["read", "write"]},
+		"channels": {"slack": {"token": "xoxb-test"}},
+		"dmPolicy": "restricted"
+	}`)
+
+	result, err := scanOpenClawConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if result.Client != "openclaw" {
+		t.Errorf("client = %q, want openclaw", result.Client)
+	}
+
+	// Expect: 1 gateway + 2 agents + 1 channel = 4 servers
+	if len(result.Servers) != 4 {
+		t.Errorf("got %d servers, want 4", len(result.Servers))
+	}
+
+	found := map[string]bool{}
+	for _, s := range result.Servers {
+		found[s.Name] = true
+	}
+	if !found["openclaw-gateway"] {
+		t.Error("missing openclaw-gateway entry")
+	}
+	if !found["channel-slack"] {
+		t.Error("missing channel-slack entry")
+	}
+}
+
+func TestScanOpenClawConfig_JSON5Comments(t *testing.T) {
+	dir := t.TempDir()
+	path := writeOpenClawConfig(t, dir, `{
+		// This is a line comment
+		"gateway": {"port": 18789, "bind": "127.0.0.1"},
+		/* Block comment */
+		"agents": {"bot": {"sandbox": true}},
+		"tools": {"profile": "minimal"},
+		"channels": {}
+	}`)
+
+	result, err := scanOpenClawConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Client != "openclaw" {
+		t.Errorf("client = %q, want openclaw", result.Client)
+	}
+	// 1 gateway + 1 agent = 2
+	if len(result.Servers) != 2 {
+		t.Errorf("got %d servers, want 2", len(result.Servers))
+	}
+}
+
+func TestScanOpenClawConfig_NoAgents(t *testing.T) {
+	dir := t.TempDir()
+	path := writeOpenClawConfig(t, dir, `{
+		"gateway": {"port": 18789},
+		"tools": {"profile": "standard"},
+		"channels": {}
+	}`)
+
+	result, err := scanOpenClawConfig(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Only gateway entry when no agents or channels
+	if len(result.Servers) != 1 {
+		t.Errorf("got %d servers, want 1 (gateway only)", len(result.Servers))
+	}
+}
+
+func TestScanOpenClawConfig_MissingFile(t *testing.T) {
+	_, err := scanOpenClawConfig("/nonexistent/openclaw.json")
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+}
+
+func TestScanOpenClawConfig_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := writeOpenClawConfig(t, dir, "not json at all")
+
+	_, err := scanOpenClawConfig(path)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestStripJSON5Comments(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{
+			name:  "line comment",
+			input: `{"key": "value" // comment` + "\n}",
+			want:  `{"key": "value" ` + "\n}",
+		},
+		{
+			name:  "block comment",
+			input: `{"key": /* removed */ "value"}`,
+			want:  `{"key":  "value"}`,
+		},
+		{
+			name:  "comment-like inside string",
+			input: `{"url": "http://example.com"}`,
+			want:  `{"url": "http://example.com"}`,
+		},
+		{
+			name:  "escaped quote in string",
+			input: `{"msg": "say \"hello\" // not a comment"}`,
+			want:  `{"msg": "say \"hello\" // not a comment"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := string(StripJSON5Comments([]byte(tt.input)))
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// --- KnownClients tests ---
+
+func TestKnownClients_Count(t *testing.T) {
+	clients := KnownClients()
+	if len(clients) != 17 {
+		t.Errorf("got %d clients, want 17", len(clients))
+	}
+
+	names := map[string]bool{}
+	for _, c := range clients {
+		if names[c.Name] {
+			t.Errorf("duplicate client name: %s", c.Name)
+		}
+		names[c.Name] = true
+	}
+}
+
+// --- FormatTree tests ---
+
+func TestFormatTree(t *testing.T) {
+	result := &Result{
+		Clients: []ClientResult{
+			{
+				Client: "cursor",
+				Path:   "/home/user/.cursor/mcp.json",
+				Servers: []MCPServer{
+					{Name: "filesystem", Command: "npx", Args: []string{"@mcp/server-filesystem"}},
+					{Name: "database", Command: "node", Args: []string{"./db.js"}},
+				},
+			},
+		},
+	}
+
+	output := FormatTree(result)
+
+	if !strings.Contains(output, "Cursor") {
+		t.Error("should contain client display name")
+	}
+	if !strings.Contains(output, "filesystem") {
+		t.Error("should contain server name")
+	}
+	if !strings.Contains(output, "2 MCP servers") {
+		t.Error("should contain total count")
+	}
+}
+
+func TestFormatTree_Empty(t *testing.T) {
+	result := &Result{}
+	output := FormatTree(result)
+	if !strings.Contains(output, "No MCP configurations found") {
+		t.Error("empty result should show 'no configs found'")
+	}
+	for _, name := range []string{"OpenCode", "Zed", "Amp", "Gemini CLI", "Claude Code", "BoltAI", "JetBrains"} {
+		if !strings.Contains(output, name) {
+			t.Errorf("empty message should list %s", name)
+		}
+	}
+}
+
+// --- Result helper tests ---
+
+func TestResult_TotalServers(t *testing.T) {
+	result := &Result{
+		Clients: []ClientResult{
+			{Servers: []MCPServer{{Name: "a"}, {Name: "b"}}},
+			{Servers: []MCPServer{{Name: "c"}}},
+		},
+	}
+	if got := result.TotalServers(); got != 3 {
+		t.Errorf("TotalServers() = %d, want 3", got)
+	}
+}
+
+func TestResult_TotalClients(t *testing.T) {
+	result := &Result{
+		Clients: []ClientResult{
+			{Client: "a", Servers: []MCPServer{{Name: "s1"}}},
+			{Client: "b", Servers: nil},
+			{Client: "c", Servers: []MCPServer{{Name: "s2"}}},
+		},
+	}
+	if got := result.TotalClients(); got != 2 {
+		t.Errorf("TotalClients() = %d, want 2", got)
+	}
+}
+
+func TestResult_AllServers(t *testing.T) {
+	result := &Result{
+		Clients: []ClientResult{
+			{Client: "a", Servers: []MCPServer{{Name: "s1"}, {Name: "s2"}}},
+			{Client: "b", Servers: []MCPServer{{Name: "s3"}}},
+		},
+	}
+	all := result.AllServers()
+	if len(all) != 3 {
+		t.Fatalf("AllServers() returned %d, want 3", len(all))
+	}
+}
+
+func TestClientDisplayName_AllClients(t *testing.T) {
+	expected := map[string]string{
+		"claude-desktop": "Claude Desktop",
+		"cursor":         "Cursor",
+		"vscode":         "VS Code",
+		"cline":          "Cline",
+		"windsurf":       "Windsurf",
+		"openclaw":       "OpenClaw",
+		"opencode":       "OpenCode",
+		"zed":            "Zed",
+		"amp":            "Amp",
+		"gemini-cli":     "Gemini CLI",
+		"copilot-cli":    "Copilot CLI",
+		"amazon-q":       "Amazon Q",
+		"claude-code":    "Claude Code",
+		"roo-code":       "Roo Code",
+		"kilo-code":      "Kilo Code",
+		"boltai":         "BoltAI",
+		"jetbrains":      "JetBrains",
+	}
+	for name, want := range expected {
+		if got := clientDisplayName(name); got != want {
+			t.Errorf("clientDisplayName(%q) = %q, want %q", name, got, want)
+		}
+	}
+}

--- a/discover/parsers.go
+++ b/discover/parsers.go
@@ -1,0 +1,305 @@
+package discover
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// mcpConfigJSON represents the common structure of MCP client config files.
+type mcpConfigJSON struct {
+	MCPServers map[string]mcpServerJSON `json:"mcpServers"`
+}
+
+type mcpServerJSON struct {
+	Command string            `json:"command"`
+	Args    []string          `json:"args"`
+	Env     map[string]string `json:"env,omitempty"`
+}
+
+// parseConfigWithKey parses a config file using the specified JSON key for the server map.
+// If key is empty, defaults to "mcpServers".
+// For VS Code ("servers" key), also tries "mcpServers" as fallback.
+func parseConfigWithKey(path, key string) ([]MCPServer, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	if key == "" {
+		key = "mcpServers"
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	servers := extractServersFromKey(raw, key)
+
+	// Fallback: if primary key is "servers", also try "mcpServers" (VS Code compat)
+	if len(servers) == 0 && key == "servers" {
+		servers = extractServersFromKey(raw, "mcpServers")
+	}
+
+	return servers, nil
+}
+
+func extractServersFromKey(raw map[string]json.RawMessage, key string) []MCPServer {
+	serversRaw, ok := raw[key]
+	if !ok {
+		return nil
+	}
+
+	var serverMap map[string]mcpServerJSON
+	if err := json.Unmarshal(serversRaw, &serverMap); err != nil {
+		return nil
+	}
+
+	var servers []MCPServer
+	for name, srv := range serverMap {
+		servers = append(servers, MCPServer{
+			Name:    name,
+			Command: srv.Command,
+			Args:    srv.Args,
+			Env:     srv.Env,
+		})
+	}
+	return servers
+}
+
+type openCodeServer struct {
+	Command     []string          `json:"command"`
+	Environment map[string]string `json:"environment"`
+}
+
+// parseOpenCodeConfig parses OpenCode's config format where servers are under "mcp"
+// and commands are arrays: {"mcp": {"name": {"command": ["cmd", "arg1"], "environment": {...}}}}
+func parseOpenCodeConfig(path string) ([]MCPServer, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	mcpRaw, ok := raw["mcp"]
+	if !ok {
+		return nil, nil
+	}
+
+	var mcpMap map[string]openCodeServer
+	if err := json.Unmarshal(mcpRaw, &mcpMap); err != nil {
+		return nil, fmt.Errorf("parsing mcp key in %s: %w", path, err)
+	}
+
+	var servers []MCPServer
+	for name, srv := range mcpMap {
+		s := MCPServer{Name: name, Env: srv.Environment}
+		if len(srv.Command) > 0 {
+			s.Command = srv.Command[0]
+			if len(srv.Command) > 1 {
+				s.Args = srv.Command[1:]
+			}
+		}
+		servers = append(servers, s)
+	}
+	return servers, nil
+}
+
+// parseClaudeCodeConfig parses Claude Code's ~/.claude.json where mcpServers
+// may be nested under scope keys: {"projects": {"/path": {"mcpServers": {...}}}, "mcpServers": {...}}
+func parseClaudeCodeConfig(path string) ([]MCPServer, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	seen := map[string]bool{}
+	var servers []MCPServer
+
+	// Top-level mcpServers
+	if topRaw, ok := raw["mcpServers"]; ok {
+		servers = append(servers, extractUniqueServers(topRaw, seen)...)
+	}
+
+	// Nested under "projects" — each project scope may have mcpServers
+	if projectsRaw, ok := raw["projects"]; ok {
+		var projects map[string]json.RawMessage
+		if json.Unmarshal(projectsRaw, &projects) == nil {
+			for _, projRaw := range projects {
+				var proj map[string]json.RawMessage
+				if json.Unmarshal(projRaw, &proj) == nil {
+					if mcpRaw, ok := proj["mcpServers"]; ok {
+						servers = append(servers, extractUniqueServers(mcpRaw, seen)...)
+					}
+				}
+			}
+		}
+	}
+
+	return servers, nil
+}
+
+func extractUniqueServers(raw json.RawMessage, seen map[string]bool) []MCPServer {
+	var serverMap map[string]mcpServerJSON
+	if err := json.Unmarshal(raw, &serverMap); err != nil {
+		return nil
+	}
+
+	var servers []MCPServer
+	for name, srv := range serverMap {
+		if seen[name] {
+			continue
+		}
+		seen[name] = true
+		servers = append(servers, MCPServer{
+			Name:    name,
+			Command: srv.Command,
+			Args:    srv.Args,
+			Env:     srv.Env,
+		})
+	}
+	return servers
+}
+
+// OpenClaw types for config parsing.
+type openClawConfig struct {
+	Gateway  ocGateway          `json:"gateway"`
+	Agents   map[string]ocAgent `json:"agents"`
+	Tools    ocTools            `json:"tools"`
+	Channels map[string]any     `json:"channels"`
+}
+
+type ocGateway struct {
+	Port int    `json:"port"`
+	Bind string `json:"bind"`
+}
+
+type ocTools struct {
+	Profile string   `json:"profile"`
+	Allow   []string `json:"allow"`
+	Deny    []string `json:"deny"`
+}
+
+type ocAgent struct {
+	Sandbox bool `json:"sandbox"`
+}
+
+// scanOpenClawConfig parses an OpenClaw config file and maps it to ClientResult
+// for compatibility with the existing discovery model.
+func scanOpenClawConfig(path string) (*ClientResult, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	clean := StripJSON5Comments(data)
+
+	var cfg openClawConfig
+	if err := json.Unmarshal(clean, &cfg); err != nil {
+		return nil, err
+	}
+
+	var servers []MCPServer
+
+	// Map the gateway as a server entry
+	bind := cfg.Gateway.Bind
+	if bind == "" {
+		bind = "127.0.0.1"
+	}
+	servers = append(servers, MCPServer{
+		Name:    "openclaw-gateway",
+		Command: "openclaw",
+		Args:    []string{"gateway", bind},
+	})
+
+	// Map each agent as a server entry
+	for name := range cfg.Agents {
+		servers = append(servers, MCPServer{
+			Name:    name,
+			Command: "openclaw",
+			Args:    []string{"agent", name},
+		})
+	}
+
+	// Map channels as server entries
+	for name := range cfg.Channels {
+		servers = append(servers, MCPServer{
+			Name:    "channel-" + name,
+			Command: "openclaw",
+			Args:    []string{"channel", name},
+		})
+	}
+
+	return &ClientResult{
+		Client:  "openclaw",
+		Path:    path,
+		Servers: servers,
+	}, nil
+}
+
+// StripJSON5Comments removes // and /* */ comments from JSON5 data,
+// being careful not to strip inside string literals.
+func StripJSON5Comments(data []byte) []byte {
+	var out []byte
+	i := 0
+	n := len(data)
+
+	for i < n {
+		// String literal — copy verbatim
+		if data[i] == '"' {
+			out = append(out, data[i])
+			i++
+			for i < n {
+				if data[i] == '\\' && i+1 < n {
+					out = append(out, data[i], data[i+1])
+					i += 2
+					continue
+				}
+				out = append(out, data[i])
+				if data[i] == '"' {
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		}
+
+		// Line comment
+		if i+1 < n && data[i] == '/' && data[i+1] == '/' {
+			i += 2
+			for i < n && data[i] != '\n' {
+				i++
+			}
+			continue
+		}
+
+		// Block comment
+		if i+1 < n && data[i] == '/' && data[i+1] == '*' {
+			i += 2
+			for i+1 < n {
+				if data[i] == '*' && data[i+1] == '/' {
+					i += 2
+					break
+				}
+				i++
+			}
+			continue
+		}
+
+		out = append(out, data[i])
+		i++
+	}
+
+	return out
+}

--- a/discover/paths.go
+++ b/discover/paths.go
@@ -1,0 +1,176 @@
+// Package discover auto-detects MCP client configurations across 17
+// known AI coding assistants and agent frameworks.
+package discover
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+)
+
+// Client represents a known MCP client application.
+type Client struct {
+	Name      string
+	Paths     []string // Config file paths to check
+	ConfigKey string   // JSON key for server map ("" = "mcpServers")
+}
+
+// KnownClients returns all supported MCP client applications with their config paths.
+func KnownClients() []Client {
+	home, _ := os.UserHomeDir()
+	clients := []Client{
+		{
+			Name:  "claude-desktop",
+			Paths: claudeDesktopPaths(home),
+		},
+		{
+			Name:  "cursor",
+			Paths: []string{filepath.Join(home, ".cursor", "mcp.json")},
+		},
+		{
+			Name:      "vscode",
+			Paths:     []string{filepath.Join(home, ".vscode", "mcp.json")},
+			ConfigKey: "servers", // VS Code native MCP uses "servers"; parser also tries "mcpServers" fallback
+		},
+		{
+			Name:  "cline",
+			Paths: []string{filepath.Join(home, ".cline", "mcp_settings.json")},
+		},
+		{
+			Name: "windsurf",
+			Paths: []string{
+				filepath.Join(home, ".windsurf", "mcp.json"),
+				filepath.Join(home, ".codeium", "windsurf", "mcp_config.json"),
+			},
+		},
+		{
+			Name:  "openclaw",
+			Paths: []string{filepath.Join(home, ".openclaw", "openclaw.json")},
+		},
+		{
+			Name:      "opencode",
+			Paths:     []string{filepath.Join(home, ".config", "opencode", "opencode.json")},
+			ConfigKey: "opencode", // custom parser signal
+		},
+		{
+			Name:      "zed",
+			Paths:     []string{filepath.Join(home, ".config", "zed", "settings.json")},
+			ConfigKey: "context_servers",
+		},
+		{
+			Name:      "amp",
+			Paths:     []string{filepath.Join(home, ".config", "amp", "settings.json")},
+			ConfigKey: "mcpServers",
+		},
+		{
+			Name:  "gemini-cli",
+			Paths: []string{filepath.Join(home, ".gemini", "settings.json")},
+		},
+		{
+			Name:  "copilot-cli",
+			Paths: []string{filepath.Join(home, ".copilot", "mcp-config.json")},
+		},
+		{
+			Name:  "amazon-q",
+			Paths: []string{filepath.Join(home, ".aws", "amazonq", "mcp.json")},
+		},
+		{
+			Name:      "claude-code",
+			Paths:     []string{filepath.Join(home, ".claude.json")},
+			ConfigKey: "claude-code", // custom parser signal
+		},
+		{
+			Name:  "roo-code",
+			Paths: rooCodePaths(home),
+		},
+		{
+			Name:  "kilo-code",
+			Paths: kiloCodePaths(home),
+		},
+		{
+			Name:  "boltai",
+			Paths: boltAIPaths(home),
+		},
+		{
+			Name:  "jetbrains",
+			Paths: []string{filepath.Join(home, ".junie", "mcp", "mcp.json")},
+		},
+	}
+	return clients
+}
+
+func claudeDesktopPaths(home string) []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{
+			filepath.Join(home, "Library", "Application Support", "Claude", "claude_desktop_config.json"),
+		}
+	case "linux":
+		return []string{
+			filepath.Join(home, ".config", "claude", "claude_desktop_config.json"),
+		}
+	case "windows":
+		appdata := os.Getenv("APPDATA")
+		if appdata == "" {
+			appdata = filepath.Join(home, "AppData", "Roaming")
+		}
+		return []string{
+			filepath.Join(appdata, "Claude", "claude_desktop_config.json"),
+		}
+	default:
+		return nil
+	}
+}
+
+func rooCodePaths(home string) []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{
+			filepath.Join(home, "Library", "Application Support", "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json"),
+		}
+	case "linux":
+		return []string{
+			filepath.Join(home, ".config", "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json"),
+		}
+	case "windows":
+		appdata := os.Getenv("APPDATA")
+		if appdata == "" {
+			appdata = filepath.Join(home, "AppData", "Roaming")
+		}
+		return []string{
+			filepath.Join(appdata, "Code", "User", "globalStorage", "rooveterinaryinc.roo-cline", "settings", "mcp_settings.json"),
+		}
+	default:
+		return nil
+	}
+}
+
+func kiloCodePaths(home string) []string {
+	switch runtime.GOOS {
+	case "darwin":
+		return []string{
+			filepath.Join(home, "Library", "Application Support", "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
+		}
+	case "linux":
+		return []string{
+			filepath.Join(home, ".config", "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
+		}
+	case "windows":
+		appdata := os.Getenv("APPDATA")
+		if appdata == "" {
+			appdata = filepath.Join(home, "AppData", "Roaming")
+		}
+		return []string{
+			filepath.Join(appdata, "Code", "User", "globalStorage", "kilocode.kilo-code", "settings", "mcp_settings.json"),
+		}
+	default:
+		return nil
+	}
+}
+
+func boltAIPaths(home string) []string {
+	if runtime.GOOS == "darwin" {
+		return []string{filepath.Join(home, ".boltai", "mcp.json")}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

- Add public `discover/` package that auto-detects MCP server configurations across **17 clients**: Claude Desktop, Cursor, VS Code, Cline, Windsurf, OpenClaw, OpenCode, Zed, Amp, Gemini CLI, Copilot CLI, Amazon Q, Claude Code, Roo Code, Kilo Code, BoltAI, and JetBrains
- Add `aguara discover` CLI command with tree and JSON output
- Add `aguara scan --auto` flag that discovers and scans all MCP configs in one step
- Add `aguara.Discover()` to the public Go API for library consumers (e.g. Oktsec)
- Update README with discovery docs, updated architecture diagram, and usage examples

## New files

| File | Description |
|------|-------------|
| `discover/paths.go` | 17 client definitions with platform-specific path helpers |
| `discover/parsers.go` | Config parsers: generic key, OpenCode, Claude Code, OpenClaw + JSON5 comment stripper |
| `discover/discover.go` | Public types (`MCPServer`, `ClientResult`, `Result`), `Scan()`, `FormatTree()` |
| `discover/discover_test.go` | 22 test functions covering all parsers, formatters, and edge cases |
| `cmd/aguara/commands/discover.go` | `aguara discover` Cobra command |

## Modified files

| File | Change |
|------|--------|
| `cmd/aguara/commands/scan.go` | `--auto` flag with `runAutoScan()` |
| `aguara.go` | `Discover()` + re-exported types (`DiscoverResult`, `DiscoveredServer`, `DiscoveredClient`) |
| `README.md` | Discovery section, updated Quick Start, architecture, and Go library examples |

## Why public `discover/` (not `internal/`)?

Oktsec needs to import this package. Go's `internal/` convention blocks cross-module imports. The `discover/` package uses only stdlib — zero external dependencies.

## Test plan

- [x] `go build ./...` passes
- [x] `go test -race ./...` — all 15 packages pass
- [x] `aguara discover` — tree output lists local clients
- [x] `aguara discover --format json` — valid JSON
- [x] `aguara scan --auto` — discovers and scans configs
- [x] `aguara scan <path>` — existing behavior unchanged
- [x] `aguara scan` (no args) — still requires path
- [x] `aguara scan --auto somepath` — correctly rejected