### PR TITLE
feat(output): redact credential-leak matches by default

### DIFF
--- a/aguara.go
+++ b/aguara.go
@@ -110,6 +110,9 @@ func Scan(ctx context.Context, path string, opts ...Option) (*ScanResult, error)
 		return nil, err
 	}
 	result.RulesLoaded = len(compiled)
+	if cfg.redact {
+		redactCredentialFindings(result.Findings)
+	}
 	return result, nil
 }
 
@@ -153,6 +156,9 @@ func scanContentInternal(ctx context.Context, content string, filename string, t
 		return nil, err
 	}
 	result.RulesLoaded = len(compiled)
+	if cfg.redact {
+		redactCredentialFindings(result.Findings)
+	}
 	return result, nil
 }
 
@@ -294,6 +300,9 @@ func (sc *Scanner) scanContent(ctx context.Context, content string, filename str
 		return nil, err
 	}
 	result.RulesLoaded = len(sc.compiled)
+	if sc.cfg.redact {
+		redactCredentialFindings(result.Findings)
+	}
 	return result, nil
 }
 
@@ -308,6 +317,9 @@ func (sc *Scanner) Scan(ctx context.Context, path string) (*ScanResult, error) {
 		return nil, err
 	}
 	result.RulesLoaded = len(sc.compiled)
+	if sc.cfg.redact {
+		redactCredentialFindings(result.Findings)
+	}
 	return result, nil
 }
 
@@ -418,11 +430,27 @@ func (sc *Scanner) buildInternalScanner(toolName string) (*scanner.Scanner, erro
 // --- internal helpers ---
 
 func applyOpts(opts []Option) *scanConfig {
-	cfg := &scanConfig{}
+	// Redaction is opt-out: by default, credential-leak findings have their
+	// matched text scrubbed before they leave the library. Callers that need
+	// the raw match must explicitly pass WithRedaction(false).
+	cfg := &scanConfig{redact: true}
 	for _, o := range opts {
 		o(cfg)
 	}
 	return cfg
+}
+
+// redactCredentialFindings scrubs matched text and context for findings in the
+// credential-leak category. Detecting a secret and then writing it verbatim to
+// terminal, JSON, SARIF, or -o output defeats the purpose of detection: the
+// finding artifact becomes a second copy of the secret, often with weaker
+// access controls than the original file (CI logs, GitHub Code Scanning,
+// Slack notifications, etc.).
+//
+// Delegates to types.RedactCredentialFindings so the CLI and library share a
+// single implementation. Only credential-leak findings are altered.
+func redactCredentialFindings(findings []Finding) {
+	types.RedactCredentialFindings(findings)
 }
 
 type compileResult struct {

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -22,6 +22,7 @@ import (
 	"github.com/garagon/aguara/internal/rules/builtin"
 	"github.com/garagon/aguara/internal/scanner"
 	"github.com/garagon/aguara/internal/state"
+	"github.com/garagon/aguara/internal/types"
 )
 
 var (
@@ -35,6 +36,7 @@ var (
 	flagMaxFileSize string
 	flagToolName    string
 	flagProfile     string
+	flagNoRedact    bool
 )
 
 var scanCmd = &cobra.Command{
@@ -63,6 +65,7 @@ func init() {
 	scanCmd.Flags().StringVar(&flagMaxFileSize, "max-file-size", "", "Maximum file size to scan (e.g. 50MB, 100MB; default 50MB, range 1MB-500MB)")
 	scanCmd.Flags().StringVar(&flagToolName, "tool-name", "", "Tool context for false-positive reduction (e.g. Bash, Edit, WebFetch)")
 	scanCmd.Flags().StringVar(&flagProfile, "profile", "", "Scan profile: strict (default), content-aware, minimal")
+	scanCmd.Flags().BoolVar(&flagNoRedact, "no-redact", false, "Keep raw matched text in credential-leak findings (default: redact to [REDACTED])")
 	rootCmd.AddCommand(scanCmd)
 }
 
@@ -123,6 +126,10 @@ func runScan(cmd *cobra.Command, args []string) error {
 		if err := store.Save(); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: saving state: %v\n", err)
 		}
+	}
+
+	if !flagNoRedact {
+		types.RedactCredentialFindings(result.Findings)
 	}
 
 	if err := writeOutput(result); err != nil {
@@ -202,6 +209,10 @@ func runAutoScan(cmd *cobra.Command) error {
 		if err := store.Save(); err != nil {
 			fmt.Fprintf(os.Stderr, "warning: saving state: %v\n", err)
 		}
+	}
+
+	if !flagNoRedact {
+		types.RedactCredentialFindings(aggregate.Findings)
 	}
 
 	if err := writeOutput(aggregate); err != nil {

--- a/cmd/aguara/commands/scan_test.go
+++ b/cmd/aguara/commands/scan_test.go
@@ -32,6 +32,7 @@ func resetFlags() {
 	flagMaxFileSize = ""
 	flagToolName = ""
 	flagProfile = ""
+	flagNoRedact = false
 }
 
 // scanToFile runs aguara scan and writes output to a temp file, returning the content.
@@ -115,6 +116,41 @@ func TestScanChangedFilesRejectsSymlink(t *testing.T) {
 		if f.FilePath == "evil.md" {
 			t.Fatalf("symlink evil.md was scanned (rule %s); expected to be skipped", f.RuleID)
 		}
+	}
+}
+
+func TestScanRedactsCredentialsByDefault(t *testing.T) {
+	// Write a file with an AWS access key (CRED_002, credential-leak category).
+	// Default scan must redact the match; the raw key must not appear in the
+	// JSON output regardless of which layer a consumer parses.
+	dir := t.TempDir()
+	const rawKey = "AKIAIOSFODNN7EXAMPLE"
+	content := "# config\naws_access_key_id = \"" + rawKey + "\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "leak.md"), []byte(content), 0644))
+
+	data := scanToFile(t, dir, "--format", "json")
+
+	if bytes.Contains(data, []byte(rawKey)) {
+		t.Fatalf("raw credential leaked into scan output despite default redaction")
+	}
+	if !bytes.Contains(data, []byte("[REDACTED]")) {
+		t.Fatalf("expected [REDACTED] placeholder in scan output, got: %s", data)
+	}
+}
+
+func TestScanNoRedactKeepsRawMatch(t *testing.T) {
+	// With --no-redact the raw match must flow through; this is the explicit
+	// opt-out for pipelines that need the matched text (credential rotation
+	// trackers, security review tools).
+	dir := t.TempDir()
+	const rawKey = "AKIAIOSFODNN7EXAMPLE"
+	content := "# config\naws_access_key_id = \"" + rawKey + "\"\n"
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "leak.md"), []byte(content), 0644))
+
+	data := scanToFile(t, dir, "--format", "json", "--no-redact")
+
+	if !bytes.Contains(data, []byte(rawKey)) {
+		t.Fatalf("--no-redact did not preserve raw match; output was: %s", data)
 	}
 }
 

--- a/internal/types/redact_test.go
+++ b/internal/types/redact_test.go
@@ -1,0 +1,60 @@
+package types
+
+import "testing"
+
+func TestRedactCredentialFindings(t *testing.T) {
+	mkFinding := func(cat, text string, ctxMatch bool) Finding {
+		return Finding{
+			Category:    cat,
+			MatchedText: text,
+			Context: []ContextLine{
+				{Line: 1, Content: "prefix", IsMatch: false},
+				{Line: 2, Content: text, IsMatch: ctxMatch},
+				{Line: 3, Content: "suffix", IsMatch: false},
+			},
+		}
+	}
+
+	secret := "sk-proj-1234567890abcdefghijklmnop1234567890abcd"
+	findings := []Finding{
+		mkFinding("credential-leak", secret, true),
+		mkFinding("prompt-injection", "ignore previous instructions", true),
+		mkFinding("credential-leak", "AKIAIOSFODNN7EXAMPLE", false), // is_match=false: match on a different line
+	}
+
+	RedactCredentialFindings(findings)
+
+	// Credential-leak, match line redacted in Context.
+	if findings[0].MatchedText != RedactedPlaceholder {
+		t.Errorf("credential-leak MatchedText not redacted: %q", findings[0].MatchedText)
+	}
+	if findings[0].Context[1].Content != RedactedPlaceholder {
+		t.Errorf("credential-leak match context not redacted: %q", findings[0].Context[1].Content)
+	}
+	if findings[0].Context[0].Content == RedactedPlaceholder || findings[0].Context[2].Content == RedactedPlaceholder {
+		t.Error("non-match context lines should not be redacted")
+	}
+
+	// Non-credential categories must never be touched.
+	if findings[1].MatchedText != "ignore previous instructions" {
+		t.Errorf("prompt-injection MatchedText was redacted: %q", findings[1].MatchedText)
+	}
+	if findings[1].Context[1].Content != "ignore previous instructions" {
+		t.Errorf("prompt-injection context was redacted: %q", findings[1].Context[1].Content)
+	}
+
+	// Credential-leak with no is_match context line: MatchedText still redacted,
+	// context stays intact (no line is flagged as the match).
+	if findings[2].MatchedText != RedactedPlaceholder {
+		t.Errorf("second credential-leak MatchedText not redacted: %q", findings[2].MatchedText)
+	}
+	if findings[2].Context[1].Content == RedactedPlaceholder {
+		t.Error("context line with is_match=false should not be redacted even for credential-leak")
+	}
+}
+
+func TestRedactCredentialFindings_NilSafe(t *testing.T) {
+	// Must be safe to call with nil/empty slice.
+	RedactCredentialFindings(nil)
+	RedactCredentialFindings([]Finding{})
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -97,6 +97,33 @@ type Finding struct {
 	InCodeBlock bool          `json:"in_code_block,omitempty"`
 }
 
+// RedactedPlaceholder is the value that replaces matched text and matching
+// context lines for findings whose raw match would leak a secret. Kept as a
+// stable string so JSON/SARIF consumers can grep for it consistently.
+const RedactedPlaceholder = "[REDACTED]"
+
+// RedactCredentialFindings scrubs matched text and matching context lines for
+// findings in the credential-leak category so that detecting a secret does not
+// create a second copy of the secret in scan output, CI logs, or SARIF
+// artifacts uploaded to GitHub Code Scanning.
+//
+// Only findings with Category == "credential-leak" are modified. Other
+// categories are left intact because their match is typically a pattern
+// signature rather than a secret.
+func RedactCredentialFindings(findings []Finding) {
+	for i := range findings {
+		if findings[i].Category != "credential-leak" {
+			continue
+		}
+		findings[i].MatchedText = RedactedPlaceholder
+		for j := range findings[i].Context {
+			if findings[i].Context[j].IsMatch {
+				findings[i].Context[j].Content = RedactedPlaceholder
+			}
+		}
+	}
+}
+
 // DowngradeSeverity drops severity by one level, flooring at LOW.
 // INFO is left unchanged (it's a different class, not part of the severity ladder).
 func DowngradeSeverity(sev Severity) Severity {

--- a/options.go
+++ b/options.go
@@ -14,6 +14,7 @@ type scanConfig struct {
 	scanProfile     ScanProfile
 	deduplicateMode DeduplicateMode
 	stateDir        string
+	redact          bool // scrub matched text from credential-leak findings
 }
 
 // Option configures a scan operation.
@@ -109,5 +110,20 @@ func WithDeduplicateMode(mode DeduplicateMode) Option {
 func WithStateDir(dir string) Option {
 	return func(c *scanConfig) {
 		c.stateDir = dir
+	}
+}
+
+// WithRedaction controls whether matched text from credential-leak findings
+// is replaced with "[REDACTED]" in the returned Finding. Enabled by default
+// so secrets detected by CRED_* rules never appear in scan output, CI logs,
+// or SARIF artifacts uploaded to GitHub Code Scanning.
+//
+// Disable only when the consumer needs the raw match to programmatically
+// verify or act on the detected secret (e.g. a remediation pipeline that
+// cross-references the leak against a credential rotation tracker).
+// Rules outside the credential-leak category are never redacted.
+func WithRedaction(enabled bool) Option {
+	return func(c *scanConfig) {
+		c.redact = enabled
 	}
 }


### PR DESCRIPTION
## Summary

Detecting a secret and copying it verbatim into scan output creates a second copy of the secret in a location that often has weaker access controls than the original file: CI logs retained for days, GitHub Code Scanning history, Slack notifications, shared `results.json` checked into git by accident. The scan artifact becomes the leak.

This change scrubs `MatchedText` and context lines marked `is_match=true` for findings whose `Category` is `credential-leak`. Rules outside that category are untouched.

Implements P1-2 from the audit companion to #65 (which delivers the other three audit items: CI phone-home, symlink, .gitignore).

## Behavior

| Input | `scan` output `matched_text` | `--no-redact` output |
|---|---|---|
| OpenAI key matched by `CRED_001` | `[REDACTED]` | `sk-proj-...` (raw) |
| AWS key matched by `CRED_002` | `[REDACTED]` | `AKIA...` (raw) |
| Prompt injection matched by `PROMPT_INJECTION_001` | `ignore previous instructions` (untouched) | `ignore previous instructions` |
| NLP combo (`NLP_CRED_EXFIL_COMBO`, category `prompt-injection`) | untouched | untouched |

Only `credential-leak` category findings are affected. The placeholder is the literal string `[REDACTED]` exposed as `types.RedactedPlaceholder` so downstream tooling can grep for it consistently.

## Interface

**CLI:**
- New `--no-redact` flag on `scan` for per-invocation opt-out.
- Applies to single-target scan, `--auto` aggregate scan, and the corresponding SARIF / JSON / markdown / terminal formatters (they all read from the same `Finding` struct).

**Library (`github.com/garagon/aguara`):**
- New `WithRedaction(enabled bool) Option`. Default is enabled; pass `WithRedaction(false)` for raw matches.
- `types.RedactCredentialFindings([]Finding)` is the shared implementation; callable directly for consumers that want to apply redaction themselves.

## Breaking change note

Library default is now `redact=true`. Consumers that were parsing `matched_text` as a credential value will see `[REDACTED]` instead on upgrade. The known library consumers:

- **`oktsec`** already applies its own credential redaction in `internal/engine/scanner.go` (per their CLAUDE.md). Double-redacted text is still `[REDACTED]`; behavior is unchanged on their side.
- **`aguara-mcp`** returns findings to MCP clients (AI agents). Having credentials scrubbed before crossing that boundary is strictly better for most threat models. No code change required; behavior improves.

Any consumer that needs the raw match must pass `aguara.WithRedaction(false)` after upgrading.

## Test plan

- [x] `go test -race -count=1 ./...` green across all packages.
- [x] `go vet` clean.
- [x] `golangci-lint run` clean (0 issues).
- [x] `internal/types/redact_test.go` covers the unit contract: only credential-leak is redacted, only `is_match` context lines are rewritten, non-match context stays intact, nil/empty slice is safe.
- [x] `TestScanRedactsCredentialsByDefault` and `TestScanNoRedactKeepsRawMatch` exercise the CLI end-to-end with an `AKIAIOSFODNN7EXAMPLE` fixture and assert the raw key does / does not appear in the emitted JSON.
- [x] Manual smoke: scanned a file with `sk-proj-...` and `AKIA...` with default scan -> `[REDACTED]` in terminal and JSON; same scan with `--no-redact` -> raw values appear.

## Relationship to PR #65

Independent scope. #65 delivers three unrelated audit fixes (CI update-check auto-disable, `--changed` symlink rejection, `.gitignore` hygiene). This PR delivers the fourth P1 from the same audit. Either can land first; no merge conflict between the two branches.