### PR TITLE
chore(goreleaser): modernize archives schema; document brews deferral

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -20,11 +20,15 @@ builds:
       - arm64
 
 archives:
-  - format: tar.gz
+  # GoReleaser v2.x: `format`/`format_overrides.format` (singular) is
+  # deprecated in favor of `formats`/`format_overrides.formats` (plural
+  # array). The output artifacts are identical; this only updates the
+  # config schema so `goreleaser check` stays clean for future versions.
+  - formats: [tar.gz]
     name_template: "aguara_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: "checksums.txt"
@@ -51,6 +55,12 @@ signs:
 sboms:
   - artifacts: archive
 
+# GoReleaser v2.x: `brews` is being phased out in favor of
+# `homebrew_casks`. The migration is intentionally NOT done here
+# because it is user-facing: the tap layout moves from
+# `Formula/aguara.rb` to `Casks/aguara.rb`, and `brew install
+# garagon/tap/aguara` becomes a cask install. Tracked for a
+# dedicated migration PR with a deprecation window for tap users.
 brews:
   - repository:
       owner: garagon


### PR DESCRIPTION
## Summary

`goreleaser check` was returning non-zero on three deprecation warnings:

1. `archives[].format` (singular string) → deprecated.
2. `archives[].format_overrides[].format` (singular string) → deprecated.
3. `brews` → being phased out in favor of `homebrew_casks`.

This PR addresses (1) and (2) by switching to the plural `formats: [...]` array form. Both are pure schema renames with identical output artifacts; verified locally with `goreleaser build --snapshot --clean --single-target`.

(3) is intentionally NOT done in this chore PR because it is **user-facing**: the tap layout would move from `Formula/aguara.rb` to `Casks/aguara.rb`, and existing `brew install garagon/tap/aguara` users would migrate to a cask install path. That belongs in a dedicated migration PR with a deprecation window communicated in release notes. A header comment in `.goreleaser.yml` documents the deferral so a future maintainer does not silently flip the section.

After this PR:
- `goreleaser check` exits 0.
- The only remaining notice is informational ("brews is being phased out"), not a deprecation error.
- The release pipeline (`.github/workflows/release.yml`) is unaffected; ghcr workflow snapshot continues to work.

## Test plan

- [x] `goreleaser check` exit 0 (was non-zero).
- [x] `goreleaser build --snapshot --clean --single-target` PASS.
- [x] `go test ./...` clean.
- [x] No change to detection semantics, rules, or output schema.

## Out of scope

`brews` → `homebrew_casks` migration. Tracked for a follow-up PR after `v0.15.0` ships, so users get the cask migration documented in its own release notes.