### PR TITLE
fix(pattern): use overlapping AC iteration in keyword prefilter

### DIFF
--- a/internal/engine/pattern/prefilter.go
+++ b/internal/engine/pattern/prefilter.go
@@ -21,6 +21,12 @@ const minKeywordLen = 4
 //
 // Keywords are deduplicated: if multiple rules share the same keyword (e.g.
 // "ignore"), a single AC pattern maps to all of those rule IDs.
+//
+// Overlapping matches are required at query time: when one rule extracts
+// "bash" as a keyword and another extracts "bashrc", content "bashrc" must
+// route to rules keyed by both literals. Non-overlapping iteration would
+// report only one of them and silently drop the other rule set from the
+// candidate map.
 type prefilter struct {
 	ac             *ahocorasick.AhoCorasick
 	refs           [][]string      // AC pattern index -> list of rule IDs
@@ -96,7 +102,12 @@ func (p *prefilter) candidateRules(lowerContent string) map[string]bool {
 		candidates[id] = true
 	}
 	if p.ac != nil {
-		for _, m := range p.ac.FindAll(lowerContent) {
+		// IterOverlapping reports every keyword that matches at every position.
+		// FindAll would collapse overlapping hits (e.g. "bash" and "bashrc"
+		// starting at the same offset) and drop rules keyed only by the longer
+		// literal, silently hiding true positives.
+		iter := p.ac.IterOverlapping(lowerContent)
+		for m := iter.Next(); m != nil; m = iter.Next() {
 			for _, id := range p.refs[m.Pattern()] {
 				candidates[id] = true
 			}

--- a/internal/engine/pattern/prefilter_test.go
+++ b/internal/engine/pattern/prefilter_test.go
@@ -1,8 +1,10 @@
 package pattern
 
 import (
+	"regexp"
 	"testing"
 
+	"github.com/garagon/aguara/internal/rules"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,6 +92,50 @@ func TestExtractKeywords(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+// TestPrefilterOverlappingKeywords is a regression test for a bug where the
+// AC prefilter used FindAll (non-overlapping) and therefore silently dropped
+// rule candidates when a shorter keyword was a prefix of a longer keyword
+// at the same content position.
+//
+// Concrete case: "bash" and "bashrc" are both extracted as keywords, from
+// different rules. When content contains "bashrc", "bash" matches first and
+// FindAll suppresses the overlapping "bashrc" match, dropping every rule
+// that was keyed only on "bashrc". EXTDL_005 was the observed victim.
+//
+// See: bashrc false-negative bug reported April 2026.
+func TestPrefilterOverlappingKeywords(t *testing.T) {
+	shortRule := &rules.CompiledRule{
+		ID:        "SHORT",
+		MatchMode: rules.MatchAny,
+		Patterns: []rules.CompiledPattern{
+			{Type: rules.PatternRegex, Value: "(?i)bash\\b", Regex: regexp.MustCompile(`(?i)bash\b`)},
+		},
+	}
+	longRule := &rules.CompiledRule{
+		ID:        "LONG",
+		MatchMode: rules.MatchAny,
+		Patterns: []rules.CompiledPattern{
+			{Type: rules.PatternRegex, Value: "(?i)bashrc\\b", Regex: regexp.MustCompile(`(?i)bashrc\b`)},
+		},
+	}
+
+	pf := buildPrefilter([]*rules.CompiledRule{shortRule, longRule})
+
+	// Content containing only the longer literal must route to BOTH rules.
+	// "bashrc" contains "bash" as a prefix substring, so a rule keyed on
+	// "bash" is a legitimate candidate; the prefilter is a superset check,
+	// the regex layer does the final filtering.
+	got := pf.candidateRules("edit ~/.bashrc to persist")
+	require.True(t, got["LONG"], "rule keyed on 'bashrc' must be a candidate when content has 'bashrc'")
+	require.True(t, got["SHORT"], "rule keyed on 'bash' must be a candidate when content has 'bashrc' (bash is substring)")
+
+	// Content with only the shorter literal must still route to SHORT.
+	// LONG is correctly skipped because "bashrc" is not present.
+	got = pf.candidateRules("run bash command")
+	require.True(t, got["SHORT"], "rule keyed on 'bash' must be a candidate when content has 'bash'")
+	require.False(t, got["LONG"], "rule keyed on 'bashrc' must NOT be a candidate when content has only 'bash'")
 }
 
 func TestStripFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

The Aho-Corasick keyword prefilter introduced in v0.14.0 (commit 191f51b) used `FindAll` for candidate lookup. `FindAll` returns non-overlapping matches, so when a shorter keyword is a prefix of a longer keyword at the same offset, only the shorter one is emitted. Every rule keyed on the longer literal is silently dropped from the candidate set, and the regex layer never gets to evaluate them.

The fix switches `candidateRules` to `IterOverlapping`, which reports every keyword match at every position. `StandardMatch` is already configured, which is what the library requires for overlapping iteration.

## Bug reproduction

```go
scanner, _ := aguara.NewScanner()
r, _ := scanner.ScanContent(ctx, `"postinstall": "cat payload >> ~/.bashrc"`, "message.md")
// Pre-fix:  len(r.Findings) == 0  (WRONG - regex matches in isolation)
// Post-fix: len(r.Findings) == 1  (EXTDL_005 routed and matched)
```

The `zshrc` variant of the same content was detected correctly because `zshrc` has no short-prefix keyword collision. `bashrc` collided with `bash` (4 chars, used in many other rules) and lost the FindAll race.

## Reporter credit

Surfaced by oktsec integration while triaging a custom rule MEM-006 (npm/pip lifecycle hook + filesystem write). The oktsec side already deployed a workaround (use `echo` instead of `cat`, since `echo` is long enough to trigger the prefilter directly) but the bug affects built-in rules and every custom rule using short-prefix literals, so fixing the engine here is the correct path.

## Impact validated on testdata/malicious (19 files)

| | Findings | Delta |
|---|---:|---|
| Pre-fix (v0.14.3) | 98 | baseline |
| Post-fix | 102 | +4 |

Zero lost findings. The four recovered are legitimate TPs the prefilter had been hiding:

- `CRED_007` in `combined-attack/install.sh:4` - `password="hardcoded_secret_pass123"`
- `CRED_007` in `credential-leak/helper.py:6` - `password = "SuperSecret123!@#"`
- `SSRF_002` in `ssrf-metadata/helper.sh:5` - `curl http://10.0.0.1:8080/admin`
- `SSRF_002` in `ssrf-metadata/helper.sh:14` - `curl http://192.168.1.100:9090/metrics`

## Affected built-in rules

Any rule with a regex keyword that is a longer extension of a frequently-used short keyword. Confirmed impact:
- `EXTDL_005` - `bashrc`, `bash_profile` variants silently undetected when `cat` was the verb
- `SC-EX-007` - same collision
- `CRED_007`, `SSRF_002` - see above

Likely affected: any rule where a keyword is prefixed by `bash`, `curl`, `http`, `post`, `user`, etc. (all common short literals used in many rules).

## Performance

| Bench | Pre-fix | Post-fix | Delta |
|---|---:|---:|---|
| BenchmarkMatcher (isolated) | 202M ns/op | 261M ns/op | +29% |
| BenchmarkScannerE2E | 29.1M ns/op | 28.3M ns/op | noise |
| BenchmarkMatcherNoAC (reference) | 777M ns/op | 777M ns/op | - |

The pattern-matcher micro-bench shows a regression in isolation (overlapping iteration does strictly more work), but regex execution dominates real scans so it doesn't surface end to end. Still ~3x faster than the no-AC path.

## Regression test

`TestPrefilterOverlappingKeywords` locks both directions:
- Content with the longer literal routes BOTH rules (the short one's rules AND the long one's rules are candidates).
- Content with only the shorter literal routes only the short rule (the long literal's rule does not become a candidate).

## Test plan

- [x] `go test -race -count=1 ./...` green across all packages.
- [x] `make vet && make lint` clean (0 issues).
- [x] `testdata/malicious` yields 102 findings (previously 98, delta is 4 recovered TPs listed above).
- [x] `testdata/benign` yields 0 findings (no new FPs).
- [x] New regression test `TestPrefilterOverlappingKeywords` passes.
- [x] Manual reproduction case: `cat payload >> ~/.bashrc` now detected by `EXTDL_005`.

## Follow-ups (not in this PR)

- Update the `testdata/malicious = 98 findings` acceptance gate referenced in session notes to `102` (or parameterize as `>=98`).
- Consider whether the micro-bench regression warrants a build-time merge optimization (propagate short-keyword rules to their long-keyword extensions so FindAll can be used again). Not urgent given E2E bench is unchanged.