### PR TITLE
feat(ci): trust-chain analyzer for GitHub Actions workflows

### DIFF
--- a/aguara.go
+++ b/aguara.go
@@ -14,6 +14,7 @@ import (
 	"golang.org/x/text/unicode/norm"
 
 	"github.com/garagon/aguara/discover"
+	"github.com/garagon/aguara/internal/engine/ci"
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pattern"
 	"github.com/garagon/aguara/internal/engine/rugpull"
@@ -408,6 +409,9 @@ func (sc *Scanner) buildInternalScanner(toolName string) (*scanner.Scanner, erro
 
 	// Reuse pre-compiled pattern matcher (the expensive part: regex + AC automaton)
 	s.RegisterAnalyzer(sc.matcher)
+	// CI trust analyzer parses workflow YAML — runs before toxicflow so its
+	// chain findings can be deduped/correlated alongside leaf signals.
+	s.RegisterAnalyzer(ci.New())
 	// NLP and ToxicFlow are stateless, cheap to instantiate
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
@@ -543,6 +547,7 @@ func buildScanner(cfg *scanConfig) (*scanner.Scanner, []*rules.CompiledRule, err
 	}
 
 	s.RegisterAnalyzer(pattern.NewMatcher(cr.compiled))
+	s.RegisterAnalyzer(ci.New())
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
 	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -13,6 +13,7 @@ import (
 	"github.com/garagon/aguara/discover"
 	"github.com/garagon/aguara/internal/config"
 	"github.com/garagon/aguara/internal/update"
+	"github.com/garagon/aguara/internal/engine/ci"
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pattern"
 	"github.com/garagon/aguara/internal/engine/rugpull"
@@ -366,6 +367,7 @@ func buildScanner(compiled []*rules.CompiledRule, cfg config.Config, minSev scan
 	}
 
 	s.RegisterAnalyzer(pattern.NewMatcher(compiled))
+	s.RegisterAnalyzer(ci.New())
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
 	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())

--- a/internal/engine/ci/workflow.go
+++ b/internal/engine/ci/workflow.go
@@ -1,0 +1,733 @@
+// Package ci analyzes GitHub Actions workflow YAML for trust-boundary
+// chain violations: pull_request_target executing PR-controlled code,
+// cache poisoning across fork/base boundaries, OIDC token surface
+// exposed to install/build/test, and persisted credentials on untrusted
+// checkouts.
+//
+// The analyzer is fully offline and deterministic. It does not emulate
+// the workflow runtime; it parses each workflow file once with yaml.v3,
+// classifies each step against a curated set of trust-chain fingerprints
+// derived from real-world supply-chain incidents (Mini Shai-Hulud and
+// related GitHub Security Lab pwn-request patterns), and emits a small
+// number of high-confidence findings.
+//
+// Only files under a .github/workflows/ directory with extension .yml or
+// .yaml are inspected; everything else returns nil quickly. The analyzer
+// is intentionally chain-first: single weak signals (pull_request_target
+// alone, id-token: write alone, actions/cache alone) never fire.
+package ci
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+)
+
+// AnalyzerName is the value reported in Finding.Analyzer for this engine.
+const AnalyzerName = "ci-trust"
+
+// Rule IDs emitted by this analyzer.
+const (
+	RulePwnRequest = "GHA_PWN_REQUEST_001"
+	RuleCache      = "GHA_CACHE_001"
+	RuleOIDC       = "GHA_OIDC_001"
+	RuleCheckout   = "GHA_CHECKOUT_001"
+)
+
+// Analyzer implements scanner.Analyzer for GitHub Actions trust analysis.
+type Analyzer struct{}
+
+// New returns a fresh CI trust analyzer.
+func New() *Analyzer { return &Analyzer{} }
+
+// Name returns the analyzer identifier.
+func (a *Analyzer) Name() string { return AnalyzerName }
+
+// Analyze parses the target if it is a GitHub Actions workflow and returns
+// trust-chain findings. Non-workflow files and malformed YAML return nil.
+func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.Finding, error) {
+	if !isWorkflowTarget(target) {
+		return nil, nil
+	}
+	if len(target.Content) == 0 {
+		return nil, nil
+	}
+	wf, err := parseWorkflow(target.Content)
+	if err != nil || wf == nil {
+		// Malformed YAML: leave pattern rules to flag what they can; ci-trust
+		// only reports on shapes it can confidently reason about.
+		return nil, nil
+	}
+	wf.Path = target.RelPath
+	return detect(wf), nil
+}
+
+// --- target gating ---
+
+// isWorkflowTarget returns true if the target is a YAML file located under
+// any .github/workflows/ directory. Checks both Path (when scanning a real
+// repo) and RelPath (when scanning in-memory content with a hinted name).
+func isWorkflowTarget(t *scanner.Target) bool {
+	if t == nil {
+		return false
+	}
+	for _, p := range []string{t.Path, t.RelPath} {
+		if p == "" {
+			continue
+		}
+		slash := filepath.ToSlash(p)
+		if !strings.Contains(slash, ".github/workflows/") {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(slash))
+		if ext == ".yml" || ext == ".yaml" {
+			return true
+		}
+	}
+	return false
+}
+
+// --- model ---
+
+type workflow struct {
+	Path        string
+	Events      eventSet
+	Permissions perms // top-level permissions
+	Jobs        []job
+}
+
+type eventSet struct {
+	PullRequest       bool
+	PullRequestTarget bool
+	WorkflowRun       bool
+	Push              bool
+	Release           bool
+	WorkflowDispatch  bool
+}
+
+// perms captures the GitHub Actions permissions surface. Specified records
+// whether any permission key was present (needed to distinguish job-level
+// override from inheritance).
+type perms struct {
+	Contents     string
+	Actions      string
+	IDToken      string
+	Packages     string
+	Attestations string
+	WriteAll     bool
+	ReadAll      bool
+	Specified    bool
+}
+
+type job struct {
+	ID                      string
+	Line                    int
+	JobPermissionsSpecified bool
+	JobPermissions          perms
+	Steps                   []step
+}
+
+type step struct {
+	Line int
+	Name string
+	Uses string
+	Run  string
+	With map[string]string
+
+	Checkout                bool
+	CheckoutUntrustedPR     bool
+	Cache                   bool
+	PackageInstall          bool
+	PackageBuildOrTest      bool
+	Publish                 bool
+	ExecutesCode            bool
+	PersistCredentialsFalse bool
+}
+
+// --- yaml parsing ---
+
+func parseWorkflow(content []byte) (*workflow, error) {
+	var root yaml.Node
+	if err := yaml.Unmarshal(content, &root); err != nil {
+		return nil, err
+	}
+	if root.Kind != yaml.DocumentNode || len(root.Content) == 0 {
+		return nil, fmt.Errorf("empty yaml document")
+	}
+	top := root.Content[0]
+	if top.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("workflow root is not a mapping")
+	}
+
+	wf := &workflow{}
+	for i := 0; i+1 < len(top.Content); i += 2 {
+		k := top.Content[i]
+		v := top.Content[i+1]
+		// GitHub uses `on:` as a key. yaml.v3 in 1.2 mode keeps the literal
+		// text in Value; some encoders may emit it as the boolean `true`.
+		key := strings.ToLower(strings.TrimSpace(k.Value))
+		if k.Tag == "!!bool" && key == "true" {
+			key = "on"
+		}
+		switch key {
+		case "on":
+			wf.Events = parseEvents(v)
+		case "permissions":
+			wf.Permissions = parsePermissions(v)
+		case "jobs":
+			wf.Jobs = parseJobs(v)
+		}
+	}
+	return wf, nil
+}
+
+func parseEvents(n *yaml.Node) eventSet {
+	var es eventSet
+	if n == nil {
+		return es
+	}
+	switch n.Kind {
+	case yaml.ScalarNode:
+		setEvent(&es, n.Value)
+	case yaml.SequenceNode:
+		for _, item := range n.Content {
+			setEvent(&es, item.Value)
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			setEvent(&es, n.Content[i].Value)
+		}
+	}
+	return es
+}
+
+func setEvent(es *eventSet, name string) {
+	switch strings.ToLower(strings.TrimSpace(name)) {
+	case "pull_request":
+		es.PullRequest = true
+	case "pull_request_target":
+		es.PullRequestTarget = true
+	case "workflow_run":
+		es.WorkflowRun = true
+	case "push":
+		es.Push = true
+	case "release":
+		es.Release = true
+	case "workflow_dispatch":
+		es.WorkflowDispatch = true
+	}
+}
+
+func parsePermissions(n *yaml.Node) perms {
+	var p perms
+	if n == nil {
+		return p
+	}
+	p.Specified = true
+	switch n.Kind {
+	case yaml.ScalarNode:
+		switch strings.ToLower(strings.TrimSpace(n.Value)) {
+		case "write-all":
+			p.WriteAll = true
+		case "read-all":
+			p.ReadAll = true
+		}
+	case yaml.MappingNode:
+		for i := 0; i+1 < len(n.Content); i += 2 {
+			k := strings.ToLower(strings.TrimSpace(n.Content[i].Value))
+			v := strings.ToLower(strings.TrimSpace(n.Content[i+1].Value))
+			switch k {
+			case "contents":
+				p.Contents = v
+			case "actions":
+				p.Actions = v
+			case "id-token":
+				p.IDToken = v
+			case "packages":
+				p.Packages = v
+			case "attestations":
+				p.Attestations = v
+			}
+		}
+	}
+	return p
+}
+
+func parseJobs(n *yaml.Node) []job {
+	if n == nil || n.Kind != yaml.MappingNode {
+		return nil
+	}
+	var jobs []job
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		k := n.Content[i]
+		v := n.Content[i+1]
+		if v.Kind != yaml.MappingNode {
+			continue
+		}
+		j := job{ID: k.Value, Line: k.Line}
+		for jj := 0; jj+1 < len(v.Content); jj += 2 {
+			jk := strings.ToLower(strings.TrimSpace(v.Content[jj].Value))
+			jv := v.Content[jj+1]
+			switch jk {
+			case "permissions":
+				j.JobPermissions = parsePermissions(jv)
+				j.JobPermissionsSpecified = j.JobPermissions.Specified
+			case "steps":
+				j.Steps = parseSteps(jv)
+			}
+		}
+		jobs = append(jobs, j)
+	}
+	return jobs
+}
+
+func parseSteps(n *yaml.Node) []step {
+	if n == nil || n.Kind != yaml.SequenceNode {
+		return nil
+	}
+	steps := make([]step, 0, len(n.Content))
+	for _, item := range n.Content {
+		if item.Kind != yaml.MappingNode {
+			continue
+		}
+		s := step{Line: item.Line}
+		for i := 0; i+1 < len(item.Content); i += 2 {
+			k := strings.ToLower(strings.TrimSpace(item.Content[i].Value))
+			v := item.Content[i+1]
+			switch k {
+			case "name":
+				s.Name = v.Value
+			case "uses":
+				s.Uses = strings.TrimSpace(v.Value)
+			case "run":
+				s.Run = v.Value
+			case "with":
+				s.With = parseWith(v)
+			}
+		}
+		classifyStep(&s)
+		steps = append(steps, s)
+	}
+	return steps
+}
+
+func parseWith(n *yaml.Node) map[string]string {
+	if n == nil || n.Kind != yaml.MappingNode {
+		return nil
+	}
+	out := make(map[string]string, len(n.Content)/2)
+	for i := 0; i+1 < len(n.Content); i += 2 {
+		k := strings.ToLower(strings.TrimSpace(n.Content[i].Value))
+		v := n.Content[i+1]
+		// Use Value verbatim; expressions like "${{ github.head_ref }}" are
+		// preserved as strings, which is what classifyStep matches against.
+		out[k] = strings.TrimSpace(v.Value)
+	}
+	return out
+}
+
+// --- step classification ---
+
+// classifyStep populates the boolean flags on step based on uses/run/with.
+// Classification is intentionally narrow: each flag should map to a concrete
+// behavioral primitive (e.g. "installs a package manager dependency tree"),
+// not to a generic shape ("has a run command").
+func classifyStep(s *step) {
+	usesBase := stripActionRef(s.Uses)
+	usesLower := strings.ToLower(usesBase)
+
+	// checkout
+	if usesLower == "actions/checkout" || strings.HasPrefix(usesLower, "actions/checkout/") {
+		s.Checkout = true
+		if ref := s.With["ref"]; ref != "" && isUntrustedRef(ref) {
+			s.CheckoutUntrustedPR = true
+		}
+		if pc, ok := s.With["persist-credentials"]; ok {
+			v := strings.Trim(strings.ToLower(strings.TrimSpace(pc)), "'\"")
+			if v == "false" {
+				s.PersistCredentialsFalse = true
+			}
+		}
+	}
+
+	// cache
+	if usesLower == "actions/cache" ||
+		strings.HasPrefix(usesLower, "actions/cache/") {
+		s.Cache = true
+	}
+	// Setup actions with cache: <something> non-empty enable cache writes
+	// for the package manager. setup-node, setup-python, setup-go all
+	// expose this pattern.
+	if strings.HasPrefix(usesLower, "actions/setup-") {
+		if c, ok := s.With["cache"]; ok {
+			c = strings.Trim(strings.ToLower(strings.TrimSpace(c)), "'\"")
+			if c != "" && c != "false" {
+				s.Cache = true
+			}
+		}
+	}
+
+	// Local actions (./...) execute action code from the checkout; for
+	// pwn-request analysis that means PR-controlled code.
+	if strings.HasPrefix(usesBase, "./") {
+		s.ExecutesCode = true
+	}
+
+	if s.Run != "" {
+		run := s.Run
+		lower := strings.ToLower(run)
+		if matchesPackageInstall(lower) {
+			s.PackageInstall = true
+		}
+		if matchesPackageBuildOrTest(lower) {
+			s.PackageBuildOrTest = true
+		}
+		if matchesPublish(lower) {
+			s.Publish = true
+		}
+		if matchesInterpreter(lower) {
+			s.ExecutesCode = true
+		}
+	}
+}
+
+// stripActionRef returns the action name without any @ref suffix.
+func stripActionRef(uses string) string {
+	uses = strings.TrimSpace(uses)
+	if idx := strings.Index(uses, "@"); idx > 0 {
+		return uses[:idx]
+	}
+	return uses
+}
+
+// isUntrustedRef returns true for `with.ref` values that point at PR head /
+// merge refs, which is the precondition for executing PR-controlled code.
+func isUntrustedRef(ref string) bool {
+	lower := strings.ToLower(ref)
+	needles := []string{
+		"github.event.pull_request.head",
+		"github.event.pull_request.merge",
+		"github.head_ref",
+		"refs/pull/",
+		"pull_request.number",
+		"/merge",
+	}
+	for _, n := range needles {
+		if strings.Contains(lower, n) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesPackageInstall(run string) bool {
+	needles := []string{
+		"npm install", "npm i ", "npm ci",
+		"pnpm install", "pnpm i ", "pnpm i\n",
+		"yarn install", "yarn --frozen-lockfile",
+		"bun install", "bun i ",
+		"pip install", "uv pip install", "poetry install",
+	}
+	for _, n := range needles {
+		if strings.Contains(run, n) {
+			return true
+		}
+	}
+	// Bare `pnpm i` / `npm i` / `yarn` / `bun i` at end-of-line.
+	for _, line := range strings.Split(run, "\n") {
+		l := strings.TrimSpace(line)
+		switch l {
+		case "npm i", "pnpm i", "yarn", "bun i", "bun install":
+			return true
+		}
+	}
+	return false
+}
+
+func matchesPackageBuildOrTest(run string) bool {
+	needles := []string{
+		"npm run ", "npm test", "npm exec",
+		"pnpm run ", "pnpm test", "pnpm exec",
+		"yarn run ", "yarn test",
+		"bun run ", "bun test",
+		"nx run", "nx build", "nx test",
+		"turbo run",
+		"make ", "make\t",
+	}
+	for _, n := range needles {
+		if strings.Contains(run, n) {
+			return true
+		}
+	}
+	return false
+}
+
+func matchesPublish(run string) bool {
+	needles := []string{
+		"npm publish", "pnpm publish", "yarn publish", "yarn npm publish",
+		"bun publish",
+		"twine upload", "uv publish", "poetry publish",
+		"cargo publish", "goreleaser release",
+	}
+	for _, n := range needles {
+		if strings.Contains(run, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchesInterpreter returns true for run: commands that explicitly invoke
+// an interpreter or execute a script file. This is intentionally narrower
+// than matchesPackageBuildOrTest to avoid flagging passive grep/diff steps.
+func matchesInterpreter(run string) bool {
+	indicators := []string{
+		"node -e", "node -p", "node ./", "node ../",
+		"python -c", "python3 -c", "python ./", "python3 ./",
+		"ruby -e", "ruby ./",
+		"php -r", "php ./",
+		"go run ", "cargo run", "dotnet run",
+		"bash ./", "sh ./",
+	}
+	for _, n := range indicators {
+		if strings.Contains(run, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- detection ---
+
+// effectivePermissions resolves the permissions that apply to a job. Per
+// GitHub Actions semantics, job-level permissions fully replace top-level
+// permissions; if a job specifies none, the top-level set is inherited.
+func effectivePermissions(top perms, j *job) perms {
+	if j.JobPermissionsSpecified {
+		return j.JobPermissions
+	}
+	return top
+}
+
+func detect(wf *workflow) []types.Finding {
+	var out []types.Finding
+	for i := range wf.Jobs {
+		j := &wf.Jobs[i]
+		eff := effectivePermissions(wf.Permissions, j)
+		if f := detectPwnRequest(wf, j); f != nil {
+			out = append(out, *f)
+		}
+		if f := detectCache(wf, j); f != nil {
+			out = append(out, *f)
+		}
+		if f := detectOIDC(wf, j, eff); f != nil {
+			out = append(out, *f)
+		}
+		if f := detectCheckout(wf, j); f != nil {
+			out = append(out, *f)
+		}
+	}
+	return out
+}
+
+// dangerousWrite returns true if the effective permissions expose a
+// write-shaped surface (id-token write, contents write, packages write, or
+// blanket write-all) that should escalate pwn-request findings to CRITICAL.
+func dangerousWrite(p perms) bool {
+	if p.WriteAll {
+		return true
+	}
+	if p.IDToken == "write" {
+		return true
+	}
+	if p.Contents == "write" {
+		return true
+	}
+	if p.Packages == "write" {
+		return true
+	}
+	if p.Attestations == "write" {
+		return true
+	}
+	return false
+}
+
+// findUntrustedCheckoutStep returns the first step in a job that checks out
+// a PR-controlled ref. The step's line is used as the anchor for findings.
+func findUntrustedCheckoutStep(j *job) *step {
+	for i := range j.Steps {
+		if j.Steps[i].CheckoutUntrustedPR {
+			return &j.Steps[i]
+		}
+	}
+	return nil
+}
+
+func jobExecutesPRCode(j *job) bool {
+	for _, s := range j.Steps {
+		if s.PackageInstall || s.PackageBuildOrTest || s.ExecutesCode {
+			return true
+		}
+	}
+	return false
+}
+
+func jobHasCacheStep(j *job) *step {
+	for i := range j.Steps {
+		if j.Steps[i].Cache {
+			return &j.Steps[i]
+		}
+	}
+	return nil
+}
+
+func detectPwnRequest(wf *workflow, j *job) *types.Finding {
+	if !wf.Events.PullRequestTarget {
+		return nil
+	}
+	ck := findUntrustedCheckoutStep(j)
+	if ck == nil {
+		return nil
+	}
+	if !jobExecutesPRCode(j) {
+		return nil
+	}
+	sev := types.SeverityHigh
+	eff := effectivePermissions(wf.Permissions, j)
+	if dangerousWrite(eff) {
+		sev = types.SeverityCritical
+	}
+	return &types.Finding{
+		RuleID:   RulePwnRequest,
+		RuleName: "pull_request_target executes untrusted PR code",
+		Severity: sev,
+		Category: "supply-chain",
+		Description: "Workflow runs on pull_request_target (privileged) and checks out " +
+			"the PR head ref while the same job installs, builds, tests, or runs " +
+			"PR-controlled code. This is the classic pwn-request chain that turns " +
+			"untrusted contributor code into privileged CI execution.",
+		FilePath:    wf.Path,
+		Line:        ck.Line,
+		MatchedText: "pull_request_target + untrusted checkout + code execution in job " + j.ID,
+		Analyzer:    AnalyzerName,
+		Confidence:  0.95,
+		Remediation: "Use pull_request for untrusted build/test. Reserve pull_request_target for " +
+			"passive, read-only operations (labeling, commenting). Move privileged work into a " +
+			"separate workflow_run job that consumes only verified artifacts.",
+	}
+}
+
+func detectCache(wf *workflow, j *job) *types.Finding {
+	if !wf.Events.PullRequestTarget {
+		return nil
+	}
+	if findUntrustedCheckoutStep(j) == nil {
+		return nil
+	}
+	cache := jobHasCacheStep(j)
+	if cache == nil {
+		return nil
+	}
+	sev := types.SeverityHigh
+	if jobExecutesPRCode(j) {
+		sev = types.SeverityCritical
+	}
+	return &types.Finding{
+		RuleID:   RuleCache,
+		RuleName: "Untrusted PR workflow can write cache consumed by privileged workflows",
+		Severity: sev,
+		Category: "supply-chain",
+		Description: "pull_request_target jobs that check out PR code AND populate the " +
+			"GitHub Actions cache can poison cache entries consumed later by privileged " +
+			"workflows. Cache writes are not constrained by the workflow's GITHUB_TOKEN " +
+			"permissions, so trust on the cache key cannot be assumed.",
+		FilePath:    wf.Path,
+		Line:        cache.Line,
+		MatchedText: "pull_request_target + untrusted checkout + cache write in job " + j.ID,
+		Analyzer:    AnalyzerName,
+		Confidence:  0.9,
+		Remediation: "Avoid writing the cache from untrusted PR contexts. Either disable cache " +
+			"writes in pull_request_target jobs, or use a separate cache key namespace for " +
+			"untrusted runs. Prefer pull_request for any job that needs to install dependencies.",
+	}
+}
+
+func detectOIDC(wf *workflow, j *job, eff perms) *types.Finding {
+	if eff.IDToken != "write" && !eff.WriteAll {
+		return nil
+	}
+	// FP control: a job that only publishes (no install/build/test) is the
+	// intended use of OIDC and should not be flagged.
+	hasInstallOrBuild := false
+	hasPublish := false
+	for _, s := range j.Steps {
+		if s.PackageInstall || s.PackageBuildOrTest || s.ExecutesCode {
+			hasInstallOrBuild = true
+		}
+		if s.Publish {
+			hasPublish = true
+		}
+	}
+	if !hasInstallOrBuild {
+		return nil
+	}
+	sev := types.SeverityHigh
+	if hasPublish {
+		sev = types.SeverityCritical
+	}
+	return &types.Finding{
+		RuleID:   RuleOIDC,
+		RuleName: "OIDC token available in a job that executes install/build/test code",
+		Severity: sev,
+		Category: "supply-chain",
+		Description: "id-token: write (or write-all) is granted on a job that also installs, " +
+			"builds, tests, or runs scripts. The OIDC token is exposed for the lifetime of " +
+			"the job, so any compromised dependency lifecycle script can mint a trusted " +
+			"publishing token before the publish step.",
+		FilePath:    wf.Path,
+		Line:        j.Line,
+		MatchedText: "id-token: write + install/build/test in job " + j.ID,
+		Analyzer:    AnalyzerName,
+		Confidence:  0.85,
+		Remediation: "Split publishing into its own job that only consumes pre-built, verified " +
+			"artifacts. Grant id-token: write only on that publish-only job and use " +
+			"id-token: none everywhere else.",
+	}
+}
+
+func detectCheckout(wf *workflow, j *job) *types.Finding {
+	if !wf.Events.PullRequestTarget {
+		return nil
+	}
+	ck := findUntrustedCheckoutStep(j)
+	if ck == nil {
+		return nil
+	}
+	if ck.PersistCredentialsFalse {
+		return nil
+	}
+	return &types.Finding{
+		RuleID:   RuleCheckout,
+		RuleName: "Privileged workflow checks out PR code with persisted credentials",
+		Severity: types.SeverityHigh,
+		Category: "supply-chain",
+		Description: "actions/checkout in a pull_request_target job is fetching the PR head " +
+			"ref while leaving persist-credentials at its default (true). That leaves the " +
+			"job's GITHUB_TOKEN in .git/config, where any subsequent step executing PR code " +
+			"can read it.",
+		FilePath:    wf.Path,
+		Line:        ck.Line,
+		MatchedText: "pull_request_target checkout of PR ref without persist-credentials: false",
+		Analyzer:    AnalyzerName,
+		Confidence:  0.9,
+		Remediation: "Prefer not checking out untrusted PR code in privileged workflows. If a " +
+			"checkout is required, set with.persist-credentials: false so the GITHUB_TOKEN is " +
+			"not written to .git/config.",
+	}
+}

--- a/internal/engine/ci/workflow_test.go
+++ b/internal/engine/ci/workflow_test.go
@@ -1,0 +1,561 @@
+package ci
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+)
+
+// analyze runs the analyzer against an in-memory workflow at the given
+// relative path. Returns the resulting findings.
+func analyze(t *testing.T, relPath, content string) []types.Finding {
+	t.Helper()
+	a := New()
+	target := &scanner.Target{
+		Path:    relPath,
+		RelPath: relPath,
+		Content: []byte(content),
+	}
+	findings, err := a.Analyze(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Analyze returned error: %v", err)
+	}
+	return findings
+}
+
+func hasRule(findings []types.Finding, ruleID string) bool {
+	for _, f := range findings {
+		if f.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+func findRule(findings []types.Finding, ruleID string) *types.Finding {
+	for i := range findings {
+		if findings[i].RuleID == ruleID {
+			return &findings[i]
+		}
+	}
+	return nil
+}
+
+// --- target gating ---
+
+func TestIsWorkflowTarget(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{".github/workflows/ci.yml", true},
+		{".github/workflows/release.yaml", true},
+		{"a/b/.github/workflows/x.yml", true},
+		{"/repo/.github/workflows/x.YML", true},
+		{".github/workflows/README.md", false},
+		{"workflows/ci.yml", false},
+		{".github/actions/ci.yml", false},
+		{"package.json", false},
+	}
+	for _, c := range cases {
+		got := isWorkflowTarget(&scanner.Target{Path: c.path, RelPath: c.path})
+		if got != c.want {
+			t.Errorf("isWorkflowTarget(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestAnalyzer_NonWorkflowFile(t *testing.T) {
+	findings := analyze(t, "README.md", "# hello")
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for non-workflow target, got %d", len(findings))
+	}
+}
+
+func TestAnalyzer_MalformedYaml(t *testing.T) {
+	// `:` without value triggers a yaml parse error in many cases; use a
+	// blatant mapping/scalar mixup instead.
+	findings := analyze(t, ".github/workflows/bad.yml", "jobs:\n  - this is a sequence not a map\n")
+	if len(findings) != 0 {
+		t.Fatalf("expected analyzer to swallow malformed yaml, got %d findings", len(findings))
+	}
+}
+
+// --- safe workflows ---
+
+func TestSafe_PullRequestBuild(t *testing.T) {
+	wf := `
+name: CI
+on: pull_request
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install
+      - run: npm test
+`
+	findings := analyze(t, ".github/workflows/ci.yml", wf)
+	if len(findings) != 0 {
+		t.Fatalf("safe pull_request build should produce no findings, got %d: %+v", len(findings), findings)
+	}
+}
+
+func TestSafe_PullRequestTargetCommentOnly(t *testing.T) {
+	// pull_request_target without checking out PR code and without
+	// install/build/test should not flag.
+	wf := `
+name: PR Comment
+on: pull_request_target
+permissions:
+  pull-requests: write
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({...})
+`
+	findings := analyze(t, ".github/workflows/comment.yml", wf)
+	if hasRule(findings, RulePwnRequest) {
+		t.Fatalf("safe pull_request_target should not trigger PWN_REQUEST, got: %+v", findings)
+	}
+}
+
+func TestSafe_PullRequestTargetBaseCheckout(t *testing.T) {
+	// Checking out the base ref (default actions/checkout behavior on
+	// pull_request_target) is safe — only PR head checkout enables the chain.
+	wf := `
+name: PR Hello
+on: pull_request_target
+jobs:
+  hello:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "Hello PR ${{ github.event.pull_request.number }}"
+`
+	findings := analyze(t, ".github/workflows/hello.yml", wf)
+	if len(findings) != 0 {
+		t.Fatalf("base-ref checkout of pull_request_target should be clean, got %d findings", len(findings))
+	}
+}
+
+func TestSafe_PublishOnlyOIDCJob(t *testing.T) {
+	// Publish-only job with id-token: write is the *intended* use of OIDC.
+	// No install/build/test → no finding.
+	wf := `
+name: Release
+on:
+  push:
+    tags: ["v*"]
+permissions:
+  contents: write
+  id-token: write
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm publish --provenance
+`
+	findings := analyze(t, ".github/workflows/release.yml", wf)
+	if hasRule(findings, RuleOIDC) {
+		t.Fatalf("publish-only OIDC job should not trigger OIDC rule, got: %+v", findings)
+	}
+}
+
+func TestSafe_TopLevelOIDCButJobOverridesToNone(t *testing.T) {
+	// Top-level id-token: write, but the executing job overrides to id-token: none.
+	wf := `
+name: Build
+on: push
+permissions:
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: none
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - run: pnpm install
+      - run: pnpm test
+`
+	findings := analyze(t, ".github/workflows/build.yml", wf)
+	if hasRule(findings, RuleOIDC) {
+		t.Fatalf("job override id-token: none should suppress OIDC rule, got: %+v", findings)
+	}
+}
+
+// --- vulnerable workflows ---
+
+func TestVuln_PwnRequest_Basic(t *testing.T) {
+	wf := `
+name: Bundle Size
+on: pull_request_target
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: pnpm install
+      - run: pnpm build
+`
+	findings := analyze(t, ".github/workflows/bundle-size.yml", wf)
+	f := findRule(findings, RulePwnRequest)
+	if f == nil {
+		t.Fatalf("expected GHA_PWN_REQUEST_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityHigh {
+		t.Errorf("expected HIGH for default pwn-request, got %v", f.Severity)
+	}
+	if f.Analyzer != AnalyzerName {
+		t.Errorf("expected analyzer %q, got %q", AnalyzerName, f.Analyzer)
+	}
+	if f.Category != "supply-chain" {
+		t.Errorf("expected category supply-chain, got %q", f.Category)
+	}
+	if f.Line == 0 {
+		t.Errorf("expected non-zero line anchor, got 0")
+	}
+	if f.Remediation == "" {
+		t.Errorf("expected non-empty remediation text")
+	}
+}
+
+func TestVuln_PwnRequest_EscalatedByWritePerms(t *testing.T) {
+	// Same chain but with id-token: write → CRITICAL.
+	wf := `
+name: Bundle
+on: pull_request_target
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+      - run: yarn install
+      - run: yarn build
+`
+	findings := analyze(t, ".github/workflows/bundle.yml", wf)
+	f := findRule(findings, RulePwnRequest)
+	if f == nil {
+		t.Fatalf("expected GHA_PWN_REQUEST_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityCritical {
+		t.Errorf("expected CRITICAL with id-token: write, got %v", f.Severity)
+	}
+}
+
+func TestVuln_PwnRequest_PlusCache(t *testing.T) {
+	wf := `
+name: Cached Bundle
+on: pull_request_target
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'pnpm'
+      - run: pnpm install
+`
+	findings := analyze(t, ".github/workflows/cached-bundle.yml", wf)
+	if !hasRule(findings, RulePwnRequest) {
+		t.Errorf("expected PWN_REQUEST, got: %+v", findings)
+	}
+	cache := findRule(findings, RuleCache)
+	if cache == nil {
+		t.Fatalf("expected GHA_CACHE_001, got: %+v", findings)
+	}
+	if cache.Severity != types.SeverityCritical {
+		t.Errorf("expected CRITICAL for cache+install chain, got %v", cache.Severity)
+	}
+}
+
+func TestVuln_CacheWithoutCodeExecution(t *testing.T) {
+	// Untrusted checkout + cache step but no install/build/test → still HIGH
+	// because cache write can be poisoned regardless.
+	wf := `
+name: Cache Poison
+on: pull_request_target
+jobs:
+  cache_only:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache
+          key: pr-${{ github.event.pull_request.number }}
+`
+	findings := analyze(t, ".github/workflows/cache.yml", wf)
+	cache := findRule(findings, RuleCache)
+	if cache == nil {
+		t.Fatalf("expected GHA_CACHE_001 without install, got: %+v", findings)
+	}
+	if cache.Severity != types.SeverityHigh {
+		t.Errorf("expected HIGH severity, got %v", cache.Severity)
+	}
+}
+
+func TestVuln_OIDC_InstallBuildPublish(t *testing.T) {
+	wf := `
+name: Publish
+on:
+  push:
+    branches: [main]
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: pnpm install
+      - run: pnpm build
+      - run: pnpm publish
+`
+	findings := analyze(t, ".github/workflows/publish.yml", wf)
+	f := findRule(findings, RuleOIDC)
+	if f == nil {
+		t.Fatalf("expected GHA_OIDC_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityCritical {
+		t.Errorf("install+build+publish in OIDC job should be CRITICAL, got %v", f.Severity)
+	}
+}
+
+func TestVuln_OIDC_WriteAll(t *testing.T) {
+	wf := `
+name: Build
+on: push
+permissions: write-all
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install
+      - run: npm test
+`
+	findings := analyze(t, ".github/workflows/build.yml", wf)
+	if !hasRule(findings, RuleOIDC) {
+		t.Errorf("write-all should trigger OIDC rule when install/build runs, got: %+v", findings)
+	}
+}
+
+func TestVuln_Checkout_NoPersistFalse(t *testing.T) {
+	wf := `
+name: PR Hot Take
+on: pull_request_target
+jobs:
+  ht:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: cat README.md
+`
+	findings := analyze(t, ".github/workflows/ht.yml", wf)
+	if !hasRule(findings, RuleCheckout) {
+		t.Errorf("PR head checkout without persist-credentials: false should flag GHA_CHECKOUT_001, got: %+v", findings)
+	}
+}
+
+func TestSafe_Checkout_PersistFalse(t *testing.T) {
+	wf := `
+name: PR Hot Take
+on: pull_request_target
+jobs:
+  ht:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - run: cat README.md
+`
+	findings := analyze(t, ".github/workflows/ht.yml", wf)
+	if hasRule(findings, RuleCheckout) {
+		t.Errorf("persist-credentials: false should suppress GHA_CHECKOUT_001, got: %+v", findings)
+	}
+}
+
+// --- event-shape coverage ---
+
+func TestEventShapes(t *testing.T) {
+	cases := []struct {
+		name string
+		on   string
+	}{
+		{"scalar", "on: pull_request_target"},
+		{"sequence", "on: [push, pull_request_target]"},
+		{"mapping", "on:\n  pull_request_target:\n    types: [opened, synchronize]"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			wf := c.on + `
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - run: pnpm install
+`
+			findings := analyze(t, ".github/workflows/x.yml", wf)
+			if !hasRule(findings, RulePwnRequest) {
+				t.Errorf("event shape %q failed to trigger PWN_REQUEST, got: %+v", c.name, findings)
+			}
+		})
+	}
+}
+
+func TestTopLevelPermsInherited(t *testing.T) {
+	// Top-level id-token: write should reach a job that doesn't specify perms.
+	wf := `
+on: push
+permissions:
+  id-token: write
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm install
+`
+	findings := analyze(t, ".github/workflows/build.yml", wf)
+	if !hasRule(findings, RuleOIDC) {
+		t.Errorf("top-level id-token: write should be inherited, got: %+v", findings)
+	}
+}
+
+func TestUntrustedRefMatches(t *testing.T) {
+	cases := []struct {
+		ref      string
+		expected bool
+	}{
+		{"${{ github.event.pull_request.head.sha }}", true},
+		{"${{ github.event.pull_request.head.ref }}", true},
+		{"${{ github.head_ref }}", true},
+		{"refs/pull/123/merge", true},
+		{"refs/pull/${{ github.event.pull_request.number }}/merge", true},
+		{"main", false},
+		{"${{ github.sha }}", false},
+		{"v1.2.3", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		got := isUntrustedRef(c.ref)
+		if got != c.expected {
+			t.Errorf("isUntrustedRef(%q) = %v, want %v", c.ref, got, c.expected)
+		}
+	}
+}
+
+func TestFindingsHaveStableFields(t *testing.T) {
+	// Regression guard: ensure category, analyzer name, and rule IDs are
+	// stable. Observatory pipelines key on these.
+	wf := `
+on: pull_request_target
+permissions:
+  id-token: write
+jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: actions/cache@v4
+        with:
+          path: ~/.cache
+          key: x
+      - run: npm install
+      - run: npm publish
+`
+	findings := analyze(t, ".github/workflows/regression.yml", wf)
+	if len(findings) == 0 {
+		t.Fatalf("expected findings, got none")
+	}
+	for _, f := range findings {
+		if f.Analyzer != AnalyzerName {
+			t.Errorf("finding %s: analyzer = %q, want %q", f.RuleID, f.Analyzer, AnalyzerName)
+		}
+		if f.Category != "supply-chain" {
+			t.Errorf("finding %s: category = %q, want supply-chain", f.RuleID, f.Category)
+		}
+		if !strings.HasPrefix(f.RuleID, "GHA_") {
+			t.Errorf("finding ruleID %q should have GHA_ prefix", f.RuleID)
+		}
+		if f.Confidence == 0 {
+			t.Errorf("finding %s: confidence should be > 0", f.RuleID)
+		}
+		if f.Remediation == "" {
+			t.Errorf("finding %s: remediation should be non-empty", f.RuleID)
+		}
+	}
+}
+
+// Local-action execution should count as code execution for pwn-request.
+func TestLocalActionExecutesCode(t *testing.T) {
+	wf := `
+on: pull_request_target
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+      - uses: ./.github/actions/local-thing
+`
+	findings := analyze(t, ".github/workflows/local.yml", wf)
+	if !hasRule(findings, RulePwnRequest) {
+		t.Errorf("local action (./...) after PR checkout should trigger PWN_REQUEST, got: %+v", findings)
+	}
+}
+
+// pull_request_target with PR checkout and a passive grep step should NOT
+// trigger PWN_REQUEST (no install/build/test/interpreter call).
+func TestSafe_PullRequestTargetCheckoutPassiveGrep(t *testing.T) {
+	wf := `
+on: pull_request_target
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
+      - run: grep -r 'TODO' .
+`
+	findings := analyze(t, ".github/workflows/scan.yml", wf)
+	if hasRule(findings, RulePwnRequest) {
+		t.Errorf("passive grep step should not trigger PWN_REQUEST, got: %+v", findings)
+	}
+}


### PR DESCRIPTION
## Summary

First slice of an internal supply-chain trust analysis spec. Adds a new analyzer in `internal/engine/ci` that detects GitHub Actions trust-boundary chains rather than firing on isolated weak signals.

The analyzer is offline, deterministic, and only inspects files under `.github/workflows/` with `.yml`/`.yaml` extension. yaml.v3 is already a direct dependency — no new modules.

### New rule IDs (category: `supply-chain`, analyzer: `ci-trust`)

| Rule | Trigger |
|---|---|
| `GHA_PWN_REQUEST_001` | `pull_request_target` + checkout of PR head ref + install/build/test/interpreter call in the same job. Escalates to CRITICAL when the job also has `id-token`/`contents`/`packages` write or `write-all`. |
| `GHA_CACHE_001` | Same chain + cache write step (`actions/cache`, `setup-*` with `cache:`). Escalates to CRITICAL when install/build/test also runs. |
| `GHA_OIDC_001` | `id-token: write` + install/build/test in the same job. **Suppressed** for publish-only jobs (intended OIDC use). Escalates to CRITICAL when publish also runs. |
| `GHA_CHECKOUT_001` | `pull_request_target` checkout of PR head ref without `persist-credentials: false`. |

### False-positive policy (chain-first)

- `pull_request_target` alone never fires.
- `id-token: write` alone never fires.
- `actions/cache` alone never fires.
- Job-level permissions correctly override top-level, so `id-token: none` at the job level suppresses `GHA_OIDC_001` even when top-level has `id-token: write`.
- Passive `grep`/`diff`/`echo` steps do not count as code execution.
- Verified against this repo's own `release.yml` (top-level `id-token: write` for cosign keyless): scan stays clean (0 findings).

### Wiring

Analyzer is registered after pattern matching and before toxicflow in all three scanner builders:
- `aguara.go` — `buildScanner` (legacy `aguara.Scan`)
- `aguara.go` — `Scanner.buildInternalScanner` (cached `NewScanner` API used by aguara-mcp / oktsec)
- `cmd/aguara/commands/scan.go` — CLI `scan` command

Public `Finding` JSON schema unchanged. No new categories. No new flags.

### Out of scope (deferred to follow-up PRs)

- npm package metadata analyzer (`internal/engine/pkgmeta`)
- JavaScript payload risk analyzer (`internal/engine/jsrisk`)
- targeted YAML IOC rules (`SUPPLY_022`–`SUPPLY_025`)
- optional incident IOC extension for npm package/version checks
- README / RULES.md update will land with the final PR in the series, once the full feature surface is in place.

## Test plan

- [x] `make build` passes
- [x] `make test` — all packages green (including new `internal/engine/ci`)
- [x] `make vet` — clean
- [x] `make lint` — `0 issues.`
- [x] Unit tests cover: safe `pull_request` build, safe `pull_request_target` comment-only, safe base-ref checkout, safe publish-only OIDC job, safe job-level `id-token: none` override, vulnerable basic pwn-request, escalation by write perms, pwn-request + cache, cache without code execution, OIDC + install/build/publish, OIDC `write-all`, checkout without `persist-credentials: false`, `persist-credentials: false` suppression, all three `on:` event shapes (scalar/sequence/mapping), local action `./...` execution, passive grep suppression.
- [x] E2E CLI smoke against a hand-crafted vulnerable workflow surfaces all expected rule IDs with correct severity escalation.
- [x] E2E CLI scan of this repo's own `.github/workflows/` stays clean.

Source incident class: GitHub Actions pwn-request chains where `pull_request_target` plus untrusted PR checkout plus cache/OIDC turn contributor code into privileged CI execution.