### PR TITLE
feat(incident): npm ecosystem support for aguara check

### DIFF
--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -11,26 +11,40 @@ import (
 )
 
 var (
-	flagCheckPath string
+	flagCheckPath      string
+	flagCheckEcosystem string
 )
 
 var checkCmd = &cobra.Command{
 	Use:   "check",
-	Short: "Check for compromised Python packages and persistence artifacts",
-	Long: `Scan installed Python packages for known compromised versions, malicious .pth
-files, persistence backdoors, and pip/uv/npx caches. Reports which credential files are at risk.`,
+	Short: "Check for compromised packages and persistence artifacts",
+	Long: `Scan an installed package tree for known compromised versions and
+persistence artifacts. Defaults to Python (auto-discovers site-packages); pass
+--ecosystem npm with --path pointing at a node_modules directory to check
+npm packages instead. The known-bad list ships embedded with the binary.`,
 	RunE: runCheck,
 }
 
 func init() {
-	checkCmd.Flags().StringVar(&flagCheckPath, "path", "", "Path to site-packages directory (default: auto-discover)")
+	checkCmd.Flags().StringVar(&flagCheckPath, "path", "", "Path to the package tree (Python: site-packages; npm: node_modules)")
+	checkCmd.Flags().StringVar(&flagCheckEcosystem, "ecosystem", "python", "Package ecosystem to check: python or npm")
 	rootCmd.AddCommand(checkCmd)
 }
 
 func runCheck(cmd *cobra.Command, args []string) error {
-	result, err := incident.Check(incident.CheckOptions{
-		Path: flagCheckPath,
-	})
+	opts := incident.CheckOptions{Path: flagCheckPath}
+	var (
+		result *incident.CheckResult
+		err    error
+	)
+	switch flagCheckEcosystem {
+	case "", "python", "pypi":
+		result, err = incident.Check(opts)
+	case "npm":
+		result, err = incident.CheckNPM(opts)
+	default:
+		return fmt.Errorf("unsupported ecosystem %q: choose python or npm", flagCheckEcosystem)
+	}
 	if err != nil {
 		return err
 	}
@@ -38,7 +52,7 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	if flagFormat == "json" {
 		return writeCheckJSON(result)
 	}
-	return writeCheckTerminal(result)
+	return writeCheckTerminal(result, flagCheckEcosystem)
 }
 
 func writeCheckJSON(result *incident.CheckResult) error {
@@ -56,9 +70,17 @@ func writeCheckJSON(result *incident.CheckResult) error {
 	return enc.Encode(result)
 }
 
-func writeCheckTerminal(result *incident.CheckResult) error {
-	fmt.Printf("\nScanning Python environment: %s\n", result.Environment)
-	fmt.Printf("Packages read: %d  |  .pth files scanned: %d\n\n", result.PackagesRead, result.PthScanned)
+func writeCheckTerminal(result *incident.CheckResult, ecosystem string) error {
+	envLabel := "Python environment"
+	if ecosystem == "npm" {
+		envLabel = "npm node_modules tree"
+	}
+	fmt.Printf("\nScanning %s: %s\n", envLabel, result.Environment)
+	if ecosystem == "npm" {
+		fmt.Printf("Packages read: %d\n\n", result.PackagesRead)
+	} else {
+		fmt.Printf("Packages read: %d  |  .pth files scanned: %d\n\n", result.PackagesRead, result.PthScanned)
+	}
 
 	if len(result.Findings) == 0 {
 		green := "\033[32m"
@@ -123,11 +145,18 @@ func writeCheckTerminal(result *incident.CheckResult) error {
 		fmt.Println()
 	}
 
-	// Action guidance
+	// Action guidance is ecosystem-specific because `aguara clean`
+	// only knows how to remove the Python compromise artifacts.
 	fmt.Printf("%sAction required:%s\n", bold, reset)
-	fmt.Println("  1. Run 'aguara clean' to remove malicious files")
-	fmt.Println("  2. Rotate ALL credentials listed above")
-	fmt.Println("  3. If running K8s: kubectl get pods -n kube-system | grep node-setup")
+	if ecosystem == "npm" {
+		fmt.Println("  1. Remove the affected packages with the package manager (`npm uninstall <name>`)")
+		fmt.Println("  2. Rotate ALL credentials reachable from runs that included the compromised version")
+		fmt.Println("  3. Audit recent CI runs, especially trusted-publishing / OIDC steps")
+	} else {
+		fmt.Println("  1. Run 'aguara clean' to remove malicious files")
+		fmt.Println("  2. Rotate ALL credentials listed above")
+		fmt.Println("  3. If running K8s: kubectl get pods -n kube-system | grep node-setup")
+	}
 
 	// Build summary line
 	critCount := 0

--- a/internal/incident/checker.go
+++ b/internal/incident/checker.go
@@ -380,9 +380,18 @@ func checkCaches() []Finding {
 				return filepath.SkipDir
 			}
 
-			// Filename-based check for cache artifacts
+			// Filename-based check for cache artifacts. The cache scan
+			// is part of the Python check path, so only PyPI entries
+			// apply here; npm rows live in a separate scan.
 			base := strings.ToLower(name)
 			for _, cp := range KnownCompromised {
+				entryEco := cp.Ecosystem
+				if entryEco == "" {
+					entryEco = EcosystemPyPI
+				}
+				if entryEco != EcosystemPyPI {
+					continue
+				}
 				if strings.Contains(base, cp.Name) {
 					for _, v := range cp.Versions {
 						if strings.Contains(base, v) && !seen[path] {

--- a/internal/incident/compromised.go
+++ b/internal/incident/compromised.go
@@ -1,37 +1,140 @@
-// Package incident provides detection and cleanup of compromised Python
-// packages, malicious .pth files, and persistence artifacts.
+// Package incident provides detection and cleanup of compromised packages,
+// malicious .pth / lifecycle artifacts, and persistence vectors across the
+// supported language ecosystems (Python and npm).
 package incident
 
+// Ecosystem identifiers for CompromisedPackage entries and IsCompromised
+// lookups. The default empty value is treated as PyPI for backward
+// compatibility with releases that predate the ecosystem field.
+const (
+	EcosystemPyPI = "pypi"
+	EcosystemNPM  = "npm"
+)
+
 // CompromisedPackage describes a known-bad package+version combination.
+// Ecosystem identifies the registry the package belongs to so the same
+// data structure can hold PyPI and npm entries without collision (real
+// names overlap across registries). IOCs is an optional list of
+// indicators of compromise (file paths, hashes, network endpoints) that
+// extend a detector beyond the package+version tuple.
 type CompromisedPackage struct {
-	Name     string   `json:"name"`
-	Versions []string `json:"versions"`
-	Advisory string   `json:"advisory"`
-	Date     string   `json:"date"`
-	Summary  string   `json:"summary"`
+	Ecosystem string   `json:"ecosystem,omitempty"`
+	Name      string   `json:"name"`
+	Versions  []string `json:"versions"`
+	Advisory  string   `json:"advisory"`
+	Date      string   `json:"date"`
+	Summary   string   `json:"summary"`
+	IOCs      []IOC    `json:"iocs,omitempty"`
+}
+
+// IOC is a single indicator of compromise associated with a known-bad
+// package. Type names the indicator class (path, hash, endpoint); Value
+// is the literal string the detector looks for. Optional and additive;
+// older entries that do not carry IOCs continue to work.
+type IOC struct {
+	Type  string `json:"type"`
+	Value string `json:"value"`
 }
 
 // KnownCompromised is the embedded list of known compromised packages.
 // Updated with each Aguara release.
+//
+// Entries are matched by (Ecosystem, Name, Version). An entry with an
+// empty Ecosystem is treated as PyPI so IsCompromised stays
+// backward-compatible with prior callers that did not supply an
+// ecosystem argument.
 var KnownCompromised = []CompromisedPackage{
 	{
-		Name:     "litellm",
-		Versions: []string{"1.82.7", "1.82.8"},
-		Advisory: "PYSEC-2026-litellm",
-		Date:     "2026-03-24",
-		Summary:  "Malicious .pth file exfiltrates credentials (SSH, cloud, K8s) and installs backdoor with systemd persistence",
+		Ecosystem: EcosystemPyPI,
+		Name:      "litellm",
+		Versions:  []string{"1.82.7", "1.82.8"},
+		Advisory:  "PYSEC-2026-litellm",
+		Date:      "2026-03-24",
+		Summary:   "Malicious .pth file exfiltrates credentials (SSH, cloud, K8s) and installs backdoor with systemd persistence",
+	},
+
+	// --- npm ---
+	//
+	// Historical npm compromises with publicly-published advisories.
+	// Maintainers should extend this list as new incidents are
+	// confirmed via npm advisories or vendor disclosures. Each entry
+	// must cite the source advisory in the Advisory field; speculative
+	// or unverified package/version tuples do not belong here.
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "event-stream",
+		Versions:  []string{"3.3.6"},
+		Advisory:  "GHSA-mh6f-8j2x-4483",
+		Date:      "2018-11-26",
+		Summary:   "event-stream 3.3.6 shipped a malicious flatmap-stream dependency that targeted bitcoin wallets in copay-dash; the version was unpublished and remediated by maintainers.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "flatmap-stream",
+		Versions:  []string{"0.1.1"},
+		Advisory:  "GHSA-mh6f-8j2x-4483",
+		Date:      "2018-11-26",
+		Summary:   "Malicious dependency injected through event-stream 3.3.6; exfiltrated wallet data from copay-dash.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "ua-parser-js",
+		Versions:  []string{"0.7.29", "0.8.0", "1.0.0"},
+		Advisory:  "GHSA-pjwm-rvh2-c87w",
+		Date:      "2021-10-22",
+		Summary:   "Compromised ua-parser-js versions installed cryptominer and credential-stealing payloads on Linux and Windows.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "coa",
+		Versions:  []string{"2.0.3", "2.0.4", "2.1.1", "2.1.3", "3.0.1", "3.1.3"},
+		Advisory:  "GHSA-73qr-pfmq-6rp8",
+		Date:      "2021-11-04",
+		Summary:   "Compromised coa releases delivered credential-stealing payload; package was unpublished and remediated.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "rc",
+		Versions:  []string{"1.2.9", "1.3.9", "2.3.9"},
+		Advisory:  "GHSA-g2q5-5433-rhrf",
+		Date:      "2021-11-12",
+		Summary:   "Compromised rc releases delivered the same credential-stealing payload as the coa incident from the same week.",
 	},
 }
 
-// IsCompromised checks if a package name+version is in the known-bad list.
+// IsCompromised checks if a package name+version is in the known-bad
+// list. The legacy two-argument signature stays for backward
+// compatibility; it matches across all ecosystems and is sufficient
+// for the existing Python checker which only ever inspected PyPI.
 func IsCompromised(name, version string) *CompromisedPackage {
+	return findCompromised("", name, version)
+}
+
+// IsCompromisedIn restricts the lookup to a specific ecosystem. Use
+// this from the npm checker so a PyPI package that happens to share a
+// name with an npm package is not falsely flagged.
+func IsCompromisedIn(ecosystem, name, version string) *CompromisedPackage {
+	return findCompromised(ecosystem, name, version)
+}
+
+func findCompromised(ecosystem, name, version string) *CompromisedPackage {
 	for i := range KnownCompromised {
-		if KnownCompromised[i].Name != name {
+		entry := &KnownCompromised[i]
+		if entry.Name != name {
 			continue
 		}
-		for _, v := range KnownCompromised[i].Versions {
+		if ecosystem != "" {
+			entryEco := entry.Ecosystem
+			if entryEco == "" {
+				entryEco = EcosystemPyPI
+			}
+			if entryEco != ecosystem {
+				continue
+			}
+		}
+		for _, v := range entry.Versions {
 			if v == version {
-				return &KnownCompromised[i]
+				return entry
 			}
 		}
 	}

--- a/internal/incident/compromised.go
+++ b/internal/incident/compromised.go
@@ -102,12 +102,15 @@ var KnownCompromised = []CompromisedPackage{
 	},
 }
 
-// IsCompromised checks if a package name+version is in the known-bad
-// list. The legacy two-argument signature stays for backward
-// compatibility; it matches across all ecosystems and is sufficient
-// for the existing Python checker which only ever inspected PyPI.
+// IsCompromised checks if a package name+version is in the PyPI
+// section of the known-bad list. The legacy two-argument signature
+// pre-dates the Ecosystem field; it stays scoped to PyPI so a Python
+// package that happens to share a name with an npm advisory (e.g.
+// `rc`, `event-stream`) is not falsely flagged by the Python
+// checker. Callers that want a cross-ecosystem or npm-only lookup
+// should use IsCompromisedIn explicitly.
 func IsCompromised(name, version string) *CompromisedPackage {
-	return findCompromised("", name, version)
+	return findCompromised(EcosystemPyPI, name, version)
 }
 
 // IsCompromisedIn restricts the lookup to a specific ecosystem. Use

--- a/internal/incident/npm.go
+++ b/internal/incident/npm.go
@@ -65,6 +65,13 @@ func CheckNPM(opts CheckOptions) (*CheckResult, error) {
 // and parses each package.json it finds. Scoped packages (@scope/name)
 // resolve correctly because the scope directory contains the package
 // directory which contains package.json.
+//
+// Manifests are only counted when their package directory's parent is
+// a node_modules directory (directly for unscoped packages, or via a
+// @scope directory whose parent is node_modules). A package's own
+// examples/ or fixtures/ subtree may contain a stray package.json
+// that npm does not treat as an installed dependency; those are
+// skipped so they cannot trigger a false-positive compromise finding.
 func readInstalledNPMPackages(root string) []NPMPackage {
 	var pkgs []NPMPackage
 	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
@@ -77,17 +84,7 @@ func readInstalledNPMPackages(root string) []NPMPackage {
 		if filepath.Base(path) != "package.json" {
 			return nil
 		}
-		// Only count package.json files whose nearest ancestor directory
-		// looks like an installed package (under a node_modules tree).
-		// A repository's top-level package.json sits next to a sibling
-		// node_modules dir, not inside it; skipping those keeps the
-		// check from reporting on the package being audited.
-		rel, err := filepath.Rel(root, path)
-		if err != nil {
-			return nil
-		}
-		if !strings.Contains(filepath.ToSlash(rel), "/") {
-			// top-level entry, not an installed dep
+		if !isInstalledPackageManifest(path) {
 			return nil
 		}
 		pkg := parseNPMPackage(path)
@@ -97,6 +94,26 @@ func readInstalledNPMPackages(root string) []NPMPackage {
 		return nil
 	})
 	return pkgs
+}
+
+// isInstalledPackageManifest returns true if the manifest at path lives
+// at a real npm install boundary: either node_modules/<name>/package.json
+// or node_modules/@scope/<name>/package.json. Manifests nested in
+// examples / fixtures / test trees do not satisfy this and so are
+// excluded from the installed-package walk.
+func isInstalledPackageManifest(path string) bool {
+	dir := filepath.Dir(path)
+	parent := filepath.Dir(dir)
+	if filepath.Base(parent) == "node_modules" {
+		return true
+	}
+	// Scoped layout: node_modules/@scope/<name>/package.json.
+	// parent here is the @scope directory; its parent is node_modules.
+	if strings.HasPrefix(filepath.Base(parent), "@") &&
+		filepath.Base(filepath.Dir(parent)) == "node_modules" {
+		return true
+	}
+	return false
 }
 
 // parseNPMPackage reads a package.json and extracts the name and

--- a/internal/incident/npm.go
+++ b/internal/incident/npm.go
@@ -97,12 +97,19 @@ func readInstalledNPMPackages(root string) []NPMPackage {
 }
 
 // isInstalledPackageManifest returns true when path is reachable from
-// root via a canonical npm install layout: each level must be either
-// a package name (`<name>` or `@scope/<name>`) directly under the
-// scan root, or a nested `node_modules/<name>/` pair underneath the
-// previous package. Any other intermediate segment (`examples/`,
-// `test/`, `fixtures/`, `dist/`, etc.) means the manifest is bundled
-// test data rather than an installed dependency.
+// root via a canonical install layout. Two layouts are accepted:
+//
+//	npm:   <name>[/node_modules/<name>]*         (optional @scope at each name)
+//	pnpm:  .pnpm/<spec>/node_modules/<name>      (the virtual store)
+//
+// Top-level npm entries are <name> or @scope/<name>. pnpm exposes
+// top-level packages as symlinks pointing into the .pnpm virtual
+// store; filepath.WalkDir does not follow those symlinks, so the
+// real manifests are reached via the .pnpm/<spec>/node_modules/...
+// path and need to be admitted here. Any other intermediate
+// segment (examples/, test/, fixtures/, dist/, etc.) means the
+// manifest is bundled test data rather than an installed
+// dependency.
 func isInstalledPackageManifest(path, root string) bool {
 	rel, err := filepath.Rel(root, path)
 	if err != nil {
@@ -112,18 +119,21 @@ func isInstalledPackageManifest(path, root string) bool {
 	if len(parts) < 2 || parts[len(parts)-1] != "package.json" {
 		return false
 	}
-	// Walk segments preceding the manifest filename. The valid
-	// alternation is: <name> [ /node_modules/<name> ]* with an
-	// optional @scope prefix on each <name> position.
 	const (
-		expectName        = iota // start; expect a package or @scope token
-		expectScopedName         // after an @scope token, expect the leaf name
-		expectNodeOrEnd          // after a name, expect /node_modules or end
+		expectName            = iota // start; <name>, @scope, or .pnpm
+		expectScopedName             // after @scope, expect the leaf name
+		expectNodeOrEnd              // after a name, expect /node_modules or end
+		expectPnpmSpec               // after .pnpm, expect a spec token
+		expectPnpmNodeModules        // after the spec, expect /node_modules
 	)
 	state := expectName
 	for _, seg := range parts[:len(parts)-1] {
 		switch state {
 		case expectName:
+			if seg == ".pnpm" {
+				state = expectPnpmSpec
+				continue
+			}
 			if strings.HasPrefix(seg, "@") {
 				state = expectScopedName
 				continue
@@ -132,6 +142,18 @@ func isInstalledPackageManifest(path, root string) bool {
 		case expectScopedName:
 			state = expectNodeOrEnd
 		case expectNodeOrEnd:
+			if seg != "node_modules" {
+				return false
+			}
+			state = expectName
+		case expectPnpmSpec:
+			// Any non-empty token works as the pnpm spec (e.g.
+			// event-stream@3.3.6, @scope+name@1.2.3).
+			if seg == "" {
+				return false
+			}
+			state = expectPnpmNodeModules
+		case expectPnpmNodeModules:
 			if seg != "node_modules" {
 				return false
 			}

--- a/internal/incident/npm.go
+++ b/internal/incident/npm.go
@@ -84,7 +84,7 @@ func readInstalledNPMPackages(root string) []NPMPackage {
 		if filepath.Base(path) != "package.json" {
 			return nil
 		}
-		if !isInstalledPackageManifest(path) {
+		if !isInstalledPackageManifest(path, root) {
 			return nil
 		}
 		pkg := parseNPMPackage(path)
@@ -96,24 +96,49 @@ func readInstalledNPMPackages(root string) []NPMPackage {
 	return pkgs
 }
 
-// isInstalledPackageManifest returns true if the manifest at path lives
-// at a real npm install boundary: either node_modules/<name>/package.json
-// or node_modules/@scope/<name>/package.json. Manifests nested in
-// examples / fixtures / test trees do not satisfy this and so are
-// excluded from the installed-package walk.
-func isInstalledPackageManifest(path string) bool {
-	dir := filepath.Dir(path)
-	parent := filepath.Dir(dir)
-	if filepath.Base(parent) == "node_modules" {
-		return true
+// isInstalledPackageManifest returns true when path is reachable from
+// root via a canonical npm install layout: each level must be either
+// a package name (`<name>` or `@scope/<name>`) directly under the
+// scan root, or a nested `node_modules/<name>/` pair underneath the
+// previous package. Any other intermediate segment (`examples/`,
+// `test/`, `fixtures/`, `dist/`, etc.) means the manifest is bundled
+// test data rather than an installed dependency.
+func isInstalledPackageManifest(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
 	}
-	// Scoped layout: node_modules/@scope/<name>/package.json.
-	// parent here is the @scope directory; its parent is node_modules.
-	if strings.HasPrefix(filepath.Base(parent), "@") &&
-		filepath.Base(filepath.Dir(parent)) == "node_modules" {
-		return true
+	parts := strings.Split(filepath.ToSlash(rel), "/")
+	if len(parts) < 2 || parts[len(parts)-1] != "package.json" {
+		return false
 	}
-	return false
+	// Walk segments preceding the manifest filename. The valid
+	// alternation is: <name> [ /node_modules/<name> ]* with an
+	// optional @scope prefix on each <name> position.
+	const (
+		expectName        = iota // start; expect a package or @scope token
+		expectScopedName         // after an @scope token, expect the leaf name
+		expectNodeOrEnd          // after a name, expect /node_modules or end
+	)
+	state := expectName
+	for _, seg := range parts[:len(parts)-1] {
+		switch state {
+		case expectName:
+			if strings.HasPrefix(seg, "@") {
+				state = expectScopedName
+				continue
+			}
+			state = expectNodeOrEnd
+		case expectScopedName:
+			state = expectNodeOrEnd
+		case expectNodeOrEnd:
+			if seg != "node_modules" {
+				return false
+			}
+			state = expectName
+		}
+	}
+	return state == expectNodeOrEnd
 }
 
 // parseNPMPackage reads a package.json and extracts the name and

--- a/internal/incident/npm.go
+++ b/internal/incident/npm.go
@@ -1,0 +1,121 @@
+package incident
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// NPMPackage is a package parsed from a node_modules entry's package.json.
+type NPMPackage struct {
+	Name    string
+	Version string
+	Dir     string // package.json's containing directory
+}
+
+// CheckNPM scans a node_modules tree (recursively, since deps install
+// nested copies) and reports any installed package whose
+// (ecosystem, name, version) tuple matches the embedded npm IOC set.
+// The check is offline and read-only.
+//
+// opts.Path must point at a node_modules directory. The caller is
+// responsible for choosing the right tree (project node_modules, a
+// global install, an unpacked tarball under tmp). If opts.Path is
+// empty CheckNPM returns an error rather than guessing, because
+// `aguara check` for npm has no canonical autodiscovery location and
+// silently scanning the wrong tree would mislead the operator.
+func CheckNPM(opts CheckOptions) (*CheckResult, error) {
+	if opts.Path == "" {
+		return nil, fmt.Errorf("npm check requires --path pointing at a node_modules directory")
+	}
+	info, err := os.Stat(opts.Path)
+	if err != nil {
+		return nil, fmt.Errorf("npm check: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("npm check: %s is not a directory", opts.Path)
+	}
+
+	result := &CheckResult{Environment: opts.Path}
+
+	packages := readInstalledNPMPackages(opts.Path)
+	result.PackagesRead = len(packages)
+	for _, pkg := range packages {
+		cp := IsCompromisedIn(EcosystemNPM, pkg.Name, pkg.Version)
+		if cp == nil {
+			continue
+		}
+		result.Findings = append(result.Findings, Finding{
+			Severity:    SevCritical,
+			Title:       fmt.Sprintf("%s %s is a known compromised npm package (%s)", pkg.Name, pkg.Version, cp.Advisory),
+			Detail:      cp.Summary,
+			Path:        pkg.Dir,
+			Remediation: fmt.Sprintf("Remove %s@%s, audit recent runs of the surrounding pipeline, and rotate any tokens this environment has held.", pkg.Name, pkg.Version),
+		})
+	}
+
+	return result, nil
+}
+
+// readInstalledNPMPackages walks node_modules recursively (since npm
+// can install nested copies of the same package at different versions)
+// and parses each package.json it finds. Scoped packages (@scope/name)
+// resolve correctly because the scope directory contains the package
+// directory which contains package.json.
+func readInstalledNPMPackages(root string) []NPMPackage {
+	var pkgs []NPMPackage
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if filepath.Base(path) != "package.json" {
+			return nil
+		}
+		// Only count package.json files whose nearest ancestor directory
+		// looks like an installed package (under a node_modules tree).
+		// A repository's top-level package.json sits next to a sibling
+		// node_modules dir, not inside it; skipping those keeps the
+		// check from reporting on the package being audited.
+		rel, err := filepath.Rel(root, path)
+		if err != nil {
+			return nil
+		}
+		if !strings.Contains(filepath.ToSlash(rel), "/") {
+			// top-level entry, not an installed dep
+			return nil
+		}
+		pkg := parseNPMPackage(path)
+		if pkg.Name != "" && pkg.Version != "" {
+			pkgs = append(pkgs, pkg)
+		}
+		return nil
+	})
+	return pkgs
+}
+
+// parseNPMPackage reads a package.json and extracts the name and
+// version fields. Returns a zero-value NPMPackage if the file is
+// malformed or missing those fields.
+func parseNPMPackage(path string) NPMPackage {
+	pkg := NPMPackage{Dir: filepath.Dir(path)}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return pkg
+	}
+	var manifest struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return pkg
+	}
+	pkg.Name = manifest.Name
+	pkg.Version = manifest.Version
+	return pkg
+}

--- a/internal/incident/npm.go
+++ b/internal/incident/npm.go
@@ -29,19 +29,16 @@ type NPMPackage struct {
 // silently scanning the wrong tree would mislead the operator.
 func CheckNPM(opts CheckOptions) (*CheckResult, error) {
 	if opts.Path == "" {
-		return nil, fmt.Errorf("npm check requires --path pointing at a node_modules directory")
+		return nil, fmt.Errorf("npm check requires --path pointing at a node_modules directory or a project root that contains one")
 	}
-	info, err := os.Stat(opts.Path)
+	root, err := resolveNPMRoot(opts.Path)
 	if err != nil {
-		return nil, fmt.Errorf("npm check: %w", err)
-	}
-	if !info.IsDir() {
-		return nil, fmt.Errorf("npm check: %s is not a directory", opts.Path)
+		return nil, err
 	}
 
-	result := &CheckResult{Environment: opts.Path}
+	result := &CheckResult{Environment: root}
 
-	packages := readInstalledNPMPackages(opts.Path)
+	packages := readInstalledNPMPackages(root)
 	result.PackagesRead = len(packages)
 	for _, pkg := range packages {
 		cp := IsCompromisedIn(EcosystemNPM, pkg.Name, pkg.Version)
@@ -58,6 +55,31 @@ func CheckNPM(opts CheckOptions) (*CheckResult, error) {
 	}
 
 	return result, nil
+}
+
+// resolveNPMRoot turns the user-supplied path into the actual
+// node_modules directory to walk. The supplied path may already be a
+// node_modules tree, in which case it is returned unchanged; or it
+// may be a project root whose child node_modules holds the install
+// graph. Any other shape returns an error so the operator does not
+// silently get a clean report for a path the checker cannot
+// interpret.
+func resolveNPMRoot(p string) (string, error) {
+	info, err := os.Stat(p)
+	if err != nil {
+		return "", fmt.Errorf("npm check: %w", err)
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("npm check: %s is not a directory", p)
+	}
+	if filepath.Base(p) == "node_modules" {
+		return p, nil
+	}
+	candidate := filepath.Join(p, "node_modules")
+	if cinfo, cerr := os.Stat(candidate); cerr == nil && cinfo.IsDir() {
+		return candidate, nil
+	}
+	return "", fmt.Errorf("npm check: %s is not a node_modules directory and contains no node_modules subdirectory; pass the path to a node_modules tree or its parent project", p)
 }
 
 // readInstalledNPMPackages walks node_modules recursively (since npm

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -142,6 +142,29 @@ func TestCheckNPM_NonExistentPath(t *testing.T) {
 	}
 }
 
+func TestCheckNPM_PnpmStoreLayout(t *testing.T) {
+	// pnpm exposes top-level packages as symlinks into a virtual
+	// store under node_modules/.pnpm. The real manifests live at
+	// node_modules/.pnpm/<spec>/node_modules/<name>/package.json
+	// and must be parsed as installed dependencies.
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, filepath.Join(nm, ".pnpm", "event-stream@3.3.6", "node_modules"), "event-stream", "3.3.6")
+	// A scoped variant.
+	writeNPMPackage(t, filepath.Join(nm, ".pnpm", "@scope+name@1.0.0", "node_modules"), "@scope/name", "1.0.0")
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if result.PackagesRead != 2 {
+		t.Errorf("expected 2 packages in pnpm store, got %d", result.PackagesRead)
+	}
+	if len(result.Findings) != 1 || result.Findings[0].Title == "" {
+		t.Fatalf("expected one event-stream finding, got: %+v", result.Findings)
+	}
+}
+
 func TestCheckNPM_IgnoresFixtureNodeModules(t *testing.T) {
 	// A build-tool style fixture: an installed package ships a
 	// test fixture that itself has a node_modules tree

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -142,6 +142,37 @@ func TestCheckNPM_NonExistentPath(t *testing.T) {
 	}
 }
 
+func TestCheckNPM_AcceptsProjectRoot(t *testing.T) {
+	// `--path .` (project root with a sibling node_modules) is the
+	// most user-friendly invocation. The checker normalizes it to
+	// the node_modules child instead of silently reporting zero
+	// packages.
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "event-stream", "3.3.6")
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: dir})
+	if err != nil {
+		t.Fatalf("CheckNPM should accept project root, got: %v", err)
+	}
+	if result.PackagesRead != 1 {
+		t.Errorf("expected 1 package, got %d", result.PackagesRead)
+	}
+	if len(result.Findings) != 1 {
+		t.Errorf("project-root scan should still detect compromised dep, got: %+v", result.Findings)
+	}
+}
+
+func TestCheckNPM_RejectsBareDirWithoutNodeModules(t *testing.T) {
+	// A directory that is neither node_modules nor a project with
+	// one must error rather than report a clean (and misleading)
+	// zero-finding result.
+	dir := t.TempDir()
+	if _, err := incident.CheckNPM(incident.CheckOptions{Path: dir}); err == nil {
+		t.Errorf("expected error on directory without node_modules child")
+	}
+}
+
 func TestCheckNPM_PnpmStoreLayout(t *testing.T) {
 	// pnpm exposes top-level packages as symlinks into a virtual
 	// store under node_modules/.pnpm. The real manifests live at

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -1,0 +1,139 @@
+package incident_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/garagon/aguara/internal/incident"
+)
+
+func writeNPMPackage(t *testing.T, root, importPath, version string) {
+	t.Helper()
+	dir := filepath.Join(root, filepath.FromSlash(importPath))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", dir, err)
+	}
+	body := `{"name":` + jsonString(importPath) + `,"version":` + jsonString(version) + `}`
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write package.json: %v", err)
+	}
+}
+
+func jsonString(s string) string {
+	// Minimal JSON string escaping for the few cases the test writes.
+	return `"` + s + `"`
+}
+
+func TestIsCompromisedIn_NPMHit(t *testing.T) {
+	cp := incident.IsCompromisedIn(incident.EcosystemNPM, "event-stream", "3.3.6")
+	if cp == nil {
+		t.Fatalf("expected event-stream 3.3.6 to be compromised, got nil")
+	}
+	if cp.Ecosystem != incident.EcosystemNPM {
+		t.Errorf("expected ecosystem npm, got %q", cp.Ecosystem)
+	}
+}
+
+func TestIsCompromisedIn_NPMMiss(t *testing.T) {
+	// event-stream is in the npm list; checking pypi for the same name
+	// must return nil, otherwise a Python package sharing a name with
+	// an npm incident would falsely chain.
+	if cp := incident.IsCompromisedIn(incident.EcosystemPyPI, "event-stream", "3.3.6"); cp != nil {
+		t.Errorf("expected ecosystem filter to exclude pypi lookup, got: %+v", cp)
+	}
+}
+
+func TestIsCompromised_LegacyTwoArg_StillMatchesAcrossEcosystems(t *testing.T) {
+	// The legacy IsCompromised(name, version) signature must continue
+	// to match npm entries; existing callers (the Python checker)
+	// only ever inspected PyPI packages so the cross-ecosystem match
+	// is benign there.
+	if cp := incident.IsCompromised("event-stream", "3.3.6"); cp == nil {
+		t.Errorf("legacy IsCompromised should still find npm event-stream 3.3.6")
+	}
+}
+
+func TestCheckNPM_RequiresPath(t *testing.T) {
+	if _, err := incident.CheckNPM(incident.CheckOptions{}); err == nil {
+		t.Errorf("expected error when path is empty")
+	}
+}
+
+func TestCheckNPM_DetectsCompromisedPackage(t *testing.T) {
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "event-stream", "3.3.6")
+	writeNPMPackage(t, nm, "express", "4.18.2")
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if result.PackagesRead != 2 {
+		t.Errorf("expected 2 packages read, got %d", result.PackagesRead)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 finding, got %d: %+v", len(result.Findings), result.Findings)
+	}
+	if result.Findings[0].Severity != incident.SevCritical {
+		t.Errorf("expected CRITICAL severity, got %q", result.Findings[0].Severity)
+	}
+}
+
+func TestCheckNPM_ScopedPackages(t *testing.T) {
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "@scope/legit", "1.0.0")
+	writeNPMPackage(t, nm, "ua-parser-js", "0.7.29")
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if result.PackagesRead != 2 {
+		t.Errorf("expected 2 packages read, got %d", result.PackagesRead)
+	}
+	if len(result.Findings) != 1 || result.Findings[0].Path == "" {
+		t.Fatalf("expected one ua-parser-js finding with a path, got: %+v", result.Findings)
+	}
+}
+
+func TestCheckNPM_NestedNodeModules(t *testing.T) {
+	// A nested copy at node_modules/foo/node_modules/event-stream
+	// must still be detected (npm legitimately ships nested deps
+	// when a dep's version constraint cannot be hoisted).
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "foo", "1.0.0")
+	writeNPMPackage(t, filepath.Join(nm, "foo", "node_modules"), "event-stream", "3.3.6")
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 finding for nested compromised dep, got %d: %+v", len(result.Findings), result.Findings)
+	}
+}
+
+func TestCheckNPM_CleanTree(t *testing.T) {
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "react", "18.3.1")
+	writeNPMPackage(t, nm, "@scope/utils", "2.1.0")
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if len(result.Findings) != 0 {
+		t.Errorf("clean tree must produce no findings, got: %+v", result.Findings)
+	}
+}
+
+func TestCheckNPM_NonExistentPath(t *testing.T) {
+	if _, err := incident.CheckNPM(incident.CheckOptions{Path: "/nonexistent/path"}); err == nil {
+		t.Errorf("expected error for nonexistent path")
+	}
+}

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -141,3 +141,36 @@ func TestCheckNPM_NonExistentPath(t *testing.T) {
 		t.Errorf("expected error for nonexistent path")
 	}
 }
+
+func TestCheckNPM_IgnoresFixtureManifests(t *testing.T) {
+	// A package may ship its own examples / test fixtures that contain
+	// a `package.json` (e.g. fixture for a transpiler). Those are not
+	// installed dependencies and must not be parsed as such.
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "real-pkg", "1.0.0")
+	// A fixture manifest with a known-compromised tuple deep inside
+	// real-pkg/examples/.
+	fixDir := filepath.Join(nm, "real-pkg", "examples", "scenario")
+	if err := os.MkdirAll(fixDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(fixDir, "package.json"),
+		[]byte(`{"name":"event-stream","version":"3.3.6"}`),
+		0o644,
+	); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if result.PackagesRead != 1 {
+		t.Errorf("expected only 1 installed package, got %d", result.PackagesRead)
+	}
+	if len(result.Findings) != 0 {
+		t.Errorf("fixture manifests must not produce findings, got: %+v", result.Findings)
+	}
+}

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -142,6 +142,39 @@ func TestCheckNPM_NonExistentPath(t *testing.T) {
 	}
 }
 
+func TestCheckNPM_IgnoresFixtureNodeModules(t *testing.T) {
+	// A build-tool style fixture: an installed package ships a
+	// test fixture that itself has a node_modules tree
+	// (node_modules/build-tool/examples/some-app/node_modules/x/package.json).
+	// The state-machine path check must reject the nested node_modules
+	// because of the `examples/some-app` intermediate segments.
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "build-tool", "1.0.0")
+	deep := filepath.Join(nm, "build-tool", "examples", "some-app", "node_modules")
+	if err := os.MkdirAll(filepath.Join(deep, "event-stream"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(deep, "event-stream", "package.json"),
+		[]byte(`{"name":"event-stream","version":"3.3.6"}`),
+		0o644,
+	); err != nil {
+		t.Fatalf("write fixture: %v", err)
+	}
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if result.PackagesRead != 1 {
+		t.Errorf("expected only 1 installed package (build-tool), got %d", result.PackagesRead)
+	}
+	if len(result.Findings) != 0 {
+		t.Errorf("fixture node_modules must not chain, got: %+v", result.Findings)
+	}
+}
+
 func TestCheckNPM_IgnoresFixtureManifests(t *testing.T) {
 	// A package may ship its own examples / test fixtures that contain
 	// a `package.json` (e.g. fixture for a transpiler). Those are not

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -44,13 +44,17 @@ func TestIsCompromisedIn_NPMMiss(t *testing.T) {
 	}
 }
 
-func TestIsCompromised_LegacyTwoArg_StillMatchesAcrossEcosystems(t *testing.T) {
-	// The legacy IsCompromised(name, version) signature must continue
-	// to match npm entries; existing callers (the Python checker)
-	// only ever inspected PyPI packages so the cross-ecosystem match
-	// is benign there.
-	if cp := incident.IsCompromised("event-stream", "3.3.6"); cp == nil {
-		t.Errorf("legacy IsCompromised should still find npm event-stream 3.3.6")
+func TestIsCompromised_LegacyTwoArg_ScopedToPyPI(t *testing.T) {
+	// The legacy two-arg signature pre-dates the Ecosystem field
+	// and is scoped to PyPI. A Python package whose metadata
+	// name+version matches an npm advisory must not be falsely
+	// flagged by the Python checker.
+	if cp := incident.IsCompromised("event-stream", "3.3.6"); cp != nil {
+		t.Errorf("legacy IsCompromised must not match npm event-stream from a Python lookup, got: %+v", cp)
+	}
+	// PyPI entries still match.
+	if cp := incident.IsCompromised("litellm", "1.82.7"); cp == nil {
+		t.Errorf("legacy IsCompromised should still find PyPI litellm 1.82.7")
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds an npm branch to `aguara check`, sharing the existing terminal/JSON output and CheckResult structure. The default behavior of `aguara check` (Python site-packages scan) is unchanged; a new `--ecosystem npm` flag routes the check at an installed `node_modules` tree (or its parent project root).

### What changed

- `internal/incident/compromised.go`: `CompromisedPackage` gains an optional `Ecosystem` field and an optional `IOCs` slice. The legacy `IsCompromised(name, version)` helper now scopes to PyPI so a Python package whose metadata name+version coincides with an npm advisory is not falsely flagged by the Python checker. A new `IsCompromisedIn(ecosystem, name, version)` variant is added for ecosystem-specific lookups.
- `internal/incident/npm.go` (new): `CheckNPM` walks the node_modules tree (npm-style nested installs and pnpm's `.pnpm` virtual store), parses each `package.json`, and matches against the embedded npm advisory list. The walk rejects manifests that do not live at a canonical install boundary (state-machine validates each path segment) so fixture / example trees inside packages do not produce false findings.
- `cmd/aguara/commands/check.go`: new `--ecosystem` flag (default `python` for backward compat). Terminal output adapts to the ecosystem: the environment label and action-guidance block are different for npm (no `aguara clean`, no K8s lookup; recommendation is to uninstall the offending package and audit CI runs that touched it).
- The Python `checkCaches` filter now respects the ecosystem field, so npm rows are not matched against Python cache filenames.

### Embedded npm advisories

Five historical npm compromises with publicly-published advisories are shipped in the embedded list:

| Name | Versions | Advisory |
|---|---|---|
| `event-stream` | 3.3.6 | GHSA-mh6f-8j2x-4483 |
| `flatmap-stream` | 0.1.1 | GHSA-mh6f-8j2x-4483 (companion to event-stream) |
| `ua-parser-js` | 0.7.29, 0.8.0, 1.0.0 | GHSA-pjwm-rvh2-c87w |
| `coa` | 2.0.3, 2.0.4, 2.1.1, 2.1.3, 3.0.1, 3.1.3 | GHSA-73qr-pfmq-6rp8 |
| `rc` | 1.2.9, 1.3.9, 2.3.9 | GHSA-g2q5-5433-rhrf |

Maintainers extend the list as new advisories land.

### Path layouts accepted by `CheckNPM`

- npm classic: `node_modules/<name>/package.json`, `node_modules/@scope/<name>/package.json`, plus nested `node_modules/...` chains.
- pnpm virtual store: `node_modules/.pnpm/<spec>/node_modules/<name>/package.json` (since pnpm exposes top-level entries as symlinks that `filepath.WalkDir` does not follow).
- Project root: `--path .` normalizes to `<root>/node_modules` if that subdirectory exists, so the most user-friendly invocation works.

Manifests inside `examples/`, `test/`, `fixtures/`, or other non-canonical paths are skipped to avoid false-positive compromise findings from bundled test data.

## Test plan

- [x] `make build` passes.
- [x] `make test` clean across all packages.
- [x] `make vet` clean.
- [x] `make lint` reports `0 issues.`
- [x] Existing Python `check` tests continue to pass; the legacy `IsCompromised` test is updated to verify PyPI-only scoping.
- [x] 10 new test cases in `internal/incident/npm_test.go` cover: ecosystem-scoped lookup hits and misses, legacy two-arg signature scoping, `--path` requirement, basic detection, scoped packages, nested node_modules, clean tree, nonexistent path, fixture-manifest exclusion, deep-fixture node_modules exclusion, pnpm virtual store, project-root normalization, bare-dir rejection.
- [x] End-to-end CLI smoke against a hand-crafted `node_modules/event-stream@3.3.6` reports CRITICAL with npm-specific remediation guidance ("Remove the affected packages with the package manager", "Audit recent CI runs").

## Compatibility

Public `Finding` / `CheckResult` JSON schema is additive only: `CompromisedPackage` gains optional fields with `omitempty`; legacy consumers continue to read existing fields unchanged. The default `aguara check` (no flag) behaves exactly as before.

## Round closes here

This is the last PR in the supply-chain trust round. The deferred cross-cutting follow-up from #73 (`list-rules` / `explain` coverage for analyzer-emitted IDs) remains scheduled for its own dedicated PR after the round.