### PR TITLE
feat(release): cosign keyless + SPDX SBOM + trimpath

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -8,6 +8,9 @@ on:
 permissions:
   contents: read
   packages: write
+  # id-token: write is required for cosign keyless signing of the image
+  # digest via Sigstore + GitHub OIDC.
+  id-token: write
 
 concurrency:
   group: docker-${{ github.workflow }}-${{ github.ref }}
@@ -26,6 +29,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.7.0
+
       - uses: docker/metadata-action@v5
         id: meta
         with:
@@ -36,8 +42,26 @@ jobs:
             type=raw,value=latest
 
       - uses: docker/build-push-action@v6
+        id: build
         with:
           context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          # SBOM (SPDX) and SLSA build provenance attestations are pushed
+          # alongside the image and visible via `cosign download attestation`.
+          sbom: true
+          provenance: mode=max
+
+      # Sign the image digest produced by build-push-action. Signing the
+      # digest (not the tag) ensures verification cannot be tricked by a tag
+      # being later repointed.
+      - name: Sign image
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          for tag in $TAGS; do
+            cosign sign --yes "${tag}@${DIGEST}"
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 permissions:
   contents: write
+  # id-token: write is required for cosign keyless signing via Sigstore +
+  # GitHub OIDC. The token never leaves the runner.
+  id-token: write
 
 jobs:
   release:
@@ -22,6 +25,16 @@ jobs:
           go-version: "1.25"
           cache: true
           cache-dependency-path: go.sum
+
+      # cosign signs the checksums.txt produced by GoReleaser. Pinned to a
+      # specific release for reproducibility; consumers can update via
+      # Dependabot.
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.7.0
+
+      # syft generates SPDX SBOMs that GoReleaser attaches to each archive.
+      - name: Install Syft
+        uses: anchore/sbom-action/download-syft@v0.17.8
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -5,6 +5,8 @@ builds:
     binary: aguara
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
     ldflags:
       - -s -w
       - -X github.com/garagon/aguara/cmd/aguara/commands.Version={{.Version}}
@@ -26,6 +28,28 @@ archives:
 
 checksum:
   name_template: "checksums.txt"
+
+# Cosign keyless signing of the checksums.txt file. Consumers verify the
+# bundle against the OIDC identity of the GitHub Actions release workflow,
+# then verify each artifact's sha256 against the now-trusted checksums.txt.
+# The .bundle format (cosign 2.x+) packs signature, certificate, and TUF
+# metadata into a single file; the older --output-signature / --output-certificate
+# flags are deprecated and silently ignored when --new-bundle-format is in use.
+signs:
+  - cmd: cosign
+    signature: "${artifact}.bundle"
+    args:
+      - "sign-blob"
+      - "--bundle=${signature}"
+      - "--yes"
+      - "${artifact}"
+    artifacts: checksum
+    output: true
+
+# SPDX SBOMs generated with syft for each release archive. Lets consumers
+# audit the dependency tree without having to recompute it themselves.
+sboms:
+  - artifacts: archive
 
 brews:
   - repository:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
 COPY . .
-RUN CGO_ENABLED=0 go build -ldflags "-s -w" -o /aguara ./cmd/aguara
+RUN CGO_ENABLED=0 go build -trimpath -ldflags "-s -w" -o /aguara ./cmd/aguara
 
 FROM alpine:3.21
 COPY --from=builder /aguara /usr/local/bin/aguara

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ LDFLAGS := -ldflags "-s -w -X $(PKG)/cmd/aguara/commands.Version=$(VERSION) -X $
 .PHONY: build test lint run clean fmt vet wasm wasm-serve
 
 build:
-	go build $(LDFLAGS) -o $(BINARY) ./cmd/aguara
+	go build -trimpath $(LDFLAGS) -o $(BINARY) ./cmd/aguara
 
 test:
 	go test -race -count=1 ./...
@@ -25,7 +25,7 @@ run:
 	go run ./cmd/aguara $(ARGS)
 
 wasm:
-	GOOS=js GOARCH=wasm go build -o aguara.wasm ./cmd/wasm
+	GOOS=js GOARCH=wasm go build -trimpath -o aguara.wasm ./cmd/wasm
 	cp "$$(go env GOROOT)/lib/wasm/wasm_exec.js" .
 	cp cmd/wasm/index.html .
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AI agents and MCP servers run code on your behalf. A single malicious skill file
 
 - **189 detection rules across 14 categories** — prompt injection, data exfiltration, credential leaks, supply-chain attacks, MCP-specific threats, command execution, SSRF, unicode attacks, and more.
 - **4-layer analysis engine** — pattern matching, NLP analysis, taint tracking, and rug-pull detection work together to catch threats that any single technique would miss.
-- **6 decoders for encoded evasion** — base64, hex, URL encoding, Unicode escapes, HTML entities, and hex escapes. Obfuscated payloads are decoded and re-scanned automatically.
+- **8 decoders for encoded evasion** — base64, hex, URL encoding, Unicode escapes, HTML entities, hex escapes, base32, and C-style octal escapes. Obfuscated payloads are decoded and re-scanned automatically.
 - **NLP on markdown, JSON, and YAML** — goldmark AST analysis for markdown files, plus string extraction and classification for JSON/YAML tool descriptions. Catches MCP tool poisoning in structured configs.
 - **Cross-file toxic flow analysis** — detects dangerous capability combinations split across files in the same MCP server directory (e.g., one tool reads credentials, another sends to a webhook).
 - **Aggregate risk score** — 0-100 score with diminishing returns across findings. Available in JSON, SARIF, and terminal output.
@@ -94,6 +94,52 @@ go install github.com/garagon/aguara/cmd/aguara@latest
 ```
 
 Pre-built binaries for Linux, macOS, and Windows are also available on the [Releases page](https://github.com/garagon/aguara/releases).
+
+### Verifying signed releases
+
+Starting with the next release after this section landed, every release is signed with [Cosign](https://github.com/sigstore/cosign) keyless, ships an SPDX SBOM per archive, and is built with `-trimpath` for reproducibility. The container image is signed at the digest and carries SBOM + SLSA provenance attestations.
+
+**Verify the release archive**:
+
+```bash
+VERSION=vX.Y.Z
+ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
+
+# Download archive, checksums, and the cosign bundle
+curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
+curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/checksums.txt
+curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/checksums.txt.bundle
+
+# Verify checksums.txt was signed by the GitHub Actions release workflow
+cosign verify-blob \
+  --bundle checksums.txt.bundle \
+  --certificate-identity "https://github.com/garagon/aguara/.github/workflows/release.yml@refs/tags/${VERSION}" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  checksums.txt
+
+# Now verify the archive matches the signed checksums
+sha256sum --check --ignore-missing checksums.txt
+```
+
+**Verify the container image**:
+
+```bash
+cosign verify ghcr.io/garagon/aguara:${VERSION#v} \
+  --certificate-identity "https://github.com/garagon/aguara/.github/workflows/docker.yml@refs/tags/${VERSION}" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+**Inspect the SBOM**:
+
+```bash
+# Release archive SBOM (SPDX)
+curl -fsSL https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}.sbom.json | jq .
+
+# Container image SBOM attestation
+cosign download attestation ghcr.io/garagon/aguara:${VERSION#v} | jq -r '.payload' | base64 -d | jq .
+```
+
+`install.sh` performs SHA256 verification automatically and aborts if `sha256sum`/`shasum` is unavailable, so the curl-pipe install path is never silently downgraded.
 
 ## Quick Start
 


### PR DESCRIPTION
## Summary

Phase 1 (PR 1.2) of the workflow improvements spec: hardens the release pipeline so every artifact and image consumers download is **signed, attested, and reproducible**. Companion to #48 (install.sh hardening).

### What changes

| Knob | Where | Why |
|------|-------|-----|
| `-trimpath` | `Makefile`, `Dockerfile`, `.goreleaser.yml`, wasm target | Strips `$GOPATH`/`$HOME` from binary paths. Stack traces no longer leak the build host's directory layout, and bytes can be reproduced from a clean checkout. |
| `cosign sign-blob --bundle` | `.goreleaser.yml signs:`, `release.yml` | Keyless signature of `checksums.txt`. Consumers verify the OIDC identity of the GHA workflow once, then trust every artifact via its sha256 in the now-signed checksums file. |
| SPDX SBOM per archive | `.goreleaser.yml sboms:`, `release.yml` | One `<archive>.sbom.json` per `(os, arch)`. Lets consumers audit dependencies without recomputing them. |
| `sbom: true`, `provenance: mode=max` | `docker.yml` | Image push attaches SBOM and SLSA build provenance attestations natively via `docker/build-push-action@v6`. |
| `cosign sign` (image digest) | `docker.yml` | Signs each pushed tag at the digest, not the tag — a later tag repoint cannot trick verification. |
| `id-token: write` | `release.yml`, `docker.yml` | Required permission for OIDC + Sigstore keyless. No long-lived signing keys in the repo. |

### Validation

**`goreleaser release --snapshot --skip=publish --skip=sign --clean`** locally produces:

- 6 archives (linux/darwin amd64+arm64, windows zips for amd64+arm64)
- **6 SPDX 2.3 SBOMs**, one per archive (verified: `9 packages` detected by syft on linux_amd64)
- `checksums.txt` with sha256 of every artifact

**`make build && make test && make vet && make lint`** all green with `-trimpath` active. Docker image rebuilds cleanly. YAML lint passes on all 4 workflows + `action.yml` + `.goreleaser.yml`.

**`goreleaser check`**: configuration valid. The two deprecation warnings (`archives.format`, `brews`) are preexisting from upstream GoReleaser and out of scope here.

The cosign step on the local snapshot fails as expected (no GitHub OIDC token outside the runner). On the next tag pushed to GitHub, `id-token: write` + `sigstore/cosign-installer@v3.7.0` will provide the token and signing will succeed.

### Why `--bundle` (not `--output-signature` / `--output-certificate`)

Local `cosign 2.x` dry-run revealed that the older flags are deprecated and **silently ignored** when `--new-bundle-format` (now the default) is in use:

```
WARNING: --output-signature is deprecated when using --new-bundle-format and will be ignored
WARNING: --output-certificate is deprecated when using --new-bundle-format and will be ignored
```

Using the deprecated flags would have produced empty `.sig` and `.pem` files and broken verification. The PR uses `--bundle=${signature}` which packs signature + certificate + TUF metadata into a single `checksums.txt.bundle`.

### Consumer verification (added to README)

```bash
VERSION=vX.Y.Z

# Verify checksums.txt was signed by the release workflow
cosign verify-blob \
  --bundle checksums.txt.bundle \
  --certificate-identity "https://github.com/garagon/aguara/.github/workflows/release.yml@refs/tags/${VERSION}" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
  checksums.txt

# Now verify the archive matches the signed checksums
sha256sum --check --ignore-missing checksums.txt

# Verify the container image
cosign verify ghcr.io/garagon/aguara:${VERSION#v} \
  --certificate-identity "https://github.com/garagon/aguara/.github/workflows/docker.yml@refs/tags/${VERSION}" \
  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
```

### Backwards compatibility

- Anyone not verifying signatures (the current default) sees no behavior change. Same archives, same checksums, same tags.
- `install.sh` keeps working unchanged. Sigstore verification is opt-in for users who want it.
- Container image users on `docker pull ghcr.io/garagon/aguara:vX.Y.Z` get unchanged image semantics; the SBOM and provenance attestations are extra metadata, not blocking.
- Library consumers (`aguara-mcp`, `oktsec`) are unaffected — only the release pipeline changes.

### Out of scope (deferred)

- `archives.format` → `archives.formats` migration (cosmetic preexisting deprecation).
- `brews` → `homebrew_casks` migration (requires Homebrew tap publish validation; tracked separately).
- ROT13 / Punycode decoders (Phase A done in #47, no further encoders planned right now).

### Test plan

- [ ] CI green (build + test + vet + lint)
- [ ] After merging both #48 and this PR, push a release tag (e.g. `v0.11.0`) and verify on the published assets:
  - `checksums.txt.bundle` exists alongside `checksums.txt`
  - `<archive>.sbom.json` exists for each archive
  - `cosign verify-blob ...` succeeds against the published bundle
  - `cosign verify ghcr.io/garagon/aguara:0.11.0 ...` succeeds
  - `cosign download attestation` returns SBOM and provenance for the image
