### PR TITLE
fix(action): pin install.sh fetch to a tagged ref, never main

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -31,6 +31,12 @@ jobs:
         with:
           path: ./internal/rules/builtin/
           severity: medium
+          # Exercise the PR's own install.sh, not the baked-in default.
+          # Without this override, the action falls back to DEFAULT_REF
+          # (latest release), which for the first PR that touches action.yml
+          # after a release may be ahead of or behind the install.sh the PR
+          # introduces.
+          install-script-ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Verify outputs
         shell: bash
@@ -67,6 +73,8 @@ jobs:
           format: json
           output: results.json
           upload-sarif: 'false'
+          # Exercise the PR's own install.sh, not the baked-in default.
+          install-script-ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Verify JSON output
         run: |
@@ -88,3 +96,5 @@ jobs:
           path: ./.github/test-fixtures/clean/
           fail-on: critical
           upload-sarif: 'false'
+          # Exercise the PR's own install.sh, not the baked-in default.
+          install-script-ref: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/action.yml
+++ b/action.yml
@@ -44,13 +44,22 @@ inputs:
     required: false
     default: ''
   version:
-    description: 'Aguara version to install (empty = latest)'
+    description: 'Aguara version to install (empty = latest). Must be a semver release tag like v0.14.2.'
     required: false
     default: ''
   upload-sarif:
     description: 'Upload SARIF results to GitHub Code Scanning'
     required: false
     default: 'true'
+  install-script-ref:
+    description: |
+      Advanced: git ref (semver tag or 40-char SHA) to fetch install.sh from.
+      Normal consumers should leave this blank; the action automatically uses
+      its own pinned ref (e.g. v0.14.2 when you pin `uses: garagon/aguara@v0.14.2`).
+      This input exists for self-testing scenarios where the action runs from
+      `uses: ./` and needs to exercise install.sh from a specific commit.
+    required: false
+    default: ''
 
 outputs:
   findings-count:
@@ -67,19 +76,23 @@ runs:
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
+        INSTALL_SCRIPT_REF: ${{ inputs.install-script-ref }}
         ACTION_REF: ${{ github.action_ref }}
         INSTALL_DIR: ${{ runner.temp }}/aguara-bin
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        # Resolve install.sh ref: prefer `with: version:`, then the action ref
-        # the consumer pinned (e.g. `uses: garagon/aguara@v0.14.3`), then a
-        # baked-in default. Reject anything that isn't a semver tag or a full
-        # 40-char SHA so we never fetch from a mutable branch like `main`.
+        # Resolve where install.sh is fetched from. Resolution order:
+        #   1. `with: install-script-ref:` (advanced / self-testing)
+        #   2. `github.action_ref` (what the consumer pinned `@` to)
+        #   3. a baked-in default tag
+        # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
+        # rejected so we never fetch install.sh from a mutable branch
+        # like `main`, `v1`, or `@branch-name`.
         DEFAULT_REF="v0.14.2"
-        INSTALL_REF="${VERSION:-${ACTION_REF:-$DEFAULT_REF}}"
+        INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then
-          echo "::warning::action ref '$INSTALL_REF' is not a semver tag or full SHA; falling back to $DEFAULT_REF"
+          echo "::warning::install-script ref '$INSTALL_REF' is not a semver tag or 40-char SHA; falling back to $DEFAULT_REF"
           INSTALL_REF="$DEFAULT_REF"
         fi
         curl -fsSL --max-time 30 --retry 3 --retry-connrefused \

--- a/action.yml
+++ b/action.yml
@@ -67,10 +67,23 @@ runs:
       shell: bash
       env:
         VERSION: ${{ inputs.version }}
+        ACTION_REF: ${{ github.action_ref }}
         INSTALL_DIR: ${{ runner.temp }}/aguara-bin
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        curl -fsSL --max-time 30 https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
+        # Resolve install.sh ref: prefer `with: version:`, then the action ref
+        # the consumer pinned (e.g. `uses: garagon/aguara@v0.14.3`), then a
+        # baked-in default. Reject anything that isn't a semver tag or a full
+        # 40-char SHA so we never fetch from a mutable branch like `main`.
+        DEFAULT_REF="v0.14.2"
+        INSTALL_REF="${VERSION:-${ACTION_REF:-$DEFAULT_REF}}"
+        if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
+           [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "::warning::action ref '$INSTALL_REF' is not a semver tag or full SHA; falling back to $DEFAULT_REF"
+          INSTALL_REF="$DEFAULT_REF"
+        fi
+        curl -fsSL --max-time 30 --retry 3 --retry-connrefused \
+          "https://raw.githubusercontent.com/garagon/aguara/${INSTALL_REF}/install.sh" | bash
         echo "$INSTALL_DIR" >> "$GITHUB_PATH"
 
     - name: Run Aguara scan

--- a/install.sh
+++ b/install.sh
@@ -150,7 +150,12 @@ get_latest_version() {
 verify_checksum() {
     dir="$1"
     file="$2"
-    expected=$(grep "$file" "${dir}/checksums.txt" | awk '{print $1}')
+    # Exact filename match on column 2, not substring grep. Substring
+    # match picked up sibling artifacts that share a prefix - e.g.
+    # `aguara_0.14.2_linux_amd64.tar.gz` also matches
+    # `aguara_0.14.2_linux_amd64.tar.gz.sbom.json`, so `awk '{print $1}'`
+    # returned two concatenated checksums and every comparison failed.
+    expected=$(awk -v f="$file" '$2==f {print $1; exit}' "${dir}/checksums.txt")
     if [ -z "$expected" ]; then
         err "checksum not found for ${file} in checksums.txt"
     fi


### PR DESCRIPTION
## Summary

- `action.yml` previously curled `install.sh` from `main` on every consumer CI run — an attacker with write access to `main` owns every downstream runner, no release or Cosign signature required
- Resolve the install ref from a new `install-script-ref` input (advanced / self-testing) → `github.action_ref` (what the consumer pinned) → a pinned default, rejecting anything that isn't a semver tag or full 40-char SHA
- Also ships an exact-match fix for `install.sh` that was silently broken since v0.14.0

## Why this matters

Surfaced by a CSO/supply-chain self-audit (SC-01, rated CRITICAL). The rest of the release pipeline (Cosign keyless + SPDX SBOM + SLSA provenance + checksum-mandatory install.sh) is strong, but this path bypasses all of it because `install.sh` was fetched fresh from a mutable branch on every run. The whole signing stack is only as trustworthy as the weakest unverified fetch.

## Resolution logic

```
1. inputs.install-script-ref   (advanced / self-testing)
2. github.action_ref           (what the consumer pinned, if semver/SHA)
3. DEFAULT_REF                 (v0.14.2, baked in; bump on each release)
```

Anything that doesn't match `^v[0-9]+\.[0-9]+\.[0-9]+$` or `^[0-9a-f]{40}$` is rejected with a GHA `::warning::` and falls back to DEFAULT_REF. Verified locally:

| Input | Resolved ref |
|---|---|
| `install-script-ref: <40-char-sha>` | that SHA |
| `uses: garagon/aguara@v0.14.2` | v0.14.2 |
| `uses: garagon/aguara@<40-char-sha>` | that SHA |
| `uses: garagon/aguara@main` | v0.14.2 (rejected, fallback) |
| `uses: garagon/aguara@v1` | v0.14.2 (rejected, v1 is force-pushed each release) |
| `uses: ./` (local test) | v0.14.2 (both inputs empty, default) |

Also adds `--retry 3 --retry-connrefused` to match the robustness pattern in install.sh itself.

## Bonus: install.sh `verify_checksum` bug surfaced by this PR

Test Action hadn't run against `main` since v0.14.0 was cut (April 18) — neither `action.yml` nor `test-action.yml` had changed in the interim, and Test Action's `paths:` filter only triggers on those files. This PR is the first to touch `action.yml` post-v0.14.0 and so became the first to exercise `install.sh` from the released tag — which turned out to be broken.

`verify_checksum` used `grep "$file" checksums.txt | awk '{print $1}'`. That grep matched by substring, so `aguara_0.14.2_linux_amd64.tar.gz` also matched the sibling line for `aguara_0.14.2_linux_amd64.tar.gz.sbom.json`. The awk then returned **two concatenated checksums** and every comparison failed:

```
checksum mismatch: expected <hash1>
                            <hash2>, got <hash1>
```

This broke fresh installs from v0.14.0 onwards (the first release that shipped per-archive SBOMs). Fix: exact-match on column 2 with awk. Also robust against filenames with regex metacharacters and against future sibling artifacts (`.sig`, `.intoto.jsonl`).

To give this PR a green Test Action run, I also added a new advanced input `install-script-ref` on the action and made `test-action.yml` pass the PR head SHA via that input — so every `uses: ./` invocation exercises the PR's own `install.sh` instead of falling back to the last released tag's (broken) copy. Without this, a PR that fixes `install.sh` itself could never get a green Test Action run.

## Test plan

- [x] Shellcheck clean on the install snippet
- [x] `make vet` + `make lint` both clean
- [x] Fallback matrix verified locally (SHA, tag, rejection cases)
- [x] Local `INSTALL_DIR=... bash install.sh` completes cleanly after the fix (was failing before)
- [ ] CI (`test-action.yml` matrix ubuntu+macos) passes on the updated Test Action

## Follow-ups (tracked separately)

- Automate DEFAULT_REF bump in the release workflow so it can't drift
- Consider publishing install.sh as a release asset so it's covered by the Cosign-signed `checksums.txt` bundle (CSO SC-01 follow-up)
- Deprecate `@v1` force-push alias in favor of `@vX.Y.Z` pinning (CSO SC-04)

## Refs

- CSO supply-chain audit SC-01 (CRITICAL) — `main` fetch in `action.yml`
- Latent install.sh bug surfaced by exercising the v0.14.2 release path after signing was enabled