### PR TITLE
fix(docker): run as non-root and pin base image digests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM golang:1.25-alpine AS builder
+# Base images pinned by multi-arch index digest for reproducible builds.
+# Bump digests together with the tag when upgrading (e.g. alpine 3.22).
+FROM golang:1.25-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f AS builder
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -15,7 +17,12 @@ RUN CGO_ENABLED=0 go build -trimpath \
       -X github.com/garagon/aguara/cmd/aguara/commands.Commit=${COMMIT}" \
     -o /aguara ./cmd/aguara
 
-FROM alpine:3.21
+FROM alpine:3.21@sha256:48b0309ca019d89d40f670aa1bc06e426dc0931948452e8491e3d65087abc07d
 COPY --from=builder /aguara /usr/local/bin/aguara
+
+# Run as non-root to limit blast radius on container escape or arbitrary file write bugs.
+RUN adduser -D -u 10001 aguara
+USER aguara
+
 ENTRYPOINT ["aguara"]
 CMD ["scan", "."]


### PR DESCRIPTION
## Summary

- Run the container as dedicated user `aguara` (UID 10001) instead of root. `/usr/local/bin/aguara` and `/` become non-writable; `/tmp` and mounted volumes behave as before.
- Pin `golang:1.25-alpine` and `alpine:3.21` to their current multi-arch index digests for reproducible builds across `linux/amd64` + `linux/arm64`.

## Why

Auditing the published v0.14.3 image surfaced three issues:
1. Container ran as `uid=0(root)` with no `USER` directive.
2. Base images used floating tags, so two rebuilds of the same commit could produce different layers.
3. (Deferred) `wget` and `nc` ship as BusyBox applets in the base rootfs, removing them needs distroless - out of scope here.

## Test plan

- [x] `docker build` succeeds locally with the new digests.
- [x] `docker run aguara:local-test version` reports the ldflag-injected version + commit.
- [x] `id` inside the container returns `uid=10001(aguara) gid=10001(aguara)`.
- [x] `list-rules` returns 189 rules.
- [x] Scan on a malicious fixture set yields the same 10 findings (5C / 2H / 3L) as v0.14.3.
- [x] Scan on benign fixtures yields 0 findings.
- [x] `--format json`, `sarif`, `markdown` all produce valid output.
- [x] `--fail-on high` exits 1 on findings, 0 without. `--ci` matches.
- [x] Writing to `/usr/local/bin/aguara` and `/` returns `Permission denied`; `/tmp` stays writable.
- [x] Large file (2.3 MB, ~150k lines) scans correctly and flags the buried `curl | bash` line.
- [x] CI compatibility: `.github/workflows/docker.yml` passes `VERSION`/`COMMIT` as `--build-arg` to the builder stage, which the new Dockerfile still accepts unchanged.

## Follow-ups (not in this PR)

- `.github/dependabot.yml` so the docker ecosystem auto-proposes digest bumps.
- Distroless final stage to drop `wget`/`nc`/`sh` from the image.
- Sign the BuildKit-produced SBOM and SLSA provenance attestations with Cosign so `cosign verify-attestation` succeeds (currently returns `no matching attestations`).

## Breaking change note for Linux users

On macOS Docker Desktop the non-root switch is transparent. On Linux, if `-o` writes to a host-mounted directory, that directory must be writable by UID 10001. Either `chown` the mount on the host or pass `--user $(id -u):$(id -g)` to match the host UID.