### PR TITLE
fix(install): mandatory checksum + bounded download with retry

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ BINARY="aguara"
 main() {
     need_cmd curl
     need_cmd tar
+    need_checksum_tool
 
     os=$(detect_os)
     arch=$(detect_arch)
@@ -36,11 +37,11 @@ main() {
 
     # Download archive
     log "Downloading ${archive}..."
-    curl -fsSL -o "${tmpdir}/${archive}" "$url"
+    download "$url" "${tmpdir}/${archive}"
 
     # Download and verify checksum
     log "Verifying checksum..."
-    curl -fsSL -o "${tmpdir}/checksums.txt" "$checksums_url"
+    download "$checksums_url" "${tmpdir}/checksums.txt"
     verify_checksum "$tmpdir" "$archive"
 
     # Extract binary
@@ -98,12 +99,43 @@ detect_arch() {
     esac
 }
 
+# download fetches a URL into a local file with bounded time and retries.
+# Used for release artifacts (archive, checksums.txt). Times out at 120s
+# so a hung TCP connection cannot stall the install indefinitely.
+download() {
+    url="$1"
+    output="$2"
+    curl -fsSL \
+        --max-time 120 \
+        --retry 3 \
+        --retry-delay 2 \
+        --retry-connrefused \
+        -o "$output" "$url" \
+        || err "failed to download: ${url}"
+}
+
 get_latest_version() {
     api_url="https://api.github.com/repos/${REPO}/releases/latest"
+    # GitHub API has a 60/h anonymous rate limit per IP. CI runners share
+    # IP pools and exhaust this quickly; sending GITHUB_TOKEN raises the
+    # ceiling to 5000/h authenticated. Token is never echoed or logged.
     if [ -n "${GITHUB_TOKEN:-}" ]; then
-        response=$(curl -fsSL --max-time 30 -H "Authorization: Bearer ${GITHUB_TOKEN}" "$api_url") || err "failed to fetch latest version from GitHub"
+        response=$(curl -fsSL \
+            --max-time 30 \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-connrefused \
+            -H "Authorization: Bearer ${GITHUB_TOKEN}" \
+            "$api_url") \
+            || err "failed to fetch latest version from GitHub"
     else
-        response=$(curl -fsSL --max-time 30 "$api_url") || err "failed to fetch latest version from GitHub (set GITHUB_TOKEN to avoid anonymous rate limits)"
+        response=$(curl -fsSL \
+            --max-time 30 \
+            --retry 3 \
+            --retry-delay 2 \
+            --retry-connrefused \
+            "$api_url") \
+            || err "failed to fetch latest version from GitHub (set GITHUB_TOKEN to avoid anonymous rate limits)"
     fi
     version=$(echo "$response" | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p')
     if [ -z "$version" ]; then
@@ -112,20 +144,23 @@ get_latest_version() {
     echo "$version"
 }
 
+# verify_checksum aborts on any failure, including missing tooling.
+# Skipping checksum verification would let a network MITM swap the binary,
+# so a missing sha256sum/shasum is a hard error rather than a warning.
 verify_checksum() {
     dir="$1"
     file="$2"
     expected=$(grep "$file" "${dir}/checksums.txt" | awk '{print $1}')
     if [ -z "$expected" ]; then
-        err "checksum not found for ${file}"
+        err "checksum not found for ${file} in checksums.txt"
     fi
     if command -v sha256sum >/dev/null 2>&1; then
         actual=$(sha256sum "${dir}/${file}" | awk '{print $1}')
     elif command -v shasum >/dev/null 2>&1; then
         actual=$(shasum -a 256 "${dir}/${file}" | awk '{print $1}')
     else
-        warn "sha256sum/shasum not found, skipping checksum verification"
-        return
+        # Should be unreachable: need_checksum_tool runs at startup.
+        err "no sha256 tool available; install coreutils or perl-Digest-SHA"
     fi
     if [ "$actual" != "$expected" ]; then
         err "checksum mismatch: expected ${expected}, got ${actual}"
@@ -136,6 +171,15 @@ need_cmd() {
     if ! command -v "$1" >/dev/null 2>&1; then
         err "required command not found: $1"
     fi
+}
+
+# need_checksum_tool aborts the install up front if neither sha256sum nor
+# shasum is available, rather than discovering it after downloading.
+# macOS ships shasum by default; Linux distros ship sha256sum via coreutils.
+need_checksum_tool() {
+    if command -v sha256sum >/dev/null 2>&1; then return; fi
+    if command -v shasum >/dev/null 2>&1; then return; fi
+    err "no sha256 tool found (need sha256sum or shasum). Install coreutils (Linux) or perl-Digest-SHA, then retry."
 }
 
 log() {


### PR DESCRIPTION
## Summary

Phase 1 of the workflow improvements spec: hardens `install.sh` against two real risks.

### A1 — Mandatory checksum verification

Before this PR, `verify_checksum` issued a warning and continued the install if neither `sha256sum` nor `shasum` was available. An attacker positioned on the network (open Wi-Fi, hostile proxy, hostile registry) could swap the binary on machines that happened to lack those tools, with the user only seeing a yellow warning.

Now:

- A new `need_checksum_tool` runs at startup, before any download. If neither tool is found, the script aborts with a clear remediation message (install `coreutils` on Linux, `perl-Digest-SHA` on minimal images; macOS ships `shasum` by default).
- `verify_checksum`'s missing-tool branch is now `err()` instead of `warn()`. Defensive — should be unreachable now that startup gates it, but if anyone removes the gate later, the verification path stays safe.

### A6 — Bounded downloads with retry

Two of the three `curl` invocations had no timeout — a hung TCP connection would stall the install indefinitely. The third (added in PR #46) had `--max-time` but no retry, so transient network hiccups required manual rerun.

Now:

- New `download()` helper for release artifacts: `--max-time 120`, `--retry 3 --retry-delay 2 --retry-connrefused`. Used for both the archive and `checksums.txt`.
- `get_latest_version` (the GitHub API call) gets the same retry knobs at `--max-time 30`.

## Backwards compatibility

Standard install paths work unchanged on machines with the usual tooling (Linux + coreutils, macOS, any modern container image with `curl`+`tar`+`shasum`):

- `curl ... | bash`
- `VERSION=v0.10.0 sh install.sh`
- `INSTALL_DIR=/foo sh install.sh`
- `GITHUB_TOKEN=... sh install.sh` (rate-limit bypass added in PR #46)

The only behavior change: machines that previously installed by silently skipping the integrity check now fail loudly with a remediation message. That was the security bug being fixed.

## Validation

- `shellcheck install.sh` — only the preexisting SC2016 (intentional literal `$PATH` in the help printout) remains.
- `sh -n install.sh` — syntax OK.
- Four dry runs in a sandbox `INSTALL_DIR=/tmp/aguara-h*`:
  1. `VERSION=v0.10.0`, no token — installs cleanly
  2. no `VERSION`, no token (anonymous API path) — installs cleanly
  3. `PATH=/tmp/sandbox-bin` (sandbox without `sha256sum`/`shasum`) — aborts with exit 1 and the remediation message **before any network activity**
  4. invalid `GITHUB_TOKEN` — aborts on the API call with a controlled error

## Test plan

- [ ] CI green (build + test + vet + lint)
- [ ] Test Action workflow runs (this PR touches only `install.sh`, action.yml unchanged, so the path filter on test-action.yml will not trigger — verify install.sh changes don't break end-to-end install via the existing tag tests in a future release dry-run)
