### PR TITLE
feat(check): --ci, --fail-on, and npm auto-detect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ Thumbs.db
 /testdata/
 /scripts/
 /DOCS/
+/architecture/
 /sandbox/
 __pycache__/
 *.pyc

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -125,7 +125,18 @@ func autoDetectCheckTarget(path string) (string, string, error) {
 		probe = "."
 	}
 	if info, err := os.Stat(probe); err == nil && info.IsDir() {
-		if filepath.Base(probe) == "node_modules" {
+		// Resolve the probe so `filepath.Base` returns the real
+		// directory name. Without this, `aguara check` from inside
+		// a node_modules tree (probe == ".") would yield Base == "."
+		// and the npm signal would be missed -- the npm checker
+		// never runs and a compromised package is silently reported
+		// clean. Fall back to the raw probe if Abs fails, so we
+		// still get the historical behaviour on weird inputs.
+		resolved := probe
+		if abs, err := filepath.Abs(probe); err == nil {
+			resolved = abs
+		}
+		if filepath.Base(resolved) == "node_modules" {
 			return ecoNPM, probe, nil
 		}
 		nm := filepath.Join(probe, "node_modules")

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/garagon/aguara/internal/incident"
@@ -13,46 +14,128 @@ import (
 var (
 	flagCheckPath      string
 	flagCheckEcosystem string
+	flagCheckFailOn    string
+	flagCheckCI        bool
+)
+
+const (
+	ecoPython = "python"
+	ecoNPM    = "npm"
 )
 
 var checkCmd = &cobra.Command{
 	Use:   "check",
 	Short: "Check for compromised packages and persistence artifacts",
 	Long: `Scan an installed package tree for known compromised versions and
-persistence artifacts. Defaults to Python (auto-discovers site-packages); pass
---ecosystem npm with --path pointing at a node_modules directory to check
-npm packages instead. The known-bad list ships embedded with the binary.`,
+persistence artifacts. With no flags, auto-detects an npm project (any
+directory containing node_modules) and otherwise falls back to Python
+site-packages discovery. Pass --ecosystem to force a specific check.
+The known-bad list ships embedded with the binary.`,
 	RunE: runCheck,
 }
 
 func init() {
-	checkCmd.Flags().StringVar(&flagCheckPath, "path", "", "Path to the package tree (Python: site-packages; npm: node_modules)")
-	checkCmd.Flags().StringVar(&flagCheckEcosystem, "ecosystem", "python", "Package ecosystem to check: python or npm")
+	checkCmd.Flags().StringVar(&flagCheckPath, "path", "", "Path to project root, node_modules, or Python site-packages")
+	checkCmd.Flags().StringVar(&flagCheckEcosystem, "ecosystem", "", "Package ecosystem (auto-detect by default): python or npm")
+	checkCmd.Flags().StringVar(&flagCheckFailOn, "fail-on", "", "Exit with code 1 if findings reach this severity: critical, warning, info")
+	checkCmd.Flags().BoolVar(&flagCheckCI, "ci", false, "CI mode: equivalent to --fail-on critical --no-color")
 	rootCmd.AddCommand(checkCmd)
 }
 
 func runCheck(cmd *cobra.Command, args []string) error {
-	opts := incident.CheckOptions{Path: flagCheckPath}
-	var (
-		result *incident.CheckResult
-		err    error
-	)
-	switch flagCheckEcosystem {
-	case "", "python", "pypi":
+	applyCheckCIDefaults()
+
+	eco, path, err := resolveCheckTarget(flagCheckEcosystem, flagCheckPath)
+	if err != nil {
+		return err
+	}
+
+	opts := incident.CheckOptions{Path: path}
+	var result *incident.CheckResult
+	switch eco {
+	case ecoPython:
 		result, err = incident.Check(opts)
-	case "npm":
+	case ecoNPM:
 		result, err = incident.CheckNPM(opts)
 	default:
-		return fmt.Errorf("unsupported ecosystem %q: choose python or npm", flagCheckEcosystem)
+		return fmt.Errorf("internal error: unresolved ecosystem %q", eco)
 	}
 	if err != nil {
 		return err
 	}
 
 	if flagFormat == "json" {
-		return writeCheckJSON(result)
+		if err := writeCheckJSON(result); err != nil {
+			return err
+		}
+	} else {
+		if err := writeCheckTerminal(result, eco); err != nil {
+			return err
+		}
 	}
-	return writeCheckTerminal(result, flagCheckEcosystem)
+
+	return checkIncidentFailOnThreshold(result, flagCheckFailOn)
+}
+
+// applyCheckCIDefaults wires --ci to the equivalent explicit flags.
+// --ci sets --fail-on critical (unless the user already set --fail-on
+// explicitly) and disables color. NO_COLOR also disables color so the
+// flag interacts cleanly with CI runners that set it by convention.
+func applyCheckCIDefaults() {
+	if flagCheckCI {
+		if flagCheckFailOn == "" {
+			flagCheckFailOn = "critical"
+		}
+		flagNoColor = true
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		flagNoColor = true
+	}
+}
+
+// resolveCheckTarget turns the user-supplied --ecosystem / --path pair
+// into a (resolved-ecosystem, path) tuple the runner can dispatch on.
+//
+// Explicit --ecosystem values short-circuit auto-detection; only when
+// --ecosystem is empty does auto-detection run. An empty --path remains
+// empty for Python (so the legacy site-packages auto-discovery still
+// works) and resolves to "." for npm probing only.
+func resolveCheckTarget(eco, path string) (string, string, error) {
+	switch strings.ToLower(strings.TrimSpace(eco)) {
+	case "python", "pypi":
+		return ecoPython, path, nil
+	case "npm":
+		return ecoNPM, path, nil
+	case "":
+		return autoDetectCheckTarget(path)
+	default:
+		return "", "", fmt.Errorf("unsupported ecosystem %q: choose python or npm", eco)
+	}
+}
+
+// autoDetectCheckTarget chooses an ecosystem from the filesystem shape
+// at path. The rules are deliberately narrow so the default
+// `aguara check` does not silently switch ecosystems on directories
+// that merely happen to share a name with one. npm wins only when
+// there is a real node_modules directory; otherwise the call falls
+// back to the historical Python check path.
+func autoDetectCheckTarget(path string) (string, string, error) {
+	probe := path
+	if probe == "" {
+		probe = "."
+	}
+	if info, err := os.Stat(probe); err == nil && info.IsDir() {
+		if filepath.Base(probe) == "node_modules" {
+			return ecoNPM, probe, nil
+		}
+		nm := filepath.Join(probe, "node_modules")
+		if nmInfo, err := os.Stat(nm); err == nil && nmInfo.IsDir() {
+			return ecoNPM, probe, nil
+		}
+	}
+	// Fall back to Python. Preserve the caller's original (possibly
+	// empty) path so discoverSitePackages() can still kick in.
+	return ecoPython, path, nil
 }
 
 func writeCheckJSON(result *incident.CheckResult) error {
@@ -72,11 +155,11 @@ func writeCheckJSON(result *incident.CheckResult) error {
 
 func writeCheckTerminal(result *incident.CheckResult, ecosystem string) error {
 	envLabel := "Python environment"
-	if ecosystem == "npm" {
+	if ecosystem == ecoNPM {
 		envLabel = "npm node_modules tree"
 	}
 	fmt.Printf("\nScanning %s: %s\n", envLabel, result.Environment)
-	if ecosystem == "npm" {
+	if ecosystem == ecoNPM {
 		fmt.Printf("Packages read: %d\n\n", result.PackagesRead)
 	} else {
 		fmt.Printf("Packages read: %d  |  .pth files scanned: %d\n\n", result.PackagesRead, result.PthScanned)
@@ -89,7 +172,7 @@ func writeCheckTerminal(result *incident.CheckResult, ecosystem string) error {
 			green = ""
 			reset = ""
 		}
-		fmt.Printf("  %s\u2714 No compromised packages or artifacts found.%s\n\n", green, reset)
+		fmt.Printf("  %s✔ No compromised packages or artifacts found.%s\n\n", green, reset)
 		return nil
 	}
 
@@ -148,7 +231,7 @@ func writeCheckTerminal(result *incident.CheckResult, ecosystem string) error {
 	// Action guidance is ecosystem-specific because `aguara clean`
 	// only knows how to remove the Python compromise artifacts.
 	fmt.Printf("%sAction required:%s\n", bold, reset)
-	if ecosystem == "npm" {
+	if ecosystem == ecoNPM {
 		fmt.Println("  1. Remove the affected packages with the package manager (`npm uninstall <name>`)")
 		fmt.Println("  2. Rotate ALL credentials reachable from runs that included the compromised version")
 		fmt.Println("  3. Audit recent CI runs, especially trusted-publishing / OIDC steps")
@@ -176,7 +259,45 @@ func writeCheckTerminal(result *incident.CheckResult, ecosystem string) error {
 	if warnCount > 0 {
 		parts = append(parts, fmt.Sprintf("%s%d warning%s", yellow, warnCount, reset))
 	}
-	fmt.Printf("\n%s\n", strings.Join(parts, " \u00b7 "))
+	fmt.Printf("\n%s\n", strings.Join(parts, " · "))
 
+	return nil
+}
+
+// checkSeverityRank orders Finding.Severity strings against the
+// --fail-on threshold. Unknown severities (defensive: future entries
+// the runtime predates) sort below INFO so they cannot trip the gate.
+var checkSeverityRank = map[string]int{
+	incident.SevInfo:     0,
+	incident.SevWarning:  1,
+	incident.SevCritical: 2,
+}
+
+// checkIncidentFailOnThreshold returns ErrThresholdExceeded when any
+// finding in result meets or exceeds the configured severity threshold.
+// An empty threshold disables the gate (return nil).
+//
+// Kept separate from scan's checkFailOnThreshold because the check
+// pipeline uses string severities (CRITICAL/WARNING/INFO) rather than
+// scan's numeric Severity enum. Both gates fail with the same
+// sentinel so main.go's exit-code logic stays uniform.
+func checkIncidentFailOnThreshold(result *incident.CheckResult, threshold string) error {
+	if threshold == "" {
+		return nil
+	}
+	thrKey := strings.ToUpper(strings.TrimSpace(threshold))
+	thr, ok := checkSeverityRank[thrKey]
+	if !ok {
+		return fmt.Errorf("invalid --fail-on %q: choose critical, warning, or info", threshold)
+	}
+	for _, f := range result.Findings {
+		rank, ok := checkSeverityRank[strings.ToUpper(f.Severity)]
+		if !ok {
+			continue
+		}
+		if rank >= thr {
+			return ErrThresholdExceeded
+		}
+	}
 	return nil
 }

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -136,12 +136,18 @@ func autoDetectCheckTarget(path string) (string, string, error) {
 		if abs, err := filepath.Abs(probe); err == nil {
 			resolved = abs
 		}
+		// On the npm-detected branches, return the resolved path so
+		// incident.CheckNPM -> resolveNPMRoot does not have to repeat
+		// the same dot-aware basename trick. Passing a literal "."
+		// through here breaks the npm walker because
+		// filepath.Base(".") == "." and the path has no
+		// `./node_modules` child.
 		if filepath.Base(resolved) == "node_modules" {
-			return ecoNPM, probe, nil
+			return ecoNPM, resolved, nil
 		}
-		nm := filepath.Join(probe, "node_modules")
+		nm := filepath.Join(resolved, "node_modules")
 		if nmInfo, err := os.Stat(nm); err == nil && nmInfo.IsDir() {
-			return ecoNPM, probe, nil
+			return ecoNPM, resolved, nil
 		}
 	}
 	// Fall back to Python. Preserve the caller's original (possibly

--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -337,6 +337,31 @@ func TestResolveCheckTargetExplicitFlags(t *testing.T) {
 	require.True(t, strings.Contains(err.Error(), "unsupported"))
 }
 
+func TestResolveCheckTargetAutoDetectFromInsideNodeModules(t *testing.T) {
+	// Regression for codex P2 (PR review, 2026-05-15): when the
+	// probe is "." -- e.g. the user runs `aguara check` from inside
+	// a node_modules directory -- filepath.Base(".") is ".", which
+	// previously caused the auto-detector to fall through to Python
+	// even though cwd was already an npm tree. We now resolve to an
+	// absolute path before the basename check, so the npm signal is
+	// preserved and the npm checker runs.
+	nm := filepath.Join(t.TempDir(), "node_modules")
+	require.NoError(t, os.MkdirAll(nm, 0o755))
+	t.Chdir(nm)
+
+	eco, path, err := resolveCheckTarget("", ".")
+	require.NoError(t, err)
+	require.Equal(t, ecoNPM, eco)
+	require.Equal(t, ".", path, "auto-detect must keep the caller's original path so the npm walker sees the same input")
+
+	// Same shape, but with no --path flag (empty string) -- the
+	// dispatcher uses "." as a probe internally and must still
+	// detect npm.
+	eco, _, err = resolveCheckTarget("", "")
+	require.NoError(t, err)
+	require.Equal(t, ecoNPM, eco)
+}
+
 func TestResolveCheckTargetAutoDetect(t *testing.T) {
 	// Auto-detect (empty ecosystem) prefers npm only when a
 	// node_modules directory is present at the probe path.

--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -340,26 +340,32 @@ func TestResolveCheckTargetExplicitFlags(t *testing.T) {
 func TestResolveCheckTargetAutoDetectFromInsideNodeModules(t *testing.T) {
 	// Regression for codex P2 (PR review, 2026-05-15): when the
 	// probe is "." -- e.g. the user runs `aguara check` from inside
-	// a node_modules directory -- filepath.Base(".") is ".", which
-	// previously caused the auto-detector to fall through to Python
-	// even though cwd was already an npm tree. We now resolve to an
-	// absolute path before the basename check, so the npm signal is
-	// preserved and the npm checker runs.
+	// a node_modules directory -- filepath.Base(".") is ".". The
+	// auto-detector must (a) recognise the npm signal anyway and
+	// (b) return a path that resolveNPMRoot can walk, since
+	// filepath.Base(".") and `./node_modules` both fail under
+	// resolveNPMRoot. We resolve to an absolute path before the
+	// basename check AND return that resolved path so the npm
+	// walker sees a usable input.
 	nm := filepath.Join(t.TempDir(), "node_modules")
 	require.NoError(t, os.MkdirAll(nm, 0o755))
 	t.Chdir(nm)
 
+	resolvedNM, err := filepath.Abs(".")
+	require.NoError(t, err)
+
 	eco, path, err := resolveCheckTarget("", ".")
 	require.NoError(t, err)
 	require.Equal(t, ecoNPM, eco)
-	require.Equal(t, ".", path, "auto-detect must keep the caller's original path so the npm walker sees the same input")
+	require.Equal(t, resolvedNM, path, "auto-detect must hand the npm walker a resolved path so resolveNPMRoot can find node_modules")
 
 	// Same shape, but with no --path flag (empty string) -- the
 	// dispatcher uses "." as a probe internally and must still
-	// detect npm.
-	eco, _, err = resolveCheckTarget("", "")
+	// detect npm with a resolved path.
+	eco, path, err = resolveCheckTarget("", "")
 	require.NoError(t, err)
 	require.Equal(t, ecoNPM, eco)
+	require.Equal(t, resolvedNM, path)
 }
 
 func TestResolveCheckTargetAutoDetect(t *testing.T) {

--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -1,0 +1,372 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/garagon/aguara/internal/incident"
+	"github.com/stretchr/testify/require"
+)
+
+// checkToFile runs `aguara check` with the given args, writes JSON
+// output to a temp file via `-o`, and returns the parsed result. Use
+// this instead of capturing stdout because writeCheckJSON writes to
+// os.Stdout directly (matches the helper in scan_test.go).
+func checkToFile(t *testing.T, args ...string) *incident.CheckResult {
+	t.Helper()
+	resetFlags()
+	outFile := filepath.Join(t.TempDir(), "check.json")
+	fullArgs := append([]string{"check"}, args...)
+	fullArgs = append(fullArgs, "-o", outFile, "--format", "json", "--no-update-check")
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs(fullArgs)
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		resetFlags()
+	})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	var result incident.CheckResult
+	require.NoError(t, json.Unmarshal(data, &result))
+	return &result
+}
+
+// writeFakeNPMPackage materialises a node_modules/<name>/package.json
+// with the given name and version. Helper kept inline to avoid coupling
+// to the internal/incident test helper which lives in a different
+// package.
+func writeFakeNPMPackage(t *testing.T, nodeModules, name, version string) {
+	t.Helper()
+	dir := filepath.Join(nodeModules, filepath.FromSlash(name))
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	body := `{"name":"` + name + `","version":"` + version + `"}`
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(body), 0o644))
+}
+
+func TestCheckAutoDetectsNPMFromProjectRoot(t *testing.T) {
+	// With no --ecosystem flag, `aguara check --path <dir>` must
+	// detect the node_modules child and route to the npm checker.
+	// Regression guard for the v0.16 UX promise: a user inside a
+	// real npm project must get an npm report without being asked
+	// to spell out the ecosystem.
+	project := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(project, "node_modules"), 0o755))
+	writeFakeNPMPackage(t, filepath.Join(project, "node_modules"), "event-stream", "3.3.6")
+
+	result := checkToFile(t, "--path", project)
+
+	require.NotZero(t, result.PackagesRead, "expected npm checker to read at least one package")
+	require.NotEmpty(t, result.Findings, "expected event-stream 3.3.6 to be reported as compromised")
+	require.Equal(t, incident.SevCritical, result.Findings[0].Severity)
+}
+
+func TestCheckAutoDetectsNPMFromNodeModulesDir(t *testing.T) {
+	// Passing the node_modules directory itself (not its parent)
+	// must also resolve to an npm check without --ecosystem.
+	nm := filepath.Join(t.TempDir(), "node_modules")
+	require.NoError(t, os.MkdirAll(nm, 0o755))
+	writeFakeNPMPackage(t, nm, "lodash", "4.17.21") // not compromised
+
+	result := checkToFile(t, "--path", nm)
+
+	require.Equal(t, 1, result.PackagesRead)
+	require.Empty(t, result.Findings)
+}
+
+func TestCheckExplicitEcosystemNPMStillWorks(t *testing.T) {
+	// Legacy contract: `aguara check --ecosystem npm --path X` must
+	// continue to route to the npm checker even when X has a non-npm
+	// shape (here: a node_modules tree without ./node_modules child).
+	nm := filepath.Join(t.TempDir(), "node_modules")
+	require.NoError(t, os.MkdirAll(nm, 0o755))
+	writeFakeNPMPackage(t, nm, "event-stream", "3.3.6")
+
+	result := checkToFile(t, "--ecosystem", "npm", "--path", nm)
+
+	require.NotEmpty(t, result.Findings)
+}
+
+func TestCheckExplicitEcosystemPythonSkipsNPMAutoDetect(t *testing.T) {
+	// Auto-detection must NEVER override an explicit --ecosystem
+	// python flag. We arrange a directory that would auto-detect as
+	// npm and confirm the Python check path runs instead. The Python
+	// checker errors out with the "no Python site-packages" message
+	// when the path is empty/non-Python; that error surface is the
+	// signal that the Python pipeline ran (not npm).
+	project := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(project, "node_modules"), 0o755))
+
+	resetFlags()
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{
+		"check",
+		"--ecosystem", "python",
+		"--path", project,
+		"--format", "json",
+		"--no-update-check",
+	})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		resetFlags()
+	})
+
+	err := rootCmd.Execute()
+	// Either the Python checker accepted the path (empty findings)
+	// or rejected it as not-a-site-packages directory. Both are
+	// fine; what must NOT happen is npm taking over silently.
+	if err == nil {
+		// runCheck succeeded under Python ecosystem, fine.
+		return
+	}
+	require.NotContains(t, err.Error(), "npm check", "ecosystem=python must not delegate to npm")
+}
+
+func TestCheckRejectsUnsupportedEcosystem(t *testing.T) {
+	resetFlags()
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"check", "--ecosystem", "ruby", "--no-update-check"})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		resetFlags()
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported ecosystem")
+}
+
+func TestCheckFailOnThresholdHelper(t *testing.T) {
+	// Verifies the threshold logic in isolation, without paying the
+	// subprocess cost. Each row sets up a CheckResult with known
+	// severities and asserts whether the gate trips.
+	tests := []struct {
+		name      string
+		findings  []incident.Finding
+		threshold string
+		wantErr   bool
+	}{
+		{
+			name:      "empty threshold never trips",
+			findings:  []incident.Finding{{Severity: incident.SevCritical}},
+			threshold: "",
+			wantErr:   false,
+		},
+		{
+			name:      "critical trips critical",
+			findings:  []incident.Finding{{Severity: incident.SevCritical}},
+			threshold: "critical",
+			wantErr:   true,
+		},
+		{
+			name:      "warning does not trip critical",
+			findings:  []incident.Finding{{Severity: incident.SevWarning}},
+			threshold: "critical",
+			wantErr:   false,
+		},
+		{
+			name:      "warning trips warning",
+			findings:  []incident.Finding{{Severity: incident.SevWarning}},
+			threshold: "warning",
+			wantErr:   true,
+		},
+		{
+			name:      "critical trips warning",
+			findings:  []incident.Finding{{Severity: incident.SevCritical}},
+			threshold: "warning",
+			wantErr:   true,
+		},
+		{
+			name:      "no findings never trips",
+			findings:  nil,
+			threshold: "critical",
+			wantErr:   false,
+		},
+		{
+			name:      "case insensitive threshold",
+			findings:  []incident.Finding{{Severity: incident.SevCritical}},
+			threshold: "CRITICAL",
+			wantErr:   true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := &incident.CheckResult{Findings: tc.findings}
+			err := checkIncidentFailOnThreshold(result, tc.threshold)
+			if tc.wantErr {
+				require.ErrorIs(t, err, ErrThresholdExceeded)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCheckFailOnInvalidValue(t *testing.T) {
+	result := &incident.CheckResult{Findings: []incident.Finding{{Severity: incident.SevCritical}}}
+	err := checkIncidentFailOnThreshold(result, "ludicrous")
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrThresholdExceeded)
+	require.Contains(t, err.Error(), "invalid --fail-on")
+}
+
+func TestCheckCIAppliesDefaults(t *testing.T) {
+	// --ci must imply --fail-on critical and disable color.
+	// We don't exercise the full command (would need an os.Exit
+	// subprocess for the compromised case); instead we invoke
+	// applyCheckCIDefaults directly so the flag wiring stays unit
+	// tested.
+	resetFlags()
+	t.Cleanup(resetFlags)
+
+	flagCheckCI = true
+	applyCheckCIDefaults()
+	require.Equal(t, "critical", flagCheckFailOn)
+	require.True(t, flagNoColor)
+}
+
+func TestCheckCIPreservesExplicitFailOn(t *testing.T) {
+	// --ci must not clobber an explicit --fail-on. A user who
+	// writes `aguara check --ci --fail-on warning` is asking for a
+	// stricter gate than --ci's default; the override has to win.
+	resetFlags()
+	t.Cleanup(resetFlags)
+
+	flagCheckCI = true
+	flagCheckFailOn = "warning"
+	applyCheckCIDefaults()
+	require.Equal(t, "warning", flagCheckFailOn)
+}
+
+func TestCheckCIExitsNonZero(t *testing.T) {
+	// End-to-end smoke: `aguara check --ci` on a directory that
+	// auto-detects an npm project with a known-compromised package
+	// must return ErrThresholdExceeded so main.go can exit(1). The
+	// subprocess pattern matches TestScanFailOn; the helper test
+	// runs the actual cobra command and exits with code 1 on the
+	// sentinel.
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	require.NoError(t, os.MkdirAll(nm, 0o755))
+	writeFakeNPMPackage(t, nm, "event-stream", "3.3.6")
+
+	cmd := exec.Command("go", "test", "-race", "-count=1",
+		"-run", "TestCheckCIExitsNonZeroHelper",
+		"./cmd/aguara/commands/",
+	)
+	cmd.Dir = filepath.Join("..", "..", "..")
+	cmd.Env = append(os.Environ(), "AGUARA_TEST_CHECK_CI_DIR="+dir)
+
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err, "expected non-zero exit: %s", string(out))
+}
+
+// TestCheckCIExitsNonZeroHelper is invoked by TestCheckCIExitsNonZero
+// in a subprocess. It is skipped when not called by the parent test.
+func TestCheckCIExitsNonZeroHelper(t *testing.T) {
+	dir := os.Getenv("AGUARA_TEST_CHECK_CI_DIR")
+	if dir == "" {
+		t.Skip("only runs as subprocess of TestCheckCIExitsNonZero")
+	}
+	resetFlags()
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{
+		"check",
+		"--path", dir,
+		"--ci",
+		"--format", "json",
+		"-o", filepath.Join(t.TempDir(), "out.json"),
+		"--no-update-check",
+	})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		resetFlags()
+	})
+
+	if err := rootCmd.Execute(); errors.Is(err, ErrThresholdExceeded) {
+		os.Exit(1)
+	}
+}
+
+func TestResolveCheckTargetExplicitFlags(t *testing.T) {
+	// Direct unit test for the dispatcher: explicit ecosystem flags
+	// route without auto-detect, even when --path contains a node_modules
+	// child (proves auto-detect is suppressed by an explicit override).
+	dir := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, "node_modules"), 0o755))
+
+	eco, path, err := resolveCheckTarget("python", dir)
+	require.NoError(t, err)
+	require.Equal(t, ecoPython, eco)
+	require.Equal(t, dir, path)
+
+	eco, path, err = resolveCheckTarget("PyPI", dir)
+	require.NoError(t, err)
+	require.Equal(t, ecoPython, eco)
+	require.Equal(t, dir, path)
+
+	eco, path, err = resolveCheckTarget("npm", dir)
+	require.NoError(t, err)
+	require.Equal(t, ecoNPM, eco)
+	require.Equal(t, dir, path)
+
+	_, _, err = resolveCheckTarget("crates", dir)
+	require.Error(t, err)
+	require.True(t, strings.Contains(err.Error(), "unsupported"))
+}
+
+func TestResolveCheckTargetAutoDetect(t *testing.T) {
+	// Auto-detect (empty ecosystem) prefers npm only when a
+	// node_modules directory is present at the probe path.
+	withNM := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(withNM, "node_modules"), 0o755))
+
+	withoutNM := t.TempDir()
+
+	eco, path, err := resolveCheckTarget("", withNM)
+	require.NoError(t, err)
+	require.Equal(t, ecoNPM, eco)
+	require.Equal(t, withNM, path)
+
+	eco, path, err = resolveCheckTarget("", withoutNM)
+	require.NoError(t, err)
+	require.Equal(t, ecoPython, eco)
+	require.Equal(t, withoutNM, path)
+
+	// Empty path with empty ecosystem must not crash and must
+	// fall back to Python (preserves the legacy site-packages
+	// auto-discovery contract).
+	eco, path, err = resolveCheckTarget("", "")
+	require.NoError(t, err)
+	// In a CI workspace cwd will rarely have node_modules; if it
+	// happens to (e.g. someone runs the suite from inside an npm
+	// project), the auto-detect is allowed to pick npm. Either
+	// answer is acceptable; what matters is no error and an empty
+	// path is preserved for Python's auto-discovery.
+	require.Contains(t, []string{ecoPython, ecoNPM}, eco)
+	if eco == ecoPython {
+		require.Equal(t, "", path)
+	}
+}

--- a/cmd/aguara/commands/scan_test.go
+++ b/cmd/aguara/commands/scan_test.go
@@ -33,6 +33,10 @@ func resetFlags() {
 	flagToolName = ""
 	flagProfile = ""
 	flagNoRedact = false
+	flagCheckPath = ""
+	flagCheckEcosystem = ""
+	flagCheckFailOn = ""
+	flagCheckCI = false
 }
 
 // scanToFile runs aguara scan and writes output to a temp file, returning the content.


### PR DESCRIPTION
## Summary

`aguara check` now auto-detects npm projects and grows the same `--ci` and
`--fail-on` exit-code controls that `aguara scan` already has. Step 1 of a
multi-PR roadmap that lands native supply-chain threat intel.

- New `--fail-on critical|warning|info` returns exit code 1 (via the existing
  `ErrThresholdExceeded` sentinel) when findings reach the configured severity.
- New `--ci` is shorthand for `--fail-on critical --no-color`. Does not clobber
  an explicit `--fail-on`.
- `aguara check` with no flags now detects an npm project (cwd or `--path` with
  a `node_modules` child, or a `node_modules` directory itself) and routes to
  the npm checker. Without a node_modules signal it falls back to the legacy
  Python site-packages discovery.
- Explicit `--ecosystem python` / `--ecosystem npm` always wins over
  auto-detection.

No OSV, no network, no new data sources -- purely the check command UX surface.

## Codex pre-PR review

- Round 1: P2 (`filepath.Base(".")` false negative). Fixed by resolving the
  probe to an absolute path before the basename comparison.
- Round 2: second-order P2 (raw `"."` returned to the npm walker;
  `resolveNPMRoot(".")` rejects it). Fixed by returning the resolved path on
  both npm branches.
- Round 3: CLEAN PASS, no actionable findings.

## Test plan

- [x] `go test -race -count=1 ./...` (all packages green)
- [x] `make vet`
- [x] `make lint` (0 issues)
- [x] Regression test `TestResolveCheckTargetAutoDetectFromInsideNodeModules`
      for the codex `.` edge case
- [x] Legacy `aguara check --ecosystem npm --path ./node_modules` still works
- [x] Legacy `aguara check --ecosystem python` still routes to Python
- [x] `--ci` exits non-zero on a compromised package (subprocess test)