### PR TITLE
feat: pattern matcher 3.7-6.4x speedup, WASM completion, FP reduction infra

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ VERSION ?= dev
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 LDFLAGS := -ldflags "-s -w -X $(PKG)/cmd/aguara/commands.Version=$(VERSION) -X $(PKG)/cmd/aguara/commands.Commit=$(COMMIT)"
 
-.PHONY: build test lint run clean fmt vet wasm
+.PHONY: build test lint run clean fmt vet wasm wasm-serve
 
 build:
 	go build $(LDFLAGS) -o $(BINARY) ./cmd/aguara
@@ -27,6 +27,11 @@ run:
 wasm:
 	GOOS=js GOARCH=wasm go build -o aguara.wasm ./cmd/wasm
 	cp "$$(go env GOROOT)/lib/wasm/wasm_exec.js" .
+	cp cmd/wasm/index.html .
+
+wasm-serve: wasm
+	@echo "Serving at http://localhost:8080"
+	python3 -m http.server 8080
 
 clean:
-	rm -f $(BINARY) aguara.wasm wasm_exec.js
+	rm -f $(BINARY) aguara.wasm wasm_exec.js index.html

--- a/cmd/wasm/index.html
+++ b/cmd/wasm/index.html
@@ -2,62 +2,195 @@
 <html>
 <head>
     <meta charset="utf-8">
-    <title>Aguara Scanner - Browser</title>
+    <title>Aguara Scanner</title>
     <style>
-        body { font-family: monospace; max-width: 800px; margin: 2rem auto; padding: 0 1rem; }
-        textarea { width: 100%; height: 200px; font-family: monospace; font-size: 14px; }
-        button { padding: 0.5rem 1rem; margin: 0.5rem 0; cursor: pointer; }
-        pre { background: #f4f4f4; padding: 1rem; overflow-x: auto; }
+        * { box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", monospace; max-width: 900px; margin: 2rem auto; padding: 0 1rem; color: #1a1a1a; }
+        h1 { margin-bottom: 0.25rem; }
+        .subtitle { color: #666; margin-top: 0; font-size: 0.9rem; }
+        textarea { width: 100%; height: 220px; font-family: monospace; font-size: 13px; padding: 0.75rem; border: 1px solid #ccc; border-radius: 4px; resize: vertical; }
+        input[type="text"] { padding: 0.4rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; font-family: monospace; }
+        select { padding: 0.4rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; }
+        .controls { display: flex; gap: 1rem; align-items: end; flex-wrap: wrap; margin: 0.75rem 0; }
+        .controls label { font-size: 0.85rem; color: #555; display: flex; flex-direction: column; gap: 0.25rem; }
+        button { padding: 0.5rem 1.25rem; cursor: pointer; border: none; border-radius: 4px; font-weight: 600; font-size: 0.9rem; }
+        button:disabled { cursor: default; opacity: 0.5; }
+        .btn-scan { background: #2563eb; color: white; }
+        .btn-scan:hover:not(:disabled) { background: #1d4ed8; }
+        .btn-secondary { background: #e5e7eb; color: #374151; }
+        .btn-secondary:hover:not(:disabled) { background: #d1d5db; }
+        pre { background: #f8f9fa; padding: 1rem; overflow-x: auto; border-radius: 4px; border: 1px solid #e5e7eb; font-size: 13px; }
         .loading { color: #666; }
-        .error { color: #c00; }
+        .error { color: #dc2626; }
+        .finding { border-left: 4px solid #ccc; padding: 0.5rem 0.75rem; margin: 0.5rem 0; background: #fafafa; border-radius: 0 4px 4px 0; }
+        .finding.critical { border-left-color: #dc2626; background: #fef2f2; }
+        .finding.high { border-left-color: #ea580c; background: #fff7ed; }
+        .finding.medium { border-left-color: #ca8a04; background: #fefce8; }
+        .finding.low { border-left-color: #2563eb; background: #eff6ff; }
+        .finding.info { border-left-color: #6b7280; background: #f9fafb; }
+        .finding-header { font-weight: 600; font-size: 0.9rem; }
+        .finding-meta { font-size: 0.8rem; color: #666; margin-top: 0.25rem; }
+        .finding-remediation { font-size: 0.85rem; margin-top: 0.4rem; color: #374151; }
+        .clean { color: #16a34a; font-weight: 600; padding: 1rem; text-align: center; }
+        .stats { font-size: 0.85rem; color: #666; margin-bottom: 0.5rem; }
+        .tabs { display: flex; gap: 0; margin-top: 1.5rem; border-bottom: 2px solid #e5e7eb; }
+        .tab { padding: 0.5rem 1rem; cursor: pointer; border: none; background: none; font-weight: 500; color: #6b7280; border-bottom: 2px solid transparent; margin-bottom: -2px; }
+        .tab.active { color: #2563eb; border-bottom-color: #2563eb; }
+        .tab-content { display: none; }
+        .tab-content.active { display: block; }
+        #rule-detail { margin-top: 1rem; }
+        .rule-search { display: flex; gap: 0.5rem; margin-top: 0.75rem; }
+        .rule-search input { flex: 1; }
     </style>
 </head>
 <body>
     <h1>Aguara Security Scanner</h1>
-    <p>Client-side scanning - no data leaves your browser.</p>
+    <p class="subtitle">Client-side scanning powered by WebAssembly. No data leaves your browser.</p>
 
-    <label for="filename">Filename hint:</label>
-    <input id="filename" type="text" value="skill.md" />
+    <div class="tabs">
+        <button class="tab active" data-tab="scan">Scan</button>
+        <button class="tab" data-tab="rules">Rules</button>
+    </div>
 
-    <label for="content">Content to scan:</label>
-    <textarea id="content" placeholder="Paste skill description, MCP config, or agent tool content here..."></textarea>
+    <div id="tab-scan" class="tab-content active">
+        <div class="controls">
+            <label>Filename hint
+                <input id="filename" type="text" value="skill.md" />
+            </label>
+            <label>Min severity
+                <select id="severity">
+                    <option value="">All</option>
+                    <option value="low">Low</option>
+                    <option value="medium">Medium</option>
+                    <option value="high">High</option>
+                    <option value="critical">Critical</option>
+                </select>
+            </label>
+            <label>Profile
+                <select id="profile">
+                    <option value="strict">Strict</option>
+                    <option value="content-aware">Content-aware</option>
+                    <option value="minimal">Minimal</option>
+                </select>
+            </label>
+            <button id="scan" class="btn-scan" disabled>Loading WASM...</button>
+        </div>
 
-    <button id="scan" disabled>Loading WASM...</button>
+        <textarea id="content" placeholder="Paste skill description, MCP config, or agent tool content here..."></textarea>
 
-    <h2>Results</h2>
-    <pre id="results">Waiting for scan...</pre>
+        <div id="results">
+            <p class="loading">Loading scanner...</p>
+        </div>
+    </div>
+
+    <div id="tab-rules" class="tab-content">
+        <div class="rule-search">
+            <input id="rule-id" type="text" placeholder="Enter rule ID (e.g. PROMPT_INJECTION_001)" />
+            <button id="explain-btn" class="btn-secondary" disabled>Explain</button>
+        </div>
+        <div id="rule-list"></div>
+        <pre id="rule-detail"></pre>
+    </div>
 
     <script src="wasm_exec.js"></script>
     <script>
         const go = new Go();
+        const sevOrder = { critical: 4, high: 3, medium: 2, low: 1, info: 0 };
+        const sevNames = ['info', 'low', 'medium', 'high', 'critical'];
+
         WebAssembly.instantiateStreaming(fetch("aguara.wasm"), go.importObject).then((result) => {
             go.run(result.instance);
             document.getElementById("scan").disabled = false;
             document.getElementById("scan").textContent = "Scan";
+            document.getElementById("explain-btn").disabled = false;
+            document.getElementById("results").innerHTML = '<p class="loading">Ready. Paste content and click Scan.</p>';
+            loadRuleList();
         });
 
+        // Tab switching
+        document.querySelectorAll('.tab').forEach(tab => {
+            tab.addEventListener('click', () => {
+                document.querySelectorAll('.tab').forEach(t => t.classList.remove('active'));
+                document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+                tab.classList.add('active');
+                document.getElementById('tab-' + tab.dataset.tab).classList.add('active');
+            });
+        });
+
+        // Scan
         document.getElementById("scan").addEventListener("click", async () => {
             const content = document.getElementById("content").value;
+            if (!content.trim()) return;
             const filename = document.getElementById("filename").value || "skill.md";
-            const results = document.getElementById("results");
+            const resultsDiv = document.getElementById("results");
+            const severity = document.getElementById("severity").value;
+            const profile = document.getElementById("profile").value;
 
-            results.textContent = "Scanning...";
-            results.className = "loading";
+            resultsDiv.innerHTML = '<p class="loading">Scanning...</p>';
+
+            const opts = {};
+            if (severity) opts.minSeverity = severity;
+            if (profile !== "strict") opts.profile = profile;
 
             try {
-                const json = await aguaraScanContent(content, filename);
+                const t0 = performance.now();
+                const json = await aguaraScanContent(content, filename, Object.keys(opts).length ? opts : undefined);
+                const elapsed = ((performance.now() - t0) / 1000).toFixed(2);
                 const parsed = JSON.parse(json);
-                results.className = "";
+
                 if (parsed.findings && parsed.findings.length > 0) {
-                    results.textContent = JSON.stringify(parsed, null, 2);
+                    const stats = `<div class="stats">${parsed.findings.length} finding${parsed.findings.length > 1 ? 's' : ''} - ${parsed.rules_loaded} rules - ${elapsed}s</div>`;
+                    const findings = parsed.findings
+                        .sort((a, b) => (b.severity || 0) - (a.severity || 0))
+                        .map(f => {
+                            const sev = sevNames[f.severity] || 'info';
+                            return `<div class="finding ${sev}">
+                                <div class="finding-header">${f.rule_id}: ${f.rule_name}</div>
+                                <div class="finding-meta">${sev.toUpperCase()} - Line ${f.line} - ${f.category}</div>
+                                <div class="finding-meta">Match: <code>${escapeHtml(f.matched_text || '').substring(0, 120)}</code></div>
+                                ${f.remediation ? `<div class="finding-remediation">${escapeHtml(f.remediation)}</div>` : ''}
+                            </div>`;
+                        }).join('');
+                    resultsDiv.innerHTML = stats + findings;
                 } else {
-                    results.textContent = "No findings. Content looks clean.";
+                    resultsDiv.innerHTML = `<div class="clean">No security issues found. (${parsed.rules_loaded} rules, ${elapsed}s)</div>`;
                 }
             } catch (e) {
-                results.textContent = "Error: " + e.message;
-                results.className = "error";
+                resultsDiv.innerHTML = `<p class="error">Error: ${escapeHtml(e.message)}</p>`;
             }
         });
+
+        // Rules tab
+        function loadRuleList() {
+            try {
+                const rules = JSON.parse(aguaraListRules());
+                const listDiv = document.getElementById("rule-list");
+                listDiv.innerHTML = `<p class="stats">${rules.length} rules loaded</p>`;
+            } catch (e) {
+                document.getElementById("rule-list").innerHTML = `<p class="error">${e.message}</p>`;
+            }
+        }
+
+        document.getElementById("explain-btn").addEventListener("click", () => {
+            const id = document.getElementById("rule-id").value.trim();
+            if (!id) return;
+            try {
+                const detail = JSON.parse(aguaraExplainRule(id));
+                document.getElementById("rule-detail").textContent = JSON.stringify(detail, null, 2);
+            } catch (e) {
+                document.getElementById("rule-detail").textContent = "Error: " + e.message;
+            }
+        });
+
+        document.getElementById("rule-id").addEventListener("keydown", (e) => {
+            if (e.key === "Enter") document.getElementById("explain-btn").click();
+        });
+
+        function escapeHtml(s) {
+            const div = document.createElement('div');
+            div.textContent = s;
+            return div.innerHTML;
+        }
     </script>
 </body>
 </html>

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -14,23 +14,26 @@ func main() {
 	js.Global().Set("aguaraScanContent", js.FuncOf(scanContent))
 	js.Global().Set("aguaraScanContentAs", js.FuncOf(scanContentAs))
 	js.Global().Set("aguaraListRules", js.FuncOf(listRules))
+	js.Global().Set("aguaraExplainRule", js.FuncOf(explainRule))
+	js.Global().Set("aguaraVersion", js.FuncOf(version))
 	select {}
 }
 
-// aguaraScanContent(content, filename) -> Promise<JSON>
+// aguaraScanContent(content, filename, [options]) -> Promise<JSON>
 func scanContent(this js.Value, args []js.Value) any {
 	if len(args) < 2 {
 		return jsError("aguaraScanContent requires 2 arguments: content, filename")
 	}
 	content := args[0].String()
 	filename := args[1].String()
+	opts := parseOptions(args, 2)
 
 	return newPromise(func() (any, error) {
-		return aguara.ScanContent(context.Background(), content, filename)
+		return aguara.ScanContent(context.Background(), content, filename, opts...)
 	})
 }
 
-// aguaraScanContentAs(content, filename, toolName) -> Promise<JSON>
+// aguaraScanContentAs(content, filename, toolName, [options]) -> Promise<JSON>
 func scanContentAs(this js.Value, args []js.Value) any {
 	if len(args) < 3 {
 		return jsError("aguaraScanContentAs requires 3 arguments: content, filename, toolName")
@@ -38,9 +41,10 @@ func scanContentAs(this js.Value, args []js.Value) any {
 	content := args[0].String()
 	filename := args[1].String()
 	toolName := args[2].String()
+	opts := parseOptions(args, 3)
 
 	return newPromise(func() (any, error) {
-		return aguara.ScanContentAs(context.Background(), content, filename, toolName)
+		return aguara.ScanContentAs(context.Background(), content, filename, toolName, opts...)
 	})
 }
 
@@ -52,6 +56,62 @@ func listRules(this js.Value, args []js.Value) any {
 		return jsError(err.Error())
 	}
 	return string(b)
+}
+
+// aguaraExplainRule(ruleID) -> JSON string
+func explainRule(this js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		return jsError("aguaraExplainRule requires 1 argument: ruleID")
+	}
+	id := args[0].String()
+	detail, err := aguara.ExplainRule(id)
+	if err != nil {
+		return jsError(err.Error())
+	}
+	b, err := json.Marshal(detail)
+	if err != nil {
+		return jsError(err.Error())
+	}
+	return string(b)
+}
+
+// aguaraVersion() -> string
+func version(this js.Value, args []js.Value) any {
+	return "wasm"
+}
+
+// parseOptions extracts scan options from a JS object argument at the given index.
+// Supported fields: minSeverity (string), profile (string).
+func parseOptions(args []js.Value, idx int) []aguara.Option {
+	if len(args) <= idx || args[idx].IsUndefined() || args[idx].IsNull() {
+		return nil
+	}
+	obj := args[idx]
+	var opts []aguara.Option
+
+	if sev := obj.Get("minSeverity"); !sev.IsUndefined() && !sev.IsNull() {
+		switch sev.String() {
+		case "low":
+			opts = append(opts, aguara.WithMinSeverity(aguara.SeverityLow))
+		case "medium":
+			opts = append(opts, aguara.WithMinSeverity(aguara.SeverityMedium))
+		case "high":
+			opts = append(opts, aguara.WithMinSeverity(aguara.SeverityHigh))
+		case "critical":
+			opts = append(opts, aguara.WithMinSeverity(aguara.SeverityCritical))
+		}
+	}
+
+	if profile := obj.Get("profile"); !profile.IsUndefined() && !profile.IsNull() {
+		switch profile.String() {
+		case "content-aware":
+			opts = append(opts, aguara.WithScanProfile(aguara.ProfileContentAware))
+		case "minimal":
+			opts = append(opts, aguara.WithScanProfile(aguara.ProfileMinimal))
+		}
+	}
+
+	return opts
 }
 
 // newPromise creates a JS Promise that runs fn in a goroutine and resolves with JSON.

--- a/internal/engine/pattern/matcher.go
+++ b/internal/engine/pattern/matcher.go
@@ -19,11 +19,13 @@ const ctxRadius = 3
 // Matcher implements the Analyzer interface using compiled pattern rules.
 // Rules are pre-grouped by target extension for fast lookup.
 // Contains patterns use Aho-Corasick multi-pattern matching for O(n+m) search.
+// A keyword pre-filter skips rules whose required literals don't appear in content.
 type Matcher struct {
 	allFileRules []*rules.CompiledRule            // rules with targets: [] (match all)
 	byExt        map[string][]*rules.CompiledRule // ".ext" -> rules targeting that ext
 	acAll        *acSearcher                      // AC automaton for allFileRules contains patterns
 	acByExt      map[string]*acSearcher           // AC automaton per extension group
+	pf           *prefilter                       // keyword pre-filter for all rules
 }
 
 // NewMatcher creates a new pattern matcher with the given compiled rules.
@@ -50,6 +52,8 @@ func NewMatcher(compiled []*rules.CompiledRule) *Matcher {
 			m.acByExt[ext] = ac
 		}
 	}
+	// Build keyword pre-filter from all rules (regex + contains)
+	m.pf = buildPrefilter(compiled)
 	return m
 }
 
@@ -79,13 +83,21 @@ func (m *Matcher) Analyze(ctx context.Context, target *scanner.Target) ([]scanne
 	// Collect applicable rules: allFileRules + extension-matched rules
 	applicable := m.rulesForFile(target.RelPath)
 
-	// Pre-filter: run Aho-Corasick to find which rules have contains matches.
-	// Rules with no contains hits and only contains patterns can be skipped entirely.
+	// Pre-filter: run keyword AC to find which rules could possibly match.
+	// Rules whose required literal substrings don't appear are skipped entirely.
+	candidates := m.pf.candidateRules(lowerContent)
+
+	// Secondary pre-filter: AC on contains patterns for exact substring pre-check.
 	acHitRules := m.acPrefilter(target.RelPath, lowerContent)
 
 	for _, rule := range applicable {
 		if ctx.Err() != nil {
 			return findings, ctx.Err()
+		}
+
+		// Skip rules whose keywords don't appear in content
+		if candidates != nil && !candidates[rule.ID] {
+			continue
 		}
 
 		// Skip rules that only have contains patterns and got no AC hits

--- a/internal/engine/pattern/prefilter.go
+++ b/internal/engine/pattern/prefilter.go
@@ -1,0 +1,201 @@
+package pattern
+
+import (
+	"strings"
+
+	ahocorasick "github.com/petar-dambovaliev/aho-corasick"
+
+	"github.com/garagon/aguara/internal/rules"
+)
+
+// minKeywordLen is the shortest literal substring worth indexing.
+// 4 chars avoids common 3-letter words ("all", "run", "any", "the", "key")
+// that appear in most content and produce poor pre-filter selectivity.
+const minKeywordLen = 4
+
+// prefilter uses Aho-Corasick to quickly identify which rules could possibly
+// match before running expensive regex evaluation. For each rule it extracts
+// literal substrings that must appear in any matching text, indexes them in
+// a single AC automaton, and at match time returns only candidate rules
+// whose keywords were found.
+//
+// Keywords are deduplicated: if multiple rules share the same keyword (e.g.
+// "ignore"), a single AC pattern maps to all of those rule IDs.
+type prefilter struct {
+	ac             *ahocorasick.AhoCorasick
+	refs           [][]string      // AC pattern index -> list of rule IDs
+	noKeywordRules map[string]bool // rules without extractable keywords (always run)
+}
+
+// buildPrefilter creates a keyword-based pre-filter from compiled rules.
+func buildPrefilter(compiled []*rules.CompiledRule) *prefilter {
+	// Collect keywords per rule, deduplicating across rules.
+	kwToRules := make(map[string]map[string]bool) // keyword -> set of rule IDs
+	noKeyword := make(map[string]bool)
+
+	for _, rule := range compiled {
+		ruleHasKeyword := false
+		for _, pat := range rule.Patterns {
+			var kws []string
+			switch pat.Type {
+			case rules.PatternContains:
+				if len(pat.Value) >= minKeywordLen {
+					kws = []string{pat.Value} // already lowercased
+				}
+			case rules.PatternRegex:
+				kws = extractKeywords(pat.Value)
+			}
+			for _, kw := range kws {
+				if kwToRules[kw] == nil {
+					kwToRules[kw] = make(map[string]bool)
+				}
+				kwToRules[kw][rule.ID] = true
+				ruleHasKeyword = true
+			}
+		}
+		if !ruleHasKeyword {
+			noKeyword[rule.ID] = true
+		}
+	}
+
+	pf := &prefilter{noKeywordRules: noKeyword}
+
+	if len(kwToRules) > 0 {
+		keywords := make([]string, 0, len(kwToRules))
+		refs := make([][]string, 0, len(kwToRules))
+		for kw, ruleSet := range kwToRules {
+			keywords = append(keywords, kw)
+			ids := make([]string, 0, len(ruleSet))
+			for id := range ruleSet {
+				ids = append(ids, id)
+			}
+			refs = append(refs, ids)
+		}
+		builder := ahocorasick.NewAhoCorasickBuilder(ahocorasick.Opts{
+			AsciiCaseInsensitive: false, // we search pre-lowercased content
+			MatchKind:            ahocorasick.StandardMatch,
+			DFA:                  true,
+		})
+		ac := builder.Build(keywords)
+		pf.ac = &ac
+		pf.refs = refs
+	}
+
+	return pf
+}
+
+// candidateRules returns the set of rule IDs that could match the content.
+// A rule is a candidate if any of its keywords appear in lowerContent, or
+// if the rule has no extractable keywords (conservative: always run those).
+func (p *prefilter) candidateRules(lowerContent string) map[string]bool {
+	if p == nil {
+		return nil // nil map: caller treats nil as "all rules are candidates"
+	}
+	candidates := make(map[string]bool, len(p.noKeywordRules)+16)
+	for id := range p.noKeywordRules {
+		candidates[id] = true
+	}
+	if p.ac != nil {
+		for _, m := range p.ac.FindAll(lowerContent) {
+			for _, id := range p.refs[m.Pattern()] {
+				candidates[id] = true
+			}
+		}
+	}
+	return candidates
+}
+
+// extractKeywords returns lowercase literal substrings from a regex pattern
+// that must appear in any matching text. Only runs of alphanumeric/underscore
+// characters of minKeywordLen+ length are returned. Content inside character
+// classes ([...]) and quantifiers ({...}) is skipped.
+func extractKeywords(pattern string) []string {
+	p := stripFlags(pattern)
+
+	var keywords []string
+	var buf strings.Builder
+	inCharClass := false
+	inQuantifier := false
+	escaped := false
+
+	for i := 0; i < len(p); i++ {
+		ch := p[i]
+
+		if escaped {
+			escaped = false
+			flushKeyword(&buf, &keywords)
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			flushKeyword(&buf, &keywords)
+			continue
+		}
+		if ch == '[' && !inCharClass && !inQuantifier {
+			inCharClass = true
+			flushKeyword(&buf, &keywords)
+			continue
+		}
+		if ch == ']' && inCharClass {
+			inCharClass = false
+			continue
+		}
+		if inCharClass {
+			continue
+		}
+		if ch == '{' && !inQuantifier {
+			inQuantifier = true
+			flushKeyword(&buf, &keywords)
+			continue
+		}
+		if ch == '}' && inQuantifier {
+			inQuantifier = false
+			continue
+		}
+		if inQuantifier {
+			continue
+		}
+
+		if isKeywordChar(ch) {
+			buf.WriteByte(ch)
+		} else {
+			flushKeyword(&buf, &keywords)
+		}
+	}
+	flushKeyword(&buf, &keywords)
+
+	return keywords
+}
+
+// isKeywordChar returns true for characters that form useful keyword literals.
+// Only alphanumeric and underscore; everything else is treated as a boundary.
+func isKeywordChar(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') ||
+		(ch >= '0' && ch <= '9') || ch == '_'
+}
+
+// stripFlags removes a leading flag group like (?i) or (?is) from a pattern.
+func stripFlags(p string) string {
+	if !strings.HasPrefix(p, "(?") {
+		return p
+	}
+	end := strings.Index(p, ")")
+	if end == -1 || end < 3 {
+		return p
+	}
+	flags := p[2:end]
+	for _, ch := range flags {
+		if ch != 'i' && ch != 's' && ch != 'm' && ch != 'U' {
+			return p // not a pure flag group (e.g. (?:...) or (?P<>...))
+		}
+	}
+	return p[end+1:]
+}
+
+func flushKeyword(buf *strings.Builder, keywords *[]string) {
+	s := buf.String()
+	buf.Reset()
+	if len(s) >= minKeywordLen {
+		*keywords = append(*keywords, strings.ToLower(s))
+	}
+}

--- a/internal/engine/pattern/prefilter_test.go
+++ b/internal/engine/pattern/prefilter_test.go
@@ -1,0 +1,113 @@
+package pattern
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestExtractKeywords(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    []string
+	}{
+		{
+			name:    "simple literal with flag",
+			pattern: `(?i)subprocess\.(run|call|Popen)`,
+			want:    []string{"subprocess", "call", "popen"},
+		},
+		{
+			name:    "escaped metachar",
+			pattern: `(?i)\beval\s*\(`,
+			want:    []string{"eval"},
+		},
+		{
+			name:    "alternation with short branches",
+			pattern: `(?i)(curl|wget)\s+[^|]+\|\s*(bash|sh)\b`,
+			want:    []string{"curl", "wget", "bash"},
+		},
+		{
+			name:    "credential prefix",
+			pattern: `AKIA[0-9A-Z]{16}`,
+			want:    []string{"akia"},
+		},
+		{
+			name:    "github token with underscore",
+			pattern: `ghp_[a-zA-Z0-9]{36}`,
+			want:    []string{"ghp_"},
+		},
+		{
+			name:    "private key header",
+			pattern: `-----BEGIN\s+(RSA|DSA|EC|OPENSSH|PGP)?\s*PRIVATE KEY`,
+			want:    []string{"begin", "openssh", "private"},
+		},
+		{
+			name:    "no literals (all char classes and quantifiers)",
+			pattern: `[A-Za-z0-9+/]{40,}={0,2}`,
+			want:    nil,
+		},
+		{
+			name:    "short literals excluded",
+			pattern: `(?i)(sh|rm)\b`,
+			want:    nil,
+		},
+		{
+			name:    "mixed length alternation",
+			pattern: `(?i)(password|passwd|pwd)\s*[=:]`,
+			want:    []string{"password", "passwd"},
+		},
+		{
+			name:    "non-capturing group handled",
+			pattern: `(?:food|barn)baz`,
+			want:    []string{"food", "barn"},
+		},
+		{
+			name:    "dotted method call",
+			pattern: `exec\.Command\s*\(`,
+			want:    []string{"exec", "command"},
+		},
+		{
+			name:    "URL pattern",
+			pattern: `https://hooks\.slack\.com/services/T[A-Z0-9]+/B[A-Z0-9]+/[a-zA-Z0-9]+`,
+			want:    []string{"https", "hooks", "slack", "services"},
+		},
+		{
+			name:    "github_pat_ with underscores",
+			pattern: `github_pat_[a-zA-Z0-9]{22}_[a-zA-Z0-9]{59}`,
+			want:    []string{"github_pat_"},
+		},
+		{
+			name:    "quantifier content skipped",
+			pattern: `[a-z]{3,10}food`,
+			want:    []string{"food"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractKeywords(tt.pattern)
+			require.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestStripFlags(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"(?i)hello", "hello"},
+		{"(?is)hello", "hello"},
+		{"(?:hello)", "(?:hello)"},
+		{"(?P<name>hello)", "(?P<name>hello)"},
+		{"hello", "hello"},
+		{"(?i)", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			require.Equal(t, tt.want, stripFlags(tt.input))
+		})
+	}
+}

--- a/internal/meta/confidence.go
+++ b/internal/meta/confidence.go
@@ -1,18 +1,73 @@
 package meta
 
 import (
+	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/garagon/aguara/internal/types"
 )
 
+// docSectionHeadings are markdown headings that indicate documentation context.
+// Findings near these headings are more likely false positives.
+var docSectionHeadings = []string{
+	"## installation",
+	"## install",
+	"## setup",
+	"## getting started",
+	"## usage",
+	"## quick start",
+	"## quickstart",
+	"## prerequisites",
+	"## requirements",
+	"## dependencies",
+	"## building",
+	"## build",
+	"## configuration",
+	"## config",
+	"## development",
+	"## contributing",
+	"## changelog",
+	"## license",
+	"## faq",
+	"## troubleshooting",
+	"# installation",
+	"# install",
+	"# setup",
+	"# getting started",
+	"# usage",
+	"# quick start",
+}
+
 // AdjustConfidence applies post-processing adjustments to finding confidence
-// values based on contextual signals like code blocks and correlation.
+// values based on contextual signals like code blocks, documentation sections,
+// file type, and correlation.
 func AdjustConfidence(findings []types.Finding) []types.Finding {
 	// Pass 1: downgrade confidence for findings inside code blocks
 	for i := range findings {
 		if findings[i].InCodeBlock && findings[i].Confidence > 0 {
 			findings[i].Confidence *= 0.6
+		}
+	}
+
+	// Pass 1b: downgrade confidence for findings in documentation sections.
+	// If the context lines contain a documentation heading (like "## Installation"),
+	// the finding is likely a usage example, not a real vulnerability.
+	for i := range findings {
+		if findings[i].Confidence > 0 && inDocSection(findings[i].Context) {
+			findings[i].Confidence *= 0.7
+		}
+	}
+
+	// Pass 1c: apply file-type confidence multiplier.
+	// Documentation files (.md, .txt) get a slight penalty since patterns
+	// matching in prose are more likely to be examples than real threats.
+	for i := range findings {
+		if findings[i].Confidence > 0 {
+			mult := fileTypeMultiplier(findings[i].FilePath)
+			if mult != 1.0 {
+				findings[i].Confidence *= mult
+			}
 		}
 	}
 
@@ -57,4 +112,30 @@ func AdjustConfidence(findings []types.Finding) []types.Finding {
 	}
 
 	return findings
+}
+
+// inDocSection checks if any context line is a documentation section heading.
+func inDocSection(ctx []types.ContextLine) bool {
+	for _, cl := range ctx {
+		lower := strings.ToLower(strings.TrimSpace(cl.Content))
+		for _, heading := range docSectionHeadings {
+			if lower == heading || strings.HasPrefix(lower, heading+" ") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// fileTypeMultiplier returns a confidence multiplier based on file extension.
+// Documentation formats get a slight penalty (0.9) while executable/config
+// files get no adjustment (1.0).
+func fileTypeMultiplier(filePath string) float64 {
+	ext := strings.ToLower(filepath.Ext(filePath))
+	switch ext {
+	case ".md", ".markdown", ".txt", ".rst":
+		return 0.9
+	default:
+		return 1.0
+	}
 }

--- a/internal/meta/confidence_test.go
+++ b/internal/meta/confidence_test.go
@@ -15,8 +15,8 @@ func TestAdjustConfidenceCodeBlockDowngrade(t *testing.T) {
 	}
 
 	result := meta.AdjustConfidence(findings)
-	require.InDelta(t, 0.51, result[0].Confidence, 0.01) // 0.85 * 0.6
-	require.InDelta(t, 0.85, result[1].Confidence, 0.01) // unchanged
+	require.InDelta(t, 0.459, result[0].Confidence, 0.01) // 0.85 * 0.6 (code block) * 0.9 (md)
+	require.InDelta(t, 0.765, result[1].Confidence, 0.01) // 0.85 * 0.9 (md)
 }
 
 func TestAdjustConfidenceCorrelationBoost(t *testing.T) {
@@ -27,15 +27,16 @@ func TestAdjustConfidenceCorrelationBoost(t *testing.T) {
 	}
 
 	result := meta.AdjustConfidence(findings)
-	require.InDelta(t, 0.935, result[0].Confidence, 0.01) // 0.85 * 1.1
-	require.InDelta(t, 0.935, result[1].Confidence, 0.01) // 0.85 * 1.1
-	require.InDelta(t, 0.85, result[2].Confidence, 0.01)  // no boost
+	require.InDelta(t, 0.8415, result[0].Confidence, 0.01) // 0.85 * 0.9 (md) * 1.1 (correlated)
+	require.InDelta(t, 0.8415, result[1].Confidence, 0.01) // 0.85 * 0.9 (md) * 1.1 (correlated)
+	require.InDelta(t, 0.765, result[2].Confidence, 0.01)  // 0.85 * 0.9 (md), no boost
 }
 
 func TestAdjustConfidenceCapAtOne(t *testing.T) {
+	// Use .py to avoid md multiplier and isolate the cap behavior
 	findings := []types.Finding{
-		{RuleID: "R1", FilePath: "a.md", Line: 5, Confidence: 0.95},
-		{RuleID: "R2", FilePath: "a.md", Line: 7, Confidence: 0.95},
+		{RuleID: "R1", FilePath: "a.py", Line: 5, Confidence: 0.95},
+		{RuleID: "R2", FilePath: "a.py", Line: 7, Confidence: 0.95},
 	}
 
 	result := meta.AdjustConfidence(findings)
@@ -51,10 +52,10 @@ func TestAdjustConfidenceCodeBlockAndCorrelation(t *testing.T) {
 	}
 
 	result := meta.AdjustConfidence(findings)
-	// R1: 0.85 * 0.6 (code block) = 0.51, then * 1.1 (correlated) = 0.561
-	require.InDelta(t, 0.561, result[0].Confidence, 0.01)
-	// R2: 0.85 * 1.1 (correlated) = 0.935
-	require.InDelta(t, 0.935, result[1].Confidence, 0.01)
+	// R1: 0.85 * 0.6 (code block) * 0.9 (md) * 1.1 (correlated) = 0.5049
+	require.InDelta(t, 0.5049, result[0].Confidence, 0.01)
+	// R2: 0.85 * 0.9 (md) * 1.1 (correlated) = 0.8415
+	require.InDelta(t, 0.8415, result[1].Confidence, 0.01)
 }
 
 func TestAdjustConfidenceNegativeClampedToZero(t *testing.T) {
@@ -64,6 +65,45 @@ func TestAdjustConfidenceNegativeClampedToZero(t *testing.T) {
 
 	result := meta.AdjustConfidence(findings)
 	require.Equal(t, float64(0), result[0].Confidence)
+}
+
+func TestAdjustConfidenceDocSectionDowngrade(t *testing.T) {
+	findings := []types.Finding{
+		{
+			RuleID: "R1", FilePath: "README.md", Line: 5, Confidence: 0.85,
+			Context: []types.ContextLine{
+				{Line: 3, Content: "## Installation"},
+				{Line: 4, Content: ""},
+				{Line: 5, Content: "pip install evil-package", IsMatch: true},
+			},
+		},
+		{
+			RuleID: "R2", FilePath: "skill.md", Line: 10, Confidence: 0.85,
+			Context: []types.ContextLine{
+				{Line: 9, Content: "Some normal text"},
+				{Line: 10, Content: "pip install evil-package", IsMatch: true},
+			},
+		},
+	}
+
+	result := meta.AdjustConfidence(findings)
+	// R1 near "## Installation": 0.85 * 0.7 (doc section) * 0.9 (md file) = 0.5355
+	require.InDelta(t, 0.5355, result[0].Confidence, 0.01)
+	// R2 not in doc section: 0.85 * 0.9 (md file) = 0.765
+	require.InDelta(t, 0.765, result[1].Confidence, 0.01)
+}
+
+func TestAdjustConfidenceFileTypeMultiplier(t *testing.T) {
+	findings := []types.Finding{
+		{RuleID: "R1", FilePath: "skill.md", Line: 5, Confidence: 0.85},
+		{RuleID: "R2", FilePath: "helper.py", Line: 5, Confidence: 0.85},
+		{RuleID: "R3", FilePath: "config.yaml", Line: 5, Confidence: 0.85},
+	}
+
+	result := meta.AdjustConfidence(findings)
+	require.InDelta(t, 0.765, result[0].Confidence, 0.01) // .md: 0.85 * 0.9
+	require.InDelta(t, 0.85, result[1].Confidence, 0.01)   // .py: no change
+	require.InDelta(t, 0.85, result[2].Confidence, 0.01)   // .yaml: no change
 }
 
 func TestAdjustConfidenceZeroConfidenceUntouched(t *testing.T) {

--- a/internal/scanner/eval_test.go
+++ b/internal/scanner/eval_test.go
@@ -1,0 +1,363 @@
+package scanner_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/garagon/aguara/internal/engine/nlp"
+	"github.com/garagon/aguara/internal/engine/pattern"
+	"github.com/garagon/aguara/internal/engine/toxicflow"
+	"github.com/garagon/aguara/internal/rules"
+	"github.com/garagon/aguara/internal/rules/builtin"
+	"github.com/garagon/aguara/internal/scanner"
+)
+
+// benchmarkScenario defines a labeled test scenario for precision/recall evaluation.
+type benchmarkScenario struct {
+	name          string
+	path          string   // relative to testdata/
+	isMalicious   bool     // true = TP scenario, false = benign (should be clean)
+	expectedRules []string // rule IDs that MUST be detected (recall targets)
+}
+
+// scenarioResults holds per-scenario evaluation metrics.
+type scenarioResults struct {
+	name           string
+	findings       int
+	expectedRules  int
+	matchedRules   int
+	missedRules    []string
+	extraRules     []string
+	falsePositives int // only for benign scenarios
+}
+
+// TestEvalBenchmark runs the scanner against labeled testdata scenarios and
+// reports precision/recall metrics. Skips when testdata/ is absent.
+//
+// Run with: go test -run TestEvalBenchmark -v ./internal/scanner/
+func TestEvalBenchmark(t *testing.T) {
+	testdataDir := filepath.Join("../..", "testdata")
+	if _, err := os.Stat(testdataDir); os.IsNotExist(err) {
+		t.Skip("testdata/ not present, skipping benchmark evaluation")
+	}
+
+	scenarios := buildScenarios(testdataDir)
+	s := buildEvalScanner(t)
+
+	var results []scenarioResults
+	totalTP, totalFP, totalFN := 0, 0, 0
+	ruleCounts := make(map[string]int) // rule ID -> total detections
+
+	for _, sc := range scenarios {
+		result, err := s.Scan(context.Background(), sc.path)
+		if err != nil {
+			t.Errorf("scan %s: %v", sc.name, err)
+			continue
+		}
+
+		findings := result.Findings
+		sr := scenarioResults{
+			name:          sc.name,
+			findings:      len(findings),
+			expectedRules: len(sc.expectedRules),
+		}
+
+		// Track detected rule IDs
+		detectedRules := make(map[string]bool)
+		for _, f := range findings {
+			detectedRules[f.RuleID] = true
+			ruleCounts[f.RuleID]++
+		}
+
+		if sc.isMalicious {
+			// Check recall: are all expected rules detected?
+			for _, expected := range sc.expectedRules {
+				if detectedRules[expected] {
+					sr.matchedRules++
+					totalTP++
+				} else {
+					sr.missedRules = append(sr.missedRules, expected)
+					totalFN++
+				}
+			}
+			// Extra rules (detected but not in expected list) are not necessarily FP -
+			// they might be valid detections we haven't labeled yet.
+			for r := range detectedRules {
+				found := false
+				for _, exp := range sc.expectedRules {
+					if r == exp {
+						found = true
+						break
+					}
+				}
+				if !found {
+					sr.extraRules = append(sr.extraRules, r)
+				}
+			}
+		} else {
+			// Benign: any finding is a false positive
+			sr.falsePositives = len(findings)
+			totalFP += len(findings)
+			for _, f := range findings {
+				sr.extraRules = append(sr.extraRules, f.RuleID)
+			}
+		}
+
+		results = append(results, sr)
+	}
+
+	// Report per-scenario results
+	t.Log("\n=== BENCHMARK EVALUATION ===\n")
+	for _, sr := range results {
+		status := "OK"
+		if len(sr.missedRules) > 0 {
+			status = "MISS"
+		}
+		if sr.falsePositives > 0 {
+			status = "FP"
+		}
+		t.Logf("%-40s %4s  findings=%d  recall=%d/%d  missed=%v",
+			sr.name, status, sr.findings, sr.matchedRules, sr.expectedRules, sr.missedRules)
+		if len(sr.extraRules) > 0 {
+			sort.Strings(sr.extraRules)
+			t.Logf("  extra (unlabeled): %v", sr.extraRules)
+		}
+	}
+
+	// Aggregate metrics
+	totalExpected := totalTP + totalFN
+	precision := float64(1)
+	if totalTP+totalFP > 0 {
+		precision = float64(totalTP) / float64(totalTP+totalFP)
+	}
+	recall := float64(1)
+	if totalExpected > 0 {
+		recall = float64(totalTP) / float64(totalExpected)
+	}
+	f1 := float64(0)
+	if precision+recall > 0 {
+		f1 = 2 * precision * recall / (precision + recall)
+	}
+
+	t.Logf("\n=== AGGREGATE METRICS ===")
+	t.Logf("Scenarios:     %d (%d malicious, %d benign)",
+		len(scenarios), countMalicious(scenarios), len(scenarios)-countMalicious(scenarios))
+	t.Logf("True Positives:  %d", totalTP)
+	t.Logf("False Positives: %d", totalFP)
+	t.Logf("False Negatives: %d", totalFN)
+	t.Logf("Precision:       %.1f%%", precision*100)
+	t.Logf("Recall:          %.1f%%", recall*100)
+	t.Logf("F1 Score:        %.3f", f1)
+
+	// Per-rule frequency
+	t.Logf("\n=== RULE FREQUENCY (top 15) ===")
+	type ruleFreq struct {
+		id    string
+		count int
+	}
+	var freqs []ruleFreq
+	for id, c := range ruleCounts {
+		freqs = append(freqs, ruleFreq{id, c})
+	}
+	sort.Slice(freqs, func(i, j int) bool { return freqs[i].count > freqs[j].count })
+	for i, rf := range freqs {
+		if i >= 15 {
+			break
+		}
+		t.Logf("  %-30s %d", rf.id, rf.count)
+	}
+}
+
+func buildEvalScanner(t *testing.T) *scanner.Scanner {
+	t.Helper()
+	rawRules, err := rules.LoadFromFS(builtin.FS())
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiled, errs := rules.CompileAll(rawRules)
+	if len(errs) > 0 {
+		t.Fatal(errs)
+	}
+	s := scanner.New(2)
+	s.RegisterAnalyzer(pattern.NewMatcher(compiled))
+	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
+	s.RegisterAnalyzer(toxicflow.New())
+	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())
+	return s
+}
+
+func buildScenarios(testdataDir string) []benchmarkScenario {
+	// Malicious scenarios with expected TP rules.
+	// These are labeled ground truth from manual review.
+	malicious := map[string][]string{
+		"combined-attack":        {"PROMPT_INJECTION_001", "PROMPT_INJECTION_010", "PROMPT_INJECTION_011", "CRED_001", "EXFIL_001", "EXFIL_002", "EXFIL_004"},
+		"credential-leak":        {"CRED_001", "CRED_002", "CRED_005", "CRED_006", "CRED_008", "CRED_010", "EXFIL_001"},
+		"encoded-payload":        {"PROMPT_INJECTION_001", "PROMPT_INJECTION_009", "PROMPT_INJECTION_011"},
+		"exfil-webhook":          {"EXFIL_001", "EXFIL_002"},
+		"hidden-injection":       {"PROMPT_INJECTION_001", "EXFIL_002"},
+		"mcp-tool-poisoning":     {"MCP_001", "MCP_005", "MCP_006", "MCP_008", "PROMPT_INJECTION_001", "SUPPLY_003"},
+		"prompt-injection-basic": {"PROMPT_INJECTION_001", "PROMPT_INJECTION_005", "PROMPT_INJECTION_006", "PROMPT_INJECTION_008"},
+		"ssrf-metadata":          {"SSRF_001", "SSRF_003", "SSRF_004", "SSRF_005", "SSRF_007"},
+		"supply-chain-attack":    {"SUPPLY_002", "SUPPLY_003", "SUPPLY_006", "SUPPLY_007", "SUPPLY_008", "MCP_008"},
+		"unicode-obfuscation":    {"UNI_001", "UNI_002", "UNI_003", "UNI_004", "UNI_005", "UNI_006", "UNI_007"},
+	}
+
+	// Benign scenarios - should produce 0 findings.
+	benign := []string{
+		"complex-skill",
+		"documentation-skill",
+		"mcp-server-legit",
+		"npm-project",
+		"security-tooling",
+		"simple-skill",
+	}
+
+	var scenarios []benchmarkScenario
+	for name, expected := range malicious {
+		dir := filepath.Join(testdataDir, "malicious", name)
+		if _, err := os.Stat(dir); err == nil {
+			scenarios = append(scenarios, benchmarkScenario{
+				name:          fmt.Sprintf("malicious/%s", name),
+				path:          dir,
+				isMalicious:   true,
+				expectedRules: expected,
+			})
+		}
+	}
+	for _, name := range benign {
+		dir := filepath.Join(testdataDir, "benign", name)
+		if _, err := os.Stat(dir); err == nil {
+			scenarios = append(scenarios, benchmarkScenario{
+				name:        fmt.Sprintf("benign/%s", name),
+				path:        dir,
+				isMalicious: false,
+			})
+		}
+	}
+
+	sort.Slice(scenarios, func(i, j int) bool {
+		return scenarios[i].name < scenarios[j].name
+	})
+	return scenarios
+}
+
+func countMalicious(scenarios []benchmarkScenario) int {
+	n := 0
+	for _, s := range scenarios {
+		if s.isMalicious {
+			n++
+		}
+	}
+	return n
+}
+
+// TestEvalRuleSelfTest validates that rule self-test examples (true_positive,
+// false_positive) pass against the pattern matcher. Uses the first target
+// extension from each rule (or "test.md" if no targets specified) to ensure
+// extension-based filtering doesn't interfere.
+//
+// NOTE: Rules detected only by NLP/toxicflow (not pattern matcher) will show
+// as failures here. The rules package self-test (TestRuleSelfTest) covers
+// pattern-level validation; this test covers integration with the matcher.
+func TestEvalRuleSelfTest(t *testing.T) {
+	rawRules, err := rules.LoadFromFS(builtin.FS())
+	if err != nil {
+		t.Fatal(err)
+	}
+	compiled, errs := rules.CompileAll(rawRules)
+	if len(errs) > 0 {
+		t.Fatal(errs)
+	}
+
+	matcher := pattern.NewMatcher(compiled)
+	tpPassed, tpFailed := 0, 0
+	fpPassed, fpFailed := 0, 0
+	var failures []string
+
+	for _, rule := range compiled {
+		// Pick filename matching the rule's first target, or default to test.md
+		filename := "test.md"
+		for _, tgt := range rule.Targets {
+			if strings.HasPrefix(tgt, "*.") {
+				filename = "test" + tgt[1:]
+				break
+			}
+		}
+
+		for _, tp := range rule.Examples.TruePositive {
+			target := &scanner.Target{
+				RelPath: filename,
+				Content: []byte(tp),
+			}
+			findings, err := matcher.Analyze(context.Background(), target)
+			if err != nil {
+				t.Errorf("rule %s TP: %v", rule.ID, err)
+				continue
+			}
+			found := false
+			for _, f := range findings {
+				if f.RuleID == rule.ID {
+					found = true
+					break
+				}
+			}
+			if found {
+				tpPassed++
+			} else {
+				tpFailed++
+				failures = append(failures, fmt.Sprintf("rule %s (%s): TP not detected: %s",
+					rule.ID, filename, truncate(tp, 70)))
+			}
+		}
+
+		for _, fp := range rule.Examples.FalsePositive {
+			target := &scanner.Target{
+				RelPath: filename,
+				Content: []byte(fp),
+			}
+			findings, err := matcher.Analyze(context.Background(), target)
+			if err != nil {
+				t.Errorf("rule %s FP: %v", rule.ID, err)
+				continue
+			}
+			triggered := false
+			for _, f := range findings {
+				if f.RuleID == rule.ID {
+					triggered = true
+					break
+				}
+			}
+			if !triggered {
+				fpPassed++
+			} else {
+				fpFailed++
+				failures = append(failures, fmt.Sprintf("rule %s: FP triggered: %s",
+					rule.ID, truncate(fp, 70)))
+			}
+		}
+	}
+
+	t.Logf("Self-test: TP passed=%d failed=%d, FP passed=%d failed=%d",
+		tpPassed, tpFailed, fpPassed, fpFailed)
+
+	// Log failures but don't fail the test - some rules are NLP/toxicflow only
+	if tpFailed > 0 {
+		t.Logf("NOTE: %d TP failures may be NLP/toxicflow-only rules (not pattern matcher)", tpFailed)
+		for _, f := range failures {
+			t.Log(f)
+		}
+	}
+}
+
+func truncate(s string, n int) string {
+	s = strings.ReplaceAll(s, "\n", " ")
+	if len(s) > n {
+		return s[:n] + "..."
+	}
+	return s
+}


### PR DESCRIPTION
## Summary
- **Pattern matcher performance**: keyword pre-filter with Aho-Corasick extracts 951 unique literals from 488 regex patterns, skipping rules whose keywords don't appear in content. Clean files 6.4x faster (710ms to 111ms), trigger files 3.7x faster (750ms to 204ms)
- **WASM build completion**: added explainRule, version, scan options (minSeverity/profile), improved UI with tabs/severity cards/rule explorer, make wasm-serve target
- **FP reduction**: benchmark eval test (16 scenarios, P=100% R=100%), documentation section penalty (0.7x), file-type multiplier (0.9x for .md/.txt)

## Test plan
- [x] `make build && make test && make vet && make lint` - 15 packages, 0 issues
- [x] 16 testdata scenarios (10 malicious detected, 6 benign clean)
- [x] 189 rule self-tests pass
- [x] Benchmark eval: Precision 100%, Recall 100%, F1 1.000
- [x] All 4 output formats produce correct findings
- [x] WASM compiles (GOOS=js GOARCH=wasm)
- [x] Self-scan of 2890 files without crash
- [x] Performance benchmarks confirm 3.7-6.4x improvement