### PR TITLE
fix(install): tar -o flag for hardened cap-drop containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to Aguara are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [Unreleased]
+
+### Fixed
+
+- `install.sh` extraction now passes `-o` to tar so the install succeeds under hardened container runtimes that drop `CAP_CHOWN` (`--cap-drop ALL`, rootless containers). Without the flag, tar attempted to restore the archive's recorded `uid/gid 1001` and failed with `Cannot change ownership`. POSIX-portable across GNU, BSD, and BusyBox tar.
+
+### Added
+
+- `make test-install-sh-docker` acceptance target. Builds an Alpine image with the tooling `install.sh` itself requires and runs the full install path under `--cap-drop ALL --security-opt no-new-privileges`, asserting the installed binary reports the expected version. Kept out of `verify-docker` because it requires network access (downloads the published release archive).
+
 ## [0.15.0] - 2026-05-13
 
 Minor release. Supply-chain trust analysis round: three new chain-aware scan analyzers (ci-trust, pkgmeta, jsrisk), an npm ecosystem check added to `aguara check`, four new pattern rules, and a hardened Docker validation harness. Detection coverage grows from 189 to 193 rules. JSON output shape stabilized so machine consumers see `findings: []` instead of `findings: null` on clean scans.

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ SMOKE_ARTIFACTS := smoke-npm-compromised.json smoke-npm-clean.json \
 
 .PHONY: build test lint run clean fmt vet wasm wasm-serve bench \
 	bench-docker-image race-docker-image \
-	bench-docker smoke-docker test-race-docker verify-docker
+	bench-docker smoke-docker test-race-docker verify-docker \
+	test-install-sh-docker
 
 build:
 	go build -trimpath $(LDFLAGS) -o $(BINARY) ./cmd/aguara
@@ -85,6 +86,23 @@ smoke-docker: bench-docker-image
 
 verify-docker: bench-docker test-race-docker smoke-docker
 	@echo "verify-docker: all Docker validation targets passed"
+
+# Reproduces the install.sh extraction failure mode under
+# `--cap-drop ALL`. Requires network access (install.sh pulls the
+# archive + checksums from github.com), so this target is intentionally
+# NOT folded into `verify-docker` which runs offline.
+# Override INSTALL_SH_TEST_VERSION to pin to a different release.
+INSTALL_SH_TEST_VERSION ?= v0.15.0
+INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
+
+test-install-sh-docker:
+	docker build -f benchmarks/Dockerfile.install-sh-cap \
+		-t $(INSTALL_SH_TEST_IMAGE) .
+	docker run --rm \
+		--cap-drop ALL \
+		--security-opt no-new-privileges \
+		-e VERSION=$(INSTALL_SH_TEST_VERSION) \
+		$(INSTALL_SH_TEST_IMAGE)
 
 lint:
 	golangci-lint run ./...

--- a/benchmarks/Dockerfile.install-sh-cap
+++ b/benchmarks/Dockerfile.install-sh-cap
@@ -1,0 +1,20 @@
+# Minimal image for the install.sh cap-drop acceptance test.
+#
+# The image only needs the tooling install.sh itself requires
+# (curl, tar, a sha256 implementation), plus the install.sh script
+# under test. Network is required at runtime because install.sh
+# pulls the archive + checksums from github.com; the harness wraps
+# this with `--cap-drop ALL --security-opt no-new-privileges` so the
+# test reproduces the original failure mode without granting CAP_CHOWN.
+FROM alpine:3.20
+
+RUN apk add --no-cache curl tar coreutils ca-certificates
+
+WORKDIR /work
+
+COPY install.sh /work/install.sh
+COPY benchmarks/test-install-sh-cap-drop.sh /work/test-install-sh-cap-drop.sh
+
+RUN chmod +x /work/install.sh /work/test-install-sh-cap-drop.sh
+
+ENTRYPOINT ["/work/test-install-sh-cap-drop.sh"]

--- a/benchmarks/test-install-sh-cap-drop.sh
+++ b/benchmarks/test-install-sh-cap-drop.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+#
+# Acceptance test: install.sh must succeed inside a container started
+# with `--cap-drop ALL --security-opt no-new-privileges`.
+#
+# Background: the release archive records uid/gid 1001 for its entries.
+# Without CAP_CHOWN, tar's default behavior of restoring ownership
+# fails with `Cannot change ownership to uid 1001, gid 1001`. The
+# install.sh extract step passes `-o` (POSIX no-same-owner) so the
+# extract succeeds even when the runtime cannot apply ownership.
+#
+# This script is invoked as the container ENTRYPOINT. It assumes the
+# image bundles install.sh at /work/install.sh and that the caller
+# exports VERSION (e.g. v0.15.0) so the test pins to a known release.
+set -eu
+
+VERSION="${VERSION:-}"
+if [ -z "$VERSION" ]; then
+    echo "TEST FAIL: VERSION env var is required (e.g. VERSION=v0.15.0)" >&2
+    exit 1
+fi
+
+INSTALL_DIR="${INSTALL_DIR:-/tmp/bin}"
+mkdir -p "$INSTALL_DIR"
+
+echo "Running install.sh with VERSION=${VERSION} INSTALL_DIR=${INSTALL_DIR}"
+echo "Container caps: $(cat /proc/self/status | grep -E '^Cap(Eff|Bnd):' || true)"
+
+VERSION="$VERSION" INSTALL_DIR="$INSTALL_DIR" sh /work/install.sh
+
+bin="${INSTALL_DIR}/aguara"
+if [ ! -x "$bin" ]; then
+    echo "TEST FAIL: ${bin} not installed" >&2
+    exit 1
+fi
+
+# Strip the leading v to compare against `aguara version` output which
+# prints the GoReleaser-stripped semver.
+version_stripped=$(echo "$VERSION" | sed 's/^v//')
+out=$("$bin" version 2>&1)
+echo "binary output: ${out}"
+
+if ! echo "$out" | grep -Fq "${version_stripped}"; then
+    echo "TEST FAIL: installed binary did not report version ${version_stripped}" >&2
+    exit 1
+fi
+
+echo "TEST OK: install.sh succeeded under --cap-drop ALL, binary reports ${version_stripped}"

--- a/install.sh
+++ b/install.sh
@@ -44,8 +44,12 @@ main() {
     download "$checksums_url" "${tmpdir}/checksums.txt"
     verify_checksum "$tmpdir" "$archive"
 
-    # Extract binary
-    tar -xzf "${tmpdir}/${archive}" -C "$tmpdir"
+    # Extract binary. `-o` instructs tar not to restore archive
+    # ownership; without it, hardened containers running with
+    # `--cap-drop ALL` (no CAP_CHOWN) fail on `Cannot change ownership`
+    # when the archive records a uid/gid the runtime cannot apply.
+    # `-o` is POSIX-portable across GNU, BSD, and BusyBox tar.
+    tar -xzof "${tmpdir}/${archive}" -C "$tmpdir"
 
     if [ ! -f "${tmpdir}/${BINARY}" ]; then
         err "binary not found in archive"


### PR DESCRIPTION
## Summary
- install.sh:48 now extracts with `tar -xzof` so the install succeeds inside containers run with `--cap-drop ALL` (no CAP_CHOWN). Without `-o`, tar tries to restore the archive's recorded uid/gid 1001 and fails with `Cannot change ownership`. `-o` is POSIX-portable across GNU, BSD, and BusyBox tar.
- New `make test-install-sh-docker` target. Builds an Alpine image with curl/tar/coreutils + install.sh, runs the full install path under `--cap-drop ALL --security-opt no-new-privileges`, asserts the installed binary reports the expected version. Kept out of `verify-docker` because it needs network access to github.com.
- CHANGELOG `[Unreleased]` updated under Fixed + Added.

## Background
v0.15.0 release acceptance run on a hardened harness surfaced an install-script gap: `sh install.sh` works fine on normal hosts but fails inside `docker run --cap-drop ALL` because tar's default behavior of restoring archive ownership requires CAP_CHOWN. Reproduced exactly by the new test target; the fix is one flag.

## Test plan
- [x] `make test-install-sh-docker` PASSES with fix (binary reports 0.15.0 under CapEff=0/CapBnd=0).
- [x] Same target FAILS with the exact original error after reverting the fix (`tar: aguara: Cannot change ownership to uid 1001, gid 1001`).
- [x] `make build && make test && make vet && make lint` all green.
- [x] codex review CLEAN at first pass (no P1/P2 findings).