### PR TITLE
fix(update-check): normalize v-prefix + validate tag shape

### DIFF
--- a/internal/update/check.go
+++ b/internal/update/check.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"regexp"
+	"strings"
 	"time"
 )
 
@@ -14,9 +16,26 @@ type Result struct {
 	UpdateURL string // "go install github.com/garagon/aguara/cmd/aguara@latest"
 }
 
-// NeedsUpdate returns true if Latest differs from Current and Current is not "dev".
+// semverTag matches a well-formed release tag like v0.14.2 or v1.2.3.
+var semverTag = regexp.MustCompile(`^v\d+\.\d+\.\d+$`)
+
+// normalizeVersion strips a leading "v" so comparisons tolerate the
+// ldflags-stripped binary version ("0.14.2") against the GitHub tag
+// ("v0.14.2"). Inputs that aren't plain semver are returned unchanged
+// so caller-side equality still works for edge cases like "dev".
+func normalizeVersion(s string) string {
+	return strings.TrimPrefix(s, "v")
+}
+
+// NeedsUpdate returns true if Latest and Current refer to different
+// releases. Both are normalized to strip the leading "v" so the binary's
+// ldflag-injected version (without "v") compares cleanly against the
+// GitHub tag (with "v"). Dev builds never report an update.
 func (r *Result) NeedsUpdate() bool {
-	return r.Latest != r.Current && r.Current != "dev"
+	if r.Current == "dev" {
+		return false
+	}
+	return normalizeVersion(r.Latest) != normalizeVersion(r.Current)
 }
 
 // githubRelease is the minimal JSON shape we need from the GitHub API.
@@ -56,7 +75,11 @@ func checkLatestWithBase(baseURL, currentVersion, repo string) *Result {
 		return nil
 	}
 
-	if release.TagName == "" {
+	// Validate the returned tag shape. The GitHub response is authenticated
+	// by TLS, but defense-in-depth: only accept well-formed semver tags so a
+	// typo-squatted or hijacked release can't surface arbitrary text in the
+	// user's terminal via the update notice.
+	if !semverTag.MatchString(release.TagName) {
 		return nil
 	}
 

--- a/internal/update/check_test.go
+++ b/internal/update/check_test.go
@@ -1,6 +1,7 @@
 package update
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -95,17 +96,62 @@ func TestCheckLatest_Non200(t *testing.T) {
 
 func TestNeedsUpdate(t *testing.T) {
 	tests := []struct {
-		name    string
-		result  Result
-		want    bool
+		name   string
+		result Result
+		want   bool
 	}{
 		{"different versions", Result{Latest: "v0.4.0", Current: "v0.3.0"}, true},
 		{"same version", Result{Latest: "v0.3.0", Current: "v0.3.0"}, false},
 		{"dev version", Result{Latest: "v0.4.0", Current: "dev"}, false},
+		// The binary's ldflag version comes in without the "v" prefix
+		// ("0.14.2") while GitHub returns the tag ("v0.14.2"). Before
+		// normalization these compared unequal and NeedsUpdate returned
+		// true for every binary on every invocation.
+		{"v-prefix mismatch same version", Result{Latest: "v0.14.2", Current: "0.14.2"}, false},
+		{"v-prefix mismatch different version", Result{Latest: "v0.14.3", Current: "0.14.2"}, true},
+		{"both without v, same", Result{Latest: "0.14.2", Current: "0.14.2"}, false},
+		{"both with v, same", Result{Latest: "v0.14.2", Current: "v0.14.2"}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.want, tt.result.NeedsUpdate())
 		})
 	}
+}
+
+// TestCheckLatest_RejectsBadTagShape verifies that the update check
+// refuses tag_name values that aren't well-formed semver. A hijacked or
+// typosquatted release page can't surface arbitrary text in the user's
+// terminal via the update notice this way.
+func TestCheckLatest_RejectsBadTagShape(t *testing.T) {
+	badTags := []string{
+		"main",                               // branch-like
+		"latest",                             // floating alias
+		"v1",                                 // major-only, force-pushed
+		"v0.14",                              // missing patch
+		"0.14.2",                             // missing v prefix
+		"v0.14.2-rc1",                        // prerelease suffix not accepted
+		"v0.14.2+build",                      // build metadata not accepted
+		"<script>alert(1)</script>",          // hostile
+		"v0.14.2; rm -rf /",                  // command injection
+		"go install github.com/evil/pkg@v1",  // typosquat via tag text
+	}
+	for _, tag := range badTags {
+		t.Run("reject_"+tag, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"tag_name": ` + toJSONString(tag) + `}`))
+			}))
+			defer srv.Close()
+
+			r := checkLatestWithBase(srv.URL, "v0.14.2", "garagon/aguara")
+			assert.Nil(t, r, "should reject tag %q", tag)
+		})
+	}
+}
+
+// toJSONString is a minimal JSON string encoder for test fixtures.
+func toJSONString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
 }


### PR DESCRIPTION
## Summary

Two bugs in `internal/update/check.go` surfaced by the post-release Docker validation and the CSO self-audit.

## 1. `NeedsUpdate` always returned true

The binary's ldflag-injected version comes in without the leading `v` (`0.14.2`), while the GitHub Releases API returns the tag with it (`v0.14.2`). The old implementation compared them as raw strings:

```go
return r.Latest != r.Current && r.Current != "dev"
```

So every `aguara version` / `aguara scan` printed an "Update available" notice pointing to the version you were already running:

```
$ aguara version
aguara 0.14.2 (commit: 2d34f38...)
Update available: v0.14.2 → go install github.com/garagon/aguara/cmd/aguara@latest
```

**Fix**: trim the leading `v` from both sides before comparing. `NeedsUpdate` now returns false when only the prefix differs.

## 2. `tag_name` surfaced to stderr without shape validation

CSO audit SC-10: the GitHub response's `tag_name` is json-decoded and printed to the user's terminal verbatim. TLS authenticates the response, but defense in depth — a hijacked release page should not be able to surface arbitrary text (XSS-style, typosquatted "go install" URLs, command injection attempts) in the user's terminal.

**Fix**: only accept `tag_name` values matching `^v\d+\.\d+\.\d+$`. Anything else (`main`, `v1`, `latest`, prereleases, build metadata, hostile payloads) is rejected and `CheckLatest` returns nil.

## Test plan

- [x] 4 new `TestNeedsUpdate` cases covering v-prefix mismatch, both-with-v, both-without-v
- [x] `TestCheckLatest_RejectsBadTagShape` with 10 adversarial inputs: `main`, `latest`, `v1`, `v0.14`, `0.14.2`, `v0.14.2-rc1`, `v0.14.2+build`, `<script>alert(1)</script>`, `v0.14.2; rm -rf /`, `go install github.com/evil/pkg@v1`
- [x] `make test` green across all packages
- [x] Empirical: built with `Version=0.14.2` → no update notice. Built with `Version=0.13.0` → update notice correctly shown.

## Refs

- Post-release Docker validation session (same-version false-positive confirmed against the published v0.14.2 image)
- CSO supply-chain audit SC-10