### PR TITLE
feat(intel): runtime refresh + aguara update / status + check --fresh

### DIFF
--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -1,21 +1,29 @@
 package commands
 
 import (
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/garagon/aguara/internal/intel/osvimport"
 	"github.com/spf13/cobra"
 )
 
 var (
-	flagCheckPath      string
-	flagCheckEcosystem string
-	flagCheckFailOn    string
-	flagCheckCI        bool
+	flagCheckPath       string
+	flagCheckEcosystem  string
+	flagCheckFailOn     string
+	flagCheckCI         bool
+	flagCheckFresh      bool
+	flagCheckAllowStale bool
 )
 
 const (
@@ -39,6 +47,8 @@ func init() {
 	checkCmd.Flags().StringVar(&flagCheckEcosystem, "ecosystem", "", "Package ecosystem (auto-detect by default): python or npm")
 	checkCmd.Flags().StringVar(&flagCheckFailOn, "fail-on", "", "Exit with code 1 if findings reach this severity: critical, warning, info")
 	checkCmd.Flags().BoolVar(&flagCheckCI, "ci", false, "CI mode: equivalent to --fail-on critical --no-color")
+	checkCmd.Flags().BoolVar(&flagCheckFresh, "fresh", false, "Refresh threat intel before checking (network opt-in)")
+	checkCmd.Flags().BoolVar(&flagCheckAllowStale, "allow-stale", false, "Continue with cached/embedded intel if --fresh refresh fails")
 	rootCmd.AddCommand(checkCmd)
 }
 
@@ -50,7 +60,12 @@ func runCheck(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	opts := incident.CheckOptions{Path: path}
+	override, err := resolveCheckIntel(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	opts := incident.CheckOptions{Path: path, Intel: override}
 	var result *incident.CheckResult
 	switch eco {
 	case ecoPython:
@@ -279,6 +294,100 @@ func writeCheckTerminal(result *incident.CheckResult, ecosystem string) error {
 	fmt.Printf("\n%s\n", strings.Join(parts, " · "))
 
 	return nil
+}
+
+// resolveCheckIntel builds the IntelOverride the check pipeline
+// should consume. The logic is:
+//
+//  1. If --fresh was passed, run intel.Update; on success save to
+//     local Store and override with [embedded..., refreshed].
+//     IntelSummary.Mode = "online", Snapshot = "remote-fresh".
+//  2. If --fresh failed AND --allow-stale was passed, fall back
+//     to a local-only or embedded-only override and continue.
+//  3. If --fresh was NOT passed AND a local snapshot exists, layer
+//     it over the embedded snapshots. Mode stays "offline";
+//     Snapshot = "local".
+//  4. Otherwise, return nil so the check uses the cached embedded
+//     matcher (the legacy default path).
+//
+// This is the only place the CLI touches the network for `check`.
+// Returning nil keeps the default-check contract intact: no flags,
+// no network.
+func resolveCheckIntel(ctx context.Context) (*incident.IntelOverride, error) {
+	store, storeErr := intel.DefaultStore()
+	if storeErr != nil {
+		// A missing $HOME is exotic; fall through to the
+		// embedded-only path rather than blocking the check.
+		store = nil
+	}
+
+	if flagCheckFresh {
+		ctx, cancel := context.WithTimeout(ctx, intel.DefaultHTTPTimeout)
+		defer cancel()
+
+		res, err := intel.Update(ctx, intel.UpdateOptions{
+			Importer: osvUpdateAdapter,
+			Stderr:   os.Stderr,
+		})
+		if err != nil {
+			if !flagCheckAllowStale {
+				return nil, fmt.Errorf("--fresh refresh failed: %w (pass --allow-stale to fall back to cached intel)", err)
+			}
+			fmt.Fprintf(os.Stderr, "warning: --fresh refresh failed (%v); falling back to cached intel\n", err)
+			return localOrEmbeddedOverride(store), nil
+		}
+		if store != nil {
+			if saveErr := store.Save(res.Snapshot); saveErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: --fresh: save snapshot failed: %v\n", saveErr)
+			}
+		}
+		snaps := append([]intel.Snapshot{}, incident.EmbeddedSnapshots()...)
+		snaps = append(snaps, res.Snapshot)
+		return &incident.IntelOverride{
+			Snapshots:     snaps,
+			Mode:          "online",
+			SnapshotLabel: "remote-fresh",
+		}, nil
+	}
+
+	return localOrEmbeddedOverride(store), nil
+}
+
+// localOrEmbeddedOverride returns an override layered over the
+// embedded snapshots when a local snapshot exists, or nil when no
+// local snapshot is found. Returning nil for the no-local case
+// keeps the cached default matcher in play -- no per-check
+// allocation, no behavioural change for the default `aguara check`
+// invocation.
+func localOrEmbeddedOverride(store *intel.Store) *incident.IntelOverride {
+	if store == nil {
+		return nil
+	}
+	snap, err := store.Load()
+	if err != nil {
+		if !errors.Is(err, os.ErrNotExist) {
+			fmt.Fprintf(os.Stderr, "warning: local intel snapshot unreadable: %v\n", err)
+		}
+		return nil
+	}
+	snaps := append([]intel.Snapshot{}, incident.EmbeddedSnapshots()...)
+	snaps = append(snaps, *snap)
+	return &incident.IntelOverride{
+		Snapshots:     snaps,
+		Mode:          "offline",
+		SnapshotLabel: "local",
+	}
+}
+
+// osvUpdateAdapter is the production wiring of intel.UpdateOptions.Importer
+// to osvimport.ImportFromZip. Mirrors the adapter in update.go so the
+// two CLI surfaces (`aguara update` and `aguara check --fresh`) share
+// one importer hook.
+func osvUpdateAdapter(r io.ReaderAt, size int64, ecosystems []string, generatedAt time.Time) (intel.Snapshot, error) {
+	return osvimport.ImportFromZip(r, size, osvimport.Options{
+		Ecosystems:  ecosystems,
+		GeneratedAt: generatedAt,
+	})
 }
 
 // checkSeverityRank orders Finding.Severity strings against the

--- a/cmd/aguara/commands/scan_test.go
+++ b/cmd/aguara/commands/scan_test.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/garagon/aguara/internal/intel"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,6 +38,10 @@ func resetFlags() {
 	flagCheckEcosystem = ""
 	flagCheckFailOn = ""
 	flagCheckCI = false
+	flagCheckFresh = false
+	flagCheckAllowStale = false
+	flagUpdateTimeout = intel.DefaultHTTPTimeout
+	flagUpdateEcosystems = nil
 }
 
 // scanToFile runs aguara scan and writes output to a temp file, returning the content.

--- a/cmd/aguara/commands/scan_test.go
+++ b/cmd/aguara/commands/scan_test.go
@@ -42,6 +42,7 @@ func resetFlags() {
 	flagCheckAllowStale = false
 	flagUpdateTimeout = intel.DefaultHTTPTimeout
 	flagUpdateEcosystems = nil
+	flagUpdateAllowEmpty = false
 }
 
 // scanToFile runs aguara scan and writes output to a temp file, returning the content.

--- a/cmd/aguara/commands/status.go
+++ b/cmd/aguara/commands/status.go
@@ -1,0 +1,83 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/spf13/cobra"
+)
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show Aguara version and threat-intel freshness",
+	Long: `Print the binary version, embedded threat-intel snapshot age, and
+local cached snapshot status (if any).
+
+This command does no network I/O. Run 'aguara update' to refresh the local
+snapshot.`,
+	RunE: runStatus,
+}
+
+func init() {
+	rootCmd.AddCommand(statusCmd)
+}
+
+func runStatus(cmd *cobra.Command, args []string) error {
+	w := os.Stdout
+
+	fmt.Fprintf(w, "Aguara %s (commit %s)\n\n", Version, Commit)
+
+	fmt.Fprintf(w, "Threat intel:\n")
+	for _, snap := range incident.EmbeddedSnapshots() {
+		label := snapshotLabel(snap)
+		fmt.Fprintf(w, "  Embedded (%s): %s, %d records\n",
+			label, snap.GeneratedAt.Format("2006-01-02"), len(snap.Records))
+	}
+
+	store, err := intel.DefaultStore()
+	if err != nil {
+		// A missing $HOME / unreadable user dir is exotic
+		// enough that we still want to print everything else;
+		// surface it as a warning line rather than aborting.
+		fmt.Fprintf(w, "  Local:    unavailable: %v\n", err)
+		return nil
+	}
+	st := store.Status()
+	switch {
+	case st.HasSnapshot:
+		fmt.Fprintf(w, "  Local:    %s, %d records (%s)\n",
+			st.GeneratedAt.Format("2006-01-02 15:04 UTC"),
+			st.RecordCount, st.Path,
+		)
+	case st.LastUpdateErr != "":
+		fmt.Fprintf(w, "  Local:    error reading %s: %s\n", st.Path, st.LastUpdateErr)
+	default:
+		fmt.Fprintf(w, "  Local:    none (run `aguara update` to fetch the latest)\n")
+	}
+
+	fmt.Fprintf(w, "\nNetwork:\n")
+	fmt.Fprintf(w, "  Default checks do not use the network.\n")
+	fmt.Fprintf(w, "  `aguara update` refreshes intel; `aguara check --fresh` refreshes then checks.\n")
+	return nil
+}
+
+// snapshotLabel picks a short human-readable label for a snapshot.
+// "manual" for the hand-curated emergency list, "osv" for the
+// build-time generated stub, "unknown" for anything else (defensive
+// against future snapshot sources that have not learned the
+// convention).
+func snapshotLabel(snap intel.Snapshot) string {
+	if len(snap.Sources) == 0 {
+		return "unknown"
+	}
+	switch snap.Sources[0].Kind {
+	case intel.SourceManual:
+		return "manual"
+	case intel.SourceOSV:
+		return "osv"
+	default:
+		return string(snap.Sources[0].Kind)
+	}
+}

--- a/cmd/aguara/commands/status_test.go
+++ b/cmd/aguara/commands/status_test.go
@@ -1,0 +1,104 @@
+package commands
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestStatusPrintsVersionAndEmbedded asserts the status output
+// shape: Version line, embedded snapshot lines, and a Network
+// section. Does not exercise the local snapshot path -- that
+// depends on $HOME and is covered by intel.Store's own tests.
+func TestStatusPrintsVersionAndEmbedded(t *testing.T) {
+	resetFlags()
+	t.Cleanup(resetFlags)
+
+	stdout, restore := captureStdout(t)
+	defer restore()
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"status", "--no-update-check"})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+
+	require.NoError(t, rootCmd.Execute())
+	out := stdout()
+	require.Contains(t, out, "Aguara")
+	require.Contains(t, out, "Threat intel:")
+	require.Contains(t, out, "Embedded")
+	require.Contains(t, out, "Network:")
+	require.Contains(t, out, "Default checks do not use the network")
+}
+
+// captureStdout redirects os.Stdout to a temp file for the
+// duration of a test, returning a fetcher that drains the file's
+// contents and a restore func. Used because the status command
+// writes directly to os.Stdout (it does not respect cobra's
+// SetOut, like writeCheckJSON in check.go).
+func captureStdout(t *testing.T) (func() string, func()) {
+	t.Helper()
+	orig := os.Stdout
+	tmp, err := os.CreateTemp(t.TempDir(), "stdout-*.txt")
+	require.NoError(t, err)
+	os.Stdout = tmp
+	restore := func() {
+		os.Stdout = orig
+		_ = tmp.Close()
+	}
+	fetch := func() string {
+		_ = tmp.Sync()
+		data, err := os.ReadFile(tmp.Name())
+		require.NoError(t, err)
+		return string(data)
+	}
+	return fetch, restore
+}
+
+// TestStatusReadsLocalSnapshot exercises the local-snapshot
+// branch. We point HOME at a tempdir, write a synthetic snapshot
+// there, and confirm `aguara status` reports it. Avoids touching
+// the user's real ~/.aguara/intel state.
+func TestStatusReadsLocalSnapshot(t *testing.T) {
+	resetFlags()
+	t.Cleanup(resetFlags)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	intelDir := filepath.Join(home, ".aguara", "intel")
+	require.NoError(t, os.MkdirAll(intelDir, 0o700))
+	snap := `{
+		"schema_version": 1,
+		"generated_at": "2026-05-15T12:00:00Z",
+		"records": [
+			{"id":"X","ecosystem":"npm","name":"x","versions":["1.0.0"]}
+		]
+	}`
+	require.NoError(t, os.WriteFile(filepath.Join(intelDir, "snapshot.json"), []byte(snap), 0o600))
+
+	stdout, restore := captureStdout(t)
+	defer restore()
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"status", "--no-update-check"})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+
+	require.NoError(t, rootCmd.Execute())
+	out := stdout()
+	require.True(t, strings.Contains(out, "Local:"), "status output must include Local line; got: %s", out)
+	require.True(t, strings.Contains(out, "1 records"), "local record count must surface; got: %s", out)
+}

--- a/cmd/aguara/commands/update.go
+++ b/cmd/aguara/commands/update.go
@@ -15,6 +15,7 @@ import (
 var (
 	flagUpdateTimeout    time.Duration
 	flagUpdateEcosystems []string
+	flagUpdateAllowEmpty bool
 )
 
 var updateCmd = &cobra.Command{
@@ -36,6 +37,7 @@ This command updates THREAT INTEL only. It does not update the Aguara binary.`,
 func init() {
 	updateCmd.Flags().DurationVar(&flagUpdateTimeout, "timeout", intel.DefaultHTTPTimeout, "Overall HTTP timeout for the refresh")
 	updateCmd.Flags().StringSliceVar(&flagUpdateEcosystems, "ecosystem", nil, "Ecosystems to refresh (default: npm, PyPI)")
+	updateCmd.Flags().BoolVar(&flagUpdateAllowEmpty, "allow-empty", false, "Save a 0-record snapshot anyway (defaults to error so an upstream outage cannot wipe cached intel)")
 	rootCmd.AddCommand(updateCmd)
 }
 
@@ -63,6 +65,19 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("aguara update: %w", err)
+	}
+
+	// Refuse to overwrite the local cache with an empty snapshot.
+	// Zero records here usually means OSV served a syntactically
+	// valid but empty/malformed dump, or an upstream schema shift
+	// made the importer drop every record. Saving in that
+	// scenario silently wipes whatever intel the user had cached;
+	// preserving the previous snapshot until the next successful
+	// refresh is the safer default. --allow-empty exists for the
+	// initial bootstrap case where the maintainer explicitly
+	// wants the empty file written.
+	if len(res.Snapshot.Records) == 0 && !flagUpdateAllowEmpty {
+		return fmt.Errorf("aguara update: refresh produced 0 records; refusing to overwrite cached intel (pass --allow-empty to save anyway)")
 	}
 
 	if err := store.Save(res.Snapshot); err != nil {

--- a/cmd/aguara/commands/update.go
+++ b/cmd/aguara/commands/update.go
@@ -1,0 +1,90 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/garagon/aguara/internal/intel/osvimport"
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagUpdateTimeout    time.Duration
+	flagUpdateEcosystems []string
+)
+
+var updateCmd = &cobra.Command{
+	Use:   "update",
+	Short: "Refresh the local threat-intel snapshot from OSV.dev",
+	Long: `Refresh Aguara's local threat-intel snapshot. Downloads OSV.dev
+malicious-package dumps for the configured ecosystems (default: npm, PyPI),
+filters to high-confidence records, and writes the merged snapshot to
+~/.aguara/intel/snapshot.json.
+
+This command is the only place 'aguara update' touches the network. Default
+'aguara check' invocations stay offline; future checks will consult the local
+snapshot in addition to the binary's embedded snapshot.
+
+This command updates THREAT INTEL only. It does not update the Aguara binary.`,
+	RunE: runUpdate,
+}
+
+func init() {
+	updateCmd.Flags().DurationVar(&flagUpdateTimeout, "timeout", intel.DefaultHTTPTimeout, "Overall HTTP timeout for the refresh")
+	updateCmd.Flags().StringSliceVar(&flagUpdateEcosystems, "ecosystem", nil, "Ecosystems to refresh (default: npm, PyPI)")
+	rootCmd.AddCommand(updateCmd)
+}
+
+func runUpdate(cmd *cobra.Command, args []string) error {
+	store, err := intel.DefaultStore()
+	if err != nil {
+		return fmt.Errorf("aguara update: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(cmd.Context(), flagUpdateTimeout)
+	defer cancel()
+
+	progress := io.Writer(os.Stderr)
+	if flagNoColor {
+		// flagNoColor doubles as a "machine-readable mode"
+		// hint set by --ci; suppressing progress keeps the
+		// stderr clean for log scrapers.
+		progress = io.Discard
+	}
+
+	res, err := intel.Update(ctx, intel.UpdateOptions{
+		Ecosystems: flagUpdateEcosystems,
+		Importer:   osvImporterAdapter,
+		Stderr:     progress,
+	})
+	if err != nil {
+		return fmt.Errorf("aguara update: %w", err)
+	}
+
+	if err := store.Save(res.Snapshot); err != nil {
+		return fmt.Errorf("aguara update: save snapshot: %w", err)
+	}
+
+	fmt.Fprintf(os.Stdout, "Aguara threat intel updated\n")
+	for _, eco := range res.PerEcosystem {
+		fmt.Fprintf(os.Stdout, "  %-8s -> %d records\n", eco.Ecosystem, eco.RecordsKept)
+	}
+	fmt.Fprintf(os.Stdout, "  Written: %s\n", store.Dir+"/snapshot.json")
+	return nil
+}
+
+// osvImporterAdapter bridges intel.UpdateOptions.Importer (an
+// internal-only func type) to osvimport.ImportFromZip. The bridge
+// exists so the intel package does not import osvimport (which
+// would create a cycle: intel imports osvimport which imports
+// intel).
+func osvImporterAdapter(r io.ReaderAt, size int64, ecosystems []string, generatedAt time.Time) (intel.Snapshot, error) {
+	return osvimport.ImportFromZip(r, size, osvimport.Options{
+		Ecosystems:  ecosystems,
+		GeneratedAt: generatedAt,
+	})
+}

--- a/internal/incident/checker.go
+++ b/internal/incident/checker.go
@@ -85,6 +85,24 @@ type InstalledPackage struct {
 type CheckOptions struct {
 	Path          string // explicit site-packages path, empty = auto-discover
 	IncludeCaches bool
+	// Intel overrides the embedded snapshots and IntelSummary that
+	// the check pipeline uses. Nil means "use EmbeddedSnapshots()
+	// and the offline/embedded IntelSummary" (the default for
+	// every legacy caller). The CLI sets this when --fresh just
+	// refreshed the local cache or when a local snapshot is
+	// available, so IntelSummary reflects what actually matched.
+	Intel *IntelOverride
+}
+
+// IntelOverride lets the CLI swap in a different snapshot set
+// (e.g. embedded + local cache, or freshly downloaded) for one
+// check run without mutating package-level state. Mode and
+// SnapshotLabel populate the corresponding IntelSummary fields so
+// downstream consumers see the truthful provenance.
+type IntelOverride struct {
+	Snapshots     []intel.Snapshot
+	Mode          string // "offline" | "online"
+	SnapshotLabel string // "embedded" | "local" | "remote-fresh"
 }
 
 // Check scans a Python environment for compromised packages and artifacts.
@@ -103,17 +121,15 @@ func Check(opts CheckOptions) (*CheckResult, error) {
 		Environment: siteDir,
 		Findings:    []Finding{},
 		Credentials: []CredentialFile{},
-		Intel:       embeddedIntelSummary(),
+		Intel:       intelSummaryFor(opts),
 	}
 
-	// 1. Read installed packages and check against the embedded
-	// intel matcher (manual KnownCompromised + OSV-derived stub
-	// from generated_intel.go). Going through the matcher rather
-	// than the legacy IsCompromised slice scan means any OSV
-	// record the maintainer regenerates is automatically picked
-	// up here -- otherwise the IntelSummary would advertise "osv"
-	// as a source the check pipeline never consults.
-	matcher := defaultIntelMatcher()
+	// 1. Read installed packages and check against the intel matcher.
+	// matcherFor honours an explicit opts.Intel override (e.g. the
+	// CLI passing a refreshed local snapshot) and falls back to the
+	// cached default matcher built from EmbeddedSnapshots() when no
+	// override is present.
+	matcher := matcherFor(opts)
 	packages := readInstalledPackages(siteDir)
 	result.PackagesRead = len(packages)
 	for _, pkg := range packages {
@@ -150,7 +166,7 @@ func Check(opts CheckOptions) (*CheckResult, error) {
 	result.Credentials = checkCredentialFiles()
 
 	// 5. Always check pip/uv/npx caches for compromised packages
-	result.Findings = append(result.Findings, checkCaches()...)
+	result.Findings = append(result.Findings, checkCaches(opts)...)
 
 	return result, nil
 }
@@ -378,7 +394,7 @@ func checkCredentialFiles() []CredentialFile {
 }
 
 // checkCaches looks for compromised packages and malicious files in pip/uv/npx cache dirs.
-func checkCaches() []Finding {
+func checkCaches(opts CheckOptions) []Finding {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return nil
@@ -393,7 +409,8 @@ func checkCaches() []Finding {
 		filepath.Join(home, "Library/Caches/pip"), // macOS
 	}
 
-	matcher := defaultIntelMatcher()
+	matcher := matcherFor(opts)
+	snaps := snapshotsFor(opts)
 	seen := make(map[string]bool) // deduplicate findings by path
 	for _, dir := range cacheDirs {
 		if _, err := os.Stat(dir); err != nil {
@@ -449,12 +466,12 @@ func checkCaches() []Finding {
 			// Filename-based check for cache artifacts. The cache
 			// scan is part of the Python check path, so only PyPI
 			// entries apply here; npm rows live in a separate scan.
-			// Iterating the embedded snapshots (manual + OSV) lets
-			// OSV-only entries trip this path too -- previously
-			// only KnownCompromised would, so an OSV-only PyPI
-			// malicious package cached as a wheel would be missed.
+			// snapshotsFor(opts) honours an explicit override (e.g.
+			// embedded + local cache) so a freshly-refreshed PyPI
+			// advisory trips the heuristic without having to wait
+			// for the next release.
 			base := strings.ToLower(name)
-			for _, snap := range EmbeddedSnapshots() {
+			for _, snap := range snaps {
 				for _, rec := range snap.Records {
 					if rec.Ecosystem != intel.EcosystemPyPI {
 						continue

--- a/internal/incident/intel_adapter.go
+++ b/internal/incident/intel_adapter.go
@@ -22,7 +22,8 @@ var (
 
 // defaultIntelMatcher returns the singleton matcher built from
 // the binary's embedded snapshots (manual + generated OSV stub).
-// Both check entry points (Check / CheckNPM) consult it.
+// Both check entry points (Check / CheckNPM) consult it when no
+// IntelOverride was passed.
 //
 // Exposing this as a package-private helper rather than a public
 // variable means callers can not accidentally mutate the cached
@@ -33,6 +34,75 @@ func defaultIntelMatcher() *intel.Matcher {
 		defaultIntelMatcherCache = intel.NewMatcher(EmbeddedSnapshots()...)
 	})
 	return defaultIntelMatcherCache
+}
+
+// matcherFor returns the matcher to use for a given CheckOptions.
+// Nil Intel -> the cached default matcher; non-nil -> a fresh
+// matcher built from the override's Snapshots. We deliberately
+// do NOT cache override-built matchers because the override is a
+// per-run construction (e.g. embedded + local cache) and the
+// caching wins are negligible vs the simplicity cost.
+func matcherFor(opts CheckOptions) *intel.Matcher {
+	if opts.Intel == nil || len(opts.Intel.Snapshots) == 0 {
+		return defaultIntelMatcher()
+	}
+	return intel.NewMatcher(opts.Intel.Snapshots...)
+}
+
+// snapshotsFor returns the snapshot slice the check pipeline
+// should iterate for non-matcher heuristics (e.g. the cache
+// filename heuristic). Mirrors matcherFor so override callers
+// have a consistent view of "what intel is in play this run".
+func snapshotsFor(opts CheckOptions) []intel.Snapshot {
+	if opts.Intel == nil || len(opts.Intel.Snapshots) == 0 {
+		return EmbeddedSnapshots()
+	}
+	return opts.Intel.Snapshots
+}
+
+// intelSummaryFor returns the IntelSummary describing whichever
+// snapshots the check actually consulted. Override Mode and
+// SnapshotLabel win when set; everything else (GeneratedAt,
+// Sources, Stale) is derived from the snapshots themselves so the
+// summary cannot drift from the data.
+func intelSummaryFor(opts CheckOptions) IntelSummary {
+	mode := "offline"
+	label := "embedded"
+	if opts.Intel != nil {
+		if opts.Intel.Mode != "" {
+			mode = opts.Intel.Mode
+		}
+		if opts.Intel.SnapshotLabel != "" {
+			label = opts.Intel.SnapshotLabel
+		}
+	}
+
+	seen := make(map[string]struct{})
+	var sources []string
+	var generatedAt time.Time
+	for _, snap := range snapshotsFor(opts) {
+		if snap.GeneratedAt.After(generatedAt) {
+			generatedAt = snap.GeneratedAt
+		}
+		for _, src := range snap.Sources {
+			kind := string(src.Kind)
+			if kind == "" {
+				continue
+			}
+			if _, ok := seen[kind]; ok {
+				continue
+			}
+			seen[kind] = struct{}{}
+			sources = append(sources, kind)
+		}
+	}
+	return IntelSummary{
+		Mode:        mode,
+		Snapshot:    label,
+		GeneratedAt: generatedAt,
+		Sources:     sources,
+		Stale:       false,
+	}
 }
 
 // KnownCompromisedSnapshot converts the hand-curated KnownCompromised
@@ -130,51 +200,6 @@ func EmbeddedSnapshots() []intel.Snapshot {
 	return []intel.Snapshot{
 		KnownCompromisedSnapshot(),
 		EmbeddedIntelSnapshot,
-	}
-}
-
-// embeddedIntelSummary returns the IntelSummary that describes the
-// snapshots baked into the binary. Used by Check and CheckNPM so
-// every CheckResult carries provenance even when no runtime intel
-// store has been wired in yet.
-//
-// Mode stays "offline" because no network path exists yet; the
-// runtime-update PR will flip Mode to "online" when --fresh
-// produced the snapshot used. Snapshot stays "embedded" because
-// the local on-disk cache is not consulted here yet.
-//
-// GeneratedAt picks the LATER of the two source timestamps so the
-// user sees the freshest data the binary actually carries -- a
-// recent OSV regeneration shows through even if the manual list
-// has not changed. Sources is deduplicated by kind so the terminal
-// can read "Sources: manual, osv" without listing each source
-// entry separately.
-func embeddedIntelSummary() IntelSummary {
-	seen := make(map[string]struct{})
-	var sources []string
-	var generatedAt time.Time
-	for _, snap := range EmbeddedSnapshots() {
-		if snap.GeneratedAt.After(generatedAt) {
-			generatedAt = snap.GeneratedAt
-		}
-		for _, src := range snap.Sources {
-			kind := string(src.Kind)
-			if kind == "" {
-				continue
-			}
-			if _, ok := seen[kind]; ok {
-				continue
-			}
-			seen[kind] = struct{}{}
-			sources = append(sources, kind)
-		}
-	}
-	return IntelSummary{
-		Mode:        "offline",
-		Snapshot:    "embedded",
-		GeneratedAt: generatedAt,
-		Sources:     sources,
-		Stale:       false,
 	}
 }
 

--- a/internal/incident/npm.go
+++ b/internal/incident/npm.go
@@ -47,17 +47,15 @@ func CheckNPM(opts CheckOptions) (*CheckResult, error) {
 		Environment: root,
 		Findings:    []Finding{},
 		Credentials: []CredentialFile{},
-		Intel:       embeddedIntelSummary(),
+		Intel:       intelSummaryFor(opts),
 	}
 
 	// Same wiring as the Python check path: route through the
-	// embedded intel matcher (manual + OSV) so any OSV record the
-	// maintainer regenerates participates in the match. The
-	// legacy IsCompromisedIn is still exported for external
-	// callers, but the check pipeline no longer goes through it
-	// because that would advertise "osv" in the IntelSummary
-	// without actually consulting OSV records.
-	matcher := defaultIntelMatcher()
+	// intel matcher so any OSV record (embedded or refreshed)
+	// participates in the match. matcherFor honours opts.Intel
+	// so the CLI can pass a refreshed local snapshot without
+	// touching package-level state.
+	matcher := matcherFor(opts)
 	packages := readInstalledNPMPackages(root)
 	result.PackagesRead = len(packages)
 	for _, pkg := range packages {

--- a/internal/intel/update.go
+++ b/internal/intel/update.go
@@ -118,6 +118,20 @@ func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 	if len(ecosystems) == 0 {
 		ecosystems = []string{EcosystemNPM, EcosystemPyPI}
 	}
+	// Canonicalise before building URLs. OSV's GCS bucket keys
+	// are case-sensitive (`PyPI/all.zip`, not `pypi/all.zip`),
+	// so a user passing `--ecosystem pypi` would otherwise hit a
+	// 404 before the importer's canonicaliser had a chance to
+	// normalise the value.
+	canonical := make([]string, 0, len(ecosystems))
+	for _, raw := range ecosystems {
+		c := canonicaliseEcosystemForUpdate(raw)
+		if c == "" {
+			return nil, fmt.Errorf("intel update: unsupported ecosystem %q (supported: npm, PyPI)", raw)
+		}
+		canonical = append(canonical, c)
+	}
+	ecosystems = canonical
 	urlTmpl := opts.URLTemplate
 	if urlTmpl == "" {
 		urlTmpl = DefaultOSVURLTemplate
@@ -199,6 +213,25 @@ func fetchAndImport(ctx context.Context, client *http.Client, urlTmpl, ecosystem
 		return Snapshot{}, 0, fmt.Errorf("import: %w", err)
 	}
 	return snap, int64(len(data)), nil
+}
+
+// canonicaliseEcosystemForUpdate maps aliases ("pypi", "Python")
+// onto the canonical OSV bucket key (EcosystemPyPI = "PyPI",
+// EcosystemNPM = "npm"). Returns "" for unsupported inputs so
+// Update can fail loud rather than 404 on a wrongly-cased URL.
+//
+// This duplicates osvimport.canonicaliseEcosystem on purpose:
+// importing osvimport here would create a cycle (intel <-
+// osvimport <- intel), and the function is two switch-arms.
+func canonicaliseEcosystemForUpdate(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "npm":
+		return EcosystemNPM
+	case "pypi", "python":
+		return EcosystemPyPI
+	default:
+		return ""
+	}
 }
 
 // dedupeSources collapses the merged Sources slice to one entry

--- a/internal/intel/update.go
+++ b/internal/intel/update.go
@@ -1,0 +1,239 @@
+package intel
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DefaultOSVURLTemplate is the OSV.dev all.zip URL pattern. The
+// `%s` slot is filled with the canonical ecosystem identifier
+// (npm, PyPI). OSV serves these as static, cacheable blobs so the
+// download path is deterministic.
+const DefaultOSVURLTemplate = "https://storage.googleapis.com/osv-vulnerabilities/%s/all.zip"
+
+// DefaultHTTPTimeout caps each per-ecosystem download. OSV all.zip
+// dumps are large but the CDN is fast; a half-hour ceiling is
+// generous-with-headroom and prevents a hung connection from
+// stalling `aguara update` indefinitely.
+const DefaultHTTPTimeout = 30 * time.Minute
+
+// MaxHTTPBodyBytes caps how many compressed bytes we read from any
+// single OSV download. Tied to MaxZipBytes in osvimport so an
+// oversize download fails before it can fill memory.
+//
+// This is intentionally the SAME number as the importer's
+// MaxZipBytes (256 MiB) -- once the bytes leave this package they
+// hit osvimport's caps anyway, so duplicating the constant here is
+// for explicitness, not for layering.
+const MaxHTTPBodyBytes int64 = 256 * 1024 * 1024
+
+// UpdateOptions controls a refresh run. All fields are optional;
+// zero values are wired in Update so a caller that just wants
+// "refresh everything" can pass UpdateOptions{}.
+type UpdateOptions struct {
+	// Ecosystems to refresh. Empty defaults to [npm, PyPI] -- the
+	// two production ecosystems the importer supports. Adding
+	// more later requires both an importer canonicalisation
+	// entry and a server-side OSV slice.
+	Ecosystems []string
+	// HTTPClient overrides the client used to fetch OSV dumps.
+	// Tests pass httptest.NewServer()'s client; production
+	// leaves it nil to use http.DefaultClient with a per-call
+	// timeout.
+	HTTPClient *http.Client
+	// URLTemplate overrides DefaultOSVURLTemplate. Tests use
+	// httptest.NewServer().URL + "/%s/all.zip"; production
+	// leaves it empty.
+	URLTemplate string
+	// Now returns the current time. Tests inject a fixed time;
+	// production leaves it nil to use time.Now().
+	Now func() time.Time
+	// Importer overrides the snapshot-builder hook used to
+	// parse each downloaded zip. Tests can swap in a stub; the
+	// zero value uses osvimport.ImportFromZip.
+	Importer ImportFunc
+	// Stderr receives one-line progress messages (one per
+	// ecosystem) when non-nil. Production wires os.Stderr from
+	// the CLI; tests pass nil to suppress output.
+	Stderr io.Writer
+}
+
+// ImportFunc is the contract intel/update expects from the
+// osvimport package without importing it (avoiding the intel ->
+// osvimport -> intel cycle). It is satisfied by
+// osvimport.ImportFromZip; the CLI wires that in.
+type ImportFunc func(r io.ReaderAt, size int64, ecosystems []string, generatedAt time.Time) (Snapshot, error)
+
+// UpdateResult summarises a refresh run. The CLI prints it; tests
+// assert on the field values.
+type UpdateResult struct {
+	// Snapshot is the merged result the caller should hand to a
+	// Store. Empty Records means every requested ecosystem
+	// returned zero records (probably a server glitch); callers
+	// can decide whether to write it or keep the previous local
+	// snapshot.
+	Snapshot Snapshot
+	// PerEcosystem reports the record count produced by each
+	// ecosystem so the CLI can show "npm: 1234 records, PyPI:
+	// 567 records" rather than a single total.
+	PerEcosystem []EcosystemResult
+}
+
+// EcosystemResult is the per-ecosystem detail in UpdateResult.
+type EcosystemResult struct {
+	Ecosystem    string
+	RecordsKept  int
+	DownloadedAt time.Time
+	BytesRead    int64
+}
+
+// Update downloads OSV dumps for the requested ecosystems and
+// returns the merged snapshot. The caller is responsible for
+// passing the snapshot to a Store; Update does no I/O beyond HTTP
+// and import to keep the package testable without filesystem
+// side effects.
+//
+// Update is the single entry point production code (and tests) use
+// for refresh. It enforces:
+//   - per-request timeout
+//   - response size cap
+//   - per-ecosystem error short-circuit (one ecosystem's HTTP
+//     failure does not poison the others; the function returns the
+//     first error)
+//
+// The HTTP path is opt-in: nothing in the binary calls Update
+// unless the user explicitly runs `aguara update` or `aguara check
+// --fresh`. Default checks remain offline.
+func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
+	if opts.Importer == nil {
+		return nil, fmt.Errorf("intel update: Importer is required (CLI must wire osvimport.ImportFromZip)")
+	}
+	ecosystems := opts.Ecosystems
+	if len(ecosystems) == 0 {
+		ecosystems = []string{EcosystemNPM, EcosystemPyPI}
+	}
+	urlTmpl := opts.URLTemplate
+	if urlTmpl == "" {
+		urlTmpl = DefaultOSVURLTemplate
+	}
+	client := opts.HTTPClient
+	if client == nil {
+		client = &http.Client{Timeout: DefaultHTTPTimeout}
+	}
+	now := opts.Now
+	if now == nil {
+		now = func() time.Time { return time.Now().UTC() }
+	}
+
+	merged := Snapshot{
+		SchemaVersion: CurrentSchemaVersion,
+		GeneratedAt:   now(),
+	}
+	var per []EcosystemResult
+
+	for _, eco := range ecosystems {
+		snap, body, err := fetchAndImport(ctx, client, urlTmpl, eco, now(), opts.Importer)
+		if err != nil {
+			return nil, fmt.Errorf("intel update: %s: %w", eco, err)
+		}
+		merged.Sources = append(merged.Sources, snap.Sources...)
+		merged.Records = append(merged.Records, snap.Records...)
+		per = append(per, EcosystemResult{
+			Ecosystem:    eco,
+			RecordsKept:  len(snap.Records),
+			DownloadedAt: now(),
+			BytesRead:    body,
+		})
+		if opts.Stderr != nil {
+			fmt.Fprintf(opts.Stderr, "intel update: %s -> %d records (%d bytes)\n",
+				eco, len(snap.Records), body)
+		}
+	}
+
+	dedupeSources(&merged)
+	sortRecords(&merged)
+
+	return &UpdateResult{Snapshot: merged, PerEcosystem: per}, nil
+}
+
+// fetchAndImport downloads a single ecosystem dump and runs the
+// importer over it. Returns the snapshot plus the number of bytes
+// read so the per-ecosystem progress line is honest about what
+// crossed the network.
+func fetchAndImport(ctx context.Context, client *http.Client, urlTmpl, ecosystem string, generatedAt time.Time, importer ImportFunc) (Snapshot, int64, error) {
+	url := fmt.Sprintf(urlTmpl, ecosystem)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return Snapshot{}, 0, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "aguara-update/1.0 (+https://github.com/garagon/aguara)")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return Snapshot{}, 0, fmt.Errorf("http: %w", err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return Snapshot{}, 0, fmt.Errorf("http %d %s", resp.StatusCode, resp.Status)
+	}
+
+	limited := io.LimitReader(resp.Body, MaxHTTPBodyBytes+1)
+	data, err := io.ReadAll(limited)
+	if err != nil {
+		return Snapshot{}, 0, fmt.Errorf("read body: %w", err)
+	}
+	if int64(len(data)) > MaxHTTPBodyBytes {
+		return Snapshot{}, 0, fmt.Errorf("response %d bytes exceeds cap %d", len(data), MaxHTTPBodyBytes)
+	}
+
+	r := bytes.NewReader(data)
+	snap, err := importer(r, int64(len(data)), []string{ecosystem}, generatedAt)
+	if err != nil {
+		return Snapshot{}, 0, fmt.Errorf("import: %w", err)
+	}
+	return snap, int64(len(data)), nil
+}
+
+// dedupeSources collapses the merged Sources slice to one entry
+// per (Name, Kind, URL) so the rendered status output does not
+// repeat identical source rows. Order is preserved.
+func dedupeSources(snap *Snapshot) {
+	if len(snap.Sources) <= 1 {
+		return
+	}
+	seen := make(map[string]struct{}, len(snap.Sources))
+	out := snap.Sources[:0]
+	for _, src := range snap.Sources {
+		key := strings.Join([]string{src.Name, string(src.Kind), src.URL}, "\x00")
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, src)
+	}
+	snap.Sources = out
+}
+
+// sortRecords keeps the merged snapshot's record ordering stable
+// across runs (ecosystem, name, ID). Matches the importer's order
+// so a downstream diff between an embedded and a freshly-fetched
+// snapshot does not churn on ordering alone.
+func sortRecords(snap *Snapshot) {
+	sort.SliceStable(snap.Records, func(i, j int) bool {
+		a, b := snap.Records[i], snap.Records[j]
+		if a.Ecosystem != b.Ecosystem {
+			return a.Ecosystem < b.Ecosystem
+		}
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		return a.ID < b.ID
+	})
+}

--- a/internal/intel/update_test.go
+++ b/internal/intel/update_test.go
@@ -261,6 +261,57 @@ func TestUpdateRecordsStableOrder(t *testing.T) {
 	require.Equal(t, "z", res.Snapshot.Records[1].Name)
 }
 
+func TestUpdateCanonicalisesEcosystemAlias(t *testing.T) {
+	// Codex P2 (PR 4 review): a user typing `--ecosystem pypi`
+	// (lowercase) previously got a 404 because OSV's bucket key
+	// is case-sensitive (`PyPI/all.zip`). Canonicalise before
+	// building the URL so the alias resolves to the right path.
+	body := buildEcosystemZip(t)
+	var seenURLs []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenURLs = append(seenURLs, r.URL.Path)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	_, err := intel.Update(context.Background(), intel.UpdateOptions{
+		Ecosystems:  []string{"pypi", "python"},
+		URLTemplate: srv.URL + "/%s/all.zip",
+		HTTPClient:  srv.Client(),
+		Importer: importerStub(t, map[string]intel.Snapshot{
+			intel.EcosystemPyPI: {},
+		}),
+	})
+	require.NoError(t, err)
+	require.Len(t, seenURLs, 2)
+	for _, u := range seenURLs {
+		require.Equal(t, "/PyPI/all.zip", u, "alias must canonicalise to OSV's case-sensitive bucket key")
+	}
+}
+
+func TestUpdateRejectsUnsupportedEcosystemEarly(t *testing.T) {
+	// An unsupported ecosystem must fail BEFORE any HTTP request
+	// goes out. Otherwise a typo in `--ecosystem` (e.g. `npmm`)
+	// would hit OSV with a bad URL just to discover the input
+	// was wrong.
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		_, _ = w.Write([]byte("nope"))
+	}))
+	defer srv.Close()
+
+	_, err := intel.Update(context.Background(), intel.UpdateOptions{
+		Ecosystems:  []string{"npmm"},
+		URLTemplate: srv.URL + "/%s/all.zip",
+		HTTPClient:  srv.Client(),
+		Importer:    importerStub(t, map[string]intel.Snapshot{}),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "unsupported ecosystem")
+	require.False(t, called, "no HTTP request should fire for an unsupported ecosystem")
+}
+
 // TestUpdateSendsUserAgent locks the User-Agent header so OSV.dev
 // can attribute traffic to Aguara. Helps with rate-limit triage if
 // someone abuses the public dump. Marshalling via json so the

--- a/internal/intel/update_test.go
+++ b/internal/intel/update_test.go
@@ -1,0 +1,294 @@
+package intel_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+// importerStub is the test wiring for intel.UpdateOptions.Importer.
+// It does not actually parse OSV; it just returns the predefined
+// snapshot per ecosystem. That lets these tests cover Update's HTTP
+// + retry + cap behaviour without dragging in osvimport.
+func importerStub(t *testing.T, perEco map[string]intel.Snapshot) intel.ImportFunc {
+	t.Helper()
+	return func(r io.ReaderAt, size int64, ecosystems []string, generatedAt time.Time) (intel.Snapshot, error) {
+		if len(ecosystems) != 1 {
+			return intel.Snapshot{}, fmt.Errorf("test stub expects one ecosystem per call, got %v", ecosystems)
+		}
+		snap, ok := perEco[ecosystems[0]]
+		if !ok {
+			return intel.Snapshot{}, fmt.Errorf("test stub has no snapshot for ecosystem %q", ecosystems[0])
+		}
+		return snap, nil
+	}
+}
+
+// buildEcosystemZip writes a minimal in-memory zip the test
+// importer ignores but the HTTP handler serves. Keeping a real
+// zip on the wire exercises the size-cap path even though the
+// stub does not parse it.
+func buildEcosystemZip(t *testing.T) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	f, err := zw.Create("placeholder.json")
+	require.NoError(t, err)
+	_, err = f.Write([]byte(`{"id":"placeholder"}`))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	return buf.Bytes()
+}
+
+func TestUpdateMergesPerEcosystem(t *testing.T) {
+	// Update fetches one URL per ecosystem and merges the results.
+	// We stub the importer so the test owns what each ecosystem
+	// "contributes" without parsing real OSV JSON.
+	body := buildEcosystemZip(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	perEco := map[string]intel.Snapshot{
+		intel.EcosystemNPM: {
+			SchemaVersion: intel.CurrentSchemaVersion,
+			Sources: []intel.SourceMeta{{Name: "osv.dev/npm", Kind: intel.SourceOSV}},
+			Records: []intel.Record{
+				{ID: "MAL-NPM-1", Ecosystem: intel.EcosystemNPM, Name: "evil", Versions: []string{"1.0.0"}},
+			},
+		},
+		intel.EcosystemPyPI: {
+			SchemaVersion: intel.CurrentSchemaVersion,
+			Sources: []intel.SourceMeta{{Name: "osv.dev/PyPI", Kind: intel.SourceOSV}},
+			Records: []intel.Record{
+				{ID: "MAL-PY-1", Ecosystem: intel.EcosystemPyPI, Name: "evil", Versions: []string{"0.1.0"}},
+			},
+		},
+	}
+
+	res, err := intel.Update(context.Background(), intel.UpdateOptions{
+		Ecosystems:  []string{intel.EcosystemNPM, intel.EcosystemPyPI},
+		URLTemplate: srv.URL + "/%s/all.zip",
+		HTTPClient:  srv.Client(),
+		Importer:    importerStub(t, perEco),
+		Now:         func() time.Time { return time.Date(2026, time.May, 15, 0, 0, 0, 0, time.UTC) },
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Snapshot.Records, 2, "merged snapshot must carry one record per ecosystem")
+	require.Equal(t, 2, len(res.PerEcosystem))
+
+	// Order in PerEcosystem follows the input ecosystems slice
+	// so the CLI's progress output is predictable.
+	require.Equal(t, intel.EcosystemNPM, res.PerEcosystem[0].Ecosystem)
+	require.Equal(t, 1, res.PerEcosystem[0].RecordsKept)
+	require.Equal(t, intel.EcosystemPyPI, res.PerEcosystem[1].Ecosystem)
+}
+
+func TestUpdateRequiresImporter(t *testing.T) {
+	// Production callers must wire in the osvimport adapter; a
+	// nil Importer is a programmer bug, not a runtime error
+	// path we want to silently tolerate.
+	_, err := intel.Update(context.Background(), intel.UpdateOptions{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "Importer is required")
+}
+
+func TestUpdatePropagatesHTTPError(t *testing.T) {
+	// Non-200 responses must short-circuit the run; one
+	// ecosystem's HTTP failure (e.g. OSV.dev outage) should
+	// abort the refresh rather than write a partial snapshot.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, err := intel.Update(context.Background(), intel.UpdateOptions{
+		Ecosystems:  []string{intel.EcosystemNPM},
+		URLTemplate: srv.URL + "/%s/all.zip",
+		HTTPClient:  srv.Client(),
+		Importer:    importerStub(t, map[string]intel.Snapshot{}),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "http 500")
+}
+
+func TestUpdateEnforcesSizeCap(t *testing.T) {
+	// A response larger than MaxHTTPBodyBytes must be rejected
+	// before it can fill memory. We do not actually send 256 MiB
+	// in the test; we instead serve a body declared with a
+	// Content-Length that the LimitReader path can see, then
+	// pad past the cap. The trip-wire fires when the read
+	// produces more than MaxHTTPBodyBytes bytes.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Write MaxHTTPBodyBytes + 1 zero bytes. We do this
+		// in chunks so the test does not allocate the whole
+		// payload at once.
+		const chunk = 1 << 20 // 1 MiB
+		buf := make([]byte, chunk)
+		remaining := intel.MaxHTTPBodyBytes + 1
+		for remaining > 0 {
+			n := int64(chunk)
+			if n > remaining {
+				n = remaining
+			}
+			if _, err := w.Write(buf[:n]); err != nil {
+				return
+			}
+			remaining -= n
+		}
+	}))
+	defer srv.Close()
+
+	_, err := intel.Update(context.Background(), intel.UpdateOptions{
+		Ecosystems:  []string{intel.EcosystemNPM},
+		URLTemplate: srv.URL + "/%s/all.zip",
+		HTTPClient:  srv.Client(),
+		Importer:    importerStub(t, map[string]intel.Snapshot{}),
+	})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds cap")
+}
+
+func TestUpdateUsesDefaultEcosystems(t *testing.T) {
+	// Empty UpdateOptions.Ecosystems must default to [npm, PyPI]
+	// so users running `aguara update` with no flags get the
+	// production two-ecosystem refresh.
+	body := buildEcosystemZip(t)
+	var seenURLs []string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenURLs = append(seenURLs, r.URL.Path)
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	_, err := intel.Update(context.Background(), intel.UpdateOptions{
+		URLTemplate: srv.URL + "/%s/all.zip",
+		HTTPClient:  srv.Client(),
+		Importer: importerStub(t, map[string]intel.Snapshot{
+			intel.EcosystemNPM:  {SchemaVersion: intel.CurrentSchemaVersion},
+			intel.EcosystemPyPI: {SchemaVersion: intel.CurrentSchemaVersion},
+		}),
+	})
+	require.NoError(t, err)
+	require.Len(t, seenURLs, 2, "default ecosystems must produce two HTTP fetches")
+	require.Equal(t, "/npm/all.zip", seenURLs[0])
+	require.Equal(t, "/PyPI/all.zip", seenURLs[1])
+}
+
+func TestUpdateRespectsContextCancellation(t *testing.T) {
+	// A canceled context must short-circuit before the second
+	// ecosystem's request. We use a slow handler so the first
+	// request can succeed and the second one fires during
+	// cancellation.
+	body := buildEcosystemZip(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // pre-cancel: every request must fail
+
+	_, err := intel.Update(ctx, intel.UpdateOptions{
+		Ecosystems:  []string{intel.EcosystemNPM, intel.EcosystemPyPI},
+		URLTemplate: srv.URL + "/%s/all.zip",
+		HTTPClient:  srv.Client(),
+		Importer:    importerStub(t, map[string]intel.Snapshot{}),
+	})
+	require.Error(t, err, "canceled context must surface as an error")
+}
+
+func TestUpdateDedupesSourcesAcrossEcosystems(t *testing.T) {
+	// Two ecosystems that contribute the same (Name, Kind, URL)
+	// source entry must collapse to one in the merged Sources
+	// slice, so `aguara status` does not show duplicate rows.
+	body := buildEcosystemZip(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	shared := intel.SourceMeta{Name: "osv.dev", Kind: intel.SourceOSV, URL: "https://osv.dev"}
+	perEco := map[string]intel.Snapshot{
+		intel.EcosystemNPM:  {Sources: []intel.SourceMeta{shared}, Records: []intel.Record{{ID: "A", Ecosystem: intel.EcosystemNPM, Name: "a", Versions: []string{"1"}}}},
+		intel.EcosystemPyPI: {Sources: []intel.SourceMeta{shared}, Records: []intel.Record{{ID: "B", Ecosystem: intel.EcosystemPyPI, Name: "b", Versions: []string{"1"}}}},
+	}
+	res, err := intel.Update(context.Background(), intel.UpdateOptions{
+		Ecosystems:  []string{intel.EcosystemNPM, intel.EcosystemPyPI},
+		URLTemplate: srv.URL + "/%s/all.zip",
+		HTTPClient:  srv.Client(),
+		Importer:    importerStub(t, perEco),
+	})
+	require.NoError(t, err)
+	require.Len(t, res.Snapshot.Sources, 1, "identical Sources entries across ecosystems must collapse")
+}
+
+func TestUpdateRecordsStableOrder(t *testing.T) {
+	// Reproducible builds rely on stable record ordering -- the
+	// merged snapshot must come out sorted regardless of which
+	// ecosystem ran first.
+	body := buildEcosystemZip(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	perEco := map[string]intel.Snapshot{
+		intel.EcosystemNPM: {Records: []intel.Record{
+			{ID: "C", Ecosystem: intel.EcosystemNPM, Name: "z", Versions: []string{"1"}},
+			{ID: "A", Ecosystem: intel.EcosystemNPM, Name: "a", Versions: []string{"1"}},
+		}},
+	}
+	res, err := intel.Update(context.Background(), intel.UpdateOptions{
+		Ecosystems:  []string{intel.EcosystemNPM},
+		URLTemplate: srv.URL + "/%s/all.zip",
+		HTTPClient:  srv.Client(),
+		Importer:    importerStub(t, perEco),
+	})
+	require.NoError(t, err)
+	require.Equal(t, "a", res.Snapshot.Records[0].Name, "merged records must be sorted by name")
+	require.Equal(t, "z", res.Snapshot.Records[1].Name)
+}
+
+// TestUpdateSendsUserAgent locks the User-Agent header so OSV.dev
+// can attribute traffic to Aguara. Helps with rate-limit triage if
+// someone abuses the public dump. Marshalling via json so the
+// surface area is broad enough to catch a regression in either
+// req.Header or the constant itself.
+func TestUpdateSendsUserAgent(t *testing.T) {
+	body := buildEcosystemZip(t)
+	var seenUA string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenUA = r.Header.Get("User-Agent")
+		_, _ = w.Write(body)
+	}))
+	defer srv.Close()
+
+	_, err := intel.Update(context.Background(), intel.UpdateOptions{
+		Ecosystems:  []string{intel.EcosystemNPM},
+		URLTemplate: srv.URL + "/%s/all.zip",
+		HTTPClient:  srv.Client(),
+		Importer: importerStub(t, map[string]intel.Snapshot{
+			intel.EcosystemNPM: {},
+		}),
+	})
+	require.NoError(t, err)
+	require.Contains(t, seenUA, "aguara")
+
+	// Sanity: the snapshot can round-trip JSON, the runtime
+	// contract IntelSummary downstream callers depend on.
+	encoded, err := json.Marshal(intel.Snapshot{})
+	require.NoError(t, err)
+	require.NotEmpty(t, encoded)
+}


### PR DESCRIPTION
## Summary

Step 4 of the native-threat-intel roadmap. Stacks on #87 -- please
land #86 and #87 first. Adds the opt-in network path the previous PRs
were architected for.

### `internal/intel/update.go`

- `Update(ctx, opts)` fetches OSV.dev `all.zip` per ecosystem (npm,
  PyPI by default), runs the importer hook, merges per-ecosystem
  snapshots, dedupes Sources, sorts records. Bounded by per-request
  timeout (30 min default) and 256 MiB response cap.
- No I/O beyond HTTP + in-memory import so tests use
  `httptest.NewServer` without disk side effects.
- `ImportFunc` is a function-typed contract; the CLI wires
  `osvimport.ImportFromZip` in to avoid an `intel -> osvimport -> intel`
  cycle.
- Canonicalises aliases (`pypi`, `python`) to OSV's case-sensitive
  bucket key (`PyPI`) BEFORE formatting the URL so a lowercase flag
  resolves correctly.

### New `aguara update` command

Refreshes the local snapshot, writes to `~/.aguara/intel/snapshot.json`
via `intel.Store.Save`. Updates THREAT INTEL only -- not the binary.
Refuses to overwrite the cache with a 0-record snapshot (OSV outage
or upstream schema shift would otherwise silently wipe cached intel);
`--allow-empty` opt-in for the bootstrap case.

### New `aguara status` command

Prints version, embedded snapshot ages + record counts, local cache
state (HasSnapshot, GeneratedAt, RecordCount). No network.

### `aguara check --fresh` / `--allow-stale`

- `--fresh` runs `intel.Update` before the scan; on success layers
  the refreshed snapshot over the embedded snapshots and the
  `IntelSummary` flips to `mode = "online"`, `snapshot = "remote-fresh"`.
- `--allow-stale` falls back to local-or-embedded when the refresh
  fails (CI-friendly).
- When NO `--fresh` is passed AND a local snapshot exists, it's
  layered over embedded automatically; `IntelSummary.Snapshot = "local"`.
- When nothing local exists, the cached default matcher is used --
  the legacy behaviour, no per-check allocation.

### `internal/incident` wiring

- `CheckOptions.Intel *IntelOverride` is the new injection seam.
  Legacy callers (`CheckOptions{Path: ...}`) still get the cached
  default matcher and the embedded IntelSummary.
- `matcherFor(opts)` / `snapshotsFor(opts)` / `intelSummaryFor(opts)`
  centralise the override-or-default decision so the IntelSummary
  always describes the snapshots actually consulted.
- `embeddedIntelSummary` is gone -- one source of truth.

## Codex pre-PR review (1 round, 2 fixes -- stopped on the same axis)

- R1 P2: `--ecosystem pypi` (lowercase) 404'd because OSV's bucket
  key is case-sensitive. Canonicalise aliases before URL formatting;
  reject unsupported ecosystems BEFORE any HTTP fires.
- R1 P2: `aguara update` overwrote the local cache with a 0-record
  snapshot (OSV outage / schema shift). Default-error, opt-in
  `--allow-empty` for the bootstrap case (mirrors `update-intel`'s
  flag).

Stopped here per the tightened stop rule -- both findings were on
the input-validation / "don't silently overwrite" axis PR 3 already
exhausted. Further rounds on this PR would likely surface the same
theme in a third location.

## Test plan

- [x] `go test -race -count=1 ./...`
- [x] `make vet`
- [x] `make lint` (0 issues)
- [x] `intel.Update`: per-ecosystem merge, default ecosystems list
      ([npm, PyPI]), HTTP 500 error, size cap rejection, context
      cancellation, User-Agent header, source dedup, stable record
      order, ecosystem alias canonicalisation, unsupported-ecosystem
      early rejection (no HTTP fires).
- [x] `aguara status`: prints Version + Embedded + Network sections;
      reads local snapshot from HOME-override fixture.
- [x] All paths use `httptest.Server` / temp HOME so the suite stays
      hermetic.