### PR TITLE
release: v0.14.0 - signed releases, install.sh hardening, base32+octal decoders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,87 @@
 All notable changes to Aguara are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.14.0] — 2026-04-17
+
+Supply-chain hardening release. Every release artifact and the container image are now cryptographically signed with Cosign keyless via GitHub OIDC, ship an SPDX SBOM, and are built reproducibly with `-trimpath`. The `install.sh` script now refuses to install when integrity verification cannot be performed. Two new evasion decoders (base32, C-style octal escapes) extend pattern-layer coverage to 8 encodings.
+
+### Added
+
+#### Signed releases (Cosign keyless)
+
+`checksums.txt` is signed during release with `cosign sign-blob --bundle`, producing `checksums.txt.bundle`. The container image is signed at the digest. No long-lived signing keys; identity is proven by the GitHub Actions OIDC token at release time.
+
+```bash
+VERSION=v0.14.0
+cosign verify-blob \
+  --bundle checksums.txt.bundle \
+  --certificate-identity "https://github.com/garagon/aguara/.github/workflows/release.yml@refs/tags/${VERSION}" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+  checksums.txt
+
+cosign verify ghcr.io/garagon/aguara:${VERSION#v} \
+  --certificate-identity "https://github.com/garagon/aguara/.github/workflows/docker.yml@refs/tags/${VERSION}" \
+  --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
+```
+
+#### SPDX SBOMs per archive
+
+Goreleaser invokes `syft` to generate an SBOM (`<archive>.sbom.json`) for every release archive. The container image carries SBOM and SLSA build provenance attestations attached via `docker/build-push-action` (`sbom: true`, `provenance: mode=max`); fetch with `cosign download attestation`.
+
+#### Reproducible builds (`-trimpath`)
+
+All build paths (`Makefile`, `Dockerfile`, `.goreleaser.yml`, wasm target) now pass `-trimpath`. Strips `$GOPATH`/`$HOME` from binaries, so stack traces no longer leak the build host's directory layout, and bytes can be reproduced from a clean checkout.
+
+#### Two new evasion decoders
+
+Pattern layer now decodes 8 encodings (was 6):
+
+- `base32` (RFC 4648, alphabet `A-Z` + `2-7`, min 40 chars to avoid matching ALL_CAPS identifiers, padding optional)
+- `octal escapes` (`\NNN`, 4+ contiguous, first digit constrained to `[0-3]` to keep byte values in 0-255)
+
+Both feed into the existing `DecodeAndRescan` pipeline and respect the shared `maxBlobsPerFile=10` cap.
+
+### Changed
+
+#### `install.sh` aborts when SHA256 tooling is missing
+
+Previously `install.sh` issued a warning and continued the install if neither `sha256sum` (Linux coreutils) nor `shasum` (macOS, perl-Digest-SHA on minimal Linux) was available. An attacker positioned on the network could swap the binary on machines lacking those tools while users only saw a yellow warning.
+
+Now `install.sh` checks for a SHA256 tool at startup, before any download, and aborts with a clear remediation message if neither is found. **This is technically a breaking change** for users on minimal images that lacked these tools and were silently installing without verification — but those installs were never safe.
+
+#### `install.sh` downloads are bounded with retry
+
+All `curl` invocations now use `--max-time` (120s for archives, 30s for the API call) and `--retry 3 --retry-delay 2 --retry-connrefused`. Hung TCP connections can no longer stall the install indefinitely; transient network blips no longer require manual rerun.
+
+#### CI pipeline (no runtime impact)
+
+- Go module cache enabled in `setup-go@v5` via `cache: true` (CI runs ~30-45s faster).
+- `concurrency` groups with `cancel-in-progress: true` on `ci.yml`, `test-action.yml`, `docker.yml` (release.yml intentionally excluded so an in-flight release is never cancelled).
+- Explicit `timeout-minutes` per job (10 CI / 15 test-action / 30 release+docker).
+- `fail-fast: false` on the test-action OS matrix.
+- Dockerfile runtime layer no longer installs `git` (image shrinks ~28MB → ~24MB; `aguara` never invoked git).
+
+#### GitHub Action authenticates the GitHub API
+
+`install.sh` (and therefore the action's install step) now sends `Authorization: Bearer ${GITHUB_TOKEN}` when the env var is present, raising the rate limit from 60/h anonymous to 5000/h authenticated. Fixes intermittent 403 failures on macOS Actions runners that share IP pools. The action passes `${{ github.token }}` into the install step automatically.
+
+#### Test isolation for `fail-on` action job
+
+The `test-action-fail-on` workflow job previously scanned `internal/rules/builtin/` and assumed it was clean — but as of v0.10.0 the rules detect their own `true_positive` examples (260 findings, risk 100/100). The job now scans a controlled `.github/test-fixtures/clean/` fixture (verified to produce zero findings even at `--severity info`).
+
+### Fixed
+
+- `install.sh`: silent-fallback bypass when SHA256 tools were missing (see Changed).
+- Container image: removed unused `git` package (~5MB smaller).
+
+### Library API
+
+No public API changes. Existing `aguara.Scan`, `aguara.ScanContent`, `aguara.NewScanner`, options, and re-exported types are unchanged. Library consumers (`aguara-mcp`, `oktsec`) need no migration. The new decoders may produce additional `Finding` entries on payloads that were previously undetected; rule IDs and the `Analyzer` field (`pattern-decoder`) follow the existing scheme, with new `RuleName` suffixes `(decoded base32)` and `(decoded octal-escape)`.
+
+### Known gap
+
+The CHANGELOG entries for `v0.11.0`, `v0.11.1`, `v0.12.0`, `v0.12.1`, `v0.13.0` were not added at the time of those releases. The git history records what each one contained; reconstructing those entries is tracked separately.
+
 ## [0.10.0] — 2026-03-24
 
 Engine improvements for evasion prevention, signal quality, and library consumer API. Derived from oktsec IPI Arena benchmark analysis. Validated against 28,207 real MCP skills from Aguara Watch.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.10.0 (2026-03-24). 177 rules, 13 categories, 4 analysis layers, 80% test coverage, 550 tests, 0 lint issues.
+Aguara v0.14.0 (2026-04-17). 189 rules, 13 categories, 4 analysis layers, ~630 tests, 0 lint issues.
 
-Distribution: install.sh, Homebrew tap, Docker (GHCR), GoReleaser, GitHub Action, go install.
+Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
 GitHub: 48 stars, 6 forks. 0 open PRs, 0 open issues. 7 awesome-list PRs pending review in external repos. 7 forks on garagon account (pending cleanup after awesome-list PRs resolve).
 
@@ -17,7 +17,7 @@ Internal docs (gitignored) in `DOCS/` as an Obsidian vault. See `DOCS/Aguara/CON
 Key locations:
 - Dashboard (MOC): `DOCS/Aguara/00 Dashboard.md`
 - Conventions: `DOCS/Aguara/CONVENTIONS.md` - frontmatter schema, types, statuses, tags, naming
-- Product versions: `DOCS/Aguara/product/v0.10.0/_index.md` (version hub with links to all generated content)
+- Product versions: `DOCS/Aguara/product/v0.10.0/_index.md` (version hub with links to all generated content; v0.11.0–v0.14.0 hubs not yet created)
 - Distribution channels: `DOCS/Aguara/distribution/<channel>/_index.md` (each has submission log)
 - Growth plan: `DOCS/Aguara/product/roadmap.md`
 - Templates: `DOCS/Aguara/templates/` (channel.md, product-version.md)
@@ -58,7 +58,7 @@ Root package re-exports types from `internal/types` and exposes: `Scan()`, `Scan
 
 ### Analysis Pipeline (4 layers, run sequentially per file)
 
-1. **Pattern Matcher** (`internal/engine/pattern/`) - Regex/contains matching against compiled rules. 6 decoders (base64, hex, URL encoding, Unicode escapes, HTML entities, hex escapes) for encoded evasion detection. Markdown code-block severity downgrade. Dynamic confidence based on pattern hit ratio.
+1. **Pattern Matcher** (`internal/engine/pattern/`) - Regex/contains matching against compiled rules. 8 decoders (base64, hex, URL encoding, Unicode escapes, HTML entities, hex escapes, base32, C-style octal escapes) for encoded evasion detection. Markdown code-block severity downgrade. Dynamic confidence based on pattern hit ratio.
 2. **NLP Analyzer** (`internal/engine/nlp/`) - Goldmark AST walker for markdown; JSON/YAML string extractor for structured files. Keyword classification with proximity weighting. Detects prompt injection, authority claims, credential+exfil combos.
 3. **ToxicFlow** (`internal/engine/toxicflow/`) - Single-file taint tracking + cross-file correlation (`crossfile.go`). Detects dangerous capability combinations within and across files in the same directory. Flat-dir filter (>50 files) prevents FPs on registries.
 4. **Rug-Pull** (`internal/engine/rugpull/`) - SHA256-based tool description change detection. CLI via `--monitor`, library via `WithStateDir()`.
@@ -82,11 +82,11 @@ All four implement the `Analyzer` interface (`internal/scanner/analyzer.go`): `N
 
 ## Rules System
 
-177 rules in `internal/rules/builtin/*.yaml` across 12 files. Each rule requires:
+189 rules in `internal/rules/builtin/*.yaml` across 14 files. Each rule requires:
 
 - `id`, `name`, `severity`, `category`, `patterns` (type: `regex` or `contains`)
 - `match_mode`: `any` (OR, default) or `all` (AND)
-- `remediation`: actionable fix guidance (all 177 rules have this)
+- `remediation`: actionable fix guidance (all 189 rules have this)
 - `examples.true_positive` and `examples.false_positive` - **self-tested automatically by `make test`**
 - Optional: `targets` (file globs), `exclude_patterns` (context-based suppression)
 
@@ -143,12 +143,12 @@ When completing a product task (fixing a bug, adding a feature, releasing a vers
 ### Data consistency rule
 
 When any of these values change, update ALL references across the vault:
-- Rule count (currently 177)
-- Test count (currently 550)
+- Rule count (currently 189)
+- Test count (currently ~630)
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)
 - Watch skill count (currently 28,000+)
-- Version number (currently v0.10.0)
+- Version number (currently v0.14.0)
 
 Use `Grep` to find all occurrences before updating.
 


### PR DESCRIPTION
## Summary

Release PR for **v0.14.0**. Bundles five merged PRs (#45–#49) plus two preexisting commits (#43, #44) that landed after the v0.13.0 tag, into a single tagged release.

This is **the first Aguara release with cryptographically signed artifacts**. Once tagged, every release archive and the container image will be Cosign-signed via GitHub OIDC, ship an SPDX SBOM, and be built with `-trimpath` for reproducibility.

## What's in v0.14.0

| PR | What it does |
|----|---------|
| #43 | fix: reject symlinked config files, clamp negative confidence |
| #44 | feat: pattern matcher 3.7-6.4x speedup, WASM completion, FP reduction infra |
| #45 | ci: cache Go modules, concurrency groups, timeouts, slim Docker (-5MB) |
| #46 | fix(action): authenticate GitHub API + isolate fail-on test fixture |
| #47 | feat(pattern): base32 + octal-escape decoders (6 → 8 encodings) |
| #48 | fix(install): mandatory checksum + bounded download with retry |
| #49 | feat(release): cosign keyless + SPDX SBOM + trimpath |

## Files in this PR

- `CHANGELOG.md` — full v0.14.0 entry covering all of the above, with copy-paste `cosign verify-blob` and `cosign verify` commands.
- `CLAUDE.md` — updates the project metadata block:
  - Version `v0.10.0` → `v0.14.0`
  - Rule count `177` → `189`
  - Test count `550` → `~630`
  - Decoders `6` → `8` (adds base32, C-style octal escapes)
  - Distribution section reflects signed releases, SBOM, `-trimpath`

## Breaking change to call out

`install.sh` no longer silently skips checksum verification when `sha256sum`/`shasum` is missing — it aborts with a remediation message instead. Anyone on a minimal image without those tools now needs `coreutils` (Linux) or `perl-Digest-SHA`. This was the security bug #48 fixed; documented in the v0.14.0 changelog under "Changed".

## Known gap (not blocking)

CHANGELOG entries for `v0.11.0`, `v0.11.1`, `v0.12.0`, `v0.12.1`, `v0.13.0` were never written at the time of those releases. The git history records what each one contained. Reconstructing those entries is tracked separately so this release does not block on it. Called out explicitly under "Known gap" in the v0.14.0 entry so future readers see it.

## Release sequence after this PR merges

1. `git tag v0.14.0 && git push origin v0.14.0` — triggers `release.yml` (GoReleaser + Cosign signing + SBOM) and `docker.yml` (image push + sign at digest + SBOM + provenance).
2. Verify the published assets:
   - `checksums.txt.bundle` exists alongside `checksums.txt`
   - `<archive>.sbom.json` exists for each archive
   - `cosign verify-blob ...` succeeds on the published bundle
   - `cosign verify ghcr.io/garagon/aguara:0.14.0 ...` succeeds
   - `cosign download attestation` returns SBOM and SLSA provenance for the image
3. Validate Homebrew formula installs cleanly via `brew upgrade garagon/tap/aguara`.
4. Bump consumer projects (`aguara-mcp`, `oktsec`) to `v0.14.0` and add the `cosign verify` step to their pipelines.

## Test plan

- [ ] CI green
- [ ] After merge: tag, watch GoReleaser + Docker workflows finish
- [ ] After release: cosign verification commands succeed from a clean machine
