### PR TITLE
feat: add 5 detection rules for supply-chain, MCP, SSRF, and credential leak categories

### DIFF
--- a/internal/rules/builtin/credential-leak.yaml
+++ b/internal/rules/builtin/credential-leak.yaml
@@ -379,3 +379,31 @@ examples:
   false_positive:
     - "Configure OTEL to export anonymized performance metrics"
     - "Set up Datadog monitoring for latency tracking"
+---
+id: CRED_020
+name: "OAuth PKCE verifier exposure"
+description: "Detects OAuth flows where the PKCE code_verifier is stored in or transmitted via URL parameters, state, redirect URIs, or logs"
+severity: HIGH
+category: credential-leak
+targets: []
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)(state|redirect_uri|callback_url|return_url|query|url_param)\\s*[=:].{0,40}code_verifier"
+  - type: regex
+    value: "(?i)code_verifier\\s*[=:].{0,30}(state|url|query|param|redirect)"
+  - type: regex
+    value: "(?i)code_verifier.{0,30}(redirect_uri|state|query.param|url.param|callback)"
+  - type: regex
+    value: "(?i)(log|print|console|debug|trace|stdout|stderr)\\s*[.(].{0,30}code_verifier"
+  - type: regex
+    value: "(?i)code_verifier.{0,20}(visible|exposed|leaked|sent|passed|included).{0,20}(url|redirect|state|browser|history)"
+examples:
+  true_positive:
+    - "state = JSON.stringify({code_verifier: verifier})"
+    - "Store the code_verifier in the redirect_uri query params"
+    - "console.log('PKCE verifier:', code_verifier)"
+    - "The code_verifier is exposed in the browser URL bar"
+  false_positive:
+    - "Store the code_verifier in server-side session storage"
+    - "The PKCE code_verifier must never be transmitted in URLs"

--- a/internal/rules/builtin/mcp-attack.yaml
+++ b/internal/rules/builtin/mcp-attack.yaml
@@ -258,4 +258,50 @@ examples:
   false_positive:
     - "Filter out __proto__ from user input before merging"
     - "Prototype pollution attacks target JavaScript objects"
+---
+id: MCP_013
+name: "Approval-execution binding gap"
+description: "Detects tools where user approval and command execution are decoupled, enabling TOCTOU substitution of the approved action"
+severity: HIGH
+category: mcp-attack
+targets: ["*.md", "*.txt"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)(ask|prompt|confirm|approve|consent).{0,30}(then|before).{0,20}(run|exec|execute|spawn|system|shell)"
+  - type: regex
+    value: "(?i)(run|execute).{0,30}(previously|already|pre)[- ]?(approved|confirmed|authorized)"
+  - type: regex
+    value: "(?i)(cached|stored|saved|queued)\\s+(approval|confirmation).{0,30}(execute|run|spawn)"
+examples:
+  true_positive:
+    - "Ask the user for confirmation, then execute the command"
+    - "Run the previously approved shell command"
+    - "Use the cached approval to execute the pending operation"
+  false_positive:
+    - "The approval process must verify the exact command before execution"
+    - "Each command requires a separate approval"
+---
+id: MCP_014
+name: "Unscoped resource identifier"
+description: "Detects tool parameters that accept global resource identifiers without binding them to the current session or conversation context"
+severity: MEDIUM
+category: mcp-attack
+targets: ["*.md", "*.txt"]
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)(accept|take|use)s?\\s+(any|arbitrary|external)\\s+(upload|file|session|conversation|message|thread)[_-]?id"
+  - type: regex
+    value: "(?i)(access|modify|delete|cancel)\\s+.{0,20}(upload|file|message|request)\\s+(by|using|via|with)\\s+.{0,10}(its\\s+)?id\\b"
+  - type: regex
+    value: "(?i)(any|all)\\s+(user|agent|client)s?\\s+can\\s+(access|read|write|modify|delete)\\s+.{0,20}(by|via|using)\\s+(the\\s+)?(resource\\s+)?id"
+examples:
+  true_positive:
+    - "Accepts any upload_id to download the corresponding file"
+    - "Delete a message by its ID without checking ownership"
+    - "Any user can access uploads using the resource id"
+  false_positive:
+    - "Access is scoped to the current session's resources"
+    - "Only the owner can delete their uploads by ID"
     - "delete obj['__proto__']"

--- a/internal/rules/builtin/ssrf-cloud.yaml
+++ b/internal/rules/builtin/ssrf-cloud.yaml
@@ -215,4 +215,25 @@ examples:
     - "http://[2002:c0a8:0101::]/config"
   false_positive:
     - "IPv6 transition mechanisms are described in RFC 6146"
+---
+id: SSRF_011
+name: "IPv6 multicast SSRF bypass"
+description: "Detects IPv6 multicast addresses (ff00::/8) used in URLs to bypass SSRF IP blocklists and probe internal network topology"
+severity: HIGH
+category: ssrf-cloud
+targets: []
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)https?://\\[?ff[0-9a-f]{2}:[0-9a-f:]+"
+  - type: regex
+    value: "(?i)(fetch|request|curl|wget|http\\.get|axios)\\s*\\(?\\s*[\"']?[^\"']*\\[?ff[0-9a-f]{2}:"
+examples:
+  true_positive:
+    - "curl http://[ff02::1]:8080/admin"
+    - "fetch('http://[ff05::1]/config')"
+    - "http://[ff0e::1]:443/internal-api"
+  false_positive:
+    - "IPv6 multicast is used for neighbor discovery (RFC 4861)"
+    - "The ff02::1 address represents all-nodes on the link"
     - "The ::ffff prefix denotes IPv4-mapped IPv6 addresses"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -358,3 +358,32 @@ examples:
     - "Files are restricted to the workspace directory"
     - "The sandbox prevents access to host files"
     - "This skill does not modify any files on the system"
+---
+id: SUPPLY_017
+name: "Hardlink workspace escape"
+description: "Detects hardlink creation patterns that bypass realpath-based workspace boundary checks, allowing read/write access to files outside the sandbox"
+severity: HIGH
+category: supply-chain
+targets: []
+match_mode: any
+patterns:
+  - type: regex
+    value: "(?i)\\bln\\s+[/~.\"][^|;&]{0,60}(etc/|root/|home/|var/run/|\\.ssh/|\\.aws/|\\.env)"
+  - type: regex
+    value: "(?i)\\bln\\s+-[^s\\s][^|;&]{0,60}(etc/|root/|home/|var/run/|\\.ssh/|\\.aws/|\\.env)"
+  - type: regex
+    value: "(?i)\\b(os\\.link|fs\\.link(Sync)?|link\\()\\s*\\("
+  - type: regex
+    value: "(?i)(hard\\s*link|hardlink)\\s+.{0,30}(outside|escape|bypass|sensitive|passwd|shadow|secret|credential)"
+  - type: regex
+    value: "(?i)(create|make|add)\\s+(a\\s+)?hard\\s*links?\\s+.{0,30}(to|from|targeting)"
+examples:
+  true_positive:
+    - "ln /etc/passwd /workspace/myfile"
+    - "os.link('/etc/shadow', '/workspace/shadow_copy')"
+    - "Create a hardlink to escape the sandbox boundary"
+    - "fs.linkSync('/etc/hosts', './hosts_link')"
+  false_positive:
+    - "ln -s ./relative/path ./link"
+    - "Symlinks are blocked to prevent workspace escape"
+    - "Hardlink attacks are mitigated by filesystem checks"


### PR DESCRIPTION
## Summary

5 new detection rules covering emerging attack patterns:

- **SUPPLY_017** — Hardlink workspace escape: detects `ln` (without `-s`) targeting sensitive paths to bypass realpath sandbox checks
- **MCP_013** — Approval-execution binding gap: detects TOCTOU patterns where user approval is decoupled from command execution
- **MCP_014** — Unscoped resource identifier: detects tools accepting arbitrary resource IDs without ownership validation
- **SSRF_011** — IPv6 multicast SSRF bypass: detects `ff00::/8` multicast addresses in HTTP URLs
- **CRED_020** — OAuth PKCE verifier exposure: detects `code_verifier` leaked via URL params, logs, or redirect URIs

Rule count: 148 → 153

## Test plan

- [x] `make test` passes (16 packages)
- [x] All 5 rules pass built-in self-test (true_positive + false_positive examples)
- [x] No regressions in existing rules