### PR TITLE
docs: refresh CLAUDE.md and README for v0.14.4

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,13 +4,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.14.2 (2026-04-18). 189 rules, 13 categories, 4 analysis layers, ~630 tests, 0 lint issues.
+Aguara v0.14.4 (2026-04-24). 189 rules, 13 categories, 4 analysis layers, ~630 tests, 0 lint issues.
 
-Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
+Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, multi-arch `linux/amd64+arm64`, runs as non-root UID 10001, base images digest-pinned, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
 GitHub: 48 stars, 6 forks. 0 open PRs, 0 open issues. 7 awesome-list PRs pending review in external repos. 7 forks on garagon account (pending cleanup after awesome-list PRs resolve).
 
-Pending improvements: pattern matcher performance (~770ms/file), WASM build (cmd/wasm/ incomplete), adoption/marketing.
+Pattern matcher already uses an Aho-Corasick keyword prefilter (active in production since v0.14.0). Real perf is ~210ms/op on the synthetic bench (was ~770ms without AC), so do not treat "pattern matcher perf" as an open backlog item unless pprof shows a concrete regression. Pending improvements: WASM build (cmd/wasm/ incomplete), adoption/marketing.
 
 Internal docs (gitignored) in `DOCS/` as an Obsidian vault. See `DOCS/Aguara/CONVENTIONS.md` for vault rules and `DOCS/Aguara/00 Dashboard.md` for the entry point.
 
@@ -68,7 +68,7 @@ All four implement the `Analyzer` interface (`internal/scanner/analyzer.go`): `N
 ### Key Package Relationships
 
 - `internal/types/` - Lowest layer. `Finding`, `Severity`, `ScanResult`. No internal imports. **`Severity` is `type int`, serializes as a number in JSON (0=INFO, 1=LOW, 2=MEDIUM, 3=HIGH, 4=CRITICAL), NOT a string.**
-- `internal/rules/` - YAML to CompiledRule. `builtin/` embeds 12 YAML files via `go:embed`.
+- `internal/rules/` - YAML to CompiledRule. `builtin/` embeds 13 YAML files via `go:embed`.
 - `internal/scanner/` - Orchestrator. Discovers files, spawns workers, runs analyzers, applies inline ignore filtering, aggregates results. Imports `meta/` for post-processing.
 - `internal/meta/` - Dedup, scoring, correlation. Imports `types/` only (NOT `scanner/` - this prevents import cycles).
 - `internal/output/` - Formatters (terminal, JSON, SARIF, markdown) implementing `Formatter` interface. Markdown header is `## Aguara Security Scan`, not `# Aguara Scan Report`.
@@ -82,7 +82,7 @@ All four implement the `Analyzer` interface (`internal/scanner/analyzer.go`): `N
 
 ## Rules System
 
-189 rules in `internal/rules/builtin/*.yaml` across 14 files. Each rule requires:
+189 rules in `internal/rules/builtin/*.yaml` across 13 files. Each rule requires:
 
 - `id`, `name`, `severity`, `category`, `patterns` (type: `regex` or `contains`)
 - `match_mode`: `any` (OR, default) or `all` (AND)
@@ -148,7 +148,7 @@ When any of these values change, update ALL references across the vault:
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)
 - Watch skill count (currently 28,000+)
-- Version number (currently v0.14.2)
+- Version number (currently v0.14.4)
 
 Use `Grep` to find all occurrences before updating.
 

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | ba
 Installs the latest binary to `~/.local/bin`. Customize with environment variables:
 
 ```bash
-VERSION=v0.12.0 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
+VERSION=v0.14.4 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
 INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
 ```
 
@@ -84,7 +84,7 @@ docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara scan /scan
 docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara scan /scan --severity high --format json
 
 # Use a specific version
-docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara:v0.12.0 scan /scan
+docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara:0.14.4 scan /scan
 ```
 
 **From source** (requires Go 1.25+):


### PR DESCRIPTION
## Summary

Post-release docs refresh for v0.14.4. Small, no code changes.

### `CLAUDE.md`
- Bump version + date to `v0.14.4 / 2026-04-24`.
- Document the Docker hardening that landed in v0.14.4 (multi-arch, non-root `UID 10001`, digest-pinned base images).
- Reframe the pattern-matcher performance item: the Aho-Corasick prefilter is already in production since v0.14.0. Real perf is ~210ms/op on the synthetic bench, not the ~770ms no-AC path that was listed as an open item. Flag as "not open backlog unless pprof shows a regression" so future sessions do not chase a fixed problem.
- Fix the builtin YAML file count: 13 files, not 12 and not 14 (both numbers appeared in different places).
- Bump the data-consistency anchor version to `v0.14.4`.

### `README.md`
- Install-script example pinned to `v0.14.4` (was `v0.12.0`, 9 releases stale).
- Docker example uses `:0.14.4` (without `v`), matching the actual registry tag produced by `docker/metadata-action`. The previous `:v0.12.0` tag never existed in GHCR.

## Test plan

- [x] `git diff --stat` - 2 files, +8 -8 lines.
- [x] `grep` confirms no remaining `v0.14.2` / `v0.14.3` / `v0.12.0` references in `CLAUDE.md` or `README.md`.
- [x] `README.md:443` `v0.11.0` link preserved - it points to the litellm-response release notes (historical context, not a version claim).