### PR TITLE
release: v0.15.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,104 @@
 All notable changes to Aguara are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.15.0] - 2026-05-13
+
+Minor release. Supply-chain trust analysis round: four new chain-aware analyzers (ci-trust, pkgmeta, jsrisk, plus an npm ecosystem check), four new pattern rules, and a hardened Docker validation harness. Detection coverage grows from 189 to 193 rules. JSON output shape stabilized so machine consumers see `findings: []` instead of `findings: null` on clean scans.
+
+### Added
+
+#### Chain-aware analyzers
+
+Four new `supply-chain` category analyzers detect attack shapes that require multiple aligned signals at the same call site or syntactic structure. Single weak signals never fire.
+
+`ci-trust` (`internal/engine/ci/`) inspects `.github/workflows/*.yml`:
+
+- `GHA_PWN_REQUEST_001` (HIGH; CRITICAL with write perms): `pull_request_target` with PR-controlled checkout running install/build/test/interpreter code in the same job.
+- `GHA_CACHE_001` (HIGH; CRITICAL with code execution): same chain plus a cache write (`actions/cache`, `actions/cache/save`).
+- `GHA_OIDC_001` (HIGH; CRITICAL with publish): `id-token: write` granted on a job that also runs install/build/test. Suppressed for publish-only jobs (intended OIDC use).
+- `GHA_CHECKOUT_001` (HIGH): `pull_request_target` checkout of PR head ref without `persist-credentials: false`.
+
+`pkgmeta` (`internal/engine/pkgmeta/`) inspects `package.json`:
+
+- `NPM_LIFECYCLE_GIT_001` (HIGH; CRITICAL on `optionalDependencies` + suspicious name): git-sourced dependency plus install-time lifecycle script (`preinstall`, `install`, `postinstall`, `prepublish`, `preprepare`, `prepare`, `postprepare`).
+- `NPM_OPTIONAL_GIT_001` (MEDIUM; HIGH on suspicious name): git-sourced `optionalDependency` on its own. Suppressed when `NPM_LIFECYCLE_GIT_001` covers the same dep.
+- `NPM_PUBLISH_SURFACE_001` (HIGH): `publishConfig` or publish script plus install/build/test script plus a value-aware reference to trusted publishing.
+
+`jsrisk` (`internal/engine/jsrisk/`) inspects `.js` / `.mjs` / `.cjs`:
+
+- `JS_OBF_001` (MEDIUM; HIGH with env/cp/network): obfuscator-shape payload (hex identifier density, dispatcher calls, `while(!![])`, plus a size or line-length signal).
+- `JS_DAEMON_001` (HIGH; CRITICAL with secret/sink): real `child_process` invocation with `detached: true` AND `stdio: 'ignore'` in its own arguments.
+- `JS_CI_SECRET_HARVEST_001` (CRITICAL): real `process.env` read of a CI/cloud secret (direct, bracket, optional-chaining, template-bracket, destructured forms including aliases and ESM imports) plus a network, npm registry, GitHub GraphQL, or session-exfil sink.
+- `JS_PROC_MEM_OIDC_001` (CRITICAL): `/proc/<pid>/(mem|maps|cmdline|environ)` access plus `ACTIONS_ID_TOKEN_REQUEST_*` or `Runner.Worker` reference.
+- `AGENT_PERSISTENCE_001` (HIGH; CRITICAL with harvest or daemonization): reference to a Claude Code automation file (`.claude/settings.json`, `.claude/router_runtime.js`, `.claude/setup.mjs`, `.claude/hooks/`) OR the pair `.vscode/tasks.json` plus `runOn: folderOpen`.
+
+#### Pattern rules
+
+Four targeted YAML rules complement the chain analyzers, covering shell/Python/Ruby/Perl/Go/Rust + workflow YAML + `action.yml` composite manifests:
+
+- `SUPPLY_022` (HIGH): `ACTIONS_ID_TOKEN_REQUEST_TOKEN` / `_URL` in executable code (excludes workflow YAML, owned by `ci-trust`).
+- `SUPPLY_023` (CRITICAL, match-all): `/proc/<pid>/(mem|maps|cmdline|environ)` plus `Runner.Worker` or `ACTIONS_ID_TOKEN` env in the same file.
+- `SUPPLY_024` (HIGH, category `supply-chain-exfil`): Session-Network exfil endpoints (`*.getsession.org`) used in the Mini Shai-Hulud incident.
+- `SUPPLY_025` (HIGH): Claude Code workspace persistence path (`.claude/settings.json`, `.claude/router_runtime.js`, `.claude/setup.mjs`, `.claude/hooks/`). VS Code persistence is handled by `jsrisk` with the precise `tasks.json` + `runOn:folderOpen` pair.
+
+#### `aguara check --ecosystem npm`
+
+The incident checker grows an npm branch. `aguara check --ecosystem npm --path <node_modules>` (or a project root with a `node_modules` child) walks the install graph, supports npm classic and pnpm's `.pnpm` virtual store, handles scoped packages and nested installs, and rejects fixture trees inside packages. Five historical npm advisories ship in the embedded list:
+
+| Name | Versions | Advisory |
+|---|---|---|
+| `event-stream` | 3.3.6 | GHSA-mh6f-8j2x-4483 |
+| `flatmap-stream` | 0.1.1 | GHSA-mh6f-8j2x-4483 |
+| `ua-parser-js` | 0.7.29, 0.8.0, 1.0.0 | GHSA-pjwm-rvh2-c87w |
+| `coa` | 2.0.3, 2.0.4, 2.1.1, 2.1.3, 3.0.1, 3.1.3 | GHSA-73qr-pfmq-6rp8 |
+| `rc` | 1.2.9, 1.3.9, 2.3.9 | GHSA-g2q5-5433-rhrf |
+
+The Python `aguara check` path is unchanged and continues to auto-discover site-packages.
+
+#### Docker validation harness
+
+New `make` targets give reproducible offline validation that any maintainer or agent can run:
+
+- `make bench-docker`: existing target, now passes `AGUARA_VERSION` / `AGUARA_COMMIT` build args so the in-image binary reports the real revision instead of `dev` / `none`.
+- `make test-race-docker`: `go test -race -count=1 ./...` inside a hardened Docker image (same Go base + digest pin, `build-base` for cgo).
+- `make smoke-docker`: behavioral smokes for the npm incident check (compromised / clean / fixture-nested / bare-dir cases) and the supply-chain chain rules (pwn-request workflow + lifecycle-git package + CI-secret-exfil payload).
+- `make verify-docker`: meta-target chaining bench, race, and smokes.
+
+All Docker invocations share the existing hardened runtime: `--network none`, `--cap-drop ALL`, `--security-opt no-new-privileges`, `--read-only`, `/tmp` tmpfs. New artifacts: `.bench/provenance.json` and `.bench/provenance-race.json` record `aguara_version`, `aguara_commit`, `go_version`, `docker_image`, `timestamp_utc`, and command for each run. Per-target artifact cleanup at the start of each Docker target prevents stale outputs from mixing with fresh runs.
+
+#### Analyzer micro-benchmarks
+
+`BenchmarkCITrustAnalyzer`, `BenchmarkPkgMetaAnalyzer`, `BenchmarkJSRiskAnalyzer`, `BenchmarkIncidentNPMCheck`. No thresholds; the runs land in `.bench/go-bench-analyzers.txt` so per-analyzer cost is observable across releases.
+
+### Changed
+
+#### `--disable-rule` now suppresses analyzer-emitted findings
+
+The flag previously filtered only the compiled pattern rule list, so analyzer-emitted IDs (`GHA_*`, `NPM_*`, `JS_*`, `AGENT_PERSISTENCE_001`, `TOXIC_*`, `RUGPULL_001`, NLP injection IDs) bypassed it. The filter now runs inside the scanner pipeline before tool exemptions, dedup, scoring, and min-severity filtering, so every analyzer sees the same suppression. `.aguara.yml disable_rules` benefits the same way. No flag or schema change; behavior expansion only.
+
+#### JSON output stability: `findings: []` on clean results
+
+Both `aguara scan --format json` and `aguara check --format json` emit `"findings": []` (and `"credentials": []` for `check`) on clean results instead of `null`. `ScanResult.MarshalJSON` normalizes at the serialization boundary, covering every producer including the CLI's auto-discover aggregate path. `CheckResult` is initialized with empty slices at construction in both `Check` and `CheckNPM`. Public schema unchanged; only the empty-list representation flips from `null` to `[]`.
+
+#### `goreleaser` archives schema modernized
+
+`archives[].format` / `format_overrides[].format` updated to the plural `formats: [...]` array form. Output artifacts unchanged. `brews` to `homebrew_casks` migration is intentionally deferred to a follow-up release because it changes the Homebrew tap layout from `Formula/aguara.rb` to `Casks/aguara.rb` and is user-facing.
+
+### Fixed
+
+- `IsCompromised(name, version)` (the legacy two-argument helper) now scopes to PyPI, so a Python package whose metadata name+version coincides with a newly-shipped npm advisory (`rc`, `event-stream`) is not falsely flagged by the Python checker.
+- `/proc/<pid>/<sub>` detection correctly excludes root-level files (`/proc/meminfo`, `/proc/cmdline`, `/proc/stat`, `/proc/cpuinfo`).
+- VS Code persistence detection requires the actual auto-execution primitive (`.vscode/tasks.json` plus `runOn: folderOpen`) rather than firing on either alone.
+- `actions/cache/restore` no longer triggers `GHA_CACHE_001` (the action is read-only and cannot poison a downstream privileged workflow).
+- `GHA_PWN_REQUEST_001` requires code execution AFTER the untrusted checkout, not anywhere in the job, so trusted setup before the PR checkout no longer creates a false chain.
+- npm metadata: credentialed git URLs (`git+https://user:token@host/...`) are stripped of credentials before being emitted in finding text.
+
+### Internal
+
+- 7 PRs (#70 - #78) drove the round; 1 follow-up chore (#79) cleaned the GoReleaser deprecation warnings.
+- 193 detection rules (up from 189), 13 categories, 4 analysis layers, ~750 tests.
+- The `--disable-rule` analyzer-wide filter, `findings: []` JSON normalization, and Docker harness are durable infrastructure available to every future PR.
+
 ## [0.14.5] — 2026-04-24
 
 Patch release. Four audit items surfaced by an external review of v0.14.4: the public library used to print credentials verbatim in scan output, the bare CLI used to phone home from CI, `--changed` used to follow committed symlinks, and `.gitignore` did not cover the obvious secret file patterns. One API addition (`WithRedaction`), one new CLI flag (`--no-redact`), one behavior change that library consumers must know about (credential-leak `matched_text` is now scrubbed by default). Plus incidental docs and dev-tooling cleanup landed in the same window.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,7 +98,7 @@ Both `aguara scan --format json` and `aguara check --format json` emit `"finding
 ### Internal
 
 - 7 PRs (#70 - #78) drove the round; 1 follow-up chore (#79) cleaned the GoReleaser deprecation warnings.
-- 193 detection rules (up from 189), 13 categories, 4 analysis layers, ~750 tests.
+- 193 detection rules (up from 189), 13 categories, 7 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, NLP, toxicflow, rugpull) up from 4, ~750 tests.
 - The `--disable-rule` analyzer-wide filter, `findings: []` JSON normalization, and Docker harness are durable infrastructure available to every future PR.
 
 ## [0.14.5] — 2026-04-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [0.15.0] - 2026-05-13
 
-Minor release. Supply-chain trust analysis round: four new chain-aware analyzers (ci-trust, pkgmeta, jsrisk, plus an npm ecosystem check), four new pattern rules, and a hardened Docker validation harness. Detection coverage grows from 189 to 193 rules. JSON output shape stabilized so machine consumers see `findings: []` instead of `findings: null` on clean scans.
+Minor release. Supply-chain trust analysis round: three new chain-aware scan analyzers (ci-trust, pkgmeta, jsrisk), an npm ecosystem check added to `aguara check`, four new pattern rules, and a hardened Docker validation harness. Detection coverage grows from 189 to 193 rules. JSON output shape stabilized so machine consumers see `findings: []` instead of `findings: null` on clean scans.
 
 ### Added
 
-#### Chain-aware analyzers
+#### Chain-aware scan analyzers
 
-Four new `supply-chain` category analyzers detect attack shapes that require multiple aligned signals at the same call site or syntactic structure. Single weak signals never fire.
+Three new `supply-chain` category analyzers run as part of `aguara scan` and detect attack shapes that require multiple aligned signals at the same call site or syntactic structure. Single weak signals never fire.
 
 `ci-trust` (`internal/engine/ci/`) inspects `.github/workflows/*.yml`:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.14.4 (2026-04-24). 189 rules, 13 categories, 4 analysis layers, ~630 tests, 0 lint issues.
+Aguara v0.15.0 (2026-05-13). 193 rules, 13 categories, 7 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, NLP, toxicflow, rugpull) plus the `aguara check --ecosystem {python,npm}` incident command, ~750 tests, 0 lint issues.
 
 Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, multi-arch `linux/amd64+arm64`, runs as non-root UID 10001, base images digest-pinned, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
@@ -56,14 +56,17 @@ Aguara is a deterministic static security scanner for AI agent skills and MCP se
 
 Root package re-exports types from `internal/types` and exposes: `Scan()`, `ScanContent()`, `ListRules()`, `ExplainRule()`, `Discover()`. Used by external consumers like `aguara-mcp`. Functional options pattern (`WithMinSeverity()`, `WithWorkers()`, etc.).
 
-### Analysis Pipeline (4 layers, run sequentially per file)
+### Analysis Pipeline (7 analyzers, run sequentially per file)
 
 1. **Pattern Matcher** (`internal/engine/pattern/`) - Regex/contains matching against compiled rules. 8 decoders (base64, hex, URL encoding, Unicode escapes, HTML entities, hex escapes, base32, C-style octal escapes) for encoded evasion detection. Markdown code-block severity downgrade. Dynamic confidence based on pattern hit ratio.
-2. **NLP Analyzer** (`internal/engine/nlp/`) - Goldmark AST walker for markdown; JSON/YAML string extractor for structured files. Keyword classification with proximity weighting. Detects prompt injection, authority claims, credential+exfil combos.
-3. **ToxicFlow** (`internal/engine/toxicflow/`) - Single-file taint tracking + cross-file correlation (`crossfile.go`). Detects dangerous capability combinations within and across files in the same directory. Flat-dir filter (>50 files) prevents FPs on registries.
-4. **Rug-Pull** (`internal/engine/rugpull/`) - SHA256-based tool description change detection. CLI via `--monitor`, library via `WithStateDir()`.
+2. **CI Trust** (`internal/engine/ci/`) - YAML parser for `.github/workflows/*.yml`. Detects `pull_request_target` pwn-request chains, cache poisoning, OIDC token surface, and persisted-credentials checkouts. Emits `GHA_PWN_REQUEST_001` / `GHA_CACHE_001` / `GHA_OIDC_001` / `GHA_CHECKOUT_001`.
+3. **PkgMeta** (`internal/engine/pkgmeta/`) - JSON parser for `package.json`. Detects npm install-time lifecycle scripts paired with git-sourced dependencies, optional-git deps, and publish-surface chains. Emits `NPM_LIFECYCLE_GIT_001` / `NPM_OPTIONAL_GIT_001` / `NPM_PUBLISH_SURFACE_001`.
+4. **JSRisk** (`internal/engine/jsrisk/`) - Single-pass JavaScript scanner for `.js`/`.mjs`/`.cjs`. Detects obfuscator-shape payloads, install-time daemonization, CI secret harvesting, runner process-memory pivots, and Claude Code/VS Code persistence. Emits `JS_OBF_001` / `JS_DAEMON_001` / `JS_CI_SECRET_HARVEST_001` / `JS_PROC_MEM_OIDC_001` / `AGENT_PERSISTENCE_001`.
+5. **NLP Analyzer** (`internal/engine/nlp/`) - Goldmark AST walker for markdown; JSON/YAML string extractor for structured files. Keyword classification with proximity weighting. Detects prompt injection, authority claims, credential+exfil combos.
+6. **ToxicFlow** (`internal/engine/toxicflow/`) - Single-file taint tracking + cross-file correlation (`crossfile.go`). Detects dangerous capability combinations within and across files in the same directory. Flat-dir filter (>50 files) prevents FPs on registries.
+7. **Rug-Pull** (`internal/engine/rugpull/`) - SHA256-based tool description change detection. CLI via `--monitor`, library via `WithStateDir()`.
 
-All four implement the `Analyzer` interface (`internal/scanner/analyzer.go`): `Name() string` + `Analyze(ctx, *Target) ([]Finding, error)`.
+All seven implement the `Analyzer` interface (`internal/scanner/analyzer.go`): `Name() string` + `Analyze(ctx, *Target) ([]Finding, error)`. `aguara check --ecosystem npm` (`internal/incident/npm.go`) is a separate command-line entry point, not part of the scan pipeline.
 
 ### Key Package Relationships
 
@@ -82,11 +85,11 @@ All four implement the `Analyzer` interface (`internal/scanner/analyzer.go`): `N
 
 ## Rules System
 
-189 rules in `internal/rules/builtin/*.yaml` across 13 files. Each rule requires:
+193 rules in `internal/rules/builtin/*.yaml` across 13 files. Each rule requires:
 
 - `id`, `name`, `severity`, `category`, `patterns` (type: `regex` or `contains`)
 - `match_mode`: `any` (OR, default) or `all` (AND)
-- `remediation`: actionable fix guidance (all 189 rules have this)
+- `remediation`: actionable fix guidance (all 193 rules have this)
 - `examples.true_positive` and `examples.false_positive` - **self-tested automatically by `make test`**
 - Optional: `targets` (file globs), `exclude_patterns` (context-based suppression)
 
@@ -143,12 +146,12 @@ When completing a product task (fixing a bug, adding a feature, releasing a vers
 ### Data consistency rule
 
 When any of these values change, update ALL references across the vault:
-- Rule count (currently 189)
+- Rule count (currently 193)
 - Test count (currently ~630)
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)
 - Watch skill count (currently 28,000+)
-- Version number (currently v0.14.4)
+- Version number (currently v0.15.0)
 
 Use `Grep` to find all occurrences before updating.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,7 +147,7 @@ When completing a product task (fixing a bug, adding a feature, releasing a vers
 
 When any of these values change, update ALL references across the vault:
 - Rule count (currently 193)
-- Test count (currently ~630)
+- Test count (currently ~750)
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)
 - Watch skill count (currently 28,000+)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,7 +56,7 @@ Aguara is a deterministic static security scanner for AI agent skills and MCP se
 
 Root package re-exports types from `internal/types` and exposes: `Scan()`, `ScanContent()`, `ListRules()`, `ExplainRule()`, `Discover()`. Used by external consumers like `aguara-mcp`. Functional options pattern (`WithMinSeverity()`, `WithWorkers()`, etc.).
 
-### Analysis Pipeline (7 analyzers, run sequentially per file)
+### Analysis Pipeline (6 default analyzers + rug-pull when --monitor is set, run sequentially per file)
 
 1. **Pattern Matcher** (`internal/engine/pattern/`) - Regex/contains matching against compiled rules. 8 decoders (base64, hex, URL encoding, Unicode escapes, HTML entities, hex escapes, base32, C-style octal escapes) for encoded evasion detection. Markdown code-block severity downgrade. Dynamic confidence based on pattern hit ratio.
 2. **CI Trust** (`internal/engine/ci/`) - YAML parser for `.github/workflows/*.yml`. Detects `pull_request_target` pwn-request chains, cache poisoning, OIDC token surface, and persisted-credentials checkouts. Emits `GHA_PWN_REQUEST_001` / `GHA_CACHE_001` / `GHA_OIDC_001` / `GHA_CHECKOUT_001`.
@@ -66,7 +66,7 @@ Root package re-exports types from `internal/types` and exposes: `Scan()`, `Scan
 6. **ToxicFlow** (`internal/engine/toxicflow/`) - Single-file taint tracking + cross-file correlation (`crossfile.go`). Detects dangerous capability combinations within and across files in the same directory. Flat-dir filter (>50 files) prevents FPs on registries.
 7. **Rug-Pull** (`internal/engine/rugpull/`) - SHA256-based tool description change detection. CLI via `--monitor`, library via `WithStateDir()`.
 
-All seven implement the `Analyzer` interface (`internal/scanner/analyzer.go`): `Name() string` + `Analyze(ctx, *Target) ([]Finding, error)`. `aguara check --ecosystem npm` (`internal/incident/npm.go`) is a separate command-line entry point, not part of the scan pipeline.
+All seven implement the `Analyzer` interface (`internal/scanner/analyzer.go`): `Name() string` + `Analyze(ctx, *Target) ([]Finding, error)`. The first six run on every scan; rug-pull only joins when the caller passes `--monitor` (CLI) or `WithStateDir` (library). `aguara check --ecosystem npm` (`internal/incident/npm.go`) is a separate command-line entry point, not part of the scan pipeline.
 
 ### Key Package Relationships
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,7 +40,7 @@ internal/
     rugpull/           Rug-pull detection analyzer
     toxicflow/         Taint tracking: source -> sink flow analysis
   rules/               Rule engine: YAML loader, compiler, self-tester
-    builtin/           189 embedded rules across 13 YAML files (go:embed)
+    builtin/           193 embedded rules across 13 YAML files (go:embed)
   scanner/             Orchestrator: file discovery, parallel analysis, result aggregation
   meta/                Post-processing: dedup, scoring, cross-finding correlation
   output/              Formatters: terminal (ANSI), JSON, SARIF, Markdown

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Supported directives:
 |----------|-------|-----------------|
 | Credential Leak | 22 | API keys (OpenAI, AWS, GCP, Stripe, ...), private keys, DB strings, HMAC secrets |
 | Prompt Injection | 18 + NLP | Instruction overrides, role switching, delimiter injection, jailbreaks, event injection |
-| Supply Chain | 21 | Download-and-execute, reverse shells, sandbox escape, symlink attacks, privilege escalation |
+| Supply Chain | 24 | Download-and-execute, reverse shells, sandbox escape, symlink attacks, privilege escalation, OIDC token vars, runner-pivot memory, Claude Code persistence path |
 | External Download | 16 | Binary downloads, curl-pipe-shell, auto-installs, profile persistence |
 | MCP Attack | 16 | Tool injection, name shadowing, canonicalization bypass, capability escalation |
 | Data Exfiltration | 16 + NLP | Webhook exfil, DNS tunneling, sensitive file reads, env var leaks |
@@ -376,7 +376,7 @@ Supported directives:
 | SSRF & Cloud | 11 | Cloud metadata, IMDS, Docker socket, internal IPs, redirect following |
 | Third-Party Content | 10 | eval with external data, unsafe deserialization, missing SRI, HTTP downgrade |
 | Unicode Attack | 10 | RTL override, bidi, homoglyphs, zero-width sequences, normalization bypass |
-| Supply Chain Exfil | 10 | Credential file reads, .pth executable code, bulk env collection, K8s secrets access, systemd persistence, archive+POST exfil |
+| Supply Chain Exfil | 11 | Credential file reads, .pth executable code, bulk env collection, K8s secrets access, systemd persistence, archive+POST exfil, Session-Network endpoints |
 | Toxic Flow | 3 + cross-file | Single-file taint tracking plus cross-file correlation across MCP server directories |
 
 See [RULES.md](RULES.md) for the complete rule catalog with IDs and severity levels.

--- a/README.md
+++ b/README.md
@@ -360,7 +360,7 @@ Supported directives:
 
 ## Rules
 
-193 built-in rules across 13 categories:
+193 built-in rules across 13 pattern-rule categories (what `aguara list-rules` enumerates) plus the toxic-flow chain analyzer with its own emit-time category. The table groups coverage by emit-time category for readability:
 
 | Category | Rules | What it detects |
 |----------|-------|-----------------|

--- a/README.md
+++ b/README.md
@@ -564,10 +564,13 @@ cmd/aguara/            CLI entry point (Cobra)
 cmd/wasm/              WASM build for browser-based scanning
 internal/
   engine/
-    pattern/           Layer 1: Aho-Corasick + regex, 8 decoders (base64, hex, URL, Unicode, HTML, hex-escape, base32, octal-escape)
-    nlp/               Layer 2: markdown AST + JSON/YAML string extraction, proximity-weighted classifier
-    toxicflow/         Layer 3: single-file taint tracking + cross-file correlation across directories
-    rugpull/           Layer 4: SHA256 change detection (CLI --monitor, library WithStateDir)
+    pattern/           Pattern matcher: Aho-Corasick + regex, 8 decoders (base64, hex, URL, Unicode, HTML, hex-escape, base32, octal-escape)
+    ci/                CI Trust: .github/workflows/ YAML parser, pwn-request / cache / OIDC / persisted-credentials chains
+    pkgmeta/           PkgMeta: package.json parser, npm lifecycle / git source / publish-surface chains
+    jsrisk/            JSRisk: .js / .mjs / .cjs scanner, obfuscation / daemonization / CI-secret-harvest / runner-pivot / agent-persistence
+    nlp/               NLP: markdown AST + JSON/YAML string extraction, proximity-weighted classifier
+    toxicflow/         Taint: single-file taint tracking + cross-file correlation across directories
+    rugpull/           Rug-pull: SHA256 change detection (CLI --monitor, library WithStateDir)
   rules/               Rule engine: YAML loader, compiler, self-tester
     builtin/           193 embedded rules across 13 YAML files (go:embed)
   scanner/             Orchestrator: file discovery, parallel analysis, inline ignore, result aggregation

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ https://github.com/user-attachments/assets/851333be-048f-48fa-aaf3-f8cc1d4aa594
 
 AI agents and MCP servers run code on your behalf. A single malicious skill file can exfiltrate credentials, inject prompts, or install backdoors. Aguara catches these threats **before deployment** with static analysis that requires no API keys, no cloud, and no LLM.
 
-- **189 detection rules across 14 categories** — prompt injection, data exfiltration, credential leaks, supply-chain attacks, MCP-specific threats, command execution, SSRF, unicode attacks, and more.
+- **193 detection rules across 13 categories** — prompt injection, data exfiltration, credential leaks, supply-chain attacks, MCP-specific threats, command execution, SSRF, unicode attacks, and more.
 - **4-layer analysis engine** — pattern matching, NLP analysis, taint tracking, and rug-pull detection work together to catch threats that any single technique would miss.
 - **8 decoders for encoded evasion** — base64, hex, URL encoding, Unicode escapes, HTML entities, hex escapes, base32, and C-style octal escapes. Obfuscated payloads are decoded and re-scanned automatically.
 - **NLP on markdown, JSON, and YAML** — goldmark AST analysis for markdown files, plus string extraction and classification for JSON/YAML tool descriptions. Catches MCP tool poisoning in structured configs.
@@ -46,7 +46,7 @@ AI agents and MCP servers run code on your behalf. A single malicious skill file
 - **Scan profiles** — `strict` (default), `content-aware`, or `minimal` enforcement. Findings are always preserved for audit; only the verdict (clean/flag/block) changes.
 - **Evasion prevention** — NFKC normalization catches fullwidth character evasion. 6 decoders catch encoded payloads. Crypto address filtering prevents hex decoder false positives.
 - **Dynamic confidence scoring** — every finding carries a confidence level (0.50-0.95) that reflects signal quality: pattern hit ratio, classifier score, and code-block awareness.
-- **Remediation guidance** — all 189 rules include actionable fix suggestions, shown in every output format.
+- **Remediation guidance** — all 193 rules include actionable fix suggestions, shown in every output format.
 - **Deterministic** — same input, same output. Every scan is reproducible.
 - **CI-ready** — JSON, SARIF, and Markdown output. GitHub Action. `--fail-on` threshold. `--changed` for incremental scans.
 - **17 MCP clients supported** — auto-discover and scan configs from Claude Desktop, Cursor, VS Code, Windsurf, and 13 more.
@@ -62,7 +62,7 @@ curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | ba
 Installs the latest binary to `~/.local/bin`. Customize with environment variables:
 
 ```bash
-VERSION=v0.14.4 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
+VERSION=v0.15.0 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
 INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
 ```
 
@@ -84,7 +84,7 @@ docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara scan /scan
 docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara scan /scan --severity high --format json
 
 # Use a specific version
-docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara:0.14.4 scan /scan
+docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara:0.15.0 scan /scan
 ```
 
 **From source** (requires Go 1.25+):
@@ -180,14 +180,19 @@ aguara clean
 
 ## How It Works
 
-Aguara runs 4 analysis layers sequentially on every file. Each layer catches different attack patterns:
+Aguara runs 7 scan analyzers sequentially on every file. Each catches a different class of attack:
 
-| Layer | Engine | What it catches |
-|-------|--------|-----------------|
-| **Pattern Matcher** | Regex + Aho-Corasick matching | Known attack signatures, credential patterns, dangerous commands. Aho-Corasick automaton for O(n+m) multi-pattern search. 6 decoders (base64, hex, URL encoding, Unicode escapes, HTML entities, hex escapes) decode obfuscated payloads and re-scan. Code-block severity downgrade. Dynamic confidence based on pattern hit ratio. |
-| **NLP Analyzer** | Goldmark AST + JSON/YAML extraction | Prompt injection in markdown structure, plus tool poisoning in JSON/YAML description fields. Keyword classification with proximity weighting - clustered keywords score higher, sparse keywords in long text get penalized. |
-| **Taint Tracker** | Source-to-sink flow analysis | Dangerous capability combinations within a single file and across files in the same directory. Detects credential reads paired with webhook sends, env vars flowing to shell execution, and destructive + exec combos across MCP server tools. |
+| Analyzer | Engine | What it catches |
+|----------|--------|-----------------|
+| **Pattern Matcher** | Regex + Aho-Corasick matching | Known attack signatures, credential patterns, dangerous commands. Aho-Corasick automaton for O(n+m) multi-pattern search. 8 decoders (base64, hex, URL encoding, Unicode escapes, HTML entities, hex escapes, base32, octal escapes) decode obfuscated payloads and re-scan. Code-block severity downgrade. Dynamic confidence based on pattern hit ratio. |
+| **CI Trust** | GitHub Actions YAML parser | `pull_request_target` chains, cache poisoning across fork boundaries, OIDC token surface paired with install/build/test, persisted-credentials checkouts on PR head refs. |
+| **PkgMeta** | `package.json` JSON parser | npm install-time lifecycle scripts plus git-sourced dependencies, optional-git deps with suspicious names, publish surfaces paired with trusted-publishing references. |
+| **JSRisk** | JavaScript single-pass scanner | Obfuscator-shape payloads, install-time daemonization via `child_process`, CI secret harvesting through real `process.env` reads plus network/registry sinks, runner-process memory pivots to extract OIDC tokens, Claude Code / VS Code workspace persistence. |
+| **NLP Analyzer** | Goldmark AST + JSON/YAML extraction | Prompt injection in markdown structure, plus tool poisoning in JSON/YAML description fields. Keyword classification with proximity weighting; clustered keywords score higher, sparse keywords in long text get penalized. |
+| **Taint Tracker** | Source-to-sink flow analysis | Dangerous capability combinations within a single file and across files in the same directory. Detects credential reads paired with webhook sends, env vars flowing to shell execution, destructive plus exec combos across MCP server tools. |
 | **Rug-Pull Detector** | SHA256 hash tracking | Tool descriptions that change between scans. CLI: `--monitor` flag. Library: `WithStateDir()` for persistent consumers. |
+
+A separate `aguara check --ecosystem {python,npm}` command inspects installed package trees (`site-packages` for Python, `node_modules` for npm including the pnpm `.pnpm` store) for known-compromised package versions.
 
 All content is NFKC-normalized before scanning to prevent Unicode evasion attacks. All layers report findings with severity, dynamic confidence score (0.50-0.95), matched text, file location with context lines, and remediation guidance. An aggregate risk score (0-100) summarizes overall threat level.
 
@@ -355,7 +360,7 @@ Supported directives:
 
 ## Rules
 
-189 built-in rules across 14 categories:
+193 built-in rules across 13 categories:
 
 | Category | Rules | What it detects |
 |----------|-------|-----------------|
@@ -378,7 +383,7 @@ See [RULES.md](RULES.md) for the complete rule catalog with IDs and severity lev
 
 ### Remediation Guidance
 
-All 189 rules include remediation text. It appears in every output format:
+All 193 rules include remediation text. It appears in every output format:
 
 - **Terminal**: always shown for CRITICAL findings, shown for all severities with `--verbose`
 - **JSON**: included in every finding object
@@ -564,7 +569,7 @@ internal/
     toxicflow/         Layer 3: single-file taint tracking + cross-file correlation across directories
     rugpull/           Layer 4: SHA256 change detection (CLI --monitor, library WithStateDir)
   rules/               Rule engine: YAML loader, compiler, self-tester
-    builtin/           189 embedded rules across 13 YAML files (go:embed)
+    builtin/           193 embedded rules across 13 YAML files (go:embed)
   scanner/             Orchestrator: file discovery, parallel analysis, inline ignore, result aggregation
     exemptions.go      Tool exemptions, scan profiles, verdict computation
   meta/                Post-processing: configurable dedup, scoring, risk score, correlation, confidence

--- a/README.md
+++ b/README.md
@@ -37,14 +37,14 @@ https://github.com/user-attachments/assets/851333be-048f-48fa-aaf3-f8cc1d4aa594
 AI agents and MCP servers run code on your behalf. A single malicious skill file can exfiltrate credentials, inject prompts, or install backdoors. Aguara catches these threats **before deployment** with static analysis that requires no API keys, no cloud, and no LLM.
 
 - **193 detection rules across 13 categories** — prompt injection, data exfiltration, credential leaks, supply-chain attacks, MCP-specific threats, command execution, SSRF, unicode attacks, and more.
-- **4-layer analysis engine** — pattern matching, NLP analysis, taint tracking, and rug-pull detection work together to catch threats that any single technique would miss.
+- **7 scan analyzers** — pattern matching, GitHub Actions trust-chain detection (ci-trust), npm package metadata (pkgmeta), JavaScript payload risk (jsrisk), NLP analysis, taint tracking, and rug-pull detection work together to catch threats that any single technique would miss. A separate `aguara check --ecosystem {python,npm}` command flags installed package trees against known-compromised version sets.
 - **8 decoders for encoded evasion** — base64, hex, URL encoding, Unicode escapes, HTML entities, hex escapes, base32, and C-style octal escapes. Obfuscated payloads are decoded and re-scanned automatically.
 - **NLP on markdown, JSON, and YAML** — goldmark AST analysis for markdown files, plus string extraction and classification for JSON/YAML tool descriptions. Catches MCP tool poisoning in structured configs.
 - **Cross-file toxic flow analysis** — detects dangerous capability combinations split across files in the same MCP server directory (e.g., one tool reads credentials, another sends to a webhook).
 - **Aggregate risk score** — 0-100 score with diminishing returns across findings. Available in JSON, SARIF, and terminal output.
 - **Context-aware scanning** — pass the tool name (`--tool-name Edit`) and the scanner automatically skips rules that are always false positives for that tool. Built-in exemptions for Edit, Write, WebFetch, Bash, and more.
 - **Scan profiles** — `strict` (default), `content-aware`, or `minimal` enforcement. Findings are always preserved for audit; only the verdict (clean/flag/block) changes.
-- **Evasion prevention** — NFKC normalization catches fullwidth character evasion. 6 decoders catch encoded payloads. Crypto address filtering prevents hex decoder false positives.
+- **Evasion prevention** — NFKC normalization catches fullwidth character evasion. 8 decoders catch encoded payloads. Crypto address filtering prevents hex decoder false positives.
 - **Dynamic confidence scoring** — every finding carries a confidence level (0.50-0.95) that reflects signal quality: pattern hit ratio, classifier score, and code-block awareness.
 - **Remediation guidance** — all 193 rules include actionable fix suggestions, shown in every output format.
 - **Deterministic** — same input, same output. Every scan is reproducible.
@@ -564,7 +564,7 @@ cmd/aguara/            CLI entry point (Cobra)
 cmd/wasm/              WASM build for browser-based scanning
 internal/
   engine/
-    pattern/           Layer 1: Aho-Corasick + regex, 6 decoders (base64/hex/URL/Unicode/HTML/hex-escape)
+    pattern/           Layer 1: Aho-Corasick + regex, 8 decoders (base64, hex, URL, Unicode, HTML, hex-escape, base32, octal-escape)
     nlp/               Layer 2: markdown AST + JSON/YAML string extraction, proximity-weighted classifier
     toxicflow/         Layer 3: single-file taint tracking + cross-file correlation across directories
     rugpull/           Layer 4: SHA256 change detection (CLI --monitor, library WithStateDir)

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ aguara clean
 
 ## How It Works
 
-Aguara runs 7 scan analyzers sequentially on every file. Each catches a different class of attack:
+Aguara runs 6 scan analyzers sequentially on every file by default; a 7th (Rug-Pull) joins when `--monitor` is enabled and a state store is configured. Each catches a different class of attack:
 
 | Analyzer | Engine | What it catches |
 |----------|--------|-----------------|

--- a/RULES.md
+++ b/RULES.md
@@ -110,7 +110,7 @@ For writing custom rules, see the [Custom Rules](#custom-rules) section below or
 
 ## Supply Chain
 
-Highlighted SUPPLY_* rules. The full list is available via `aguara list-rules --category supply-chain`; SUPPLY_015 through SUPPLY_023 and SUPPLY_025 land alongside the chain-aware analyzers introduced in v0.15.0 and are not enumerated row-by-row here.
+Highlighted SUPPLY_* rules. The catalog below covers SUPPLY_001-014 (shipped before v0.15.0) plus SUPPLY_020-025 (the workflow / pwn-request / OIDC / runner-pivot / agent-persistence series that landed with the supply-chain trust round). SUPPLY_015-019 are tracked via `aguara list-rules --category supply-chain` and `aguara explain <RULE_ID>`; they cover narrower IOC and lockfile checks that are kept current via the live catalog rather than this static table.
 
 | Rule | Severity | Description |
 |------|----------|-------------|

--- a/RULES.md
+++ b/RULES.md
@@ -8,7 +8,7 @@ For writing custom rules, see the [Custom Rules](#custom-rules) section below or
 
 ---
 
-## Prompt Injection (17 rules + NLP)
+## Prompt Injection (18 rules + NLP)
 
 | Rule | Severity | Description |
 |------|----------|-------------|
@@ -57,7 +57,7 @@ For writing custom rules, see the [Custom Rules](#custom-rules) section below or
 | EXFIL_016 | MEDIUM | Git history or diff access with transmission |
 | NLP_CRED_EXFIL_COMBO | CRITICAL | Credential access combined with network transmission |
 
-## Credential Leak (19 rules)
+## Credential Leak (22 rules)
 
 | Rule | Severity | Description |
 |------|----------|-------------|
@@ -79,7 +79,7 @@ For writing custom rules, see the [Custom Rules](#custom-rules) section below or
 | CRED_016 | MEDIUM | SSH private key in command |
 | CRED_017 | LOW | Docker environment credentials |
 
-## MCP Attack (12 rules)
+## MCP Attack (16 rules)
 
 | Rule | Severity | Description |
 |------|----------|-------------|
@@ -95,7 +95,7 @@ For writing custom rules, see the [Custom Rules](#custom-rules) section below or
 | MCP_010 | HIGH | Prompt cache poisoning |
 | MCP_011 | HIGH | Arbitrary MCP server execution |
 
-## MCP Config (8 rules)
+## MCP Config (13 rules)
 
 | Rule | Severity | Description |
 |------|----------|-------------|
@@ -140,7 +140,7 @@ Highlighted SUPPLY_* rules. The catalog below covers SUPPLY_001-014 (shipped bef
 |------|----------|-------------|
 | SUPPLY_024 | HIGH | Session-Network exfil endpoint (Mini Shai-Hulud IOC set) |
 
-## External Download (17 rules)
+## External Download (16 rules)
 
 | Rule | Severity | Description |
 |------|----------|-------------|
@@ -179,7 +179,7 @@ Highlighted SUPPLY_* rules. The catalog below covers SUPPLY_001-014 (shipped bef
 | CMDEXEC_012 | LOW | Chained shell command execution |
 | CMDEXEC_013 | LOW | Shell script file execution |
 
-## Indirect Injection (6 rules)
+## Indirect Injection (10 rules)
 
 | Rule | Severity | Description |
 |------|----------|-------------|
@@ -191,7 +191,7 @@ Highlighted SUPPLY_* rules. The catalog below covers SUPPLY_001-014 (shipped bef
 | INDIRECT_009 | MEDIUM | External API response drives agent behavior |
 | INDIRECT_010 | LOW | Unscoped Bash tool in allowed tools |
 
-## Third-Party Content (5 rules)
+## Third-Party Content (10 rules)
 
 | Rule | Severity | Description |
 |------|----------|-------------|
@@ -200,7 +200,7 @@ Highlighted SUPPLY_* rules. The catalog below covers SUPPLY_001-014 (shipped bef
 | THIRDPARTY_004 | LOW | External API response used without validation |
 | THIRDPARTY_005 | HIGH | Remote template or prompt loaded at runtime |
 
-## SSRF & Cloud (10 rules)
+## SSRF & Cloud (11 rules)
 
 | Rule | Severity | Description |
 |------|----------|-------------|
@@ -213,7 +213,7 @@ Highlighted SUPPLY_* rules. The catalog below covers SUPPLY_001-014 (shipped bef
 | SSRF_007 | CRITICAL | Cloud credential endpoint |
 | SSRF_008 | MEDIUM | DNS rebinding setup |
 
-## Unicode Attack (7 rules)
+## Unicode Attack (10 rules)
 
 | Rule | Severity | Description |
 |------|----------|-------------|

--- a/RULES.md
+++ b/RULES.md
@@ -1,6 +1,6 @@
 # Aguara Rule Catalog
 
-Aguara ships with **148+ built-in rules** across 13 categories, plus NLP-based and toxic-flow analyzers.
+Aguara ships with **193 built-in pattern rules** across 13 categories, plus four chain-aware scan analyzers (ci-trust, pkgmeta, jsrisk, toxicflow) and a rug-pull detector. Run `aguara list-rules` for the live count and `aguara explain <RULE_ID>` for details.
 
 Use `aguara list-rules` to list all rules from the CLI, or `aguara explain <RULE_ID>` for details on a specific rule.
 
@@ -108,7 +108,9 @@ For writing custom rules, see the [Custom Rules](#custom-rules) section below or
 | MCPCFG_007 | HIGH | Docker privileged or host mount in MCP config |
 | MCPCFG_008 | MEDIUM | Auto-confirm flag bypassing user verification |
 
-## Supply Chain (15 rules)
+## Supply Chain
+
+Highlighted SUPPLY_* rules. The full list is available via `aguara list-rules --category supply-chain`; SUPPLY_015 through SUPPLY_023 and SUPPLY_025 land alongside the chain-aware analyzers introduced in v0.15.0 and are not enumerated row-by-row here.
 
 | Rule | Severity | Description |
 |------|----------|-------------|
@@ -126,6 +128,17 @@ For writing custom rules, see the [Custom Rules](#custom-rules) section below or
 | SUPPLY_012 | MEDIUM | Git clone and execute chain |
 | SUPPLY_013 | MEDIUM | Unpinned GitHub Actions |
 | SUPPLY_014 | MEDIUM | Package install from arbitrary URL |
+| SUPPLY_020 | HIGH | GitHub Actions untrusted input injection |
+| SUPPLY_021 | MEDIUM | GitHub Actions overly broad permissions |
+| SUPPLY_022 | HIGH | GitHub Actions OIDC token request variables in executable code |
+| SUPPLY_023 | CRITICAL | GitHub Actions runner process memory access |
+| SUPPLY_025 | HIGH | Claude Code workspace persistence path |
+
+## Supply Chain Exfil
+
+| Rule | Severity | Description |
+|------|----------|-------------|
+| SUPPLY_024 | HIGH | Session-Network exfil endpoint (Mini Shai-Hulud IOC set) |
 
 ## External Download (17 rules)
 


### PR DESCRIPTION
## Summary

Release prep for v0.15.0. Documentation-only changes that aggregate the supply-chain trust round (#70 to #78) plus the GoReleaser chore (#79) into a coherent release narrative. No code changes; the maintainer cuts the tag after merge.

### CHANGELOG.md

Full `## [0.15.0] - 2026-05-13` entry covering:

- Three new chain-aware scan analyzers (`ci-trust`, `pkgmeta`, `jsrisk`) with every emitted rule ID, severity escalation rules, and false-positive guards documented.
- Four new pattern rules (`SUPPLY_022/023/024/025`) with scope and category.
- The new `aguara check --ecosystem npm` command and its embedded npm IOC list (event-stream, flatmap-stream, ua-parser-js, coa, rc).
- Docker validation harness: `bench-docker`, `test-race-docker`, `smoke-docker`, `verify-docker`. Provenance JSON. Analyzer micro-benchmarks.
- Behavior changes: `--disable-rule` now covers analyzer-emitted IDs; clean JSON outputs read `findings: []`; `goreleaser` archives schema modernized.
- Fixes from the round's review trail (`IsCompromised` ecosystem scoping, root-level `/proc` exclusion, `.vscode/tasks.json` gating, `actions/cache/restore` correctness, post-checkout execution gating, npm metadata credential redaction).

### CLAUDE.md / README.md / CONTRIBUTING.md

Bumped to v0.15.0. Rule count 189 to 193 across all references. Analyzer pipeline documentation updated to show 6 default scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, NLP, toxicflow) plus rug-pull when `--monitor` is enabled. Decoder count corrected from 6 to 8 (base32 and octal-escape decoders had shipped previously but the README was stale). Category count corrected from 14 to 13 (the 14-row category table includes a row for the toxic-flow analyzer's emit category, clarified in the table header).

### RULES.md

Top header now reads "193 built-in pattern rules" with a pointer to `aguara list-rules` as the live catalog. Supply Chain section picks up `SUPPLY_020`-`023` and `SUPPLY_025`; a new Supply Chain Exfil section lists `SUPPLY_024`. Per-category counts refreshed: Prompt Injection 17 to 18, Credential Leak 19 to 22, MCP Attack 12 to 16, MCP Config 8 to 13, External Download 17 to 16, Indirect Injection 6 to 10, Third-Party Content 5 to 10, SSRF and Cloud 10 to 11, Unicode Attack 7 to 10. Verified against `aguara list-rules --format json` on this branch.

## Test plan

- [x] `make build` passes.
- [x] `make test` clean.
- [x] `make vet` clean.
- [x] `make lint` reports `0 issues.`
- [x] `aguara list-rules` reports `193 rules loaded`.
- [x] `aguara list-rules --format json` per-category counts verified to match the RULES.md table and README category table.
- [x] No production code touched; only the four documentation files.

## After merge

Maintainer cuts the tag:

```sh
git tag v0.15.0 && git push origin v0.15.0
```

GoReleaser auto-runs: builds multi-arch binaries with cosign keyless signing + SPDX SBOMs, updates Homebrew tap, publishes Docker image to `ghcr.io/garagon/aguara:0.15.0` (multi-arch + cosign at digest + SBOM + SLSA provenance). Acceptance test per the release process documented in CONTRIBUTING.md:

```sh
VERSION=v0.15.0 .github/scripts/verify-release.sh
```

The deferred `brews` to `homebrew_casks` migration tracked in #79's body is a separate post-v0.15.0 PR with its own release-notes communication.