### PR TITLE
chore: add self-scan config + bump action DEFAULT_REF to v0.14.4

### DIFF
--- a/.aguara.yml
+++ b/.aguara.yml
@@ -1,0 +1,51 @@
+# .aguara.yml -- self-scan configuration for the Aguara repository.
+#
+# This file is specific to THIS repo, not a template for Aguara consumers.
+# Aguara is a security scanner, so by design its own source contains:
+#   - attack pattern signatures embedded in rule YAMLs (internal/rules/builtin/)
+#   - malicious skill fixtures used by integration tests (testdata/, sandbox/)
+#   - benchmark inputs with representative payloads (scripts/)
+#   - documentation that shows example attacks when explaining detections
+#
+# A clean `aguara scan .` against this repo without exclusions produces ~9k
+# findings dominated by that by-design content. This file scopes self-scans
+# to production code paths so contributors get a useful signal-to-noise ratio.
+# Scanning the excluded paths is still useful for research; run without a
+# config (`aguara scan internal/rules/builtin/ --rules=...`) to opt in.
+
+ignore:
+  # Rule definitions. Each rule ships its own true_positive examples so the
+  # self-test suite can assert detection; those examples are real payloads
+  # and trigger the rules that produced them.
+  - internal/rules/builtin/**
+
+  # Integration test fixtures. Malicious/benign scenarios used by
+  # `internal/scanner/integration_test.go`. Gitignored locally, but extracted
+  # into the tree when the suite runs.
+  - testdata/**
+
+  # Docker sandbox with intentionally malicious skill definitions and
+  # configs used by end-to-end test scripts.
+  - sandbox/**
+
+  # Benchmark inputs and captured outputs (JSON with finding arrays,
+  # pprof traces, etc.). Not source code.
+  - scripts/**
+
+  # Internal Obsidian vault (gitignored). Contains attack examples while
+  # drafting blog posts and distribution content.
+  - DOCS/**
+
+  # Release notes and rule docs quote attack patterns when describing what
+  # each fix or rule detects.
+  - CHANGELOG.md
+  - RULES.md
+  - README.md
+
+  # Compiled binaries produced by `make build` and `go test -c`. Aguara's
+  # built-in binary extension filter skips `.exe`/`.so`/etc. but not Go's
+  # extensionless outputs or the `.test` binaries go produces. go:embed
+  # pulls every rule YAML into the binary image, so scanning the raw bytes
+  # re-discovers every attack signature.
+  - aguara
+  - "*.test"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ internal/
     rugpull/           Rug-pull detection analyzer
     toxicflow/         Taint tracking: source -> sink flow analysis
   rules/               Rule engine: YAML loader, compiler, self-tester
-    builtin/           177 embedded rules across 12 YAML files (go:embed)
+    builtin/           189 embedded rules across 13 YAML files (go:embed)
   scanner/             Orchestrator: file discovery, parallel analysis, result aggregation
   meta/                Post-processing: dedup, scoring, cross-finding correlation
   output/              Formatters: terminal (ANSI), JSON, SARIF, Markdown
@@ -98,6 +98,30 @@ go test -race -count=1 ./internal/rules/...
 # Verbose output
 go test -race -count=1 -v ./internal/engine/pattern/...
 ```
+
+## Running Aguara on this repo
+
+Aguara is a scanner whose own source intentionally contains attack patterns: rule YAML `examples.true_positive` blocks (used by the rule self-test suite), payload fixtures under `testdata/` and `sandbox/`, benchmark inputs in `scripts/`, and documentation that cites example attacks when explaining detections. A naive `aguara scan .` against a checkout produces thousands of findings dominated by that by-design content.
+
+The repo ships a `.aguara.yml` at the root that excludes those paths so `aguara scan .` returns a manageable list of findings contributors can actually investigate. Do not copy this file into consumer projects; it is specific to scanner development.
+
+Expected behavior after a clean `make build`:
+
+```bash
+./aguara scan . --no-update-check
+# Roughly ~60 findings, all in test files that embed attack payloads as
+# unit-test fixtures. These are expected; investigate only if the file path
+# is not a `*_test.go` or similarly marked test/doc file.
+```
+
+To scan the excluded paths deliberately (e.g. when validating that rule YAMLs still self-test after a pattern change), point the scanner at the specific path and Aguara will ignore the repo-root config for that target:
+
+```bash
+./aguara scan testdata/malicious --no-update-check      # verify malicious fixtures still detected
+./aguara scan internal/rules/builtin --no-update-check  # rule examples re-scanned
+```
+
+CI currently does not gate on self-scan output; rule coverage is asserted by the Go test suite (rule self-tests against `examples.true_positive` / `false_positive`).
 
 ## Pull Request Process
 

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     required: false
     default: ''
   version:
-    description: 'Aguara version to install (empty = latest). Must be a semver release tag like v0.14.2.'
+    description: 'Aguara version to install (empty = latest). Must be a semver release tag like v0.14.4.'
     required: false
     default: ''
   upload-sarif:
@@ -55,7 +55,7 @@ inputs:
     description: |
       Advanced: git ref (semver tag or 40-char SHA) to fetch install.sh from.
       Normal consumers should leave this blank; the action automatically uses
-      its own pinned ref (e.g. v0.14.2 when you pin `uses: garagon/aguara@v0.14.2`).
+      its own pinned ref (e.g. v0.14.4 when you pin `uses: garagon/aguara@v0.14.4`).
       This input exists for self-testing scenarios where the action runs from
       `uses: ./` and needs to exercise install.sh from a specific commit.
     required: false
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.14.3"
+        DEFAULT_REF="v0.14.4"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then


### PR DESCRIPTION
## Summary

Addresses two items from an external audit of v0.14.4:

1. **Contributor `aguara scan .` is noisy by design** - the scanner's own source contains attack-pattern signatures in rule YAMLs, test fixtures, sandbox skills, benchmark inputs, and documentation. Add a repo-root `.aguara.yml` that scopes self-scan to production code paths.
2. **`action.yml` `DEFAULT_REF` was stale** - still pointed at v0.14.3 after v0.14.4 shipped.

## Self-scan reduction

| State | Findings |
|---|---:|
| No config, raw `aguara scan .` | ~9,650 |
| After excluding testdata/sandbox/scripts/DOCS/binaries manually | ~386 |
| With this `.aguara.yml` | **~63** |

The remaining ~63 are all in `*_test.go` files that embed attack payloads as unit-test fixtures, plus `AGENTS.md` which cites examples. Not excluded because removing them would also hide real signal if a test file picks up genuine bugs.

## Changes

**`.aguara.yml`** (new, 51 lines)
- Ignores: `internal/rules/builtin/**`, `testdata/**`, `sandbox/**`, `scripts/**`, `DOCS/**`, `CHANGELOG.md`, `RULES.md`, `README.md`, and compiled binaries (`aguara`, `*.test`).
- Header explains this is specific to the scanner's own repo, not a template consumers should copy.

**`action.yml`** (3 one-line edits)
- `DEFAULT_REF="v0.14.3"` -> `DEFAULT_REF="v0.14.4"` (fallback for consumers using non-semver `uses:` refs).
- Two description strings updated from `v0.14.2` example to `v0.14.4` example.

**`CONTRIBUTING.md`** (26 added lines)
- New `Running Aguara on this repo` section explaining expected noise, how the repo-root config handles it, and the escape hatch (scan excluded paths by pointing at them directly).
- Fixed stale drift: `Project Structure` block listed "177 embedded rules across 12 YAML files"; real count is 189 / 13 files.

## Not done here

The audit's second recommendation (replace `curl | bash` in the action's install step with `download -> verify -> execute`) is not addressed. The action already rejects any install ref that is not a semver tag or 40-char SHA, and `install.sh` has enforced mandatory Cosign-signed checksum verification since v0.14.0, so the residual risk is narrow. Deferred to a future hardening pass.

## Test plan

- [x] `./aguara scan .` on a clean checkout returns ~63 findings, all in `*_test.go` or `AGENTS.md`.
- [x] `./aguara scan testdata/malicious` still yields 102 findings (the .aguara.yml does not apply when targeting an excluded path directly).
- [x] `./aguara scan internal/rules/builtin` still returns thousands of TP-example matches (rule self-test path still available for investigation).
- [x] `go test -race -count=1 ./internal/config/... ./internal/scanner/...` green.
- [x] `grep` for remaining `v0.14.3` / `v0.14.2` in `action.yml` returns nothing.