### PR TITLE
ci: Phase 0 - cache Go, concurrency, timeouts, slim Docker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,15 +4,22 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-go@v5
         with:
           go-version: "1.25"
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Build
         run: make build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,9 +9,14 @@ permissions:
   contents: read
   packages: write
 
+concurrency:
+  group: docker-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
         with:
@@ -19,6 +20,8 @@ jobs:
       - uses: actions/setup-go@v5
         with:
           go-version: "1.25"
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -10,12 +10,18 @@ on:
 permissions:
   security-events: write
 
+concurrency:
+  group: test-action-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test-action:
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -49,6 +55,7 @@ jobs:
 
   test-action-json:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
@@ -71,6 +78,7 @@ jobs:
 
   test-action-fail-on:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ COPY . .
 RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o /aguara ./cmd/aguara
 
 FROM alpine:3.21
-RUN apk add --no-cache git
 COPY --from=builder /aguara /usr/local/bin/aguara
 ENTRYPOINT ["aguara"]
 CMD ["scan", "."]


### PR DESCRIPTION
## Summary

Phase 0 of the workflow improvements plan: safe, zero-risk quick wins for CI/CD and Docker. No functional changes to the binary, library API, CLI flags, action inputs/outputs, or release artifacts.

### Changes

- **Go module cache** in `ci.yml` and `release.yml` (`setup-go@v5` with `cache: true` + `cache-dependency-path: go.sum`). Expected ~30-45s shaved per run.
- **Concurrency groups** with `cancel-in-progress: true` in `ci.yml`, `test-action.yml`, `docker.yml`. `release.yml` intentionally excluded so an in-flight release is never cancelled.
- **Explicit `timeout-minutes`** per job: 10 (CI), 15 (test-action), 30 (release/docker). Prevents hung jobs from burning Action minutes.
- **`fail-fast: false`** on the `test-action.yml` OS matrix so a flake on one runner does not mask issues on the other.
- **Drop `git`** from the Dockerfile runtime stage. `aguara` never invokes git; image shrinks from ~28MB to ~24MB.

### Validation

Local checks all green on this branch:

- `make build` ok
- `make test` (550 tests, `-race`) ok
- `make vet` ok
- `make lint` (golangci-lint v2.9.0) - 0 issues
- `python3 -c "import yaml; ..."` parses all 4 workflows
- `docker build .` succeeds
- `docker run aguara version` and `aguara list-rules` work in the slimmed image

### Out of scope (later phases)

- Supply chain hardening (Cosign signing, SBOM, install.sh checksum enforcement, `-trimpath`)
- Coverage reporting + benchmarks in CI
- Shell completions, man pages, library STABILITY.md
- Engine performance work (early-exit, AC unification)

## Test plan

- [ ] CI workflow runs and turns green
- [ ] Test Action workflow runs on both Linux and macOS
- [ ] Docker image still builds via `docker.yml` on the next release tag