### PR TITLE
fix(docker): use buildx driver so SBOM + provenance attestations work

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,6 +23,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # setup-buildx switches the build to the docker-container driver,
+      # which is required for SBOM and SLSA provenance attestations.
+      # The default docker driver does not support attestations and would
+      # fail the build with "Attestation is not supported for the docker driver".
+      - uses: docker/setup-buildx-action@v3
+
       - uses: docker/login-action@v3
         with:
           registry: ghcr.io


### PR DESCRIPTION
## Summary

Fixes a bug in #49's Docker workflow that was caught by the `v0.14.0-rc1` validation tag. Without this fix, every signed release would push an unattested image.

## What broke

`v0.14.0-rc1` was tagged to validate the new release pipeline before committing to `v0.14.0` final. `release.yml` succeeded — `checksums.txt.bundle` and SPDX SBOMs per archive were produced and signed via Cosign keyless. But `docker.yml` failed at `docker/build-push-action@v6` with:

```
ERROR: failed to build: Attestation is not supported for the docker driver.
buildx failed with: Learn more at https://docs.docker.com/go/attestations/
```

PR #49 added `sbom: true` and `provenance: mode=max` to the build step, but those features require the **docker-container** driver from BuildKit, not the default **docker** driver. The `Sign image` step also got skipped because it depends on the build/push completing.

## Fix

Add `docker/setup-buildx-action@v3` before the build step. That switches the runner to the docker-container driver and unlocks SBOM + provenance attestations. Single new step, no other changes.

## Validation plan

- [ ] CI green (this PR doesn't trigger docker.yml itself — that runs only on tags)
- [ ] After merge: tag `v0.14.0-rc2`, watch both `release.yml` and `docker.yml` succeed
- [ ] Verify on the rc2 image: `cosign verify ghcr.io/garagon/aguara:0.14.0-rc2 ...` and `cosign download attestation ghcr.io/garagon/aguara:0.14.0-rc2 | jq -r '.payload' | base64 -d | jq .` returns SBOM and provenance
- [ ] If rc2 is clean: tag `v0.14.0` final
