### PR TITLE
feat: reproducible benchmark harness with offline Docker runner

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+.git/
+.bench/
+aguara
+scanner.test
+*.test
+*.wasm
+wasm_exec.js
+index.html
+coverage.out
+*.log
+.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Build
 /aguara
 *.exe
+*.test
+/.bench/
 
 # IDE
 .idea/

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,22 @@ VERSION ?= dev
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 LDFLAGS := -ldflags "-s -w -X $(PKG)/cmd/aguara/commands.Version=$(VERSION) -X $(PKG)/cmd/aguara/commands.Commit=$(COMMIT)"
 
-.PHONY: build test lint run clean fmt vet wasm wasm-serve
+.PHONY: build test lint run clean fmt vet wasm wasm-serve bench bench-docker
 
 build:
 	go build -trimpath $(LDFLAGS) -o $(BINARY) ./cmd/aguara
 
 test:
 	go test -race -count=1 ./...
+
+bench:
+	go test -run '^$$' -bench 'BenchmarkCached_(PlainText|StructuredMarkdown|JSONConfig|LargeContent|MixedWorkload)$$' -benchmem -count=3 .
+	go test -run '^$$' -bench 'Benchmark(NLPAnalyzer|ScannerE2E)$$' -benchmem -count=3 ./internal/engine/nlp ./internal/scanner
+
+bench-docker:
+	mkdir -p .bench
+	docker build -f benchmarks/Dockerfile -t aguara-bench:local .
+	docker run --rm --network none --cap-drop ALL --security-opt no-new-privileges --read-only --tmpfs /tmp:rw,exec,nosuid,size=1g -v "$(CURDIR)/.bench:/out" aguara-bench:local
 
 lint:
 	golangci-lint run ./...

--- a/benchmarks/Dockerfile
+++ b/benchmarks/Dockerfile
@@ -1,0 +1,23 @@
+# Benchmark image for Aguara.
+#
+# Build may need network to download Go modules, but the benchmark run is
+# intended to execute with --network none via `make bench-docker`.
+FROM golang:1.25-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f
+
+RUN apk add --no-cache git ca-certificates
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+
+RUN adduser -D -u 10001 bench && chown -R bench:bench /src /go
+USER bench
+
+ENV AGUARA_NO_UPDATE_CHECK=1 \
+    NO_COLOR=1 \
+    GOCACHE=/tmp/go-build \
+    GOTMPDIR=/tmp/go-tmp \
+    BENCH_OUT=/out
+
+ENTRYPOINT ["/src/benchmarks/run.sh"]

--- a/benchmarks/cmd/benchsummary/main.go
+++ b/benchmarks/cmd/benchsummary/main.go
@@ -1,0 +1,197 @@
+// Command benchsummary collapses an Aguara JSON scan result into a stable
+// text report for benchmark diffs across PRs.
+//
+// The command does NOT modify scan output, rules, or scanner behaviour. It
+// only reads the JSON, counts, and prints. Output format is deliberately
+// boring -- key: value pairs and indented sections -- so a future PR can
+// `diff` two summaries and surface meaningful regressions:
+//
+//   - aumento brusco de findings totales
+//   - aumento de HIGH/CRITICAL dentro de code blocks (likely FP source)
+//   - nuevas reglas dominando el corpus
+//   - cambios inesperados en cantidad de archivos escaneados
+//
+// "Low confidence HIGH/CRITICAL" is defined here as `severity >= HIGH AND
+// in_code_block == true`, per the benchmark spec. Code-block matches are
+// the most common false-positive class because rule examples, test
+// fixtures, and documented attack patterns all live in fenced code blocks.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+)
+
+type scanResult struct {
+	Findings     []finding `json:"findings"`
+	FilesScanned int       `json:"files_scanned"`
+	RulesLoaded  int       `json:"rules_loaded"`
+	Verdict      int       `json:"verdict"`
+	RiskScore    float64   `json:"risk_score"`
+	DurationMS   int64     `json:"duration_ms"`
+}
+
+type finding struct {
+	RuleID      string `json:"rule_id"`
+	Severity    int    `json:"severity"`
+	Category    string `json:"category"`
+	FilePath    string `json:"file_path"`
+	InCodeBlock bool   `json:"in_code_block"`
+}
+
+type kv struct {
+	Key   string
+	Count int
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "usage: benchsummary <scan-result.json>\n")
+		os.Exit(2)
+	}
+
+	data, err := os.ReadFile(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read scan result: %v\n", err)
+		os.Exit(1)
+	}
+
+	var result scanResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		fmt.Fprintf(os.Stderr, "parse scan result: %v\n", err)
+		os.Exit(1)
+	}
+
+	sevCounts := map[int]int{}
+	catCounts := map[string]int{}
+	ruleCounts := map[string]int{}
+	highRuleCounts := map[string]int{}
+	codeBlockRuleCounts := map[string]int{}
+	lowConfidenceHighRuleCounts := map[string]int{}
+	fileCounts := map[string]int{}
+	codeBlockFindings := 0
+	lowConfidenceHighs := 0
+
+	for _, f := range result.Findings {
+		sevCounts[f.Severity]++
+		catCounts[f.Category]++
+		ruleCounts[f.RuleID]++
+		fileCounts[f.FilePath]++
+		if f.Severity >= 3 {
+			highRuleCounts[f.RuleID]++
+			// Spec definition of "low confidence HIGH/CRITICAL": a HIGH or
+			// CRITICAL finding sitting inside a markdown code block. Code
+			// blocks are where rule examples, test fixtures, and docs of
+			// attack patterns live, so this overlaps strongly with the FP
+			// surface for severity escalation.
+			if f.InCodeBlock {
+				lowConfidenceHighs++
+				lowConfidenceHighRuleCounts[f.RuleID]++
+			}
+		}
+		if f.InCodeBlock {
+			codeBlockFindings++
+			codeBlockRuleCounts[f.RuleID]++
+		}
+	}
+
+	// Header block: stable key:value lines so a future PR can grep deltas.
+	fmt.Printf("files_scanned: %d\n", result.FilesScanned)
+	fmt.Printf("rules_loaded: %d\n", result.RulesLoaded)
+	fmt.Printf("duration_ms: %d\n", result.DurationMS)
+	fmt.Printf("findings: %d\n", len(result.Findings))
+	fmt.Printf("risk_score: %s\n", formatRisk(result.RiskScore))
+	fmt.Printf("verdict: %s\n", verdictName(result.Verdict))
+	fmt.Printf("findings_in_code: %d\n", codeBlockFindings)
+	fmt.Printf("high_low_confidence: %d\n", lowConfidenceHighs)
+	fmt.Println()
+
+	printSeverity(sevCounts)
+	printSection("top_categories", catCounts, 20)
+	printSection("top_rules", ruleCounts, 30)
+	printSection("top_high_critical", highRuleCounts, 30)
+	printSection("top_code_block_rules", codeBlockRuleCounts, 30)
+	printSection("top_low_confidence_high_critical", lowConfidenceHighRuleCounts, 30)
+	printSection("top_affected_files", fileCounts, 20)
+}
+
+// formatRisk prints whole-number risk scores without a trailing .0 (so
+// 100.0 reads as 100) but keeps fractional precision for non-whole values.
+func formatRisk(v float64) string {
+	if v == float64(int64(v)) {
+		return fmt.Sprintf("%d", int64(v))
+	}
+	return fmt.Sprintf("%.1f", v)
+}
+
+func printSeverity(counts map[int]int) {
+	fmt.Println("severity:")
+	// Stable ordering: highest severity first, omit zero buckets.
+	for _, sev := range []int{4, 3, 2, 1, 0} {
+		if counts[sev] == 0 {
+			continue
+		}
+		fmt.Printf("  %s: %d\n", severityName(sev), counts[sev])
+	}
+	fmt.Println()
+}
+
+func printSection(title string, counts map[string]int, limit int) {
+	if len(counts) == 0 {
+		return
+	}
+	fmt.Printf("%s:\n", title)
+
+	items := make([]kv, 0, len(counts))
+	for k, v := range counts {
+		items = append(items, kv{Key: k, Count: v})
+	}
+	// Sort by count desc, then key asc, so the output is deterministic
+	// across runs (map iteration order would otherwise reorder ties).
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].Count != items[j].Count {
+			return items[i].Count > items[j].Count
+		}
+		return items[i].Key < items[j].Key
+	})
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	for _, item := range items {
+		fmt.Printf("  %s: %d\n", item.Key, item.Count)
+	}
+	fmt.Println()
+}
+
+func severityName(sev int) string {
+	switch sev {
+	case 4:
+		return "CRITICAL"
+	case 3:
+		return "HIGH"
+	case 2:
+		return "MEDIUM"
+	case 1:
+		return "LOW"
+	case 0:
+		return "INFO"
+	default:
+		return "UNKNOWN"
+	}
+}
+
+func verdictName(v int) string {
+	// Mirrors internal/types/types.go Verdict enum (clean=0, flag=1, block=2).
+	switch v {
+	case 0:
+		return "clean"
+	case 1:
+		return "flag"
+	case 2:
+		return "block"
+	default:
+		return "unknown"
+	}
+}

--- a/benchmarks/run.sh
+++ b/benchmarks/run.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+set -eu
+
+OUT="${BENCH_OUT:-/out}"
+COUNT="${BENCH_COUNT:-3}"
+BENCHTIME="${BENCH_TIME:-1s}"
+
+mkdir -p /tmp/go-build /tmp/go-tmp "$OUT"
+
+run_capture() {
+  label="$1"
+  file="$2"
+  shift 2
+
+  echo "== $label =="
+  if "$@" > "$file" 2>&1; then
+    cat "$file"
+  else
+    status="$?"
+    cat "$file"
+    exit "$status"
+  fi
+  echo
+}
+
+echo "== Aguara benchmark =="
+echo "output: $OUT"
+echo "bench count: $COUNT"
+echo "benchtime: $BENCHTIME"
+echo
+
+run_capture "go test ./..." "$OUT/go-test.txt" go test -count=1 ./...
+
+run_capture "microbenchmarks: API" "$OUT/go-bench-api.txt" go test -run '^$' \
+  -bench 'BenchmarkCached_(PlainText|StructuredMarkdown|JSONConfig|LargeContent|MixedWorkload)$' \
+  -benchmem \
+  -benchtime "$BENCHTIME" \
+  -count "$COUNT" \
+  .
+
+run_capture "microbenchmarks: engines" "$OUT/go-bench-engines.txt" go test -run '^$' \
+  -bench 'Benchmark(NLPAnalyzer|ScannerE2E)$' \
+  -benchmem \
+  -benchtime "$BENCHTIME" \
+  -count "$COUNT" \
+  ./internal/engine/nlp ./internal/scanner
+
+echo "== build aguara =="
+go build -trimpath -o /tmp/aguara ./cmd/aguara
+/tmp/aguara version > "$OUT/aguara-version.txt"
+cat "$OUT/aguara-version.txt"
+echo
+
+if [ -d testdata/real-skills ]; then
+  echo "== corpus scan: testdata/real-skills =="
+  /tmp/aguara --no-update-check scan --format json -o "$OUT/real-skills.json" testdata/real-skills
+  go run ./benchmarks/cmd/benchsummary "$OUT/real-skills.json" > "$OUT/real-skills-summary.txt"
+  cat "$OUT/real-skills-summary.txt"
+else
+  echo "testdata/real-skills not present; skipping corpus scan" > "$OUT/real-skills-summary.txt"
+  cat "$OUT/real-skills-summary.txt"
+fi
+
+echo "== done =="


### PR DESCRIPTION
## Summary

Adds `make bench` / `make bench-docker` targets, a hardened benchmark container, and a stable summary tool. Verifies three things without touching detection logic:

| Layer | What it checks |
|---|---|
| **Correctness** | `go test ./...` |
| **Performance** | API microbenchmarks (`BenchmarkCached_*`) + engine internals (`BenchmarkNLPAnalyzer`, `BenchmarkScannerE2E`) |
| **Detection signal** | Scan `testdata/real-skills`, summarize findings |

Zero engine changes, zero rule changes, zero scoring/output changes. This is purely an addition.

## Container security posture

The Docker run enforces offline + minimal-privilege via `make bench-docker`. None of these can be relaxed from inside the container:

```
--network none                       # offline by construction
--cap-drop ALL
--security-opt no-new-privileges
--read-only                          # rootfs immutable
--tmpfs /tmp:rw,exec,nosuid,size=1g  # go test needs exec for temp binaries
-v $(CURDIR)/.bench:/out             # only writable mount
```

Plus: non-root UID 10001 inside the image, no Docker socket mount, no host `$HOME` mount, `AGUARA_NO_UPDATE_CHECK=1` in env, `--no-update-check` on the corpus scan invocation. The container has no network path even if something tried.

## Files

- `Makefile`: `bench` (local microbenchmarks) and `bench-docker` (full hardened run including corpus scan).
- `benchmarks/Dockerfile`: `golang:1.25-alpine` pinned by digest, `go mod download` at build time so runtime is fully offline. Non-root user.
- `benchmarks/run.sh`: POSIX `sh -eu`. No `cmd | tee` tricks; each step captures stdout+stderr to a file via a helper that preserves exit codes. Skips the corpus scan when `testdata/real-skills` is absent (gitignored locally).
- `benchmarks/cmd/benchsummary/main.go`: ~150 LOC. Reads `aguara scan -o ...` JSON and writes a deterministic text report. Defines "low confidence HIGH/CRITICAL" as `severity >= HIGH AND in_code_block == true` (rule examples and doc fixtures live in code blocks; most direct FP proxy without re-running the engine).
- `.dockerignore`: small build context; excludes `.bench/`, `*.test`, `aguara`, etc.
- `.gitignore`: adds `*.test` and `/.bench/`.

## Artifacts produced in `.bench/`

| File | Contents |
|---|---|
| `go-test.txt` | `go test ./...` output |
| `go-bench-api.txt` | `BenchmarkCached_*` results (3x count, `-benchmem`) |
| `go-bench-engines.txt` | `BenchmarkNLPAnalyzer` + `BenchmarkScannerE2E` |
| `aguara-version.txt` | Compiled binary's `version` output |
| `real-skills.json` | Full scan output (only when `testdata/real-skills` present) |
| `real-skills-summary.txt` | Stable text summary (only when corpus present) |

## Baseline observed at v0.14.5

Against `testdata/real-skills` (1247 files, 13 MB, 189 rules):

```
files_scanned: 1247
rules_loaded: 189
findings: 1494
findings_in_code: 884
high_low_confidence: 28

severity:
  CRITICAL: 32
  HIGH: 173
  MEDIUM: 201
  LOW: 1088
```

Numbers intentionally **not asserted** in tests yet. They are the observational baseline the next PR (FP reduction) diffs against. Future PRs touching detection should attach a `make bench-docker` run and compare.

## Test plan

- [x] `make bench` passes locally; both microbenchmark targets emit results with `-benchmem -count=3`.
- [x] `make bench-docker` builds the image and runs it with all the security flags listed above.
- [x] Runtime executes with no network reachable: confirmed by `--network none` and zero outbound calls in `run.sh`.
- [x] `.bench/go-test.txt` shows successful `go test ./...` (all packages OK).
- [x] `.bench/go-bench-api.txt` contains `BenchmarkCached_PlainText`, `_StructuredMarkdown`, `_JSONConfig`, `_LargeContent`, `_MixedWorkload`.
- [x] `.bench/go-bench-engines.txt` contains `BenchmarkNLPAnalyzer` + `BenchmarkScannerE2E`.
- [x] `.bench/real-skills.json` parses as JSON with the expected schema.
- [x] `.bench/real-skills-summary.txt` matches the spec format (`key: value` headers, `severity:` + `top_*:` indented sections).
- [x] No file outside `.bench/` is modified by the run.
- [x] No edits in `internal/`, `cmd/`, `aguara.go`, `options.go`, or rule YAMLs.
- [x] No new dependencies in `go.mod`.

## Not in this PR

The next PR (false-positive reduction RFC, separate doc kept locally for now) will attach a fresh `make bench-docker` and compare the summary. The harness here is the substrate that makes that comparison meaningful.