### PR TITLE
feat(pkgmeta): npm package metadata analyzer

### DIFF
--- a/aguara.go
+++ b/aguara.go
@@ -17,6 +17,7 @@ import (
 	"github.com/garagon/aguara/internal/engine/ci"
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pattern"
+	"github.com/garagon/aguara/internal/engine/pkgmeta"
 	"github.com/garagon/aguara/internal/engine/rugpull"
 	"github.com/garagon/aguara/internal/engine/toxicflow"
 	"github.com/garagon/aguara/internal/rules"
@@ -415,6 +416,8 @@ func (sc *Scanner) buildInternalScanner(toolName string) (*scanner.Scanner, erro
 	// CI trust analyzer parses workflow YAML — runs before toxicflow so its
 	// chain findings can be deduped/correlated alongside leaf signals.
 	s.RegisterAnalyzer(ci.New())
+	// pkgmeta inspects package.json for npm lifecycle / git-source chains.
+	s.RegisterAnalyzer(pkgmeta.New())
 	// NLP and ToxicFlow are stateless, cheap to instantiate
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
@@ -554,6 +557,7 @@ func buildScanner(cfg *scanConfig) (*scanner.Scanner, []*rules.CompiledRule, err
 
 	s.RegisterAnalyzer(pattern.NewMatcher(cr.compiled))
 	s.RegisterAnalyzer(ci.New())
+	s.RegisterAnalyzer(pkgmeta.New())
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
 	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -16,6 +16,7 @@ import (
 	"github.com/garagon/aguara/internal/engine/ci"
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pattern"
+	"github.com/garagon/aguara/internal/engine/pkgmeta"
 	"github.com/garagon/aguara/internal/engine/rugpull"
 	"github.com/garagon/aguara/internal/engine/toxicflow"
 	"github.com/garagon/aguara/internal/output"
@@ -391,6 +392,7 @@ func buildScanner(compiled []*rules.CompiledRule, cfg config.Config, minSev scan
 
 	s.RegisterAnalyzer(pattern.NewMatcher(compiled))
 	s.RegisterAnalyzer(ci.New())
+	s.RegisterAnalyzer(pkgmeta.New())
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
 	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -110,6 +110,34 @@ func parseManifest(content []byte) (*manifest, error) {
 	return &m, nil
 }
 
+// sanitizeGitURL strips an embedded `user:password@` (or token `@`) from
+// a dependency version string so a credentialed git spec like
+// `git+https://user:token@github.com/org/repo.git` does not show up
+// verbatim in scan output. Aguara's credential redaction only scrubs the
+// credential-leak category, so supply-chain findings that emit a raw
+// version must self-sanitize.
+func sanitizeGitURL(version string) string {
+	v := version
+	// Only URL forms can carry credentials. Match the scheme then look
+	// for an `@` that separates `userinfo` from `host`. Drop the
+	// userinfo block.
+	for _, scheme := range []string{"git+ssh://", "git+https://", "git+http://", "git+git://", "git://", "https://", "http://", "ssh://"} {
+		if !strings.HasPrefix(strings.ToLower(v), scheme) {
+			continue
+		}
+		rest := v[len(scheme):]
+		at := strings.Index(rest, "@")
+		slash := strings.Index(rest, "/")
+		// `@` must appear before the first `/` to belong to userinfo;
+		// otherwise it is part of a path (e.g. `@scope/...`).
+		if at > 0 && (slash < 0 || at < slash) {
+			return v[:len(scheme)] + rest[at+1:]
+		}
+		break
+	}
+	return v
+}
+
 // findLineOfQuotedKey returns the 1-based line number of the first
 // occurrence of `"<key>"` in raw, or 0 if it is not present. Used to
 // anchor findings to the manifest line declaring the offending entry so
@@ -287,16 +315,32 @@ func scriptMentionsPublish(scripts map[string]string) bool {
 // manager install/build/test verb. This is the install-time-code half of
 // the publish-surface chain.
 func scriptMentionsInstallOrBuild(scripts map[string]string) bool {
+	// Substring needles cover the common multi-word forms.
 	needles := []string{
 		"npm install", "npm i ", "npm ci", "npm run", "npm test", "npm exec",
 		"pnpm install", "pnpm i ", "pnpm run", "pnpm test", "pnpm exec",
 		"yarn install", "yarn run", "yarn test",
 		"bun install", "bun i ", "bun run", "bun test",
 	}
+	// Exact short forms: when a script body is just `npm i`, `pnpm i`,
+	// `yarn`, `bun i`, etc., the trailing-space needles above miss them.
+	exact := map[string]bool{
+		"npm i": true, "npm install": true, "npm ci": true,
+		"pnpm i": true, "pnpm install": true,
+		"yarn": true, "yarn install": true,
+		"bun i": true, "bun install": true,
+	}
 	for _, body := range scripts {
 		lower := strings.ToLower(body)
 		for _, n := range needles {
 			if strings.Contains(lower, n) {
+				return true
+			}
+		}
+		// Match the script body as a whole word after trimming, and also
+		// each newline-separated line for multi-line shell scripts.
+		for _, line := range strings.Split(lower, "\n") {
+			if exact[strings.TrimSpace(line)] {
 				return true
 			}
 		}
@@ -392,19 +436,20 @@ func detectLifecycleGit(pkg *manifest) []types.Finding {
 		if d.Section == "optionalDependencies" && isSuspiciousPackageName(d.Name) {
 			sev = types.SeverityCritical
 		}
+		safeVersion := sanitizeGitURL(d.Version)
 		findings = append(findings, types.Finding{
 			RuleID:   RuleLifecycleGit,
 			RuleName: "Git dependency can execute lifecycle code during install",
 			Severity: sev,
 			Category: "supply-chain",
-			Description: "package.json pulls " + d.Name + " from a git source (" + d.Version +
+			Description: "package.json pulls " + d.Name + " from a git source (" + safeVersion +
 				") and defines an npm install-time lifecycle script. On `npm install`, " +
 				"the git ref can change between resolutions and the lifecycle script will " +
 				"execute whatever code is at the resolved ref, with the install user's " +
 				"environment.",
 			FilePath:    pkg.path,
 			Line:        findLineOfQuotedKey(pkg.raw, d.Name),
-			MatchedText: d.Section + "." + d.Name + " = " + d.Version + " + install-time script",
+			MatchedText: d.Section + "." + d.Name + " = " + safeVersion + " + install-time script",
 			Analyzer:    AnalyzerName,
 			Confidence:  0.9,
 			Remediation: "Pin npm dependencies to registry versions with lockfile integrity. " +
@@ -424,11 +469,14 @@ func detectOptionalGit(pkg *manifest) []types.Finding {
 	if len(pkg.OptionalDependencies) == 0 {
 		return nil
 	}
-	// Anchor every optional-git finding at the optionalDependencies
-	// section header. Per-dep anchoring would collide with NPM_LIFECYCLE_GIT_001
-	// (which also points at the dep line) and the scanner's default
-	// cross-rule dedup would silently drop one of the two.
-	sectionLine := findLineOfQuotedKey(pkg.raw, "optionalDependencies")
+	// When a lifecycle script is present, NPM_LIFECYCLE_GIT_001 already
+	// covers every optional git dep with higher severity and a strictly
+	// stronger description (install-time execution). Suppress the
+	// optional-git rule in that case to avoid two findings that the
+	// scanner's cross-rule dedup would silently collapse.
+	if hasLifecycleScript(pkg.Scripts) {
+		return nil
+	}
 	names := make([]string, 0, len(pkg.OptionalDependencies))
 	for k := range pkg.OptionalDependencies {
 		names = append(names, k)
@@ -444,18 +492,21 @@ func detectOptionalGit(pkg *manifest) []types.Finding {
 		if isSuspiciousPackageName(n) {
 			sev = types.SeverityHigh
 		}
+		safeVersion := sanitizeGitURL(v)
 		findings = append(findings, types.Finding{
 			RuleID:   RuleOptionalGit,
 			RuleName: "Optional dependency resolves executable code from git",
 			Severity: sev,
 			Category: "supply-chain",
-			Description: "optionalDependencies." + n + " resolves to a git source (" + v +
+			Description: "optionalDependencies." + n + " resolves to a git source (" + safeVersion +
 				"). Optional dependencies install silently when resolution succeeds, so a " +
 				"mutable git ref here is a quieter supply-chain entry point than the same " +
 				"shape in dependencies.",
 			FilePath:    pkg.path,
-			Line:        sectionLine,
-			MatchedText: "optionalDependencies." + n + " = " + v,
+			// Per-dep line anchor: multiple optional git deps get distinct
+			// lines so the scanner's same-rule dedup keeps each one.
+			Line:        findLineOfQuotedKey(pkg.raw, n),
+			MatchedText: "optionalDependencies." + n + " = " + safeVersion,
 			Analyzer:    AnalyzerName,
 			Confidence:  0.8,
 			Remediation: "Avoid git sources in optionalDependencies. If you must use one, pin " +

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -16,6 +16,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -143,44 +144,49 @@ func sanitizeGitURL(version string) string {
 	return v
 }
 
+// keyTokenRegex compiles a regex that matches `"key"` followed by any
+// JSON-allowed whitespace and then `:`. This tolerates valid manifests
+// that format keys with extra space (e.g. `"key" : value`) which a plain
+// `"key":` substring search would miss.
+func keyTokenRegex(key string) *regexp.Regexp {
+	return regexp.MustCompile(`"` + regexp.QuoteMeta(key) + `"\s*:`)
+}
+
+// findKeyLine returns the 1-based line number of the first `"key":`
+// token in raw (whitespace-tolerant), or 0 if it is not present. Used
+// to anchor findings on top-level keys such as publishConfig or scripts.
+func findKeyLine(raw []byte, key string) int {
+	if len(raw) == 0 || key == "" {
+		return 0
+	}
+	loc := keyTokenRegex(key).FindIndex(raw)
+	if loc == nil {
+		return 0
+	}
+	return bytes.Count(raw[:loc[0]], []byte{'\n'}) + 1
+}
+
 // findDepLine returns the 1-based line of the dependency entry named
 // `name` inside the JSON section `section`. Searching is scoped to the
-// section so a key that happens to match an unrelated field (the
-// package "name", a script key, etc.) does not anchor the finding to
-// the wrong line.
+// bytes after the section's `"section":` token so a key that happens to
+// match an unrelated field (the package "name", a script key, etc.)
+// does not anchor the finding to the wrong line. Both the section and
+// the dep key are matched with optional whitespace between `"key"` and
+// `:` so valid JSON formatting variants do not regress to line 0.
 func findDepLine(raw []byte, section, name string) int {
 	if len(raw) == 0 || section == "" || name == "" {
 		return 0
 	}
-	sectionMarker := []byte(`"` + section + `":`)
-	sIdx := bytes.Index(raw, sectionMarker)
-	if sIdx < 0 {
+	secLoc := keyTokenRegex(section).FindIndex(raw)
+	if secLoc == nil {
 		return 0
 	}
-	nameMarker := []byte(`"` + name + `":`)
-	rel := bytes.Index(raw[sIdx+len(sectionMarker):], nameMarker)
-	if rel < 0 {
+	rel := keyTokenRegex(name).FindIndex(raw[secLoc[1]:])
+	if rel == nil {
 		return 0
 	}
-	absIdx := sIdx + len(sectionMarker) + rel
-	return bytes.Count(raw[:absIdx], []byte{'\n'}) + 1
-}
-
-// findLineOfQuotedKey returns the 1-based line number of the first
-// occurrence of `"<key>"` in raw, or 0 if it is not present. Used to
-// anchor findings to the manifest line declaring the offending entry so
-// cross-rule findings on the same package.json get distinct line
-// numbers and survive the scanner's default dedup pass.
-func findLineOfQuotedKey(raw []byte, key string) int {
-	if len(raw) == 0 || key == "" {
-		return 0
-	}
-	needle := []byte(`"` + key + `"`)
-	idx := bytes.Index(raw, needle)
-	if idx < 0 {
-		return 0
-	}
-	return bytes.Count(raw[:idx], []byte{'\n'}) + 1
+	abs := secLoc[1] + rel[0]
+	return bytes.Count(raw[:abs], []byte{'\n'}) + 1
 }
 
 // --- classifiers ---
@@ -675,9 +681,9 @@ func detectPublishSurface(pkg *manifest) *types.Finding {
 	}
 	// Anchor at publishConfig if declared, otherwise at the scripts block
 	// where the publish command lives.
-	line := findLineOfQuotedKey(pkg.raw, "publishConfig")
+	line := findKeyLine(pkg.raw, "publishConfig")
 	if line == 0 {
-		line = findLineOfQuotedKey(pkg.raw, "scripts")
+		line = findKeyLine(pkg.raw, "scripts")
 	}
 	return &types.Finding{
 		RuleID:   RulePublishSurface,

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -235,23 +235,28 @@ func isGitDep(version string) bool {
 //
 // Strictly install-time per npm docs: preinstall, install, postinstall.
 // prepare and its pre/post hooks also run during install (on git
-// dependencies and when packing a local install). prepublishOnly,
-// prepack, and postpack run only on `npm publish` / `npm pack` and are
-// intentionally excluded so manifests that ship with publish-only hooks
-// do not produce false-positive HIGH/CRITICAL findings.
+// dependencies and when packing a local install). prepublish is
+// deprecated but npm still executes it during `npm install` / `npm ci`,
+// so we keep it; prepublishOnly is the explicitly publish-only variant
+// and stays excluded. prepack and postpack run only on publish/pack and
+// are also excluded so publish-only manifests do not falsely trigger.
 var lifecycleScripts = []string{
 	"preinstall",
 	"install",
 	"postinstall",
+	"prepublish",
 	"preprepare",
 	"prepare",
 	"postprepare",
 }
 
-// hasLifecycleScript reports whether scripts defines any install-time hook.
+// hasLifecycleScript reports whether scripts defines any install-time hook
+// with a non-empty body. Empty-body lifecycle entries (e.g. placeholder
+// `"postinstall": ""`) do not execute project code and would otherwise
+// false-positive on harmless manifests under --fail-on high.
 func hasLifecycleScript(scripts map[string]string) bool {
 	for _, k := range lifecycleScripts {
-		if _, ok := scripts[k]; ok {
+		if body, ok := scripts[k]; ok && strings.TrimSpace(body) != "" {
 			return true
 		}
 	}
@@ -397,17 +402,37 @@ func scriptMentionsInstallOrBuild(scripts map[string]string) bool {
 	return false
 }
 
-// manifestReferencesProvenance reports whether the package manifest, taken
-// as a whole, references a provenance / trusted-publishing / OIDC string.
-// We run this against the raw bytes so a publishConfig.provenance flag,
-// an "id-token" string in a script, or an "oidc" hint in arbitrary keys
-// all count.
-func manifestReferencesProvenance(raw []byte) bool {
-	if len(raw) == 0 {
+// manifestReferencesProvenance reports whether the manifest enables a
+// trusted-publishing / provenance / OIDC surface. The check is value-aware
+// for the provenance flag (a literal `"provenance": false` does not count)
+// and substring-based for the other trust signals, which only appear as
+// references rather than as booleans.
+func manifestReferencesProvenance(pkg *manifest) bool {
+	if pkg == nil {
 		return false
 	}
+	// Honor an explicit publishConfig.provenance boolean. Only `true`
+	// counts; missing or `false` falls through to the substring checks
+	// below, which look for other ways a trust surface might be wired.
+	if len(pkg.PublishConfig) > 0 {
+		var pc struct {
+			Provenance *bool `json:"provenance"`
+		}
+		if err := json.Unmarshal(pkg.PublishConfig, &pc); err == nil {
+			if pc.Provenance != nil && *pc.Provenance {
+				return true
+			}
+		}
+	}
+	if len(pkg.raw) == 0 {
+		return false
+	}
+	lower := strings.ToLower(string(pkg.raw))
+	// `--provenance` is the npm CLI flag form (e.g. in a release script).
+	// trusted-publishing / id-token / oidc are reference strings that
+	// should not appear as boolean values in practice.
 	needles := []string{
-		"provenance",
+		"--provenance",
 		"trusted-publishing",
 		"trustedpublishing",
 		"id-token",
@@ -415,7 +440,6 @@ func manifestReferencesProvenance(raw []byte) bool {
 		"oidc",
 		"actions_id_token_request",
 	}
-	lower := strings.ToLower(string(raw))
 	for _, n := range needles {
 		if strings.Contains(lower, n) {
 			return true
@@ -579,7 +603,7 @@ func detectPublishSurface(pkg *manifest) *types.Finding {
 	if !scriptMentionsInstallOrBuild(pkg.Scripts) {
 		return nil
 	}
-	if !manifestReferencesProvenance(pkg.raw) {
+	if !manifestReferencesProvenance(pkg) {
 		return nil
 	}
 	// Anchor at publishConfig if declared, otherwise at the scripts block

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -197,31 +197,39 @@ func isGitDep(version string) bool {
 	case strings.Contains(noFrag, "://") && strings.HasSuffix(noFrag, ".git"):
 		return true
 	}
-	// owner/repo or owner/repo#ref shorthand: one slash, no protocol, no
-	// version-range characters. Guard tightly so registry-pinned versions
-	// like "^1.2.3" do not match.
-	if strings.ContainsAny(v, " \t\n") {
-		return false
-	}
-	if strings.ContainsAny(v, "^~<>=*|") {
-		return false
-	}
-	if strings.HasPrefix(v, "file:") || strings.HasPrefix(v, "link:") || strings.HasPrefix(v, "workspace:") {
-		return false
-	}
-	if strings.HasPrefix(v, "npm:") {
-		return false
-	}
-	// require exactly one slash separating owner/repo, optionally followed
-	// by a #ref. Excludes paths like "@scope/name@1.2.3".
+	// owner/repo or owner/repo#ref shorthand. Strip the #fragment first so
+	// a valid semver-fragment shorthand like "owner/repo#semver:^1.2.3"
+	// still classifies as a git dep (the ^ is inside the fragment).
 	core := v
 	if idx := strings.Index(core, "#"); idx >= 0 {
 		core = core[:idx]
+	}
+	// Reject local-path specs and non-git prefixes before the slash count.
+	// npm accepts "./runner", "../setup", "/abs/path", and "~/home/path"
+	// as filesystem dependencies; they happen to contain exactly one
+	// slash and would otherwise be misread as owner/repo shorthand.
+	if strings.HasPrefix(core, "./") || strings.HasPrefix(core, "../") ||
+		strings.HasPrefix(core, "/") || strings.HasPrefix(core, "~/") {
+		return false
+	}
+	if strings.HasPrefix(core, "file:") || strings.HasPrefix(core, "link:") ||
+		strings.HasPrefix(core, "workspace:") || strings.HasPrefix(core, "npm:") {
+		return false
+	}
+	// Whitespace and version-range characters disqualify the core (the
+	// #fragment was stripped above, so semver-style fragments do not
+	// trip this guard).
+	if strings.ContainsAny(core, " \t\n") {
+		return false
+	}
+	if strings.ContainsAny(core, "^~<>=*|") {
+		return false
 	}
 	if strings.HasPrefix(core, "@") {
 		// Scoped names use the registry, not a git shorthand.
 		return false
 	}
+	// Require exactly one slash separating owner/repo.
 	if strings.Count(core, "/") != 1 {
 		return false
 	}

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -143,6 +143,29 @@ func sanitizeGitURL(version string) string {
 	return v
 }
 
+// findDepLine returns the 1-based line of the dependency entry named
+// `name` inside the JSON section `section`. Searching is scoped to the
+// section so a key that happens to match an unrelated field (the
+// package "name", a script key, etc.) does not anchor the finding to
+// the wrong line.
+func findDepLine(raw []byte, section, name string) int {
+	if len(raw) == 0 || section == "" || name == "" {
+		return 0
+	}
+	sectionMarker := []byte(`"` + section + `":`)
+	sIdx := bytes.Index(raw, sectionMarker)
+	if sIdx < 0 {
+		return 0
+	}
+	nameMarker := []byte(`"` + name + `":`)
+	rel := bytes.Index(raw[sIdx+len(sectionMarker):], nameMarker)
+	if rel < 0 {
+		return 0
+	}
+	absIdx := sIdx + len(sectionMarker) + rel
+	return bytes.Count(raw[:absIdx], []byte{'\n'}) + 1
+}
+
 // findLineOfQuotedKey returns the 1-based line number of the first
 // occurrence of `"<key>"` in raw, or 0 if it is not present. Used to
 // anchor findings to the manifest line declaring the offending entry so
@@ -436,15 +459,18 @@ func manifestReferencesProvenance(pkg *manifest) bool {
 		return false
 	}
 	lower := strings.ToLower(string(pkg.raw))
-	// Only highly specific trust-surface strings count. Bare "oidc",
-	// "id-token", and "id_token" are dropped because they can appear in
-	// unrelated dependency names ("oidc-client-ts", "jwt-id-token", ...)
-	// and would false-positive an entire class of legitimate manifests.
-	// The remaining needles are either an npm CLI flag, a documented
-	// phrase, or a full GitHub Actions env var prefix — none of which
-	// occur as dependency-name substrings in practice.
+	// `--provenance` is value-aware: a script that explicitly opts out
+	// with `--provenance=false` or `--provenance=0` does not enable the
+	// trust surface, so the substring search alone would false-positive.
+	if hasEnabledProvenanceFlag(lower) {
+		return true
+	}
+	// The remaining needles are either a documented phrase or a full
+	// GitHub Actions env var prefix; none occur as dependency-name
+	// substrings in practice. Bare "oidc", "id-token", and "id_token"
+	// are dropped because legitimate libraries (oidc-client-ts,
+	// jwt-id-token-handler) would otherwise false-positive.
 	needles := []string{
-		"--provenance",
 		"trusted-publishing",
 		"trustedpublishing",
 		"actions_id_token_request",
@@ -453,6 +479,37 @@ func manifestReferencesProvenance(pkg *manifest) bool {
 		if strings.Contains(lower, n) {
 			return true
 		}
+	}
+	return false
+}
+
+// hasEnabledProvenanceFlag reports whether the lower-cased input mentions
+// the npm `--provenance` CLI flag in a way that enables provenance. A
+// bare `--provenance` defaults to true; `--provenance=true` is explicit
+// true; `--provenance=false` and `--provenance=0` are opt-outs that must
+// not be read as a trust signal.
+func hasEnabledProvenanceFlag(s string) bool {
+	for off := 0; off < len(s); {
+		i := strings.Index(s[off:], "--provenance")
+		if i < 0 {
+			return false
+		}
+		abs := off + i + len("--provenance")
+		if abs >= len(s) || s[abs] != '=' {
+			return true
+		}
+		// `=` follows; inspect the value.
+		tail := s[abs+1:]
+		switch {
+		case strings.HasPrefix(tail, "false"):
+			// opt-out; keep scanning in case another instance enables it.
+		case strings.HasPrefix(tail, "0"):
+			// opt-out variant; keep scanning.
+		default:
+			// =true or any other value treats as enabled.
+			return true
+		}
+		off = abs + 1
 	}
 	return false
 }
@@ -530,7 +587,7 @@ func detectLifecycleGit(pkg *manifest) []types.Finding {
 				"execute whatever code is at the resolved ref, with the install user's " +
 				"environment.",
 			FilePath:    pkg.path,
-			Line:        findLineOfQuotedKey(pkg.raw, d.Name),
+			Line:        findDepLine(pkg.raw, d.Section, d.Name),
 			MatchedText: d.Section + "." + d.Name + " = " + safeVersion + " + install-time script",
 			Analyzer:    AnalyzerName,
 			Confidence:  0.9,
@@ -585,9 +642,10 @@ func detectOptionalGit(pkg *manifest) []types.Finding {
 				"mutable git ref here is a quieter supply-chain entry point than the same " +
 				"shape in dependencies.",
 			FilePath:    pkg.path,
-			// Per-dep line anchor: multiple optional git deps get distinct
-			// lines so the scanner's same-rule dedup keeps each one.
-			Line:        findLineOfQuotedKey(pkg.raw, n),
+			// Per-dep line anchor, scoped to optionalDependencies so a
+			// dep name that also appears as the package "name" or as a
+			// script key does not anchor to the wrong line.
+			Line:        findDepLine(pkg.raw, "optionalDependencies", n),
 			MatchedText: "optionalDependencies." + n + " = " + safeVersion,
 			Analyzer:    AnalyzerName,
 			Confidence:  0.8,

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -1,0 +1,510 @@
+// Package pkgmeta inspects npm package manifests (package.json) for
+// supply-chain risk patterns that combine static metadata signals into
+// chains: install-time lifecycle hooks reachable through a git dependency,
+// optional dependencies that resolve to executable git refs, and publish
+// surfaces that share a job with install-time code paths.
+//
+// The analyzer is fully offline. It parses JSON into a small struct, runs
+// a handful of string checks against the parsed fields, and never executes
+// scripts or resolves the dependency tree. Findings stay chain-aware:
+// single weak signals (a prepare script alone, a git dependency alone,
+// publishConfig alone) never fire.
+package pkgmeta
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+)
+
+// AnalyzerName is the value reported in Finding.Analyzer for this engine.
+const AnalyzerName = "pkgmeta"
+
+// Rule IDs emitted by this analyzer.
+const (
+	RuleLifecycleGit    = "NPM_LIFECYCLE_GIT_001"
+	RuleOptionalGit     = "NPM_OPTIONAL_GIT_001"
+	RulePublishSurface  = "NPM_PUBLISH_SURFACE_001"
+)
+
+// Analyzer implements scanner.Analyzer for npm package metadata.
+type Analyzer struct{}
+
+// New returns a fresh npm package metadata analyzer.
+func New() *Analyzer { return &Analyzer{} }
+
+// Name returns the analyzer identifier.
+func (a *Analyzer) Name() string { return AnalyzerName }
+
+// Analyze parses the target if it is a package.json file and returns
+// supply-chain findings. Non-manifest files and malformed JSON return nil.
+func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.Finding, error) {
+	if !isManifestTarget(target) {
+		return nil, nil
+	}
+	if len(target.Content) == 0 {
+		return nil, nil
+	}
+	pkg, err := parseManifest(target.Content)
+	if err != nil || pkg == nil {
+		// Malformed JSON: leave pattern rules to flag what they can; pkgmeta
+		// only reports on shapes it can confidently reason about.
+		return nil, nil
+	}
+	pkg.path = target.RelPath
+	pkg.raw = target.Content
+	return detect(pkg), nil
+}
+
+// --- target gating ---
+
+// isManifestTarget returns true for files named package.json. Checks both
+// Path (when scanning a real repo) and RelPath (when scanning in-memory
+// content with a hinted name).
+func isManifestTarget(t *scanner.Target) bool {
+	if t == nil {
+		return false
+	}
+	for _, p := range []string{t.Path, t.RelPath} {
+		if p == "" {
+			continue
+		}
+		if filepath.Base(filepath.ToSlash(p)) == "package.json" {
+			return true
+		}
+	}
+	return false
+}
+
+// --- model ---
+
+type manifest struct {
+	Name                 string            `json:"name"`
+	Version              string            `json:"version"`
+	Dependencies         map[string]string `json:"dependencies"`
+	DevDependencies      map[string]string `json:"devDependencies"`
+	OptionalDependencies map[string]string `json:"optionalDependencies"`
+	PeerDependencies     map[string]string `json:"peerDependencies"`
+	Scripts              map[string]string `json:"scripts"`
+	PublishConfig        json.RawMessage   `json:"publishConfig"`
+
+	// Populated by Analyzer.Analyze before detection. Not part of the JSON
+	// schema; lowercase to keep them out of struct-tag-based marshaling.
+	path string
+	raw  []byte
+}
+
+// --- parsing ---
+
+func parseManifest(content []byte) (*manifest, error) {
+	var m manifest
+	if err := json.Unmarshal(content, &m); err != nil {
+		return nil, err
+	}
+	return &m, nil
+}
+
+// findLineOfQuotedKey returns the 1-based line number of the first
+// occurrence of `"<key>"` in raw, or 0 if it is not present. Used to
+// anchor findings to the manifest line declaring the offending entry so
+// cross-rule findings on the same package.json get distinct line
+// numbers and survive the scanner's default dedup pass.
+func findLineOfQuotedKey(raw []byte, key string) int {
+	if len(raw) == 0 || key == "" {
+		return 0
+	}
+	needle := []byte(`"` + key + `"`)
+	idx := bytes.Index(raw, needle)
+	if idx < 0 {
+		return 0
+	}
+	return bytes.Count(raw[:idx], []byte{'\n'}) + 1
+}
+
+// --- classifiers ---
+
+// isGitDep reports whether a dependency value points at a git source rather
+// than the npm registry. npm accepts several shorthand forms; we cover the
+// ones that actually resolve to executable git content during install.
+func isGitDep(version string) bool {
+	v := strings.TrimSpace(version)
+	if v == "" {
+		return false
+	}
+	lower := strings.ToLower(v)
+	// Strip an optional #ref fragment before suffix-matching so
+	// "https://github.com/owner/repo.git#abc1234" still classifies as git.
+	noFrag := lower
+	if i := strings.Index(noFrag, "#"); i >= 0 {
+		noFrag = noFrag[:i]
+	}
+	switch {
+	case strings.HasPrefix(lower, "git+"):
+		return true
+	case strings.HasPrefix(lower, "git://"):
+		return true
+	case strings.HasPrefix(lower, "github:"):
+		return true
+	case strings.HasPrefix(lower, "gitlab:"):
+		return true
+	case strings.HasPrefix(lower, "bitbucket:"):
+		return true
+	case strings.HasPrefix(lower, "gist:"):
+		return true
+	case strings.Contains(noFrag, "github.com/") && strings.HasSuffix(noFrag, ".git"):
+		return true
+	}
+	// owner/repo or owner/repo#ref shorthand: one slash, no protocol, no
+	// version-range characters. Guard tightly so registry-pinned versions
+	// like "^1.2.3" do not match.
+	if strings.ContainsAny(v, " \t\n") {
+		return false
+	}
+	if strings.ContainsAny(v, "^~<>=*|") {
+		return false
+	}
+	if strings.HasPrefix(v, "file:") || strings.HasPrefix(v, "link:") || strings.HasPrefix(v, "workspace:") {
+		return false
+	}
+	if strings.HasPrefix(v, "npm:") {
+		return false
+	}
+	// require exactly one slash separating owner/repo, optionally followed
+	// by a #ref. Excludes paths like "@scope/name@1.2.3".
+	core := v
+	if idx := strings.Index(core, "#"); idx >= 0 {
+		core = core[:idx]
+	}
+	if strings.HasPrefix(core, "@") {
+		// Scoped names use the registry, not a git shorthand.
+		return false
+	}
+	if strings.Count(core, "/") != 1 {
+		return false
+	}
+	return true
+}
+
+// lifecycleScripts are the npm script names that run automatically during
+// install or pack. A package that defines any of these AND pulls a
+// dependency from a mutable git source can execute attacker code as soon
+// as the user runs `npm install`.
+var lifecycleScripts = []string{
+	"preinstall",
+	"install",
+	"postinstall",
+	"prepare",
+	"prepublish",
+	"prepublishOnly",
+	"prepack",
+	"postpack",
+}
+
+// hasLifecycleScript reports whether scripts defines any install-time hook.
+func hasLifecycleScript(scripts map[string]string) bool {
+	for _, k := range lifecycleScripts {
+		if _, ok := scripts[k]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// suspiciousPackageRoots matches dependency names that historically front
+// install-time payloads in real supply-chain incidents. The list is
+// intentionally short; broadening it costs false positives on legitimate
+// setup/runtime libraries.
+var suspiciousPackageRoots = []string{
+	"setup",
+	"install",
+	"init",
+	"runner",
+	"runtime",
+	"bootstrap",
+	"loader",
+}
+
+// isSuspiciousPackageName reports whether a dependency name's last path
+// segment matches a known incident fingerprint root, with or without a
+// suffix (e.g. "setup", "setup-utils", "node-setup").
+func isSuspiciousPackageName(name string) bool {
+	if name == "" {
+		return false
+	}
+	// Scoped names: @scope/leaf — only the leaf segment is the package's
+	// own identifier; the scope is the publisher's namespace.
+	tail := name
+	if strings.HasPrefix(tail, "@") {
+		if idx := strings.Index(tail, "/"); idx >= 0 {
+			tail = tail[idx+1:]
+		}
+	}
+	lower := strings.ToLower(tail)
+	for _, root := range suspiciousPackageRoots {
+		if lower == root {
+			return true
+		}
+		if strings.HasPrefix(lower, root+"-") || strings.HasSuffix(lower, "-"+root) {
+			return true
+		}
+		if strings.HasPrefix(lower, root) && len(lower) > len(root) && !isAlpha(lower[len(root)]) {
+			return true
+		}
+	}
+	return false
+}
+
+func isAlpha(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// scriptMentionsPublish reports whether any script runs an npm-flavored
+// publish command. The publish ID is the sink that turns install-time
+// execution into a registry-write capability.
+func scriptMentionsPublish(scripts map[string]string) bool {
+	needles := []string{
+		"npm publish", "pnpm publish", "yarn publish", "yarn npm publish",
+		"bun publish",
+	}
+	for _, body := range scripts {
+		lower := strings.ToLower(body)
+		for _, n := range needles {
+			if strings.Contains(lower, n) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// scriptMentionsInstallOrBuild reports whether any script invokes a package
+// manager install/build/test verb. This is the install-time-code half of
+// the publish-surface chain.
+func scriptMentionsInstallOrBuild(scripts map[string]string) bool {
+	needles := []string{
+		"npm install", "npm i ", "npm ci", "npm run", "npm test", "npm exec",
+		"pnpm install", "pnpm i ", "pnpm run", "pnpm test", "pnpm exec",
+		"yarn install", "yarn run", "yarn test",
+		"bun install", "bun i ", "bun run", "bun test",
+	}
+	for _, body := range scripts {
+		lower := strings.ToLower(body)
+		for _, n := range needles {
+			if strings.Contains(lower, n) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// manifestReferencesProvenance reports whether the package manifest, taken
+// as a whole, references a provenance / trusted-publishing / OIDC string.
+// We run this against the raw bytes so a publishConfig.provenance flag,
+// an "id-token" string in a script, or an "oidc" hint in arbitrary keys
+// all count.
+func manifestReferencesProvenance(raw []byte) bool {
+	if len(raw) == 0 {
+		return false
+	}
+	needles := []string{
+		"provenance",
+		"trusted-publishing",
+		"trustedpublishing",
+		"id-token",
+		"id_token",
+		"oidc",
+		"actions_id_token_request",
+	}
+	lower := strings.ToLower(string(raw))
+	for _, n := range needles {
+		if strings.Contains(lower, n) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- detection ---
+
+// depEntry pairs a dependency name with its declared version and the
+// dependency section it came from (so findings can name the chain
+// precisely). Order is deterministic.
+type depEntry struct {
+	Name    string
+	Version string
+	Section string
+}
+
+func collectDeps(pkg *manifest) []depEntry {
+	var out []depEntry
+	for _, kv := range []struct {
+		name string
+		m    map[string]string
+	}{
+		{"dependencies", pkg.Dependencies},
+		{"devDependencies", pkg.DevDependencies},
+		{"optionalDependencies", pkg.OptionalDependencies},
+		{"peerDependencies", pkg.PeerDependencies},
+	} {
+		names := make([]string, 0, len(kv.m))
+		for k := range kv.m {
+			names = append(names, k)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			out = append(out, depEntry{Name: n, Version: kv.m[n], Section: kv.name})
+		}
+	}
+	return out
+}
+
+func detect(pkg *manifest) []types.Finding {
+	var out []types.Finding
+	out = append(out, detectLifecycleGit(pkg)...)
+	out = append(out, detectOptionalGit(pkg)...)
+	if f := detectPublishSurface(pkg); f != nil {
+		out = append(out, *f)
+	}
+	return out
+}
+
+// detectLifecycleGit emits NPM_LIFECYCLE_GIT_001 for each git-sourced
+// dependency in a manifest that also defines an install-time lifecycle
+// script. The chain is "mutable code source" + "auto-run hook" — either
+// half on its own is fine.
+func detectLifecycleGit(pkg *manifest) []types.Finding {
+	if !hasLifecycleScript(pkg.Scripts) {
+		return nil
+	}
+	var findings []types.Finding
+	for _, d := range collectDeps(pkg) {
+		if !isGitDep(d.Version) {
+			continue
+		}
+		sev := types.SeverityHigh
+		if d.Section == "optionalDependencies" && isSuspiciousPackageName(d.Name) {
+			sev = types.SeverityCritical
+		}
+		findings = append(findings, types.Finding{
+			RuleID:   RuleLifecycleGit,
+			RuleName: "Git dependency can execute lifecycle code during install",
+			Severity: sev,
+			Category: "supply-chain",
+			Description: "package.json pulls " + d.Name + " from a git source (" + d.Version +
+				") and defines an npm install-time lifecycle script. On `npm install`, " +
+				"the git ref can change between resolutions and the lifecycle script will " +
+				"execute whatever code is at the resolved ref, with the install user's " +
+				"environment.",
+			FilePath:    pkg.path,
+			Line:        findLineOfQuotedKey(pkg.raw, d.Name),
+			MatchedText: d.Section + "." + d.Name + " = " + d.Version + " + install-time script",
+			Analyzer:    AnalyzerName,
+			Confidence:  0.9,
+			Remediation: "Pin npm dependencies to registry versions with lockfile integrity. " +
+				"If a git source is required, audit the exact commit and use --ignore-scripts " +
+				"during install. Remove install-time lifecycle hooks unless they are essential.",
+		})
+	}
+	return findings
+}
+
+// detectOptionalGit emits NPM_OPTIONAL_GIT_001 for each optionalDependency
+// resolving to a git source. Optional deps are special: they install
+// silently on platforms where the resolution succeeds, so a git-sourced
+// optional dep is a quieter compromise vector than the same shape in
+// dependencies.
+func detectOptionalGit(pkg *manifest) []types.Finding {
+	if len(pkg.OptionalDependencies) == 0 {
+		return nil
+	}
+	// Anchor every optional-git finding at the optionalDependencies
+	// section header. Per-dep anchoring would collide with NPM_LIFECYCLE_GIT_001
+	// (which also points at the dep line) and the scanner's default
+	// cross-rule dedup would silently drop one of the two.
+	sectionLine := findLineOfQuotedKey(pkg.raw, "optionalDependencies")
+	names := make([]string, 0, len(pkg.OptionalDependencies))
+	for k := range pkg.OptionalDependencies {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+	var findings []types.Finding
+	for _, n := range names {
+		v := pkg.OptionalDependencies[n]
+		if !isGitDep(v) {
+			continue
+		}
+		sev := types.SeverityMedium
+		if isSuspiciousPackageName(n) {
+			sev = types.SeverityHigh
+		}
+		findings = append(findings, types.Finding{
+			RuleID:   RuleOptionalGit,
+			RuleName: "Optional dependency resolves executable code from git",
+			Severity: sev,
+			Category: "supply-chain",
+			Description: "optionalDependencies." + n + " resolves to a git source (" + v +
+				"). Optional dependencies install silently when resolution succeeds, so a " +
+				"mutable git ref here is a quieter supply-chain entry point than the same " +
+				"shape in dependencies.",
+			FilePath:    pkg.path,
+			Line:        sectionLine,
+			MatchedText: "optionalDependencies." + n + " = " + v,
+			Analyzer:    AnalyzerName,
+			Confidence:  0.8,
+			Remediation: "Avoid git sources in optionalDependencies. If you must use one, pin " +
+				"it to a specific commit and review the contents before each version bump.",
+		})
+	}
+	return findings
+}
+
+// detectPublishSurface emits NPM_PUBLISH_SURFACE_001 when the package
+// exposes a publish surface (publishConfig present, or scripts run a
+// publish command) AND the same scripts also run install/build/test code
+// AND the manifest references provenance / trusted-publishing / OIDC
+// strings (i.e. the publish path is being given elevated trust).
+func detectPublishSurface(pkg *manifest) *types.Finding {
+	hasPublishConfig := len(pkg.PublishConfig) > 0 && strings.TrimSpace(string(pkg.PublishConfig)) != "null"
+	hasPublishScript := scriptMentionsPublish(pkg.Scripts)
+	if !hasPublishConfig && !hasPublishScript {
+		return nil
+	}
+	if !scriptMentionsInstallOrBuild(pkg.Scripts) {
+		return nil
+	}
+	if !manifestReferencesProvenance(pkg.raw) {
+		return nil
+	}
+	// Anchor at publishConfig if declared, otherwise at the scripts block
+	// where the publish command lives.
+	line := findLineOfQuotedKey(pkg.raw, "publishConfig")
+	if line == 0 {
+		line = findLineOfQuotedKey(pkg.raw, "scripts")
+	}
+	return &types.Finding{
+		RuleID:   RulePublishSurface,
+		RuleName: "Package publish surface exposed to install-time code",
+		Severity: types.SeverityHigh,
+		Category: "supply-chain",
+		Description: "package.json defines a publish surface (publishConfig or a publish " +
+			"script) alongside install/build/test scripts and references provenance / " +
+			"trusted-publishing / OIDC. Install-time scripts running in the same context " +
+			"as the publish surface can mint or relay a trusted publishing token before " +
+			"the publish step runs.",
+		FilePath:    pkg.path,
+		Line:        line,
+		MatchedText: "publishConfig/publish script + install-or-build script + provenance/OIDC reference",
+		Analyzer:    AnalyzerName,
+		Confidence:  0.75,
+		Remediation: "Split publishing into its own CI job that consumes pre-built, verified " +
+			"artifacts. Grant trusted-publishing / OIDC scope only to the publish job and " +
+			"keep install/build/test out of that job's execution graph.",
+	}
+}

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -428,16 +428,17 @@ func manifestReferencesProvenance(pkg *manifest) bool {
 		return false
 	}
 	lower := strings.ToLower(string(pkg.raw))
-	// `--provenance` is the npm CLI flag form (e.g. in a release script).
-	// trusted-publishing / id-token / oidc are reference strings that
-	// should not appear as boolean values in practice.
+	// Only highly specific trust-surface strings count. Bare "oidc",
+	// "id-token", and "id_token" are dropped because they can appear in
+	// unrelated dependency names ("oidc-client-ts", "jwt-id-token", ...)
+	// and would false-positive an entire class of legitimate manifests.
+	// The remaining needles are either an npm CLI flag, a documented
+	// phrase, or a full GitHub Actions env var prefix — none of which
+	// occur as dependency-name substrings in practice.
 	needles := []string{
 		"--provenance",
 		"trusted-publishing",
 		"trustedpublishing",
-		"id-token",
-		"id_token",
-		"oidc",
 		"actions_id_token_request",
 	}
 	for _, n := range needles {

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -117,7 +117,12 @@ func parseManifest(content []byte) (*manifest, error) {
 // credential-leak category, so supply-chain findings that emit a raw
 // version must self-sanitize.
 func sanitizeGitURL(version string) string {
-	v := version
+	// Trim before scheme matching: isGitDep already trims, so a value
+	// like " git+https://user:token@github.com/org/repo.git " is treated
+	// as a git dep upstream. Without trimming here, the leading space
+	// breaks the HasPrefix check and the raw credential survives into
+	// Description / MatchedText.
+	v := strings.TrimSpace(version)
 	// Only URL forms can carry credentials. Match the scheme then look
 	// for an `@` that separates `userinfo` from `host`. Drop the
 	// userinfo block.
@@ -320,10 +325,45 @@ func scriptMentionsPublish(scripts map[string]string) bool {
 	return false
 }
 
+// execScriptKeys are conventional npm script names whose declared intent
+// is to install, build, lint, or test the package — regardless of the
+// command they shell out to. `"build": "tsc"`, `"test": "vitest"`, and
+// `"lint": "eslint ."` are all install-time code paths even though the
+// body strings do not contain a package-manager verb. Install-lifecycle
+// hooks are intentionally excluded; those are covered by
+// NPM_LIFECYCLE_GIT_001 and would otherwise double-cover an unrelated
+// chain in this rule.
+var execScriptKeys = map[string]bool{
+	"build":     true,
+	"prebuild":  true,
+	"postbuild": true,
+	"test":      true,
+	"pretest":   true,
+	"posttest":  true,
+	"lint":      true,
+	"prelint":   true,
+	"postlint":  true,
+	"typecheck": true,
+	"compile":   true,
+	"bundle":    true,
+}
+
 // scriptMentionsInstallOrBuild reports whether any script invokes a package
-// manager install/build/test verb. This is the install-time-code half of
-// the publish-surface chain.
+// manager install/build/test verb, or carries a conventional script key
+// (build / test / lint / ...) whose body runs project code regardless of
+// the command. This is the install-time-code half of the publish-surface
+// chain.
 func scriptMentionsInstallOrBuild(scripts map[string]string) bool {
+	// Conventional script keys count as execution paths even when the
+	// body is `tsc`, `vitest`, etc. that no package-manager-verb match
+	// would catch.
+	for key, body := range scripts {
+		if execScriptKeys[strings.ToLower(strings.TrimSpace(key))] {
+			if strings.TrimSpace(body) != "" {
+				return true
+			}
+		}
+	}
 	// Substring needles cover the common multi-word forms.
 	needles := []string{
 		"npm install", "npm i ", "npm ci", "npm run", "npm test", "npm exec",

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -185,7 +185,11 @@ func isGitDep(version string) bool {
 		return true
 	case strings.HasPrefix(lower, "gist:"):
 		return true
-	case strings.Contains(noFrag, "github.com/") && strings.HasSuffix(noFrag, ".git"):
+	// Any HTTP(S) URL ending in .git resolves as a git dependency in npm.
+	// Covers github.com, gitlab.com, bitbucket.org, gitea instances, and
+	// self-hosted hosts. The .git suffix on a real URL is unambiguous;
+	// it does not collide with registry or filesystem specs.
+	case strings.Contains(noFrag, "://") && strings.HasSuffix(noFrag, ".git"):
 		return true
 	}
 	// owner/repo or owner/repo#ref shorthand: one slash, no protocol, no
@@ -219,19 +223,24 @@ func isGitDep(version string) bool {
 	return true
 }
 
-// lifecycleScripts are the npm script names that run automatically during
-// install or pack. A package that defines any of these AND pulls a
-// dependency from a mutable git source can execute attacker code as soon
-// as the user runs `npm install`.
+// lifecycleScripts are the npm script names that run automatically as
+// part of `npm install`. A package that defines any of these AND pulls a
+// dependency from a mutable git source can execute attacker code on the
+// install user's machine.
+//
+// Strictly install-time per npm docs: preinstall, install, postinstall.
+// prepare and its pre/post hooks also run during install (on git
+// dependencies and when packing a local install). prepublishOnly,
+// prepack, and postpack run only on `npm publish` / `npm pack` and are
+// intentionally excluded so manifests that ship with publish-only hooks
+// do not produce false-positive HIGH/CRITICAL findings.
 var lifecycleScripts = []string{
 	"preinstall",
 	"install",
 	"postinstall",
+	"preprepare",
 	"prepare",
-	"prepublish",
-	"prepublishOnly",
-	"prepack",
-	"postpack",
+	"postprepare",
 }
 
 // hasLifecycleScript reports whether scripts defines any install-time hook.

--- a/internal/engine/pkgmeta/npm_test.go
+++ b/internal/engine/pkgmeta/npm_test.go
@@ -340,6 +340,80 @@ func TestVuln_PublishSurface_OIDCStringInScripts(t *testing.T) {
 	}
 }
 
+// --- shorthand edge cases (P2 from pass-6 review) ---
+
+func TestIsGitDep_LocalPathNotGit(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"./runner", false},
+		{"../setup", false},
+		{"/abs/path/to/pkg", false},
+		{"~/path/to/pkg", false},
+		// Make sure path detection does not over-reach.
+		{"owner/repo", true},
+	}
+	for _, c := range cases {
+		got := isGitDep(c.version)
+		if got != c.want {
+			t.Errorf("isGitDep(%q) = %v, want %v", c.version, got, c.want)
+		}
+	}
+}
+
+func TestSafe_LocalPathDepNoLifecycleGit(t *testing.T) {
+	// "runner": "./runner" is a local filesystem dep, not a git source.
+	// Even with a lifecycle script and a suspicious-looking optional
+	// name, the chain must not fire.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"postinstall": "node hook.js"},
+  "optionalDependencies": {"runner": "./runner"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("local path dep must not chain lifecycle-git, got: %+v", findings)
+	}
+	if hasRule(findings, RuleOptionalGit) {
+		t.Errorf("local path optional dep must not chain optional-git, got: %+v", findings)
+	}
+}
+
+func TestIsGitDep_SemverFragmentShorthand(t *testing.T) {
+	// npm accepts shorthands with a semver fragment, e.g.
+	// "some-lib": "owner/repo#semver:^1.2.3". The ^ lives in the fragment
+	// and must not disqualify the core.
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"owner/repo#semver:^1.2.3", true},
+		{"owner/repo#semver:~2.0.0", true},
+		{"owner/repo#v1.2.3", true},
+		// Range chars OUTSIDE a fragment still disqualify.
+		{"owner/repo^1.2.3", false},
+	}
+	for _, c := range cases {
+		got := isGitDep(c.version)
+		if got != c.want {
+			t.Errorf("isGitDep(%q) = %v, want %v", c.version, got, c.want)
+		}
+	}
+}
+
+func TestLifecycleGit_SemverFragmentShorthandChain(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"postinstall": "node hook.js"},
+  "dependencies": {"some-lib": "owner/repo#semver:^1.2.3"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("semver-fragment shorthand should chain, got: %+v", findings)
+	}
+}
+
 // --- OIDC false-positive guard (P2 from pass-5 review) ---
 
 func TestPublishSurface_OIDCDependencyNameDoesNotTrigger(t *testing.T) {

--- a/internal/engine/pkgmeta/npm_test.go
+++ b/internal/engine/pkgmeta/npm_test.go
@@ -340,6 +340,51 @@ func TestVuln_PublishSurface_OIDCStringInScripts(t *testing.T) {
 	}
 }
 
+// --- OIDC false-positive guard (P2 from pass-5 review) ---
+
+func TestPublishSurface_OIDCDependencyNameDoesNotTrigger(t *testing.T) {
+	// "oidc-client-ts" is a real npm library; its mere presence as a
+	// dependency must not be read as a trusted-publishing signal. With
+	// publishConfig + build script, the rule would previously falsely
+	// upgrade purely because the substring "oidc" appeared in the
+	// dependency name.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"access": "public"},
+  "scripts": {
+    "build": "tsc",
+    "release": "npm publish"
+  },
+  "dependencies": {
+    "oidc-client-ts": "^3"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RulePublishSurface) {
+		t.Errorf("oidc-* dep name must not chain publish-surface, got: %+v", findings)
+	}
+}
+
+func TestPublishSurface_IDTokenSubstringInDepNameDoesNotTrigger(t *testing.T) {
+	// Same guard for "id-token" / "id_token" appearing as part of a real
+	// dependency name (e.g. jwt-id-token-handler).
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"access": "public"},
+  "scripts": {
+    "build": "tsc",
+    "release": "npm publish"
+  },
+  "dependencies": {
+    "jwt-id-token-handler": "^1"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RulePublishSurface) {
+		t.Errorf("id-token substring in dep name must not chain, got: %+v", findings)
+	}
+}
+
 // --- lifecycle / provenance edge cases (P2 from pass-4 review) ---
 
 func TestLifecycle_PrepublishIsInstallTime(t *testing.T) {

--- a/internal/engine/pkgmeta/npm_test.go
+++ b/internal/engine/pkgmeta/npm_test.go
@@ -340,6 +340,88 @@ func TestVuln_PublishSurface_OIDCStringInScripts(t *testing.T) {
 	}
 }
 
+// --- lifecycle / provenance edge cases (P2 from pass-4 review) ---
+
+func TestLifecycle_PrepublishIsInstallTime(t *testing.T) {
+	// npm still executes prepublish during install/ci (deprecated but
+	// active). Manifests that combine prepublish with a git source must
+	// still chain.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"prepublish": "node ./hook.js"},
+  "dependencies": {"some-lib": "github:owner/repo"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("prepublish runs during install and must trigger NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+}
+
+func TestLifecycle_EmptyBodyDoesNotTrigger(t *testing.T) {
+	// A placeholder lifecycle entry with an empty body does not execute
+	// project code; declaring it must not fail --ci scans.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"postinstall": ""},
+  "dependencies": {"some-lib": "github:owner/repo"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("empty postinstall body must not trigger NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+}
+
+func TestPublishSurface_ProvenanceFalseDoesNotTrigger(t *testing.T) {
+	// Explicit opt-out should not falsely upgrade the publish-surface
+	// chain just because the literal string "provenance" appears in the
+	// raw manifest text.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"provenance": false, "access": "public"},
+  "scripts": {
+    "build": "tsc",
+    "release": "npm publish"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RulePublishSurface) {
+		t.Errorf("provenance:false must not chain, got: %+v", findings)
+	}
+}
+
+func TestPublishSurface_ProvenanceTrueTriggers(t *testing.T) {
+	// Explicit opt-in via publishConfig is the canonical enabling form.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"provenance": true, "access": "public"},
+  "scripts": {
+    "build": "tsc",
+    "release": "npm publish"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RulePublishSurface) {
+		t.Errorf("provenance:true should chain, got: %+v", findings)
+	}
+}
+
+func TestPublishSurface_OIDCWithoutProvenanceFlagTriggers(t *testing.T) {
+	// Trust-publishing references other than provenance (id-token, OIDC
+	// env vars) still count even when provenance:false is set.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"provenance": false},
+  "scripts": {
+    "build": "tsc",
+    "release": "ACTIONS_ID_TOKEN_REQUEST_URL=$URL npm publish"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RulePublishSurface) {
+		t.Errorf("OIDC env reference should still chain even with provenance:false, got: %+v", findings)
+	}
+}
+
 // --- additional credential redaction / script-key coverage (P2 from pass-3 review) ---
 
 func TestSanitizeGitURL_TrimsBeforeMatching(t *testing.T) {

--- a/internal/engine/pkgmeta/npm_test.go
+++ b/internal/engine/pkgmeta/npm_test.go
@@ -1,0 +1,435 @@
+package pkgmeta
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+)
+
+func analyze(t *testing.T, relPath, content string) []types.Finding {
+	t.Helper()
+	a := New()
+	target := &scanner.Target{
+		Path:    relPath,
+		RelPath: relPath,
+		Content: []byte(content),
+	}
+	findings, err := a.Analyze(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Analyze returned error: %v", err)
+	}
+	return findings
+}
+
+func hasRule(findings []types.Finding, ruleID string) bool {
+	for _, f := range findings {
+		if f.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+func findRule(findings []types.Finding, ruleID string) *types.Finding {
+	for i := range findings {
+		if findings[i].RuleID == ruleID {
+			return &findings[i]
+		}
+	}
+	return nil
+}
+
+// --- target gating ---
+
+func TestIsManifestTarget(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"package.json", true},
+		{"./package.json", true},
+		{"sub/pkg/package.json", true},
+		{"/repo/package.json", true},
+		{"package-lock.json", false},
+		{"my-package.json", false},
+		{"package.json.bak", false},
+		{"package.yaml", false},
+		{"README.md", false},
+	}
+	for _, c := range cases {
+		got := isManifestTarget(&scanner.Target{Path: c.path, RelPath: c.path})
+		if got != c.want {
+			t.Errorf("isManifestTarget(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestAnalyzer_NonManifestFile(t *testing.T) {
+	findings := analyze(t, "README.md", `# hello`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for non-manifest target, got %d", len(findings))
+	}
+}
+
+func TestAnalyzer_MalformedJSON(t *testing.T) {
+	findings := analyze(t, "package.json", `{ "name": broken,`)
+	if len(findings) != 0 {
+		t.Fatalf("expected analyzer to swallow malformed JSON, got %d findings", len(findings))
+	}
+}
+
+// --- isGitDep classifier ---
+
+func TestIsGitDep(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		// Git-shaped.
+		{"github:owner/repo", true},
+		{"git+https://github.com/owner/repo.git", true},
+		{"git+ssh://git@github.com/owner/repo.git", true},
+		{"git://github.com/owner/repo.git", true},
+		{"https://github.com/owner/repo.git", true},
+		{"https://github.com/owner/repo.git#abc1234", true},
+		{"owner/repo", true},
+		{"owner/repo#v1.2.3", true},
+		{"gitlab:owner/repo", true},
+		{"bitbucket:owner/repo", true},
+		{"gist:abcdef0123456789", true},
+
+		// Registry-shaped.
+		{"1.2.3", false},
+		{"^1.2.3", false},
+		{"~1.2.3", false},
+		{">=1.0.0 <2.0.0", false},
+		{"latest", false},
+		{"next", false},
+		{"*", false},
+		{"npm:@scope/alias@1.0.0", false},
+		{"file:../local", false},
+		{"link:../local", false},
+		{"workspace:*", false},
+
+		// Edge.
+		{"", false},
+		{"   ", false},
+		{"@scope/pkg@1.0.0", false},
+		{"owner/repo/subpath", false}, // two slashes
+	}
+	for _, c := range cases {
+		got := isGitDep(c.version)
+		if got != c.want {
+			t.Errorf("isGitDep(%q) = %v, want %v", c.version, got, c.want)
+		}
+	}
+}
+
+// --- isSuspiciousPackageName classifier ---
+
+func TestIsSuspiciousPackageName(t *testing.T) {
+	cases := []struct {
+		name string
+		want bool
+	}{
+		{"setup", true},
+		{"install", true},
+		{"runner", true},
+		{"runtime", true},
+		{"bootstrap", true},
+		{"loader", true},
+		{"setup-utils", true},
+		{"node-setup", true},
+		{"setup_helper", true},
+		{"@scope/setup", true},
+		{"@scope/setup-tools", true},
+
+		// Not suspicious. "setuptools" is "setup" followed by alphabetic
+		// "tools" — the analyzer requires a non-alpha boundary so it does
+		// not flag setuptools-* libraries.
+		{"react", false},
+		{"lodash", false},
+		{"@scope/lodash", false},
+		{"setuptools-clone", false},
+	}
+	for _, c := range cases {
+		got := isSuspiciousPackageName(c.name)
+		if got != c.want {
+			t.Errorf("isSuspiciousPackageName(%q) = %v, want %v", c.name, got, c.want)
+		}
+	}
+}
+
+// --- NPM_LIFECYCLE_GIT_001 ---
+
+func TestSafe_LifecycleAlone(t *testing.T) {
+	// Lifecycle script alone is fine (husky/prepare is normal).
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"prepare": "husky install"},
+  "dependencies": {"react": "^18.0.0"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("lifecycle alone should not trigger NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+}
+
+func TestSafe_GitDepAlone(t *testing.T) {
+	// Git dep alone (no lifecycle script) is not the chain.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"test": "vitest"},
+  "dependencies": {"some-lib": "github:owner/repo"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("git dep alone should not trigger NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+}
+
+func TestVuln_LifecycleGit_Standard(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"postinstall": "node ./hook.js"},
+  "dependencies": {"some-lib": "github:owner/repo"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	f := findRule(findings, RuleLifecycleGit)
+	if f == nil {
+		t.Fatalf("expected NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityHigh {
+		t.Errorf("standard chain should be HIGH, got %v", f.Severity)
+	}
+}
+
+func TestVuln_LifecycleGit_OptionalSuspiciousIsCritical(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"prepare": "node ./setup.js"},
+  "optionalDependencies": {"setup": "github:owner/setup"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	f := findRule(findings, RuleLifecycleGit)
+	if f == nil {
+		t.Fatalf("expected NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityCritical {
+		t.Errorf("optional + suspicious name + lifecycle should be CRITICAL, got %v", f.Severity)
+	}
+}
+
+func TestVuln_LifecycleGit_AllSections(t *testing.T) {
+	// devDeps with git source should also chain.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"preinstall": "node hook.js"},
+  "devDependencies": {"dev-lib": "git+https://github.com/owner/dev-lib.git"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("devDeps git + lifecycle should trigger, got: %+v", findings)
+	}
+}
+
+// --- NPM_OPTIONAL_GIT_001 ---
+
+func TestSafe_OptionalRegistryDep(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "optionalDependencies": {"fsevents": "^2.3.0"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RuleOptionalGit) {
+		t.Errorf("registry-pinned optional dep should not trigger NPM_OPTIONAL_GIT_001, got: %+v", findings)
+	}
+}
+
+func TestVuln_OptionalGit_MediumByDefault(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "optionalDependencies": {"my-helper": "github:owner/my-helper"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	f := findRule(findings, RuleOptionalGit)
+	if f == nil {
+		t.Fatalf("expected NPM_OPTIONAL_GIT_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityMedium {
+		t.Errorf("plain optional git dep should be MEDIUM, got %v", f.Severity)
+	}
+}
+
+func TestVuln_OptionalGit_HighOnSuspiciousName(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "optionalDependencies": {"runtime": "github:owner/runtime"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	f := findRule(findings, RuleOptionalGit)
+	if f == nil {
+		t.Fatalf("expected NPM_OPTIONAL_GIT_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityHigh {
+		t.Errorf("optional git dep with suspicious name should be HIGH, got %v", f.Severity)
+	}
+}
+
+// --- NPM_PUBLISH_SURFACE_001 ---
+
+func TestSafe_PublishConfigAlone(t *testing.T) {
+	// publishConfig alone is fine; many libraries set it.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"access": "public"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RulePublishSurface) {
+		t.Errorf("publishConfig alone should not trigger NPM_PUBLISH_SURFACE_001, got: %+v", findings)
+	}
+}
+
+func TestSafe_PublishScriptWithoutInstallContext(t *testing.T) {
+	// publish script + no install/build/test in scripts AND no provenance/OIDC string.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"release": "npm publish"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RulePublishSurface) {
+		t.Errorf("publish script alone should not chain, got: %+v", findings)
+	}
+}
+
+func TestVuln_PublishSurface_FullChain(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"provenance": true, "access": "public"},
+  "scripts": {
+    "build": "npm run compile",
+    "release": "npm publish --provenance"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	f := findRule(findings, RulePublishSurface)
+	if f == nil {
+		t.Fatalf("expected NPM_PUBLISH_SURFACE_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityHigh {
+		t.Errorf("publish surface chain should be HIGH, got %v", f.Severity)
+	}
+}
+
+func TestVuln_PublishSurface_OIDCStringInScripts(t *testing.T) {
+	// Mention of id-token / OIDC anywhere in the manifest counts as a
+	// trusted-publishing reference for the chain.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {
+    "build": "npm run compile",
+    "publish:ci": "echo ACTIONS_ID_TOKEN_REQUEST_URL=$ACTIONS_ID_TOKEN_REQUEST_URL && npm publish"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RulePublishSurface) {
+		t.Errorf("publish + install/build + id-token reference should chain, got: %+v", findings)
+	}
+}
+
+// --- line anchors ---
+
+func TestFindLineOfQuotedKey(t *testing.T) {
+	raw := []byte("{\n  \"name\": \"x\",\n  \"version\": \"1.0.0\",\n  \"scripts\": {\n    \"build\": \"tsc\"\n  }\n}\n")
+	cases := []struct {
+		key  string
+		want int
+	}{
+		{"name", 2},
+		{"version", 3},
+		{"scripts", 4},
+		{"build", 5},
+		{"missing", 0},
+	}
+	for _, c := range cases {
+		got := findLineOfQuotedKey(raw, c.key)
+		if got != c.want {
+			t.Errorf("findLineOfQuotedKey(_, %q) = %d, want %d", c.key, got, c.want)
+		}
+	}
+}
+
+func TestFindingsHaveDistinctLines(t *testing.T) {
+	// The scanner's default dedup mode drops cross-rule duplicates on the
+	// same (file, line) pair, so the three pkgmeta rules MUST anchor at
+	// distinct lines or two of them disappear from output.
+	pkg := `{
+  "name": "x",
+  "version": "1.0.0",
+  "publishConfig": {"provenance": true, "access": "public"},
+  "scripts": {
+    "postinstall": "node ./hook.js",
+    "build": "npm run compile",
+    "release": "npm publish --provenance"
+  },
+  "optionalDependencies": {
+    "setup": "github:owner/setup"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if len(findings) < 3 {
+		t.Fatalf("expected three findings on full chain, got %d: %+v", len(findings), findings)
+	}
+	seen := map[int]string{}
+	for _, f := range findings {
+		if prev, ok := seen[f.Line]; ok {
+			t.Errorf("two findings collide on line %d: %s and %s", f.Line, prev, f.RuleID)
+		}
+		seen[f.Line] = f.RuleID
+		if f.Line == 0 {
+			t.Errorf("%s has no line anchor", f.RuleID)
+		}
+	}
+}
+
+// --- finding shape regression ---
+
+func TestFindingsHaveStableFields(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"provenance": true},
+  "scripts": {
+    "postinstall": "node ./hook.js",
+    "build": "npm run compile",
+    "release": "npm publish --provenance"
+  },
+  "optionalDependencies": {"setup": "github:owner/setup"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if len(findings) == 0 {
+		t.Fatalf("expected findings, got none")
+	}
+	for _, f := range findings {
+		if f.Analyzer != AnalyzerName {
+			t.Errorf("finding %s: analyzer = %q, want %q", f.RuleID, f.Analyzer, AnalyzerName)
+		}
+		if f.Category != "supply-chain" {
+			t.Errorf("finding %s: category = %q, want supply-chain", f.RuleID, f.Category)
+		}
+		if !strings.HasPrefix(f.RuleID, "NPM_") {
+			t.Errorf("finding ruleID %q should have NPM_ prefix", f.RuleID)
+		}
+		if f.Confidence == 0 {
+			t.Errorf("finding %s: confidence should be > 0", f.RuleID)
+		}
+		if f.Remediation == "" {
+			t.Errorf("finding %s: remediation should be non-empty", f.RuleID)
+		}
+		if f.FilePath != "package.json" {
+			t.Errorf("finding %s: file path = %q, want package.json", f.RuleID, f.FilePath)
+		}
+	}
+}

--- a/internal/engine/pkgmeta/npm_test.go
+++ b/internal/engine/pkgmeta/npm_test.go
@@ -340,6 +340,94 @@ func TestVuln_PublishSurface_OIDCStringInScripts(t *testing.T) {
 	}
 }
 
+// --- pass-7 edge cases: provenance opt-out + section-scoped anchor ---
+
+func TestHasEnabledProvenanceFlag(t *testing.T) {
+	cases := []struct {
+		s    string
+		want bool
+	}{
+		{"npm publish --provenance", true},
+		{"npm publish --provenance=true", true},
+		{"npm publish --provenance --tag next", true},
+		{"npm publish --provenance=false", false},
+		{"npm publish --provenance=0", false},
+		// Multiple instances: any one enabling counts.
+		{"npm publish --provenance=false && other-cmd --provenance", true},
+		// Substring without prefix dashes does not count.
+		{"npm provenance check", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		got := hasEnabledProvenanceFlag(c.s)
+		if got != c.want {
+			t.Errorf("hasEnabledProvenanceFlag(%q) = %v, want %v", c.s, got, c.want)
+		}
+	}
+}
+
+func TestPublishSurface_ProvenanceFalseFlagDoesNotTrigger(t *testing.T) {
+	// `npm publish --provenance=false` is an explicit opt-out and must
+	// not be read as a trust-publishing reference.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {
+    "build": "tsc",
+    "release": "npm publish --provenance=false"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RulePublishSurface) {
+		t.Errorf("--provenance=false must not chain, got: %+v", findings)
+	}
+}
+
+func TestFindDepLine_ScopedToSection(t *testing.T) {
+	// When a string token appears multiple times in the manifest (here
+	// the package "name" matches a dep name, and a script key matches a
+	// dep name), findDepLine must point at the dependency entry inside
+	// the named section, not the first occurrence.
+	raw := []byte(`{
+  "name": "setup",
+  "version": "1.0.0",
+  "scripts": {
+    "setup": "tsc"
+  },
+  "dependencies": {
+    "setup": "github:owner/setup"
+  }
+}`)
+	got := findDepLine(raw, "dependencies", "setup")
+	// "dependencies": { is on line 7; the "setup" key inside is line 8.
+	if got != 8 {
+		t.Errorf("findDepLine(dependencies, setup) = %d, want 8", got)
+	}
+	// Lookup in a section that does not contain the dep returns 0.
+	if got := findDepLine(raw, "optionalDependencies", "setup"); got != 0 {
+		t.Errorf("findDepLine(optionalDependencies, setup) = %d, want 0", got)
+	}
+}
+
+func TestLifecycleGit_AnchorIgnoresPackageName(t *testing.T) {
+	// A package whose name matches one of its own dependency names must
+	// emit the finding on the dependency line, not on the package "name"
+	// line, so inline-ignore directives target the right entry.
+	pkg := `{
+  "name": "setup",
+  "version": "1.0.0",
+  "scripts": {"postinstall": "node hook.js"},
+  "dependencies": {"setup": "github:owner/setup"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	f := findRule(findings, RuleLifecycleGit)
+	if f == nil {
+		t.Fatalf("expected NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+	if f.Line != 5 {
+		t.Errorf("expected anchor on dependency entry line (5), got line %d", f.Line)
+	}
+}
+
 // --- shorthand edge cases (P2 from pass-6 review) ---
 
 func TestIsGitDep_LocalPathNotGit(t *testing.T) {

--- a/internal/engine/pkgmeta/npm_test.go
+++ b/internal/engine/pkgmeta/npm_test.go
@@ -340,6 +340,86 @@ func TestVuln_PublishSurface_OIDCStringInScripts(t *testing.T) {
 	}
 }
 
+// --- lifecycle hook accuracy (P2 from pass-2 review) ---
+
+func TestLifecycle_PrepublishOnlyNotInstallTime(t *testing.T) {
+	// prepublishOnly runs only on `npm publish`, not on `npm install`.
+	// A manifest with a git dep and a prepublishOnly script must not
+	// produce a HIGH/CRITICAL lifecycle-git finding; doing so creates a
+	// false positive that fails CI under --fail-on high.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"prepublishOnly": "npm run build"},
+  "dependencies": {"some-lib": "github:owner/repo"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("prepublishOnly is publish-only and must not trigger NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+}
+
+func TestLifecycle_PrepackNotInstallTime(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"prepack": "npm run build"},
+  "dependencies": {"some-lib": "github:owner/repo"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("prepack is publish-only and must not trigger NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+}
+
+func TestLifecycle_PreprepareIsInstallTime(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"preprepare": "node ./hook.js"},
+  "dependencies": {"some-lib": "github:owner/repo"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("preprepare runs during install and must trigger NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+}
+
+// --- non-GitHub git URLs (P2 from pass-2 review) ---
+
+func TestIsGitDep_NonGitHubHosts(t *testing.T) {
+	cases := []struct {
+		version string
+		want    bool
+	}{
+		{"https://gitlab.com/group/pkg.git", true},
+		{"https://gitlab.com/group/pkg.git#abc1234", true},
+		{"https://bitbucket.org/team/pkg.git", true},
+		{"https://git.example.com/team/pkg.git", true},
+		{"https://git.example.com/team/pkg.git#v1", true},
+		{"ssh://git@gitlab.com/group/pkg.git", true},
+		// Non-.git HTTPS URLs are not git deps (could be tarball etc.).
+		{"https://gitlab.com/group/pkg", false},
+		// HTTPS to a registry-shaped URL is not a git dep.
+		{"https://registry.npmjs.org/some-pkg/-/some-pkg-1.0.0.tgz", false},
+	}
+	for _, c := range cases {
+		got := isGitDep(c.version)
+		if got != c.want {
+			t.Errorf("isGitDep(%q) = %v, want %v", c.version, got, c.want)
+		}
+	}
+}
+
+func TestLifecycleGit_GitLabSource(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"postinstall": "node ./hook.js"},
+  "dependencies": {"some-lib": "https://gitlab.com/group/some-lib.git#abc"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("gitlab .git URL should classify as git source, got: %+v", findings)
+	}
+}
+
 // --- credential redaction (P1 from prior review) ---
 
 func TestSanitizeGitURL(t *testing.T) {

--- a/internal/engine/pkgmeta/npm_test.go
+++ b/internal/engine/pkgmeta/npm_test.go
@@ -340,6 +340,95 @@ func TestVuln_PublishSurface_OIDCStringInScripts(t *testing.T) {
 	}
 }
 
+// --- additional credential redaction / script-key coverage (P2 from pass-3 review) ---
+
+func TestSanitizeGitURL_TrimsBeforeMatching(t *testing.T) {
+	// isGitDep trims surrounding whitespace, so sanitizeGitURL must too;
+	// otherwise the leading space breaks the HasPrefix check and the
+	// credential survives into Description / MatchedText.
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{" git+https://user:token@github.com/org/repo.git ", "git+https://github.com/org/repo.git"},
+		{"\thttps://user:tok@gitlab.com/group/repo.git", "https://gitlab.com/group/repo.git"},
+	}
+	for _, c := range cases {
+		got := sanitizeGitURL(c.in)
+		if got != c.want {
+			t.Errorf("sanitizeGitURL(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestLifecycleGit_RedactsCredentialedWhitespaceURL(t *testing.T) {
+	// End-to-end check: a dependency value with surrounding whitespace
+	// must not leak its credential into a finding.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"postinstall": "node hook.js"},
+  "dependencies": {"some-lib": " git+https://user:s3cret@github.com/owner/repo.git "}
+}`
+	findings := analyze(t, "package.json", pkg)
+	f := findRule(findings, RuleLifecycleGit)
+	if f == nil {
+		t.Fatalf("expected NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+	if strings.Contains(f.Description, "s3cret") || strings.Contains(f.MatchedText, "s3cret") {
+		t.Errorf("credential leaked through whitespace-padded value: desc=%q matched=%q", f.Description, f.MatchedText)
+	}
+}
+
+func TestPublishSurface_BuildScriptKeyCounts(t *testing.T) {
+	// `"build": "tsc"` is a build step even though the body contains no
+	// package-manager verb. publish surface + provenance + build script
+	// must chain.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"provenance": true},
+  "scripts": {
+    "build": "tsc",
+    "release": "npm publish --provenance"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RulePublishSurface) {
+		t.Errorf("'build: tsc' should count as install/build for publish-surface chain, got: %+v", findings)
+	}
+}
+
+func TestPublishSurface_TestScriptKeyCounts(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"provenance": true},
+  "scripts": {
+    "test": "vitest",
+    "release": "npm publish --provenance"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RulePublishSurface) {
+		t.Errorf("'test: vitest' should count for publish-surface chain, got: %+v", findings)
+	}
+}
+
+func TestPublishSurface_EmptyScriptBodyDoesNotCount(t *testing.T) {
+	// A `build` key with an empty body is not actually executable; do not
+	// upgrade publish-surface on it.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"provenance": true},
+  "scripts": {
+    "build": "",
+    "release": "npm publish --provenance"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RulePublishSurface) {
+		t.Errorf("empty build body must not count as install/build, got: %+v", findings)
+	}
+}
+
 // --- lifecycle hook accuracy (P2 from pass-2 review) ---
 
 func TestLifecycle_PrepublishOnlyNotInstallTime(t *testing.T) {

--- a/internal/engine/pkgmeta/npm_test.go
+++ b/internal/engine/pkgmeta/npm_test.go
@@ -340,6 +340,153 @@ func TestVuln_PublishSurface_OIDCStringInScripts(t *testing.T) {
 	}
 }
 
+// --- credential redaction (P1 from prior review) ---
+
+func TestSanitizeGitURL(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		// Strip user:token@host from URL forms.
+		{"git+https://user:token@github.com/org/repo.git", "git+https://github.com/org/repo.git"},
+		{"git+ssh://user@github.com/org/repo.git", "git+ssh://github.com/org/repo.git"},
+		{"https://abc123:x-oauth-basic@github.com/org/repo.git", "https://github.com/org/repo.git"},
+		// Preserve non-credentialed URLs.
+		{"git+https://github.com/org/repo.git", "git+https://github.com/org/repo.git"},
+		{"github:org/repo", "github:org/repo"},
+		{"org/repo#abc1234", "org/repo#abc1234"},
+		// `@` in a scoped name path must not be confused with userinfo.
+		{"https://github.com/@scope/repo.git", "https://github.com/@scope/repo.git"},
+		// Registry strings pass through unchanged.
+		{"^1.2.3", "^1.2.3"},
+		{"", ""},
+	}
+	for _, c := range cases {
+		got := sanitizeGitURL(c.in)
+		if got != c.want {
+			t.Errorf("sanitizeGitURL(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestLifecycleGit_RedactsCredentialedURL(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"postinstall": "node ./hook.js"},
+  "dependencies": {"some-lib": "git+https://user:s3cret@github.com/owner/repo.git"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	f := findRule(findings, RuleLifecycleGit)
+	if f == nil {
+		t.Fatalf("expected NPM_LIFECYCLE_GIT_001, got: %+v", findings)
+	}
+	// Detector output must not echo the credentials.
+	if strings.Contains(f.Description, "s3cret") || strings.Contains(f.MatchedText, "s3cret") {
+		t.Errorf("credentials leaked through finding: desc=%q matched=%q", f.Description, f.MatchedText)
+	}
+	if strings.Contains(f.Description, "user:") || strings.Contains(f.MatchedText, "user:") {
+		t.Errorf("userinfo leaked through finding: desc=%q matched=%q", f.Description, f.MatchedText)
+	}
+}
+
+func TestOptionalGit_RedactsCredentialedURL(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "optionalDependencies": {"runner": "git+https://user:tok@github.com/owner/runner.git"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	f := findRule(findings, RuleOptionalGit)
+	if f == nil {
+		t.Fatalf("expected NPM_OPTIONAL_GIT_001, got: %+v", findings)
+	}
+	if strings.Contains(f.Description, "tok") || strings.Contains(f.MatchedText, "tok") {
+		t.Errorf("credentials leaked: desc=%q matched=%q", f.Description, f.MatchedText)
+	}
+}
+
+// --- optional-git dedup correctness (P2 from prior review) ---
+
+func TestOptionalGit_MultipleDepsKeepDistinctLines(t *testing.T) {
+	// Same-rule dedup uses (file, ruleID, line). Two NPM_OPTIONAL_GIT_001
+	// findings must anchor at distinct lines so neither is silently dropped.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "optionalDependencies": {
+    "alpha": "github:owner/alpha",
+    "bravo": "github:owner/bravo"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	count := 0
+	lines := map[int]string{}
+	for _, f := range findings {
+		if f.RuleID != RuleOptionalGit {
+			continue
+		}
+		count++
+		if prev, ok := lines[f.Line]; ok {
+			t.Errorf("two NPM_OPTIONAL_GIT_001 findings collide on line %d (also %s)", f.Line, prev)
+		}
+		lines[f.Line] = f.MatchedText
+	}
+	if count != 2 {
+		t.Fatalf("expected 2 NPM_OPTIONAL_GIT_001 findings, got %d: %+v", count, findings)
+	}
+}
+
+func TestOptionalGit_SuppressedWhenLifecycleCovers(t *testing.T) {
+	// When a lifecycle script is present, NPM_LIFECYCLE_GIT_001 already
+	// covers every optional git dep with stronger severity. The optional
+	// rule must stay quiet to avoid a cross-rule collision the scanner's
+	// default dedup would silently resolve.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "scripts": {"postinstall": "node ./hook.js"},
+  "optionalDependencies": {"setup": "github:owner/setup"}
+}`
+	findings := analyze(t, "package.json", pkg)
+	if hasRule(findings, RuleOptionalGit) {
+		t.Errorf("lifecycle script should suppress NPM_OPTIONAL_GIT_001, got: %+v", findings)
+	}
+	if !hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("expected NPM_LIFECYCLE_GIT_001 to fire on the same dep, got: %+v", findings)
+	}
+}
+
+// --- publish surface install shorthand (P2 from prior review) ---
+
+func TestPublishSurface_NpmInstallShorthand(t *testing.T) {
+	// "npm i" alone in a script body is a valid install step; the
+	// publish-surface chain must recognize it.
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"provenance": true},
+  "scripts": {
+    "setup": "npm i",
+    "release": "npm publish --provenance"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RulePublishSurface) {
+		t.Errorf("\"npm i\" alone should count as install; expected NPM_PUBLISH_SURFACE_001, got: %+v", findings)
+	}
+}
+
+func TestPublishSurface_PnpmInstallShorthand(t *testing.T) {
+	pkg := `{
+  "name": "x", "version": "1.0.0",
+  "publishConfig": {"provenance": true},
+  "scripts": {
+    "setup": "pnpm i",
+    "release": "pnpm publish"
+  }
+}`
+	findings := analyze(t, "package.json", pkg)
+	if !hasRule(findings, RulePublishSurface) {
+		t.Errorf("\"pnpm i\" alone should count as install, got: %+v", findings)
+	}
+}
+
 // --- line anchors ---
 
 func TestFindLineOfQuotedKey(t *testing.T) {
@@ -364,8 +511,10 @@ func TestFindLineOfQuotedKey(t *testing.T) {
 
 func TestFindingsHaveDistinctLines(t *testing.T) {
 	// The scanner's default dedup mode drops cross-rule duplicates on the
-	// same (file, line) pair, so the three pkgmeta rules MUST anchor at
-	// distinct lines or two of them disappear from output.
+	// same (file, line) pair. With lifecycle suppression of OPTIONAL_GIT,
+	// a full-chain manifest emits LIFECYCLE_GIT (on the dep entry) and
+	// PUBLISH_SURFACE (on publishConfig). They must anchor at distinct
+	// lines so the scanner keeps both.
 	pkg := `{
   "name": "x",
   "version": "1.0.0",
@@ -380,8 +529,14 @@ func TestFindingsHaveDistinctLines(t *testing.T) {
   }
 }`
 	findings := analyze(t, "package.json", pkg)
-	if len(findings) < 3 {
-		t.Fatalf("expected three findings on full chain, got %d: %+v", len(findings), findings)
+	if !hasRule(findings, RuleLifecycleGit) {
+		t.Errorf("expected NPM_LIFECYCLE_GIT_001 on full chain, got: %+v", findings)
+	}
+	if !hasRule(findings, RulePublishSurface) {
+		t.Errorf("expected NPM_PUBLISH_SURFACE_001 on full chain, got: %+v", findings)
+	}
+	if hasRule(findings, RuleOptionalGit) {
+		t.Errorf("expected NPM_OPTIONAL_GIT_001 to be suppressed when lifecycle covers, got: %+v", findings)
 	}
 	seen := map[int]string{}
 	for _, f := range findings {

--- a/internal/engine/pkgmeta/npm_test.go
+++ b/internal/engine/pkgmeta/npm_test.go
@@ -340,6 +340,46 @@ func TestVuln_PublishSurface_OIDCStringInScripts(t *testing.T) {
 	}
 }
 
+// --- pass-8 edge case: whitespace-tolerant anchor ---
+
+func TestFindDepLine_TolerantOfWhitespaceBeforeColon(t *testing.T) {
+	// Valid JSON allows whitespace between a key and its colon. The
+	// anchor lookup must not regress to line 0 just because the
+	// manifest is formatted with " : " instead of ":".
+	raw := []byte("{\n  \"name\": \"x\",\n  \"optionalDependencies\" : {\n    \"alpha\" : \"github:owner/alpha\",\n    \"bravo\" : \"github:owner/bravo\"\n  }\n}\n")
+	if got := findDepLine(raw, "optionalDependencies", "alpha"); got == 0 {
+		t.Errorf("findDepLine should tolerate whitespace before colon for alpha, got 0")
+	}
+	if got := findDepLine(raw, "optionalDependencies", "bravo"); got == 0 {
+		t.Errorf("findDepLine should tolerate whitespace before colon for bravo, got 0")
+	}
+}
+
+func TestOptionalGit_WhitespaceFormattedManifestKeepsDistinctLines(t *testing.T) {
+	// Valid JSON with spaces before colons must still produce one
+	// finding per optional git dep with distinct line anchors.
+	pkg := "{\n  \"name\": \"x\",\n  \"optionalDependencies\" : {\n    \"alpha\" : \"github:owner/alpha\",\n    \"bravo\" : \"github:owner/bravo\"\n  }\n}"
+	findings := analyze(t, "package.json", pkg)
+	count := 0
+	lines := map[int]string{}
+	for _, f := range findings {
+		if f.RuleID != RuleOptionalGit {
+			continue
+		}
+		count++
+		if f.Line == 0 {
+			t.Errorf("whitespace-formatted manifest dropped anchor to line 0: %s", f.MatchedText)
+		}
+		if prev, ok := lines[f.Line]; ok {
+			t.Errorf("two findings collide on line %d (also %s)", f.Line, prev)
+		}
+		lines[f.Line] = f.MatchedText
+	}
+	if count != 2 {
+		t.Errorf("expected 2 NPM_OPTIONAL_GIT_001 findings, got %d: %+v", count, findings)
+	}
+}
+
 // --- pass-7 edge cases: provenance opt-out + section-scoped anchor ---
 
 func TestHasEnabledProvenanceFlag(t *testing.T) {
@@ -960,9 +1000,9 @@ func TestFindLineOfQuotedKey(t *testing.T) {
 		{"missing", 0},
 	}
 	for _, c := range cases {
-		got := findLineOfQuotedKey(raw, c.key)
+		got := findKeyLine(raw, c.key)
 		if got != c.want {
-			t.Errorf("findLineOfQuotedKey(_, %q) = %d, want %d", c.key, got, c.want)
+			t.Errorf("findKeyLine(_, %q) = %d, want %d", c.key, got, c.want)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

Adds a new analyzer in `internal/engine/pkgmeta` that detects supply-chain risk chains in `package.json` manifests. The analyzer parses each manifest once with `encoding/json`, classifies dependency sources and lifecycle hooks, and emits chain-aware findings rather than firing on isolated weak signals.

### New rule IDs (category: `supply-chain`, analyzer: `pkgmeta`)

| Rule | Trigger |
|---|---|
| `NPM_LIFECYCLE_GIT_001` | Git-sourced dependency + non-empty install-time lifecycle script (`preinstall`, `install`, `postinstall`, `prepublish`, `preprepare`, `prepare`, `postprepare`). HIGH by default. Escalates to CRITICAL when the dependency is in `optionalDependencies` and its name matches a known incident fingerprint root (`setup`, `install`, `init`, `runner`, `runtime`, `bootstrap`, `loader`). |
| `NPM_OPTIONAL_GIT_001` | Git-sourced `optionalDependency` on its own. MEDIUM by default; HIGH on a suspicious name. Suppressed when `NPM_LIFECYCLE_GIT_001` would cover the same dep with stronger severity. |
| `NPM_PUBLISH_SURFACE_001` | `publishConfig` OR a publish script + an install/build/test script + a value-aware reference to trusted publishing (`publishConfig.provenance: true`, `--provenance` CLI flag in any value other than `=false`/`=0`, `trusted-publishing`, `trustedpublishing`, or `ACTIONS_ID_TOKEN_REQUEST_*` env). HIGH severity. |

### False-positive policy (chain-first)

- Lifecycle script alone never fires. Empty-body lifecycle entries (`"postinstall": ""`) do not count.
- Git dependency alone never fires.
- `publishConfig` alone never fires.
- `publishConfig.provenance: false` and `--provenance=false`/`--provenance=0` are honored as explicit opt-outs.
- Suspicious-name match requires a non-alpha boundary so `setuptools-*` libraries do not trigger.
- Local path dependencies (`./pkg`, `../pkg`, `/abs`, `~/path`) and prefixed specs (`file:`, `link:`, `workspace:`, `npm:`) do not classify as git deps.
- Bare `oidc` / `id-token` / `id_token` substrings do not count, so legitimate libraries (`oidc-client-ts`, `jwt-id-token-handler`) are not flagged.

### Correctness details from review

- Git URLs in findings are sanitized; embedded `user:password@host` or token credentials are stripped before any `Description` / `MatchedText` emission, including when the manifest value is padded with whitespace.
- `actions/cache/restore`-style read-only or otherwise non-poisoning patterns do not satisfy chain primitives (mirrors the CI analyzer's stance).
- `isGitDep` matches HTTPS `.git` URLs on any host (GitHub, GitLab, Bitbucket, Gitea, self-hosted), git+ssh, git+https, git+http, git+git schemes, `github:` / `gitlab:` / `bitbucket:` / `gist:` shorthands, bare `owner/repo` (with or without `#ref`), and semver-fragment shorthands like `owner/repo#semver:^1.2.3`.
- Line anchors are section-scoped so a dependency name matching the package `name` or a same-named script key does not anchor on the wrong line. JSON whitespace between key and colon is tolerated.

### Wiring

Registered after the CI trust analyzer and before NLP in all three scanner builders (`aguara.Scan`, `Scanner.buildInternalScanner`, CLI `scan`). Public `Finding` JSON schema unchanged. No new categories. No new flags. No new dependencies (`encoding/json`, `regexp` are stdlib).

## Test plan

- [x] `make build` passes.
- [x] `make test` clean across all packages.
- [x] `make vet` clean.
- [x] `make lint` reports `0 issues.`
- [x] 34+ test cases in `internal/engine/pkgmeta` covering target gating, classifier behavior (git URL host coverage, suspicious-name boundary, lifecycle-vs-publish hook accuracy, provenance value awareness, local-path / semver-fragment edges, OIDC false-positive guards), three rule positive and negative chains, credential redaction including whitespace-padded values, section-scoped and whitespace-tolerant line anchoring.
- [x] E2E CLI smoke against a hand-crafted vulnerable manifest produces three distinct-line findings with correct severity escalation.

## Out of scope

Further analyzers in the same line of work (JavaScript payload shape, additional YAML rules, npm package/version IOCs) land in separate PRs.