### PR TITLE
fix(docker): strip v prefix from injected version (v0.14.2)

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -61,11 +61,15 @@ jobs:
           # Multi-arch image: native amd64 + arm64 (Apple Silicon, Linux ARM,
           # AWS Graviton, GitHub ARM runners) without forcing --platform.
           platforms: linux/amd64,linux/arm64
-          # Inject the release tag and commit into the binary so
+          # Inject the release version and commit into the binary so
           # `aguara version` inside the container reports the actual version
           # instead of the Dockerfile defaults (dev / none).
+          # steps.meta.outputs.version is the semver-stripped form (0.14.2),
+          # matching what GoReleaser injects into the tar.gz binaries via
+          # {{.Version}}. Using github.ref_name here would inject "v0.14.2"
+          # with the leading v and break consumers that compare versions.
           build-args: |
-            VERSION=${{ github.ref_name }}
+            VERSION=${{ steps.meta.outputs.version }}
             COMMIT=${{ github.sha }}
           # SBOM (SPDX) and SLSA build provenance attestations are attached
           # to the OCI image index. Read with `docker buildx imagetools inspect`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,19 @@
 All notable changes to Aguara are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.14.2] — 2026-04-18
+
+Patch fix caught by the new `verify-release.sh` acceptance script when running it against the freshly-published `v0.14.1`. No engine, library, or rule changes.
+
+### Fixed
+
+- **Docker image reported `aguara v0.14.1`** (with the leading `v`) while the tar.gz binaries reported `aguara 0.14.1` (without). The asymmetry came from `docker.yml` passing `VERSION=${{ github.ref_name }}` (raw tag name `v0.14.1`) while `.goreleaser.yml` uses `{{.Version}}` (which strips the prefix). Anything parsing `aguara version` output as semver would see two different strings depending on whether it ran the binary or the container.
+- Fix: `docker.yml` now passes `VERSION=${{ steps.meta.outputs.version }}`, the same `0.14.2` form `docker/metadata-action` already uses for the image tags.
+
+### Process win
+
+Caught **before** announcing the release. `verify-release.sh` check 6 (extracted binary version vs. expected) failed on `v0.14.1`, the release went on hold, this patch shipped, and the script will rerun on `v0.14.2` from arm64 before this version is treated as final.
+
 ## [0.14.1] — 2026-04-18
 
 Patch release fixing two preexisting Docker distribution bugs that were exposed only after pulling and running the published `v0.14.0` image. No engine, library, or rule changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.14.1 (2026-04-18). 189 rules, 13 categories, 4 analysis layers, ~630 tests, 0 lint issues.
+Aguara v0.14.2 (2026-04-18). 189 rules, 13 categories, 4 analysis layers, ~630 tests, 0 lint issues.
 
 Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
@@ -148,7 +148,7 @@ When any of these values change, update ALL references across the vault:
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)
 - Watch skill count (currently 28,000+)
-- Version number (currently v0.14.1)
+- Version number (currently v0.14.2)
 
 Use `Grep` to find all occurrences before updating.
 


### PR DESCRIPTION
## Summary

Patch release `v0.14.2`. One-line fix to `docker.yml` for a version-string inconsistency that the new acceptance script caught **before announcing v0.14.1 to anyone**.

**No engine, library, or rule changes.** Pure release-pipeline fix.

## What broke and how we found it

`v0.14.1` was tagged. Both workflows succeeded. Then `VERSION=v0.14.1 .github/scripts/verify-release.sh` ran from arm64 and failed:

```
>> 6/6 Docker image runs natively on host arch and reports the right version
FAIL: docker image reports version 'v0.14.1', expected '0.14.1'
```

The same release reported two different version strings:

- tar.gz binary: `aguara 0.14.1` (no leading `v`)
- Docker image: `aguara v0.14.1` (with leading `v`)

Cause: `docker.yml` had `VERSION=${{ github.ref_name }}` (raw `v0.14.1`) while `.goreleaser.yml` uses `{{.Version}}` (which strips the prefix). Anything parsing `aguara version` for semver comparison would break depending on which artifact the consumer ran.

## Fix

```diff
build-args: |
-  VERSION=${{ github.ref_name }}
+  VERSION=${{ steps.meta.outputs.version }}
   COMMIT=${{ github.sha }}
```

`docker/metadata-action` already exposes `outputs.version` — the same semver-stripped value it derives from `type=semver,pattern={{version}}` for the image tags. Reusing it keeps the binary's reported version consistent with the tag name everyone references.

## Process win

This is exactly the bug class the acceptance script was designed to catch. Without it, `v0.14.1` would have shipped to `oktsec` and any other downstream with the inconsistency. With it, the release went on hold, the patch shipped, and the same script will rerun on `v0.14.2` from arm64 before this version is treated as final.

## Test plan

- [ ] CI green
- [ ] After merge: tag `v0.14.2`
- [ ] Both `release.yml` and `docker.yml` succeed (multi-arch already validated by v0.14.1)
- [ ] **`VERSION=v0.14.2 .github/scripts/verify-release.sh` exits 0 from arm64 with all 6 checks passing**
- [ ] Only after the script passes, treat the release as final
