### PR TITLE
fix: .pth false positives on known-safe Python ecosystem files

### DIFF
--- a/internal/incident/checker.go
+++ b/internal/incident/checker.go
@@ -213,8 +213,23 @@ func findPthFiles(dir string) []string {
 
 var pthExecRe = regexp.MustCompile(`(?i)(^import\s|subprocess|os\.system|os\.popen|exec\(|eval\(|compile\(|__import__|importlib|open\(|Path\()`)
 
+// knownSafePth lists .pth filenames from standard Python ecosystem packages
+// that legitimately use import statements for site customization.
+var knownSafePth = map[string]bool{
+	"_virtualenv.pth":          true,
+	"distutils-precedence.pth": true,
+	"easy-install.pth":         true,
+	"setuptools.pth":           true,
+	"coverage.pth":             true,
+	"zope-nspkg.pth":           true,
+}
+
 // checkPthFile scans a .pth file for executable content.
 func checkPthFile(path string) []Finding {
+	if knownSafePth[filepath.Base(path)] {
+		return nil
+	}
+
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil

--- a/internal/incident/checker_test.go
+++ b/internal/incident/checker_test.go
@@ -80,6 +80,38 @@ func TestCheckDetectsMaliciousPth(t *testing.T) {
 	assert.True(t, hasPth, "should detect malicious .pth file")
 }
 
+func TestCheckSkipsKnownSafePth(t *testing.T) {
+	dir := t.TempDir()
+
+	// _virtualenv.pth is a known-safe file
+	pth := filepath.Join(dir, "_virtualenv.pth")
+	require.NoError(t, os.WriteFile(pth, []byte("import _virtualenv\n"), 0644))
+
+	// distutils-precedence.pth is also known-safe
+	pth2 := filepath.Join(dir, "distutils-precedence.pth")
+	require.NoError(t, os.WriteFile(pth2, []byte("import _distutils_hack; _distutils_hack.add_shim()\n"), 0644))
+
+	// But evil.pth should still be flagged
+	evil := filepath.Join(dir, "evil.pth")
+	require.NoError(t, os.WriteFile(evil, []byte("import subprocess; subprocess.Popen(['evil'])\n"), 0644))
+
+	result, err := Check(CheckOptions{Path: dir})
+	require.NoError(t, err)
+
+	for _, f := range result.Findings {
+		assert.NotContains(t, f.Path, "_virtualenv.pth", "known-safe _virtualenv.pth should be skipped")
+		assert.NotContains(t, f.Path, "distutils-precedence.pth", "known-safe distutils-precedence.pth should be skipped")
+	}
+
+	hasEvil := false
+	for _, f := range result.Findings {
+		if f.Path == evil {
+			hasEvil = true
+		}
+	}
+	assert.True(t, hasEvil, "evil.pth should still be flagged")
+}
+
 func TestCheckCleanPth(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/rules/builtin/supply-chain-exfil.yaml
+++ b/internal/rules/builtin/supply-chain-exfil.yaml
@@ -72,7 +72,7 @@ examples:
 ---
 id: SC-EX-004
 name: ".pth file with executable content"
-description: "Detects .pth files containing import statements, subprocess calls, or any executable Python code. Legitimate .pth files contain only directory paths."
+description: "Detects .pth files containing dangerous executable Python code such as subprocess calls, exec/eval, or dynamic imports. Skips known-safe ecosystem .pth files."
 severity: CRITICAL
 category: supply-chain-exfil
 targets: ["*.pth"]
@@ -80,13 +80,22 @@ match_mode: any
 remediation: "Remove executable code from .pth files. Use proper entry points or setup scripts instead. .pth files should only contain directory paths."
 patterns:
   - type: regex
-    value: "(?i)^import\\s"
-  - type: regex
     value: "(?i)(subprocess|os\\.system|os\\.popen|exec\\(|eval\\(|compile\\()"
   - type: regex
     value: "(?i)(__import__|importlib)"
   - type: regex
     value: "(?i)(open\\(|Path\\(|read\\(\\))"
+  - type: regex
+    value: "(?i)import\\s+\\w+\\s*;\\s*\\w"
+exclude_patterns:
+  - type: contains
+    value: "import _virtualenv"
+  - type: contains
+    value: "import _distutils_hack"
+  - type: contains
+    value: "import coverage"
+  - type: contains
+    value: "import pkg_resources"
 examples:
   true_positive:
     - "import subprocess; subprocess.Popen([sys.executable, \"/tmp/payload.py\"])"
@@ -95,6 +104,7 @@ examples:
   false_positive:
     - "/usr/local/lib/python3.12/site-packages"
     - "./vendor/libs"
+    - "import _virtualenv"
 ---
 id: SC-EX-005
 name: "Cloud metadata endpoint access in Python"
@@ -224,7 +234,7 @@ examples:
 ---
 id: SC-EX-010
 name: ".pth file presence with non-path content"
-description: "Flags .pth files that contain content beyond simple directory paths for manual review. Legitimate .pth files contain only path entries."
+description: "Flags .pth files that contain content beyond simple directory paths for manual review. Skips known-safe ecosystem .pth files."
 severity: MEDIUM
 category: supply-chain-exfil
 targets: ["*.pth"]
@@ -233,9 +243,19 @@ remediation: "Review .pth file contents. Legitimate .pth files should only conta
 patterns:
   - type: regex
     value: "(?i)(import|from\\s+\\w+|def\\s+|class\\s+|print\\(|sys\\.|os\\.)"
+exclude_patterns:
+  - type: contains
+    value: "import _virtualenv"
+  - type: contains
+    value: "import _distutils_hack"
+  - type: contains
+    value: "import coverage"
+  - type: contains
+    value: "import pkg_resources"
 examples:
   true_positive:
     - "import sys; sys.path.insert(0, '/tmp/evil')"
     - "from os import system"
   false_positive:
     - "/usr/local/lib/python3.12/site-packages"
+    - "import _virtualenv"


### PR DESCRIPTION
## Problem

`aguara check` flags `_virtualenv.pth` as CRITICAL because it contains `import _virtualenv`. This is a legitimate file installed by virtualenv in every Python environment. Users running `aguara check` get dozens of false positive CRITICAL findings from their uv cache.

## Fix

Allowlist of known-safe .pth filenames that use import statements for legitimate site customization:

- `_virtualenv.pth` (virtualenv activation)
- `distutils-precedence.pth` (setuptools distutils override)
- `easy-install.pth` (legacy easy_install)
- `setuptools.pth` (setuptools shim)
- `coverage.pth` (coverage.py startup)
- `zope-nspkg.pth` (zope namespace packages)

### Changes

- **aguara check**: allowlist in `checker.go` skips known-safe filenames before scanning
- **SC-EX-004**: removed bare `^import\s` pattern (too broad), replaced with `import\s+\w+\s*;\s*\w` for compound statements. Added exclude patterns for known-safe imports.
- **SC-EX-010**: added exclude patterns for known-safe imports

Malicious .pth files (with subprocess, exec, eval, etc.) are still detected as CRITICAL.

## Test plan

- [x] `TestCheckSkipsKnownSafePth` - known-safe skipped, evil.pth still flagged
- [x] All rule self-tests pass (SC-EX-004 TPs still match, new FP `import _virtualenv` excluded)
- [x] Real virtualenv site-packages: clean scan
- [x] Full CI: all tests pass, 0 lint