### PR TITLE
fix: add file-size guardrails, symlink protection, and input validation

### DIFF
--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -257,9 +257,20 @@ func loadAndCompileRules(cfg config.Config) ([]*rules.CompiledRule, error) {
 	}
 
 	if flagRules != "" {
-		customRules, err := rules.LoadFromDir(flagRules)
+		rulesDir, err := filepath.Abs(flagRules)
 		if err != nil {
-			return nil, fmt.Errorf("loading custom rules from %s: %w", flagRules, err)
+			return nil, fmt.Errorf("resolving rules path: %w", err)
+		}
+		info, err := os.Stat(rulesDir)
+		if err != nil {
+			return nil, fmt.Errorf("rules directory: %w", err)
+		}
+		if !info.IsDir() {
+			return nil, fmt.Errorf("--rules path is not a directory: %s", rulesDir)
+		}
+		customRules, err := rules.LoadFromDir(rulesDir)
+		if err != nil {
+			return nil, fmt.Errorf("loading custom rules from %s: %w", rulesDir, err)
 		}
 		rawRules = append(rawRules, customRules...)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,11 +36,18 @@ func Load(dir string) (Config, error) {
 	}
 	for _, name := range []string{".aguara.yml", ".aguara.yaml"} {
 		path := filepath.Join(dir, name)
-		data, err := os.ReadFile(path)
+		info, err := os.Stat(path)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
+			return Config{}, fmt.Errorf("reading %s: %w", path, err)
+		}
+		if info.Size() > 1<<20 {
+			return Config{}, fmt.Errorf("config file too large: %s (%d bytes, max 1 MB)", path, info.Size())
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
 			return Config{}, fmt.Errorf("reading %s: %w", path, err)
 		}
 		var cfg Config


### PR DESCRIPTION
## Summary

- **Scan target size limits**: Files larger than 50 MB are silently skipped during discovery. `LoadContent` also performs a defense-in-depth size check before `os.ReadFile` to prevent OOM.
- **Custom rules validation**: `--rules` path is resolved to absolute and validated as an existing directory. Individual YAML rule files larger than 1 MB are skipped with a stderr warning.
- **Config size limit**: `.aguara.yml` files larger than 1 MB are rejected before parsing.
- **State file hardening**: Directories created with `0o700`, state file written with `0o600` (owner-only). Symlinks are rejected on both `Load()` and `Save()`.
- **Decoder bounds**: Encoded blobs (base64/hex) larger than 1 MB are skipped. Decoded output is truncated at 512 KB before re-scanning to prevent quadratic memory expansion.

## Test plan

- [x] `make test` — all 17 packages pass with `-race`
- [x] `go test ./internal/scanner/ -v` — discovery skips oversized files
- [x] `go test ./internal/rules/ -v` — rule loading with size limits
- [x] `go test ./internal/config/ -v` — config size limit
- [x] `go test ./internal/state/ -v` — symlink rejection, tightened permissions
- [x] `go test ./internal/engine/pattern/ -v` — decoder bounds