### PR TITLE
fix: reject symlinked config files and clamp negative confidence

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,12 +62,15 @@ func Load(dir string) (Config, error) {
 	}
 	for _, name := range []string{".aguara.yml", ".aguara.yaml"} {
 		path := filepath.Join(dir, name)
-		info, err := os.Stat(path)
+		info, err := os.Lstat(path)
 		if err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
 			return Config{}, fmt.Errorf("reading %s: %w", path, err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return Config{}, fmt.Errorf("%s is a symbolic link (rejected for security)", path)
 		}
 		if info.Size() > 1<<20 {
 			return Config{}, fmt.Errorf("config file too large: %s (%d bytes, max 1 MB)", path, info.Size())

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -159,6 +159,17 @@ rule_overrides:
 	require.Contains(t, err.Error(), "mutually exclusive")
 }
 
+func TestLoadConfigSymlinkRejected(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real.yml")
+	require.NoError(t, os.WriteFile(target, []byte("severity: high\n"), 0644))
+	require.NoError(t, os.Symlink(target, filepath.Join(dir, ".aguara.yml")))
+
+	_, err := config.Load(dir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "symbolic link")
+}
+
 func TestLoadConfigPrecedence(t *testing.T) {
 	// .aguara.yml takes priority over .aguara.yaml
 	dir := t.TempDir()

--- a/internal/meta/confidence.go
+++ b/internal/meta/confidence.go
@@ -49,5 +49,12 @@ func AdjustConfidence(findings []types.Finding) []types.Finding {
 		}
 	}
 
+	// Pass 3: clamp negative confidence values to zero
+	for i := range findings {
+		if findings[i].Confidence < 0 {
+			findings[i].Confidence = 0
+		}
+	}
+
 	return findings
 }

--- a/internal/meta/confidence_test.go
+++ b/internal/meta/confidence_test.go
@@ -57,6 +57,15 @@ func TestAdjustConfidenceCodeBlockAndCorrelation(t *testing.T) {
 	require.InDelta(t, 0.935, result[1].Confidence, 0.01)
 }
 
+func TestAdjustConfidenceNegativeClampedToZero(t *testing.T) {
+	findings := []types.Finding{
+		{RuleID: "R1", FilePath: "a.md", Line: 5, Confidence: -0.5},
+	}
+
+	result := meta.AdjustConfidence(findings)
+	require.Equal(t, float64(0), result[0].Confidence)
+}
+
 func TestAdjustConfidenceZeroConfidenceUntouched(t *testing.T) {
 	findings := []types.Finding{
 		{RuleID: "R1", FilePath: "a.md", Line: 5, Confidence: 0, InCodeBlock: true},


### PR DESCRIPTION
## Summary
- Config loader now uses `os.Lstat()` + symlink rejection before reading `.aguara.yml`, matching the existing `state.go` pattern
- Confidence adjuster now clamps negative values to zero, preventing invalid scores from reaching SARIF/JSON output

## Test plan
- [x] `TestLoadConfigSymlinkRejected` - verifies symlinked config is rejected
- [x] `TestAdjustConfidenceNegativeClampedToZero` - verifies negative confidence is clamped
- [x] Full CI pipeline passes: `make build && make test && make vet && make lint`