### PR TITLE
fix(action): authenticate GitHub API + isolate fail-on test fixture

### DIFF
--- a/.github/test-fixtures/clean/README.md
+++ b/.github/test-fixtures/clean/README.md
@@ -1,0 +1,10 @@
+# Aguara test fixture (clean)
+
+This directory is consumed by `.github/workflows/test-action.yml` to verify
+that the action exits with code 0 when scanning content that has no findings
+above the configured `fail-on` threshold.
+
+The content here is intentionally generic prose so that no Aguara rule across
+any layer (pattern, NLP, toxicflow, rugpull) produces findings. If a future
+rule starts matching this file, replace the offending wording rather than
+disabling the rule.

--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -74,9 +74,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Run Aguara action (fail-on critical)
+      - name: Run Aguara action (fail-on critical, clean fixture, expect exit 0)
         uses: ./
         with:
-          path: ./internal/rules/builtin/
+          path: ./.github/test-fixtures/clean/
           fail-on: critical
           upload-sarif: 'false'

--- a/action.yml
+++ b/action.yml
@@ -68,8 +68,9 @@ runs:
       env:
         VERSION: ${{ inputs.version }}
         INSTALL_DIR: ${{ runner.temp }}/aguara-bin
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
-        curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
+        curl -fsSL --max-time 30 https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
     - name: Run Aguara scan

--- a/install.sh
+++ b/install.sh
@@ -99,7 +99,12 @@ detect_arch() {
 }
 
 get_latest_version() {
-    response=$(curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest") || err "failed to fetch latest version from GitHub"
+    api_url="https://api.github.com/repos/${REPO}/releases/latest"
+    if [ -n "${GITHUB_TOKEN:-}" ]; then
+        response=$(curl -fsSL --max-time 30 -H "Authorization: Bearer ${GITHUB_TOKEN}" "$api_url") || err "failed to fetch latest version from GitHub"
+    else
+        response=$(curl -fsSL --max-time 30 "$api_url") || err "failed to fetch latest version from GitHub (set GITHUB_TOKEN to avoid anonymous rate limits)"
+    fi
     version=$(echo "$response" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
     if [ -z "$version" ]; then
         err "could not determine latest version"


### PR DESCRIPTION
## Summary

Two preexisting failures in the test-action workflow, hidden until now by its `paths` filter (workflow only runs when `action.yml` or `test-action.yml` change). Surfaced by PR #45.

### 1. macOS rate-limit 403 in test-action (macos-latest)

`install.sh` calls `api.github.com/repos/.../releases/latest` unauthenticated. macOS GHA runners share IP pools and exhaust the 60/h anonymous rate limit easily.

**Fix**:
- `install.sh` sends `Authorization: Bearer ${GITHUB_TOKEN}` to the API when the var is set (5000/h authenticated rate limit). Static asset downloads (archive, checksums.txt) are CDN-served and not rate-limited, so they stay unauthenticated.
- `action.yml` passes `${{ github.token }}` into the install step env.
- Adds `--max-time 30` to the API curl to fail fast on network hangs.

### 2. test-action-fail-on always exit 1

The test scanned `./internal/rules/builtin/` with `--fail-on critical`. As of v0.10.0 the rules detect their own `true_positive` examples (self-detection): 260 findings, risk 100/100. The test implicitly assumed `builtin/` was clean.

**Fix**: versioned, controlled fixture at `.github/test-fixtures/clean/`. Verified locally: 0 findings even at `--severity info`. Test now points there.

## Backwards compatibility

- `install.sh` still works without `GITHUB_TOKEN` (anonymous path preserved). Users running `curl | bash` see no behavior change beyond a clearer error message that mentions the env var when the API call fails.
- The action's public inputs and outputs are unchanged.
- No code changes to the binary.

## Local validation

- `make build && make test && make vet && make lint` - all green (550 tests with `-race`, 0 lint issues).
- `python3 -c "yaml.safe_load(...)"` - 4 workflows + `action.yml` parse OK.
- `shellcheck install.sh` - no new warnings (only the preexisting SC2016 about literal `$PATH` in the help message).
- `sh -n install.sh` - syntax OK.
- Three install.sh dry runs into a sandbox `INSTALL_DIR`:
  - `VERSION=v0.10.0` (no token, pinned) - installs cleanly
  - no `VERSION`, no token (anonymous API path) - works (low traffic)
  - no `VERSION`, invalid token - fails fast with the controlled error message
- `aguara scan ./.github/test-fixtures/clean/ --fail-on critical` - 0 findings, exit 0 (also verified at `--fail-on low`).

## Test plan

- [ ] All 4 jobs in `Test Action` workflow turn green (Linux + macOS for default, JSON, fail-on)
- [ ] CI workflow stays green
- [ ] After merge: rebase #45 (Phase 0 quick wins) on main, expect green there too