### PR TITLE
docs(readme): use docker buildx imagetools to read image SBOM + provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,14 +129,20 @@ cosign verify ghcr.io/garagon/aguara:${VERSION#v} \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 ```
 
-**Inspect the SBOM**:
+**Inspect the SBOM and provenance**:
 
 ```bash
-# Release archive SBOM (SPDX)
+# Release archive SBOM (SPDX 2.3)
 curl -fsSL https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}.sbom.json | jq .
 
-# Container image SBOM attestation
-cosign download attestation ghcr.io/garagon/aguara:${VERSION#v} | jq -r '.payload' | base64 -d | jq .
+# Container image SBOM and SLSA build provenance.
+# docker/build-push-action publishes these as BuildKit attestation manifests
+# (in-toto / SLSA spec) attached to the OCI image index, not as cosign
+# attestations. Use `docker buildx imagetools inspect` to read them:
+docker buildx imagetools inspect ghcr.io/garagon/aguara:${VERSION#v} \
+  --format '{{ json .SBOM }}' | jq .
+docker buildx imagetools inspect ghcr.io/garagon/aguara:${VERSION#v} \
+  --format '{{ json .Provenance }}' | jq .
 ```
 
 `install.sh` performs SHA256 verification automatically and aborts if `sha256sum`/`shasum` is unavailable, so the curl-pipe install path is never silently downgraded.


### PR DESCRIPTION
## Summary

Fixes a documentation bug in #49 caught during the `v0.14.0-rc1`/`rc2` validation cycle. The README told consumers to inspect the container image's SBOM/provenance with `cosign download attestation`, but that command returns `Error: found no attestations`.

## What was wrong

`docker/build-push-action` with `sbom: true` and `provenance: mode=max` publishes attestations as **BuildKit attestation manifests** (in-toto / SLSA spec) attached to the OCI image index, not as cosign-format attestations. Different accessor.

The cosign signature on the image **digest** is unaffected — `cosign verify ghcr.io/garagon/aguara:VERSION ...` still works as documented in the README.

## Fix

Replace the `cosign download attestation` snippet with the correct `docker buildx imagetools inspect` invocations.

## Validation on `v0.14.0-rc2`

```
$ docker buildx imagetools inspect ghcr.io/garagon/aguara:0.14.0-rc2 --format '{{json .SBOM}}' | jq -r '.SPDX.SPDXID, .SPDX.spdxVersion'
SPDXRef-DOCUMENT
SPDX-2.3

$ docker buildx imagetools inspect ghcr.io/garagon/aguara:0.14.0-rc2 --format '{{json .SBOM}}' | jq -r '"files: \(.SPDX.files | length)", "packages: \(.SPDX.packages | length)"'
files: 83
packages: 24

$ docker buildx imagetools inspect ghcr.io/garagon/aguara:0.14.0-rc2 --format '{{json .Provenance}}' | jq -r '.SLSA.buildDefinition.buildType'
https://github.com/moby/buildkit/blob/master/docs/attestations/slsa-definitions.md
```

## Test plan

- [ ] CI green
- [ ] After merge: tag `v0.14.0` final
