### PR TITLE
docs(install): fix pipe env-var placement; bump action default ref

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 ### Fixed
 
 - `install.sh` extraction now passes `-o` to tar so the install succeeds under hardened container runtimes that drop `CAP_CHOWN` (`--cap-drop ALL`, rootless containers). Without the flag, tar attempted to restore the archive's recorded `uid/gid 1001` and failed with `Cannot change ownership`. POSIX-portable across GNU, BSD, and BusyBox tar.
+- README install snippets had env vars on the wrong side of the pipe (`VERSION=v0.15.0 curl ... | bash`). Bash applies environment assignments to the simple command immediately following them, so `VERSION` reached `curl` (where it is unused), not `sh`. Corrected to `curl ... | VERSION=v0.15.0 sh`.
+- README and CI snippets now pipe the installer into `sh` rather than `bash`, matching the script's own `#!/bin/sh` shebang. Avoids breakage on systems without bash (Alpine, BusyBox).
+- `action.yml` `DEFAULT_REF` bumped from `v0.14.4` to `v0.15.0` so consumers who do not pin a tag (or who reference a non-semver ref that gets rejected by the action's validation) fetch the current release's `install.sh`.
 
 ### Added
 
 - `make test-install-sh-docker` acceptance target. Builds an Alpine image with the tooling `install.sh` itself requires and runs the full install path under `--cap-drop ALL --security-opt no-new-privileges`, asserting the installed binary reports the expected version. Kept out of `verify-docker` because it requires network access (downloads the published release archive).
+- README "How to update" section explaining that re-running the installer downloads the selected release archive, verifies `checksums.txt`, and replaces the binary in place.
 
 ## [0.15.0] - 2026-05-13
 

--- a/README.md
+++ b/README.md
@@ -56,14 +56,24 @@ AI agents and MCP servers run code on your behalf. A single malicious skill file
 ## Installation
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
 ```
 
 Installs the latest binary to `~/.local/bin`. Customize with environment variables:
 
 ```bash
-VERSION=v0.15.0 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
-INSTALL_DIR=/usr/local/bin curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.15.0 sh
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | INSTALL_DIR=/usr/local/bin sh
+```
+
+To update an existing install, rerun the installer. It downloads the selected release archive, verifies `checksums.txt`, and replaces the binary:
+
+```bash
+# Update to latest
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
+
+# Update/pin to a specific release
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.15.0 sh
 ```
 
 ### Alternative methods
@@ -294,7 +304,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitHub Actions (without the action)
 - name: Scan skills for security issues
   run: |
-    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
+    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
     aguara scan .claude/skills/ --ci
 ```
 
@@ -302,7 +312,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | bash
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
     - aguara scan .claude/skills/ --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.14.4"
+        DEFAULT_REF="v0.15.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then


### PR DESCRIPTION
## Summary

Three small documentation/wiring fixes after the v0.15.0 release.

**1. README install snippets**

`VERSION=v0.15.0 curl ... | bash` put the env var on curl, not on sh, so the installer never saw the version pin. Corrected to `curl ... | VERSION=v0.15.0 sh`. Codex caught this in the README; the v0.15.0 distribution-content acceptance harness caught the same shape in the dev.to draft, so the fix is consistent across surfaces.

**2. `| bash` -> `| sh`**

The installer is `#!/bin/sh`. Piping to `bash` works on most hosts but breaks Alpine / BusyBox setups (no bash by default). Switched to `sh` in the README install block, GitHub Actions snippet, and GitLab CI snippet.

**3. `action.yml` `DEFAULT_REF`**

The baked-in fallback ref was still `v0.14.4`. v0.14.5 and v0.15.0 shipped after that without bumping it. Bumped to `v0.15.0`. Consumers pinning `uses: garagon/aguara@vX.Y.Z` are unaffected (`github.action_ref` resolves first); this only matters when a non-semver ref is supplied and the validation kicks in.

Adds a small "How to update" section explaining that re-running the installer downloads the selected release, verifies checksums, and replaces the binary.

## Test plan
- [x] `make build && make test && make vet && make lint` all green.
- [x] codex review CLEAN at first pass.
- [x] Repo-wide sweep: no remaining `VERSION=<value> curl ... | bash` shape patterns (the action.yml step explicitly declares `shell: bash`, so the `| bash` there is intentional and unchanged).