### PR TITLE
fix: add regex pattern length limit and improve community docs

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,9 @@
-## Description
+## Summary
 
-<!-- What does this PR do? Why is it needed? -->
+<!-- Brief description of what this PR does and why -->
 
-## Changes
+## Test plan
 
-<!-- List the key changes -->
-
--
-
-## Checklist
-
-- [ ] Tests pass (`make test`)
-- [ ] No lint issues (`make lint`)
-- [ ] CHANGELOG.md updated (if user-facing change)
-- [ ] No breaking changes (or clearly documented)
+- [ ] `make test` passes
+- [ ] `make lint` passes
+- [ ] Manual testing (describe below if applicable)

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,11 +1,31 @@
-# Code of Conduct
+# Contributor Covenant Code of Conduct
 
-This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+## Our Pledge
 
-By participating, you agree to uphold this code of conduct.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement
 
-Instances of unacceptable behavior may be reported by opening an issue or contacting the maintainers directly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the project maintainers. All complaints will be reviewed and investigated promptly and fairly.
 
-Project maintainers are responsible for clarifying the standards of acceptable behavior and will take appropriate corrective action in response to any behavior that they deem inappropriate.
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/internal/rules/compiler.go
+++ b/internal/rules/compiler.go
@@ -57,8 +57,15 @@ func Compile(raw RawRule) (*CompiledRule, error) {
 	return compiled, nil
 }
 
+// maxPatternLength is the maximum length of a single regex or contains pattern value.
+// Protects against excessive memory use during regex compilation from custom rules.
+const maxPatternLength = 4096
+
 func compilePattern(p RawPattern) (CompiledPattern, error) {
 	cp := CompiledPattern{Type: p.Type, Value: p.Value}
+	if len(p.Value) > maxPatternLength {
+		return cp, fmt.Errorf("pattern too long (%d chars, max %d)", len(p.Value), maxPatternLength)
+	}
 	switch p.Type {
 	case PatternRegex:
 		re, err := regexp.Compile(p.Value)


### PR DESCRIPTION
## Summary

- Add `maxPatternLength` (4096 chars) guard in custom rules compiler to prevent excessive memory use during regex compilation from user-provided custom rules
- Update PR template with cleaner format
- Update Code of Conduct (Contributor Covenant 2.1)

Found during comprehensive audit (performance, security, open-source quality).

## Test plan

- [x] `make build` passes
- [x] `make test` passes
- [x] `make vet` passes
- [x] `make lint` passes (0 issues)