### PR TITLE
fix: three low-scope audit findings (CI phone-home, symlink, gitignore)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,12 @@ __pycache__/
 
 # Coverage
 coverage.out
+
+# Secrets -- prophylactic. The repo has never contained these, but a misplaced
+# .env or key file is the kind of mistake a scanner's own repo really should
+# not ship.
+.env
+.env.*
+!.env.example
+*.pem
+*.key

--- a/cmd/aguara/commands/root.go
+++ b/cmd/aguara/commands/root.go
@@ -42,8 +42,37 @@ func init() {
 
 // Execute runs the root command.
 func Execute() error {
-	if os.Getenv("AGUARA_NO_UPDATE_CHECK") == "1" {
+	if os.Getenv("AGUARA_NO_UPDATE_CHECK") == "1" || isCI() {
 		flagNoUpdateCheck = true
 	}
 	return rootCmd.Execute()
+}
+
+// isCI reports whether aguara is running inside a recognized CI environment.
+// In CI the update check is a net-egress side effect with no user to notify,
+// so it is silently suppressed. Local invocations still get the notice unless
+// the user opts out with --no-update-check or AGUARA_NO_UPDATE_CHECK=1.
+//
+// The ci env var is the de-facto standard and covers GitHub Actions, GitLab,
+// CircleCI, Travis, Buildkite, Bitbucket Pipelines, Drone, Woodpecker, and
+// most others. The explicit names are a fallback for runners that leave CI
+// unset (Jenkins historically, TeamCity).
+func isCI() bool {
+	if v := os.Getenv("CI"); v != "" && v != "false" && v != "0" {
+		return true
+	}
+	for _, k := range [...]string{
+		"GITHUB_ACTIONS",
+		"GITLAB_CI",
+		"CIRCLECI",
+		"BUILDKITE",
+		"JENKINS_URL",
+		"TEAMCITY_VERSION",
+		"TRAVIS",
+	} {
+		if os.Getenv(k) != "" {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/aguara/commands/root_test.go
+++ b/cmd/aguara/commands/root_test.go
@@ -1,0 +1,48 @@
+package commands
+
+import (
+	"testing"
+)
+
+func TestIsCI(t *testing.T) {
+	// Every CI env var the scanner recognizes, each covered by its own case.
+	// Tests use t.Setenv so values are reverted automatically.
+	cases := []struct {
+		name string
+		env  map[string]string
+		want bool
+	}{
+		{"no env", nil, false},
+		{"CI=true", map[string]string{"CI": "true"}, true},
+		{"CI=1", map[string]string{"CI": "1"}, true},
+		{"CI=false ignored", map[string]string{"CI": "false"}, false},
+		{"CI=0 ignored", map[string]string{"CI": "0"}, false},
+		{"CI= empty ignored", map[string]string{"CI": ""}, false},
+		{"GITHUB_ACTIONS", map[string]string{"GITHUB_ACTIONS": "true"}, true},
+		{"GITLAB_CI", map[string]string{"GITLAB_CI": "true"}, true},
+		{"CIRCLECI", map[string]string{"CIRCLECI": "true"}, true},
+		{"BUILDKITE", map[string]string{"BUILDKITE": "true"}, true},
+		{"JENKINS_URL", map[string]string{"JENKINS_URL": "http://ci.example.com"}, true},
+		{"TEAMCITY_VERSION", map[string]string{"TEAMCITY_VERSION": "2024.03"}, true},
+		{"TRAVIS", map[string]string{"TRAVIS": "true"}, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Clear every recognized signal first so a previously-set value
+			// from the host doesn't leak into the case.
+			for _, k := range []string{
+				"CI", "GITHUB_ACTIONS", "GITLAB_CI", "CIRCLECI",
+				"BUILDKITE", "JENKINS_URL", "TEAMCITY_VERSION", "TRAVIS",
+			} {
+				t.Setenv(k, "")
+			}
+			for k, v := range tc.env {
+				t.Setenv(k, v)
+			}
+			if got := isCI(); got != tc.want {
+				t.Errorf("isCI() = %v, want %v (env=%v)", got, tc.want, tc.env)
+			}
+		})
+	}
+}

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -405,7 +405,16 @@ func scanChangedFiles(ctx context.Context, s *scanner.Scanner, targetPath string
 	var targets []*scanner.Target
 	for _, relPath := range changedFiles {
 		absPath := filepath.Join(targetPath, relPath)
-		if _, err := os.Stat(absPath); err != nil {
+		// Lstat instead of Stat so a symlink doesn't resolve to its target.
+		// The normal directory walk already skips symlinks (internal/scanner/target.go
+		// in the walk callback); --changed gets file paths from git and must do the
+		// same check, otherwise a malicious symlink committed to the repo would make
+		// aguara read files outside the tree and surface their contents in findings.
+		info, err := os.Lstat(absPath)
+		if err != nil {
+			continue
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
 			continue
 		}
 		targets = append(targets, &scanner.Target{

--- a/cmd/aguara/commands/scan_test.go
+++ b/cmd/aguara/commands/scan_test.go
@@ -60,6 +60,64 @@ func scanToFile(t *testing.T, args ...string) []byte {
 	return data
 }
 
+func TestScanChangedFilesRejectsSymlink(t *testing.T) {
+	// --changed reads the set of modified files from git and iterates them.
+	// Regression guard: a symlink committed (or added) to the repo must NOT
+	// cause aguara to read its target and surface that target's contents as
+	// findings. The normal walk rejects symlinks; this exercises the parity
+	// fix for scanChangedFiles.
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	repo := t.TempDir()
+	runGit := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command("git", args...)
+		cmd.Dir = repo
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=t@t",
+			"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=t@t",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+	runGit("init", "-q", "-b", "main")
+	runGit("config", "core.symlinks", "true")
+
+	// Create a secret file OUTSIDE the repo and point a symlink at it.
+	// If --changed followed symlinks, scanning the symlink would leak
+	// the secret into findings.
+	outside := filepath.Join(t.TempDir(), "secret.md")
+	require.NoError(t, os.WriteFile(outside,
+		[]byte("# outside\nsk-proj-1234567890abcdefghijklmnop1234567890abcd\n"), 0o600))
+
+	require.NoError(t, os.Symlink(outside, filepath.Join(repo, "evil.md")))
+
+	// Also stage a real file so the changed-set is non-empty even if the
+	// symlink is rejected; this confirms the scan runs normally for the rest.
+	require.NoError(t, os.WriteFile(filepath.Join(repo, "ok.md"),
+		[]byte("# benign\nnothing here\n"), 0o644))
+
+	runGit("add", "-A")
+	// Stay staged (no commit): GitChangedFiles includes staged entries.
+
+	data := scanToFile(t, repo, "--changed", "--format", "json")
+	var result struct {
+		Findings []struct {
+			RuleID   string `json:"rule_id"`
+			FilePath string `json:"file_path"`
+		} `json:"findings"`
+	}
+	require.NoError(t, json.Unmarshal(data, &result))
+	for _, f := range result.Findings {
+		if f.FilePath == "evil.md" {
+			t.Fatalf("symlink evil.md was scanned (rule %s); expected to be skipped", f.RuleID)
+		}
+	}
+}
+
 func TestScanBasicDirectory(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "safe.md"), []byte("# Hello\nThis is a safe document."), 0644))


### PR DESCRIPTION
## Summary

Three unrelated findings from an external audit. All small, contained, and addressable without design discussion. Larger audit items (matched-text redaction, rule-target glob support, decoder-cap bypass) are tracked separately for v0.15.0 or follow-up PRs.

## Changes

### 1. Auto-suppress update check in CI environments (P1)

`scan` and `version` both called `update.CheckLatest()` unless `--no-update-check` was passed. The GitHub Action already passes the flag, but bare-binary invocations inside CI (Dockerfile, Makefile, ad-hoc script) were hitting the GitHub Releases API on every run. That leaked timing and user-agent metadata from environments that are supposed to be offline, and fights the "no network, no LLM" positioning.

`Execute()` now flips `flagNoUpdateCheck` automatically when `CI=true` (the de-facto standard) or any of `GITHUB_ACTIONS`, `GITLAB_CI`, `CIRCLECI`, `BUILDKITE`, `JENKINS_URL`, `TEAMCITY_VERSION`, `TRAVIS` is set. Local invocations still get the notice. `--no-update-check` and `AGUARA_NO_UPDATE_CHECK=1` remain as explicit opt-outs.

### 2. `--changed` scan no longer follows symlinks (P1)

The normal directory walk in `internal/scanner/target.go` rejects symlinks via `info.Mode()&os.ModeSymlink`. `scanChangedFiles` got its paths from git and used `os.Stat`, which resolves symlinks to their target. A symlink committed to the repo pointing at `/etc/passwd` or `~/.ssh/id_rsa` would be followed on the next `--changed` CI run and the target's contents would surface in findings (and in SARIF uploads to GitHub Code Scanning).

`os.Stat` -> `os.Lstat`, skip entries where the mode bit is set.

### 3. `.gitignore` hygiene

Adds `.env`, `.env.*`, `*.pem`, `*.key` with an allowlist for `.env.example`. Prophylactic: the repo has never contained these (`git log --all --oneline | grep -iE '\.env|\.pem|\.key'` returns nothing), but a scanner's own repo really should not ship a misplaced credential file by accident.

## Not in this PR

Three audit items that need more design discussion:

- **Finding redaction for credential-leak rules.** Proposed approach: category-based redaction of `matched_text` and `context` with `--no-redact` opt-out. Needs a dedicated PR so taxonomy and library-consumer impact (aguara-mcp, oktsec) can be reviewed in isolation.
- **Rule target glob support.** Custom rules with `skills/**/*.md` or `.github/workflows/*.yml` silently do not fire because `globToExt` collapses everything to extension or literal basename. Integration with the existing `matchGlob` from `internal/scanner/target.go` is a medium change that fits in v0.15.0 Tier 1 alongside the `match_mode` proximity work.
- **Decoder cap bypass.** The `maxBlobsPerFile=10` cap in first-match order lets an attacker push a malicious blob past the decoder by padding with benign blobs. Needs a perf benchmark before raising the cap or adding hash-based dedup.

## Test plan

- [x] `go test -race -count=1 ./...` green across all packages.
- [x] `go vet` clean.
- [x] `golangci-lint run` clean (0 issues).
- [x] New `TestIsCI` covers empty env, `CI=true`/`1`, `CI=false`/`0`/empty (correctly ignored), and each fallback variable.
- [x] New `TestScanChangedFilesRejectsSymlink` creates a git repo with a symlink to an out-of-tree secret and asserts no findings come from the symlink path.