### PR TITLE
fix: --disable-rule covers analyzer findings; ci-trust false positives

### DIFF
--- a/aguara.go
+++ b/aguara.go
@@ -403,6 +403,9 @@ func (sc *Scanner) buildInternalScanner(toolName string) (*scanner.Scanner, erro
 	if len(sc.toolScoped) > 0 {
 		s.SetToolScopedRules(sc.toolScoped)
 	}
+	if len(sc.cfg.disabledRules) > 0 {
+		s.SetDisabledRules(sc.cfg.disabledRules)
+	}
 	if sc.cfg.deduplicateMode != 0 {
 		s.SetDeduplicateMode(sc.cfg.deduplicateMode)
 	}
@@ -541,6 +544,9 @@ func buildScanner(cfg *scanConfig) (*scanner.Scanner, []*rules.CompiledRule, err
 	}
 	if len(cr.toolScopedRules) > 0 {
 		s.SetToolScopedRules(cr.toolScopedRules)
+	}
+	if len(cfg.disabledRules) > 0 {
+		s.SetDisabledRules(cfg.disabledRules)
 	}
 	if cfg.deduplicateMode != 0 {
 		s.SetDeduplicateMode(cfg.deduplicateMode)

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -315,11 +315,10 @@ func loadAndCompileRules(cfg config.Config) ([]*rules.CompiledRule, error) {
 		}
 	}
 
-	disableList := append(cfg.DisableRules, flagDisableRules...)
-	if len(disableList) > 0 {
+	if disableList := collectDisabledRules(cfg); len(disableList) > 0 {
 		disabled := make(map[string]bool)
 		for _, id := range disableList {
-			disabled[strings.TrimSpace(id)] = true
+			disabled[id] = true
 		}
 		compiled = rules.FilterByIDs(compiled, disabled)
 	}
@@ -327,9 +326,33 @@ func loadAndCompileRules(cfg config.Config) ([]*rules.CompiledRule, error) {
 	return compiled, nil
 }
 
+// collectDisabledRules merges the config file's disable_rules with the
+// --disable-rule flag, trims whitespace, and drops empties. Returned once so
+// both the pattern-rule filter and the scanner-pipeline filter see the same
+// canonical list — analyzer-emitted rule IDs (GHA_*, TOXIC_*, etc.) need the
+// pipeline-level filter because they never appear in the compiled rule list.
+func collectDisabledRules(cfg config.Config) []string {
+	raw := append([]string{}, cfg.DisableRules...)
+	raw = append(raw, flagDisableRules...)
+	if len(raw) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(raw))
+	for _, id := range raw {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
 func buildScanner(compiled []*rules.CompiledRule, cfg config.Config, minSev scanner.Severity) (*scanner.Scanner, *state.Store) {
 	s := scanner.New(flagWorkers)
 	s.SetMinSeverity(minSev)
+	if disableList := collectDisabledRules(cfg); len(disableList) > 0 {
+		s.SetDisabledRules(disableList)
+	}
 	if len(cfg.Ignore) > 0 {
 		s.SetIgnorePatterns(cfg.Ignore)
 	}

--- a/internal/engine/ci/workflow.go
+++ b/internal/engine/ci/workflow.go
@@ -561,18 +561,26 @@ func dangerousWrite(p perms) bool {
 }
 
 // findUntrustedCheckoutStep returns the first step in a job that checks out
-// a PR-controlled ref. The step's line is used as the anchor for findings.
-func findUntrustedCheckoutStep(j *job) *step {
+// a PR-controlled ref, plus its index. The step's line is used as the anchor
+// for findings; the index gates which downstream steps count as "executes
+// PR code".
+func findUntrustedCheckoutStep(j *job) (*step, int) {
 	for i := range j.Steps {
 		if j.Steps[i].CheckoutUntrustedPR {
-			return &j.Steps[i]
+			return &j.Steps[i], i
 		}
 	}
-	return nil
+	return nil, -1
 }
 
-func jobExecutesPRCode(j *job) bool {
-	for _, s := range j.Steps {
+// jobExecutesPRCodeAfter reports whether the job runs install / build /
+// test / interpreter / local-action code in any step that follows the
+// untrusted checkout. Execution that happens BEFORE the untrusted checkout
+// is operating on trusted base content (typical setup-go / setup-node
+// preludes) and does not satisfy the pwn-request chain.
+func jobExecutesPRCodeAfter(j *job, checkoutIdx int) bool {
+	for i := checkoutIdx + 1; i < len(j.Steps); i++ {
+		s := j.Steps[i]
 		if s.PackageInstall || s.PackageBuildOrTest || s.ExecutesCode {
 			return true
 		}
@@ -593,11 +601,11 @@ func detectPwnRequest(wf *workflow, j *job) *types.Finding {
 	if !wf.Events.PullRequestTarget {
 		return nil
 	}
-	ck := findUntrustedCheckoutStep(j)
+	ck, ckIdx := findUntrustedCheckoutStep(j)
 	if ck == nil {
 		return nil
 	}
-	if !jobExecutesPRCode(j) {
+	if !jobExecutesPRCodeAfter(j, ckIdx) {
 		return nil
 	}
 	sev := types.SeverityHigh
@@ -629,7 +637,8 @@ func detectCache(wf *workflow, j *job) *types.Finding {
 	if !wf.Events.PullRequestTarget {
 		return nil
 	}
-	if findUntrustedCheckoutStep(j) == nil {
+	ck, ckIdx := findUntrustedCheckoutStep(j)
+	if ck == nil {
 		return nil
 	}
 	cache := jobHasCacheStep(j)
@@ -637,7 +646,7 @@ func detectCache(wf *workflow, j *job) *types.Finding {
 		return nil
 	}
 	sev := types.SeverityHigh
-	if jobExecutesPRCode(j) {
+	if jobExecutesPRCodeAfter(j, ckIdx) {
 		sev = types.SeverityCritical
 	}
 	return &types.Finding{
@@ -707,7 +716,7 @@ func detectCheckout(wf *workflow, j *job) *types.Finding {
 	if !wf.Events.PullRequestTarget {
 		return nil
 	}
-	ck := findUntrustedCheckoutStep(j)
+	ck, _ := findUntrustedCheckoutStep(j)
 	if ck == nil {
 		return nil
 	}

--- a/internal/engine/ci/workflow.go
+++ b/internal/engine/ci/workflow.go
@@ -356,9 +356,11 @@ func classifyStep(s *step) {
 		}
 	}
 
-	// cache
-	if usesLower == "actions/cache" ||
-		strings.HasPrefix(usesLower, "actions/cache/") {
+	// cache (write only). actions/cache and actions/cache/save persist
+	// content; actions/cache/restore is read-only and cannot poison a
+	// downstream privileged workflow, so it does not satisfy the
+	// cache-write primitive that GHA_CACHE_001 requires.
+	if usesLower == "actions/cache" || usesLower == "actions/cache/save" {
 		s.Cache = true
 	}
 	// Setup actions with cache: <something> non-empty enable cache writes

--- a/internal/engine/ci/workflow_test.go
+++ b/internal/engine/ci/workflow_test.go
@@ -566,6 +566,69 @@ jobs:
 	}
 }
 
+// pwn-request must execute PR-controlled code AFTER the untrusted
+// checkout. A workflow that does trusted setup (install / build)
+// BEFORE switching to the PR ref, then only does passive reads on the
+// PR content, does not satisfy the chain — the executed code is
+// base-branch code, not PR code.
+func TestSafe_ExecutionBeforeUntrustedCheckout(t *testing.T) {
+	wf := `
+on: pull_request_target
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: npm install
+      - run: npm run build
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+          persist-credentials: false
+      - run: grep -r 'TODO' pr/
+`
+	findings := analyze(t, ".github/workflows/scan.yml", wf)
+	if hasRule(findings, RulePwnRequest) {
+		t.Errorf("install/build BEFORE untrusted checkout should not chain, got: %+v", findings)
+	}
+}
+
+// Mirror for GHA_CACHE_001: cache write + install BEFORE the untrusted
+// checkout is base-content cache, not PR-poisoned cache. The cache
+// rule still fires (cache write in same job as untrusted checkout is
+// the cache primitive that motivates the rule) but its severity stays
+// at HIGH because the install is not executing PR code.
+func TestCache_SeverityWhenExecBeforeCheckout(t *testing.T) {
+	wf := `
+on: pull_request_target
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.cache
+          key: base
+      - run: npm install
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: pr
+          persist-credentials: false
+      - run: cat pr/README.md
+`
+	findings := analyze(t, ".github/workflows/cached-scan.yml", wf)
+	cache := findRule(findings, RuleCache)
+	if cache == nil {
+		t.Fatalf("cache write + untrusted checkout should still trigger GHA_CACHE_001, got: %+v", findings)
+	}
+	if cache.Severity != types.SeverityHigh {
+		t.Errorf("execution before checkout should keep cache severity HIGH, got %v", cache.Severity)
+	}
+}
+
 // Local-action execution should count as code execution for pwn-request.
 func TestLocalActionExecutesCode(t *testing.T) {
 	wf := `

--- a/internal/engine/ci/workflow_test.go
+++ b/internal/engine/ci/workflow_test.go
@@ -290,6 +290,52 @@ jobs:
 	}
 }
 
+func TestSafe_CacheRestoreOnly(t *testing.T) {
+	// actions/cache/restore is read-only. A pull_request_target job that
+	// only restores cache cannot poison a downstream workflow, so the
+	// cache-write primitive that GHA_CACHE_001 requires is absent.
+	wf := `
+on: pull_request_target
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/cache/restore@v4
+        with:
+          path: ~/.cache
+          key: shared-cache
+`
+	findings := analyze(t, ".github/workflows/restore.yml", wf)
+	if hasRule(findings, RuleCache) {
+		t.Errorf("actions/cache/restore should not trigger GHA_CACHE_001, got: %+v", findings)
+	}
+}
+
+func TestVuln_CacheSaveExplicit(t *testing.T) {
+	// actions/cache/save is the write half. Keep flagging it.
+	wf := `
+on: pull_request_target
+jobs:
+  size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/cache/save@v4
+        with:
+          path: ~/.cache
+          key: pr-cache
+`
+	findings := analyze(t, ".github/workflows/save.yml", wf)
+	if !hasRule(findings, RuleCache) {
+		t.Errorf("actions/cache/save should trigger GHA_CACHE_001, got: %+v", findings)
+	}
+}
+
 func TestVuln_CacheWithoutCodeExecution(t *testing.T) {
 	// Untrusted checkout + cache step but no install/build/test → still HIGH
 	// because cache write can be poisoned regardless.

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -35,6 +36,7 @@ type Scanner struct {
 	toolName             string
 	scanProfile          ScanProfile
 	toolScopedRules      map[string]ToolScopedRule
+	disabledRules        map[string]bool
 	deduplicateMode      DeduplicateMode
 	crossFileAccumulator CrossFileAccumulator
 	stateStore           StateSaver
@@ -92,6 +94,32 @@ func (s *Scanner) SetScanProfile(profile ScanProfile) {
 // SetToolScopedRules sets per-rule tool filtering from user configuration.
 func (s *Scanner) SetToolScopedRules(rules map[string]ToolScopedRule) {
 	s.toolScopedRules = rules
+}
+
+// SetDisabledRules suppresses findings whose RuleID is present in ids. This
+// covers both pattern rules (which already get filtered out of the compiled
+// rule list upstream) and analyzer-emitted IDs that the compiled-list filter
+// never sees: ci-trust (GHA_*), toxicflow (TOXIC_*), rugpull (RUGPULL_001),
+// NLP injection, and any cross-file finding. The filter runs in postProcess
+// before tool exemptions and dedup so disabled findings cost nothing
+// downstream.
+func (s *Scanner) SetDisabledRules(ids []string) {
+	if len(ids) == 0 {
+		s.disabledRules = nil
+		return
+	}
+	m := make(map[string]bool, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id != "" {
+			m[id] = true
+		}
+	}
+	if len(m) == 0 {
+		s.disabledRules = nil
+		return
+	}
+	s.disabledRules = m
 }
 
 // SetDeduplicateMode sets how findings on the same line are deduplicated.
@@ -252,6 +280,23 @@ func (s *Scanner) ScanTargets(ctx context.Context, targets []*Target) (*ScanResu
 func (s *Scanner) postProcess(findings []Finding) []Finding {
 	if len(findings) == 0 {
 		return nil
+	}
+
+	// Disabled-rule filter runs first: it is the cheapest definitive drop
+	// (user explicitly silenced these IDs) and ensures analyzer-emitted IDs
+	// (GHA_*, TOXIC_*, RUGPULL_001, etc.) receive the same suppression the
+	// compiled rule list already gives pattern rules.
+	if len(s.disabledRules) > 0 {
+		kept := findings[:0]
+		for _, f := range findings {
+			if !s.disabledRules[f.RuleID] {
+				kept = append(kept, f)
+			}
+		}
+		findings = kept
+		if len(findings) == 0 {
+			return nil
+		}
 	}
 
 	// Apply tool exemptions before dedup/scoring (removes definite false positives)

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -48,6 +48,52 @@ func TestScannerOrchestrator(t *testing.T) {
 	require.Equal(t, "R1", result.Findings[0].RuleID)
 }
 
+func TestScannerDisabledRules(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.md"), []byte("content"), 0644))
+
+	s := scanner.New(1)
+	s.SetDisabledRules([]string{"GHA_PWN_REQUEST_001", "  TOXIC_001  ", "", "MISSING_ID"})
+	s.RegisterAnalyzer(&mockAnalyzer{
+		name: "test",
+		findings: []types.Finding{
+			// Suppressed: analyzer-emitted ID, exactly disabled
+			{RuleID: "GHA_PWN_REQUEST_001", Severity: types.SeverityHigh, Line: 1},
+			// Suppressed: whitespace around ID in disable list is trimmed
+			{RuleID: "TOXIC_001", Severity: types.SeverityCritical, Line: 2},
+			// Kept: not in the disable list
+			{RuleID: "GHA_CHECKOUT_001", Severity: types.SeverityHigh, Line: 3},
+		},
+	})
+
+	result, err := s.Scan(context.Background(), dir)
+	require.NoError(t, err)
+	require.Len(t, result.Findings, 1)
+	require.Equal(t, "GHA_CHECKOUT_001", result.Findings[0].RuleID)
+}
+
+func TestScannerDisabledRulesEmpty(t *testing.T) {
+	// Empty input must not stick a non-nil map on the scanner: passing an
+	// empty list is the documented "disable nothing" path used when the
+	// user has neither --disable-rule nor disable_rules: in .aguara.yml.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.md"), []byte("content"), 0644))
+
+	s := scanner.New(1)
+	s.SetDisabledRules(nil)
+	s.SetDisabledRules([]string{"   ", ""}) // whitespace-only list also no-ops
+	s.RegisterAnalyzer(&mockAnalyzer{
+		name: "test",
+		findings: []types.Finding{
+			{RuleID: "GHA_PWN_REQUEST_001", Severity: types.SeverityHigh, Line: 1},
+		},
+	})
+
+	result, err := s.Scan(context.Background(), dir)
+	require.NoError(t, err)
+	require.Len(t, result.Findings, 1)
+}
+
 func TestScannerSeverityFilter(t *testing.T) {
 	dir := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "test.md"), []byte("content"), 0644))


### PR DESCRIPTION
## Summary

Three correctness fixes on top of the ci-trust analyzer that landed in #70. The first is the user-visible one; the other two narrow the analyzer's false-positive surface.

### `--disable-rule` and `.aguara.yml disable_rules` now suppress analyzer findings

Before: the disable list was applied as a filter on the compiled pattern-rule list (via `rules.FilterByIDs`). Analyzer-emitted rule IDs went straight to the output regardless: ci-trust (`GHA_*`), toxicflow (`TOXIC_*`), rugpull (`RUGPULL_001`), NLP injection, and cross-file findings.

After: `Scanner.SetDisabledRules` is wired from the three buildScanner sites (library `Scan`, cached `NewScanner`, CLI `scan`). The filter runs inside `postProcess` before tool exemptions, dedup, scoring, and min-severity filtering, so suppressed findings cost nothing downstream. Pattern rules continue to be filtered out of the compiled list upstream; the new pipeline filter handles the analyzer half.

No flag or schema change; behavior expansion only. The CLI keeps a single canonical `collectDisabledRules(cfg)` helper so the pattern-rule filter and the scanner-pipeline filter agree on input.

### `actions/cache/restore` no longer triggers `GHA_CACHE_001`

The previous classifier matched `actions/cache/restore@v4` as a cache step. That step is read-only and cannot poison a downstream privileged workflow. Tightened the match to the two writers: `actions/cache` and `actions/cache/save`. `actions/setup-*` with `cache: <pkg-manager>` is unchanged.

### `GHA_PWN_REQUEST_001` requires code execution after the untrusted checkout

`jobExecutesPRCode` scanned every step in the job, so a workflow that did trusted setup (install/build/test on the base ref) BEFORE switching to the PR ref, then only did passive reads, would fire. The pwn-request chain requires PR code to run; only steps after the untrusted checkout count. Same gating applies to `GHA_CACHE_001`'s CRITICAL escalation.

## Test plan

- [x] `make build` passes.
- [x] `make test` clean across all packages (new tests added in `internal/scanner`, `internal/engine/ci`).
- [x] `make vet` clean.
- [x] `make lint` reports `0 issues.`
- [x] New test coverage:
  - `TestScannerDisabledRules`: exact-match disable, whitespace trimming, miss-doesn't-filter.
  - `TestScannerDisabledRulesEmpty`: nil and whitespace-only input are no-ops.
  - `TestSafe_CacheRestoreOnly`: PR checkout + `actions/cache/restore` produces no `GHA_CACHE_001`.
  - `TestVuln_CacheSaveExplicit`: `actions/cache/save` still flagged.
  - `TestSafe_ExecutionBeforeUntrustedCheckout`: install/build before PR checkout, passive read after produces no `GHA_PWN_REQUEST_001`.
  - `TestCache_SeverityWhenExecBeforeCheckout`: cache write before exec keeps cache severity HIGH, not CRITICAL.

## Compatibility

Public `Finding` JSON schema unchanged. No new flags. No new categories. The `--disable-rule` flag and `.aguara.yml disable_rules` keep their existing semantics; the only change is that they now also cover rule IDs emitted directly by analyzers (`GHA_*`, `TOXIC_*`, `RUGPULL_001`, NLP injection). The flag's existing help text describes the intent already.

## Out of scope

Further analyzers from the same line of work (npm package metadata, JavaScript payload shape, additional YAML rules) land in separate PRs.