### PR TITLE
fix(scan): emit findings: [] on clean scans; clean per-target .bench artifacts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,19 @@ DOCKER_RUN_FLAGS := --rm --network none --cap-drop ALL \
 	--security-opt no-new-privileges --read-only \
 	--tmpfs /tmp:rw,exec,nosuid,size=1g
 
+# Per-target artifact lists. Each Docker validation target removes its
+# own outputs before running so a stale artifact from a prior run on
+# a different revision cannot pretend to be part of the current run.
+# Targets do not touch each other's artifacts, so `make verify-docker`
+# accumulates the union without clobbering.
+BENCH_ARTIFACTS := aguara-version.txt provenance.json go-test.txt \
+	go-bench-api.txt go-bench-engines.txt go-bench-analyzers.txt \
+	real-skills.json real-skills-summary.txt
+RACE_ARTIFACTS := go-test-race.txt provenance-race.json
+SMOKE_ARTIFACTS := smoke-npm-compromised.json smoke-npm-clean.json \
+	smoke-npm-fixture.json smoke-npm-bare.txt \
+	smoke-supply-chain.json smoke-supply-chain-clean.json
+
 .PHONY: build test lint run clean fmt vet wasm wasm-serve bench \
 	bench-docker-image race-docker-image \
 	bench-docker smoke-docker test-race-docker verify-docker
@@ -46,6 +59,7 @@ race-docker-image:
 
 bench-docker: bench-docker-image
 	mkdir -p .bench
+	@cd .bench && rm -f $(BENCH_ARTIFACTS)
 	docker run $(DOCKER_RUN_FLAGS) \
 		-e DOCKER_IMAGE=$(DOCKER_BENCH_IMAGE) \
 		-e BENCH_COMMAND="make bench-docker" \
@@ -53,6 +67,7 @@ bench-docker: bench-docker-image
 
 test-race-docker: race-docker-image
 	mkdir -p .bench
+	@cd .bench && rm -f $(RACE_ARTIFACTS)
 	docker run $(DOCKER_RUN_FLAGS) \
 		-e DOCKER_IMAGE=$(DOCKER_RACE_IMAGE) \
 		-e BENCH_COMMAND="make test-race-docker" \
@@ -60,6 +75,7 @@ test-race-docker: race-docker-image
 
 smoke-docker: bench-docker-image
 	mkdir -p .bench
+	@cd .bench && rm -f $(SMOKE_ARTIFACTS)
 	docker run $(DOCKER_RUN_FLAGS) \
 		--entrypoint /src/benchmarks/smoke-npm-incident.sh \
 		-v "$(CURDIR)/.bench:/out" $(DOCKER_BENCH_IMAGE)

--- a/benchmarks/smoke-supply-chain.sh
+++ b/benchmarks/smoke-supply-chain.sh
@@ -116,5 +116,17 @@ for rule in $must_fire; do
 done
 ok "clean fixture chained none of the required rules"
 
+# Clean scan must emit findings: [] (NOT null). Stable shape for
+# downstream JSON consumers; mirrors the aguara check fix.
+if grep -Eq '"findings":[[:space:]]*null' "$clean_json"; then
+  cat "$clean_json"
+  fail "clean scan emitted findings: null"
+fi
+if ! grep -Eq '"findings":[[:space:]]*\[\]' "$clean_json"; then
+  cat "$clean_json"
+  fail "clean scan missing findings: []"
+fi
+ok "clean scan produced findings: []"
+
 echo
 echo "all supply-chain smokes passed"

--- a/internal/scanner/scanner.go
+++ b/internal/scanner/scanner.go
@@ -266,6 +266,15 @@ func (s *Scanner) ScanTargets(ctx context.Context, targets []*Target) (*ScanResu
 
 	riskScore := meta.ComputeRiskScore(findings)
 
+	// Normalize the empty-result shape so the JSON output reads
+	// `"findings": []` instead of `"findings": null` on a clean scan.
+	// postProcess returns nil on several happy paths (no input, all
+	// filtered out by --disable-rule, all dropped by min-severity);
+	// downstream JSON consumers expect the array shape regardless.
+	if findings == nil {
+		findings = []Finding{}
+	}
+
 	return &ScanResult{
 		Findings:     findings,
 		FilesScanned: len(targets),

--- a/internal/scanner/scanner_test.go
+++ b/internal/scanner/scanner_test.go
@@ -2,6 +2,7 @@ package scanner_test
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,6 +28,28 @@ func (m *mockAnalyzer) Analyze(_ context.Context, target *scanner.Target) ([]typ
 		result = append(result, f)
 	}
 	return result, nil
+}
+
+func TestScannerCleanScanFindingsJSONEmitsEmptyArray(t *testing.T) {
+	// JSON consumers (CI, observatory, integrations) expect a stable
+	// `findings: []` shape on a clean scan. nil findings marshal as
+	// `null`, which breaks .length / .map() over the field.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "x.md"), []byte("# hello\n"), 0644))
+
+	s := scanner.New(1)
+	// No analyzers registered: result must still serialize with an
+	// empty findings array.
+	result, err := s.Scan(context.Background(), dir)
+	require.NoError(t, err)
+
+	out, err := json.Marshal(result)
+	require.NoError(t, err)
+	js := string(out)
+	require.NotContains(t, js, `"findings":null`,
+		"clean scan must not emit findings: null, got: %s", js)
+	require.Contains(t, js, `"findings":[]`,
+		"expected findings: [] in clean scan output, got: %s", js)
 }
 
 func TestScannerOrchestrator(t *testing.T) {

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -200,8 +200,17 @@ type ScanResult struct {
 	Target       string        `json:"-"`
 }
 
-// MarshalJSON implements custom JSON marshaling so Duration serializes as milliseconds.
+// MarshalJSON implements custom JSON marshaling so Duration serializes
+// as milliseconds, and normalizes the empty-results shape so consumers
+// always see `"findings": []` instead of `"findings": null` on clean
+// scans. The normalization covers every ScanResult producer (the
+// Scanner, the CLI's aggregate runAutoScan, library callers that
+// construct results directly) without each one needing to remember
+// the contract.
 func (r ScanResult) MarshalJSON() ([]byte, error) {
+	if r.Findings == nil {
+		r.Findings = []Finding{}
+	}
 	type Alias ScanResult
 	return json.Marshal(struct {
 		Alias

--- a/internal/types/types_test.go
+++ b/internal/types/types_test.go
@@ -1,11 +1,32 @@
 package types_test
 
 import (
+	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/garagon/aguara/internal/types"
 	"github.com/stretchr/testify/require"
 )
+
+func TestScanResultMarshalJSON_NilFindingsEmitsEmptyArray(t *testing.T) {
+	// Any ScanResult producer that leaves Findings nil (the aggregate
+	// path in runAutoScan, a library consumer constructing a result
+	// directly) must still serialize as `"findings": []` so machine
+	// consumers do not have to handle null specially.
+	r := types.ScanResult{
+		FilesScanned: 0,
+		RulesLoaded:  189,
+	}
+	out, err := json.Marshal(r)
+	require.NoError(t, err)
+	js := string(out)
+	require.NotContains(t, js, `"findings":null`,
+		"nil Findings must not serialize as null, got: %s", js)
+	require.True(t,
+		strings.Contains(js, `"findings":[]`),
+		"expected findings: [] in marshaled output, got: %s", js)
+}
 
 func TestSeverityString(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

Follow-up to #76 / #77. Addresses the two minor findings from the maintainer's `make verify-docker` PASS report on commit `9b18c8bb10c4`.

### 1. `aguara scan --format json` no longer emits `findings: null` on clean scans

PR #76 fixed `aguara check`'s `CheckResult`, but `aguara scan` uses a different struct (`ScanResult`) and was unaffected. `ScanResult.Findings` could be `nil` in three places:

- The Scanner's `postProcess` returns `nil` on early-out paths (no input, all filtered by `--disable-rule`, all filtered by `--min-severity`).
- `runAutoScan` constructs an aggregate result with `Findings` left `nil` and `append(nil, []Finding{}...)` keeps it `nil` when every discovered config is clean.
- Any library caller constructing a `ScanResult` directly.

The fix lands in two layers:

- `internal/scanner/scanner.go` initializes `Findings` to `[]Finding{}` before returning, so in-memory consumers always see a non-nil slice.
- `internal/types/types.go` adds a `nil -> []Finding{}` normalization inside `ScanResult.MarshalJSON`, which closes every producer at the serialization boundary (Scanner, `runAutoScan`, any future direct constructor).

Public schema unchanged; only the empty representation flips from `null` to `[]`.

### 2. Each Docker validation target removes its own artifacts before running

Stale artifacts from earlier runs (with the pre-#76 `commit: none` or pre-this-PR `findings: null` shape) lingered in `.bench/` alongside fresh outputs, making audit harder. The Makefile now declares per-target artifact lists and removes its own subset at start:

```
BENCH_ARTIFACTS  aguara-version.txt, provenance.json, go-test.txt,
                 go-bench-{api,engines,analyzers}.txt,
                 real-skills.{json,-summary.txt}
RACE_ARTIFACTS   go-test-race.txt, provenance-race.json
SMOKE_ARTIFACTS  smoke-npm-{compromised,clean,fixture,bare}.{json,txt},
                 smoke-supply-chain{,-clean}.json
```

The three targets do not share filenames, so `make verify-docker` accumulates the full set without one target clobbering another's output. Standalone target runs only refresh their own subset.

## Test plan

- [x] `make build` passes.
- [x] `make test` clean (existing + new regression tests for nil-findings JSON shape).
- [x] `make vet` clean.
- [x] `make lint` reports `0 issues.`
- [x] `TestScannerCleanScanFindingsJSONEmitsEmptyArray`: scanner-path regression.
- [x] `TestScanResultMarshalJSON_NilFindingsEmitsEmptyArray`: types-path regression covering all producers.
- [x] `benchmarks/smoke-supply-chain.sh` clean-fixture step now also asserts `findings: []` (catches future scan regressions end-to-end).
- [x] `make -n bench-docker / test-race-docker / smoke-docker` show the expected `cd .bench && rm -f <artifacts>` lines per target.

## Compatibility

- Public `Finding` / `ScanResult` JSON schema unchanged; only the empty-array representation flips from `null` to `[]`.
- Detection semantics (rules, severities, dedup, scoring) unchanged.
- Standalone `make bench-docker`, `make test-race-docker`, `make smoke-docker` continue to work as before; the only behavior change is cleaning their own outputs at start.