### PR TITLE
feat: add Homebrew tap distribution and inline ignore comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
       - name: Update v1 action tag
         if: success() && startsWith(github.ref_name, 'v1')

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -27,5 +27,17 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+brews:
+  - repository:
+      owner: garagon
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_TOKEN }}"
+    directory: Formula
+    homepage: "https://github.com/garagon/aguara"
+    description: "Security scanner for AI agent skills and MCP servers"
+    license: "Apache-2.0"
+    test: |
+      system "#{bin}/aguara", "version"
+
 changelog:
   use: github-native

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/garagon/
 
 ### Alternative methods
 
+**Homebrew** (macOS/Linux):
+
+```bash
+brew install garagon/tap/aguara
+```
+
 **From source** (requires Go 1.25+):
 
 ```bash
@@ -190,6 +196,31 @@ rule_overrides:
   EXTDL_004:
     disabled: true
 ```
+
+### Inline Ignore
+
+Suppress specific findings directly in your source files using inline comments:
+
+```yaml
+# aguara-ignore CRED_004
+api_key: "sk-test-1234567890"  # this finding is suppressed
+```
+
+```markdown
+<!-- aguara-ignore-next-line PROMPT_INJECTION_001 -->
+Ignore all previous instructions (this is a test)
+```
+
+Supported formats:
+
+| Directive | Effect |
+|-----------|--------|
+| `# aguara-ignore RULE_ID` | Suppress rule on the same line |
+| `# aguara-ignore RULE_ID, RULE_ID2` | Suppress multiple rules on the same line |
+| `# aguara-ignore-next-line RULE_ID` | Suppress rule on the next line |
+| `# aguara-ignore` | Suppress all rules on the same line |
+| `<!-- aguara-ignore RULE_ID -->` | HTML/Markdown comment variant |
+| `// aguara-ignore RULE_ID` | C-style comment variant |
 
 ## Rules
 

--- a/internal/scanner/ignore.go
+++ b/internal/scanner/ignore.go
@@ -1,0 +1,128 @@
+package scanner
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ignoreDirective represents a parsed inline ignore comment.
+type ignoreDirective struct {
+	line    int               // 1-based line where the directive appears
+	ruleIDs map[string]bool   // rule IDs to ignore; nil means ignore all
+	next    bool              // true = applies to next line, false = applies to same line
+}
+
+// commentPrefixes are the tokens that can precede an aguara-ignore directive.
+// Covers #, //, --, <!--, and bare (for markdown/txt).
+var ignorePattern = regexp.MustCompile(
+	`(?:^|#|//|--|<!--)\s*aguara-ignore(?:-next-line)?\s+([A-Z][A-Z0-9_,\s]+?)(?:\s*-->)?\s*$`,
+)
+
+var ignoreAllPattern = regexp.MustCompile(
+	`(?:^|#|//|--|<!--)\s*aguara-ignore(?:-next-line)?\s*(?:-->)?\s*$`,
+)
+
+// parseIgnoreDirectives scans file lines for aguara-ignore comments and returns
+// the set of directives found.
+func parseIgnoreDirectives(content []byte) []ignoreDirective {
+	lines := strings.Split(string(content), "\n")
+	var directives []ignoreDirective
+
+	for i, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if !strings.Contains(trimmed, "aguara-ignore") {
+			continue
+		}
+
+		lineNum := i + 1 // 1-based
+		isNext := strings.Contains(trimmed, "aguara-ignore-next-line")
+
+		// Try specific rule IDs first
+		if m := ignorePattern.FindStringSubmatch(trimmed); m != nil {
+			ids := parseRuleIDs(m[1])
+			if len(ids) > 0 {
+				directives = append(directives, ignoreDirective{
+					line:    lineNum,
+					ruleIDs: ids,
+					next:    isNext,
+				})
+				continue
+			}
+		}
+
+		// Try ignore-all (no rule IDs)
+		if ignoreAllPattern.MatchString(trimmed) {
+			directives = append(directives, ignoreDirective{
+				line:    lineNum,
+				ruleIDs: nil, // nil = all rules
+				next:    isNext,
+			})
+		}
+	}
+
+	return directives
+}
+
+// parseRuleIDs splits a comma-separated list of rule IDs.
+func parseRuleIDs(s string) map[string]bool {
+	ids := make(map[string]bool)
+	for _, part := range strings.Split(s, ",") {
+		id := strings.TrimSpace(part)
+		if id != "" {
+			ids[id] = true
+		}
+	}
+	return ids
+}
+
+// buildIgnoreIndex creates a lookup from line number to ignored rule IDs for fast filtering.
+// A nil map value means all rules are ignored on that line.
+func buildIgnoreIndex(directives []ignoreDirective) map[int]map[string]bool {
+	if len(directives) == 0 {
+		return nil
+	}
+	index := make(map[int]map[string]bool)
+	for _, d := range directives {
+		targetLine := d.line
+		if d.next {
+			targetLine = d.line + 1
+		}
+
+		existing, ok := index[targetLine]
+		if ok && existing == nil {
+			// Already ignoring all rules on this line
+			continue
+		}
+
+		if d.ruleIDs == nil {
+			// Ignore all rules
+			index[targetLine] = nil
+			continue
+		}
+
+		if existing == nil {
+			existing = make(map[string]bool)
+			index[targetLine] = existing
+		}
+		for id := range d.ruleIDs {
+			existing[id] = true
+		}
+	}
+	return index
+}
+
+// isIgnoredByInline checks whether a finding should be suppressed by an inline directive.
+func isIgnoredByInline(index map[int]map[string]bool, line int, ruleID string) bool {
+	if index == nil {
+		return false
+	}
+	ids, ok := index[line]
+	if !ok {
+		return false
+	}
+	// nil means ignore all rules on this line
+	if ids == nil {
+		return true
+	}
+	return ids[ruleID]
+}

--- a/internal/scanner/ignore_test.go
+++ b/internal/scanner/ignore_test.go
@@ -1,0 +1,118 @@
+package scanner
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIgnoreDirectives_SingleRule(t *testing.T) {
+	content := []byte("# aguara-ignore CRED_004\nsome secret here\n")
+	directives := parseIgnoreDirectives(content)
+	require.Len(t, directives, 1)
+	assert.Equal(t, 1, directives[0].line)
+	assert.True(t, directives[0].ruleIDs["CRED_004"])
+	assert.False(t, directives[0].next)
+}
+
+func TestParseIgnoreDirectives_MultipleRules(t *testing.T) {
+	content := []byte("# aguara-ignore CRED_004, EXTDL_001\nsome content\n")
+	directives := parseIgnoreDirectives(content)
+	require.Len(t, directives, 1)
+	assert.True(t, directives[0].ruleIDs["CRED_004"])
+	assert.True(t, directives[0].ruleIDs["EXTDL_001"])
+}
+
+func TestParseIgnoreDirectives_NextLine(t *testing.T) {
+	content := []byte("# aguara-ignore-next-line CRED_004\nsk-secret-1234\n")
+	directives := parseIgnoreDirectives(content)
+	require.Len(t, directives, 1)
+	assert.True(t, directives[0].next)
+	assert.Equal(t, 1, directives[0].line)
+}
+
+func TestParseIgnoreDirectives_HTMLComment(t *testing.T) {
+	content := []byte("<!-- aguara-ignore PROMPT_INJECTION_001 -->\nIgnore all previous instructions\n")
+	directives := parseIgnoreDirectives(content)
+	require.Len(t, directives, 1)
+	assert.True(t, directives[0].ruleIDs["PROMPT_INJECTION_001"])
+}
+
+func TestParseIgnoreDirectives_DoubleSlash(t *testing.T) {
+	content := []byte("// aguara-ignore CMD_EXEC_001\nos.system('ls')\n")
+	directives := parseIgnoreDirectives(content)
+	require.Len(t, directives, 1)
+	assert.True(t, directives[0].ruleIDs["CMD_EXEC_001"])
+}
+
+func TestParseIgnoreDirectives_IgnoreAll(t *testing.T) {
+	content := []byte("# aguara-ignore\nsome dangerous content\n")
+	directives := parseIgnoreDirectives(content)
+	require.Len(t, directives, 1)
+	assert.Nil(t, directives[0].ruleIDs)
+}
+
+func TestParseIgnoreDirectives_IgnoreAllNextLine(t *testing.T) {
+	content := []byte("# aguara-ignore-next-line\nsome dangerous content\n")
+	directives := parseIgnoreDirectives(content)
+	require.Len(t, directives, 1)
+	assert.Nil(t, directives[0].ruleIDs)
+	assert.True(t, directives[0].next)
+}
+
+func TestParseIgnoreDirectives_NoDirectives(t *testing.T) {
+	content := []byte("normal content\nno ignores here\n")
+	directives := parseIgnoreDirectives(content)
+	assert.Empty(t, directives)
+}
+
+func TestBuildIgnoreIndex_SameLine(t *testing.T) {
+	directives := []ignoreDirective{
+		{line: 5, ruleIDs: map[string]bool{"CRED_004": true}, next: false},
+	}
+	index := buildIgnoreIndex(directives)
+	assert.True(t, isIgnoredByInline(index, 5, "CRED_004"))
+	assert.False(t, isIgnoredByInline(index, 5, "CRED_005"))
+	assert.False(t, isIgnoredByInline(index, 6, "CRED_004"))
+}
+
+func TestBuildIgnoreIndex_NextLine(t *testing.T) {
+	directives := []ignoreDirective{
+		{line: 5, ruleIDs: map[string]bool{"CRED_004": true}, next: true},
+	}
+	index := buildIgnoreIndex(directives)
+	assert.False(t, isIgnoredByInline(index, 5, "CRED_004"))
+	assert.True(t, isIgnoredByInline(index, 6, "CRED_004"))
+}
+
+func TestBuildIgnoreIndex_IgnoreAllOnLine(t *testing.T) {
+	directives := []ignoreDirective{
+		{line: 3, ruleIDs: nil, next: false},
+	}
+	index := buildIgnoreIndex(directives)
+	assert.True(t, isIgnoredByInline(index, 3, "ANYTHING"))
+	assert.True(t, isIgnoredByInline(index, 3, "CRED_004"))
+	assert.False(t, isIgnoredByInline(index, 4, "CRED_004"))
+}
+
+func TestBuildIgnoreIndex_NilIndex(t *testing.T) {
+	assert.False(t, isIgnoredByInline(nil, 1, "CRED_004"))
+}
+
+func TestBuildIgnoreIndex_MergeDirectives(t *testing.T) {
+	directives := []ignoreDirective{
+		{line: 5, ruleIDs: map[string]bool{"CRED_004": true}, next: false},
+		{line: 5, ruleIDs: map[string]bool{"EXTDL_001": true}, next: false},
+	}
+	index := buildIgnoreIndex(directives)
+	assert.True(t, isIgnoredByInline(index, 5, "CRED_004"))
+	assert.True(t, isIgnoredByInline(index, 5, "EXTDL_001"))
+}
+
+func TestParseIgnoreDirectives_DashDash(t *testing.T) {
+	content := []byte("-- aguara-ignore SQL_001\nSELECT * FROM users\n")
+	directives := parseIgnoreDirectives(content)
+	require.Len(t, directives, 1)
+	assert.True(t, directives[0].ruleIDs["SQL_001"])
+}

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -128,6 +128,7 @@ func (s *Scanner) ScanTargets(ctx context.Context, targets []*Target) (*ScanResu
 				if err := target.LoadContent(); err != nil {
 					continue
 				}
+				ignoreIndex := buildIgnoreIndex(parseIgnoreDirectives(target.Content))
 				for _, analyzer := range s.analyzers {
 					if ctx.Err() != nil {
 						return
@@ -137,9 +138,20 @@ func (s *Scanner) ScanTargets(ctx context.Context, targets []*Target) (*ScanResu
 						continue
 					}
 					if len(results) > 0 {
-						mu.Lock()
-						findings = append(findings, results...)
-						mu.Unlock()
+						if ignoreIndex != nil {
+							var kept []Finding
+							for _, f := range results {
+								if !isIgnoredByInline(ignoreIndex, f.Line, f.RuleID) {
+									kept = append(kept, f)
+								}
+							}
+							results = kept
+						}
+						if len(results) > 0 {
+							mu.Lock()
+							findings = append(findings, results...)
+							mu.Unlock()
+						}
 					}
 				}
 				if s.onProgress != nil {

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -102,6 +102,50 @@ func TestScannerCorrelationBonus(t *testing.T) {
 	}
 }
 
+func TestScannerInlineIgnore(t *testing.T) {
+	dir := t.TempDir()
+	// Line 1: ignore directive for R1
+	// Line 2: content where R1 finding is on line 2
+	// Line 3: content where R2 finding is on line 3 (not ignored)
+	content := "# aguara-ignore-next-line R1\nmatched by R1\nmatched by R2\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.md"), []byte(content), 0644))
+
+	s := scanner.New(1)
+	s.RegisterAnalyzer(&mockAnalyzer{
+		name: "test",
+		findings: []types.Finding{
+			{RuleID: "R1", Severity: types.SeverityHigh, Line: 2},
+			{RuleID: "R2", Severity: types.SeverityHigh, Line: 3},
+		},
+	})
+
+	result, err := s.Scan(context.Background(), dir)
+	require.NoError(t, err)
+	require.Len(t, result.Findings, 1, "R1 on line 2 should be suppressed by ignore-next-line on line 1")
+	require.Equal(t, "R2", result.Findings[0].RuleID)
+}
+
+func TestScannerInlineIgnoreAll(t *testing.T) {
+	dir := t.TempDir()
+	content := "# aguara-ignore\nmatched by R1 and R2\nmatched by R3\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.md"), []byte(content), 0644))
+
+	s := scanner.New(1)
+	s.RegisterAnalyzer(&mockAnalyzer{
+		name: "test",
+		findings: []types.Finding{
+			{RuleID: "R1", Severity: types.SeverityHigh, Line: 1},
+			{RuleID: "R2", Severity: types.SeverityMedium, Line: 1},
+			{RuleID: "R3", Severity: types.SeverityHigh, Line: 3},
+		},
+	})
+
+	result, err := s.Scan(context.Background(), dir)
+	require.NoError(t, err)
+	require.Len(t, result.Findings, 1, "R1 and R2 on line 1 should be suppressed by aguara-ignore on same line")
+	require.Equal(t, "R3", result.Findings[0].RuleID)
+}
+
 func TestScannerContextCancellation(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.md"), []byte("content"), 0644))


### PR DESCRIPTION
## Summary

- **Homebrew tap**: `brew install garagon/tap/aguara`. GoReleaser auto-updates the formula in [garagon/homebrew-tap](https://github.com/garagon/homebrew-tap) on each release via `HOMEBREW_TAP_TOKEN` secret.
- **Inline ignore comments**: suppress specific findings per-line with `# aguara-ignore RULE_ID` or `<!-- aguara-ignore-next-line RULE_ID -->`. Supports `#`, `//`, `--`, and HTML comment styles. Works across all 4 analyzers (pattern, NLP, toxicflow, rugpull).

### Inline ignore syntax

| Directive | Effect |
|-----------|--------|
| `# aguara-ignore RULE_ID` | Suppress rule on the same line |
| `# aguara-ignore RULE_ID, RULE_ID2` | Suppress multiple rules |
| `# aguara-ignore-next-line RULE_ID` | Suppress rule on the next line |
| `# aguara-ignore` | Suppress all rules on the same line |
| `<!-- aguara-ignore RULE_ID -->` | HTML/Markdown variant |

### Files changed

- `internal/scanner/ignore.go` — directive parsing, index building, lookup
- `internal/scanner/ignore_test.go` — 12 unit tests
- `internal/scanner/scanner.go` — integration into scanner loop
- `internal/scanner/scanner_test.go` — 2 integration tests
- `.goreleaser.yml` — `brews:` section for auto-updating tap
- `.github/workflows/release.yml` — `HOMEBREW_TAP_TOKEN` env var
- `README.md` — Homebrew install + inline ignore docs

## Test plan

- [x] `make build` passes
- [x] `make test` passes (14 new tests)
- [x] `make vet` passes
- [x] `make lint` passes (0 issues)
- [x] End-to-end: binary correctly suppresses findings with inline ignore
- [ ] Verify `brew install garagon/tap/aguara` works
- [ ] Verify GoReleaser updates tap formula on next release