### PR TITLE
fix(smoke): pre-create GOCACHE / GOTMPDIR dirs in smoke scripts

### DIFF
--- a/benchmarks/smoke-npm-incident.sh
+++ b/benchmarks/smoke-npm-incident.sh
@@ -11,7 +11,12 @@
 set -eu
 
 OUT="${BENCH_OUT:-/out}"
-mkdir -p "$OUT"
+# Pre-create Go's cache and temp dirs. The bench image sets
+# GOCACHE=/tmp/go-build and GOTMPDIR=/tmp/go-tmp, and the container
+# runs with --read-only + a fresh /tmp tmpfs, so the `go build` below
+# fails without these directories. Matches the prelude in run.sh and
+# race.sh so all three entrypoints share the same shape.
+mkdir -p /tmp/go-build /tmp/go-tmp "$OUT"
 FIX_ROOT="/tmp/smoke-npm"
 rm -rf "$FIX_ROOT"
 mkdir -p "$FIX_ROOT"

--- a/benchmarks/smoke-supply-chain.sh
+++ b/benchmarks/smoke-supply-chain.sh
@@ -11,7 +11,12 @@
 set -eu
 
 OUT="${BENCH_OUT:-/out}"
-mkdir -p "$OUT"
+# Pre-create Go's cache and temp dirs. The bench image sets
+# GOCACHE=/tmp/go-build and GOTMPDIR=/tmp/go-tmp, and the container
+# runs with --read-only + a fresh /tmp tmpfs, so the `go build` below
+# fails without these directories. Matches the prelude in run.sh and
+# race.sh so all three entrypoints share the same shape.
+mkdir -p /tmp/go-build /tmp/go-tmp "$OUT"
 FIX="/tmp/smoke-supply-chain"
 rm -rf "$FIX"
 mkdir -p "$FIX/.github/workflows"


### PR DESCRIPTION
## Summary

Follow-up to #76. `make verify-docker` failed end-to-end because the two smoke scripts (`benchmarks/smoke-npm-incident.sh`, `benchmarks/smoke-supply-chain.sh`) did not pre-create `/tmp/go-build` and `/tmp/go-tmp` before running `go build`. The bench image sets `GOCACHE=/tmp/go-build` and `GOTMPDIR=/tmp/go-tmp`, and the container runs with `--read-only` + a fresh `/tmp` tmpfs, so the build failed with:

```
go: creating work dir: stat /tmp/go-tmp: no such file or directory
```

`run.sh` and `race.sh` already pre-create both directories at the top of their preludes; the smoke scripts only created the output directory. The fix mirrors the existing prelude verbatim:

```sh
mkdir -p /tmp/go-build /tmp/go-tmp "$OUT"
```

A short comment in each script documents the constraint so a future maintainer adding a fourth entrypoint follows the same shape.

Detection semantics are unchanged. This is container-environment plumbing.

## Test plan

- [x] `./benchmarks/smoke-npm-incident.sh` passes locally (all four cases).
- [x] `./benchmarks/smoke-supply-chain.sh` passes locally (five required rules fire, clean fixture chains none).
- [x] Verified by the maintainer's `make verify-docker` run on `aa840dbcc932`: with the prelude applied manually, both smokes pass; the harness's bench-docker, test-race-docker, and analyzer benchmarks already passed in that same run.

## Compatibility

No behavior change beyond closing the `make verify-docker` happy path. No schema change, no rule change, no detection semantics touched.