### PR TITLE
feat(audit): aguara audit composes scan + check into one verdict

### DIFF
--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -64,10 +64,12 @@ type AuditVerdict struct {
 	Status            string `json:"status"` // "pass" | "fail"
 	CheckCriticals    int    `json:"check_criticals"`
 	CheckWarnings     int    `json:"check_warnings"`
+	CheckInfos        int    `json:"check_infos"`
 	ScanCriticals     int    `json:"scan_criticals"`
 	ScanHighs         int    `json:"scan_highs"`
 	ScanMediums       int    `json:"scan_mediums"`
 	ScanLows          int    `json:"scan_lows"`
+	ScanInfos         int    `json:"scan_infos"`
 	ThresholdExceeded bool   `json:"threshold_exceeded"`
 }
 
@@ -128,7 +130,15 @@ func runAudit(cmd *cobra.Command, args []string) error {
 		Scan:   scanResult,
 		Intel:  checkResult.Intel,
 	}
-	result.Verdict = computeAuditVerdict(result, flagAuditFailOn)
+	verdict, vErr := computeAuditVerdict(result, flagAuditFailOn)
+	if vErr != nil {
+		// An invalid --fail-on value must error rather than
+		// silently disable the gate. scan / check both do the
+		// same; audit must not be the one path where a typo
+		// (--fail-on critcal) ships green.
+		return vErr
+	}
+	result.Verdict = verdict
 
 	// 4. Emit.
 	if flagFormat == "json" {
@@ -218,7 +228,7 @@ func auditRunScan(cmd *cobra.Command, targetPath string) (*scanner.ScanResult, e
 // surprise users who expect "warning" to mean "the loudest of the
 // non-critical buckets" in both vocabularies. The simple mapping
 // also means a single --fail-on flag is unambiguous in CI logs.
-func computeAuditVerdict(result *AuditResult, threshold string) AuditVerdict {
+func computeAuditVerdict(result *AuditResult, threshold string) (AuditVerdict, error) {
 	v := AuditVerdict{Status: "pass"}
 
 	for _, f := range result.Check.Findings {
@@ -227,6 +237,8 @@ func computeAuditVerdict(result *AuditResult, threshold string) AuditVerdict {
 			v.CheckCriticals++
 		case incident.SevWarning:
 			v.CheckWarnings++
+		case incident.SevInfo:
+			v.CheckInfos++
 		}
 	}
 	for _, f := range result.Scan.Findings {
@@ -239,11 +251,13 @@ func computeAuditVerdict(result *AuditResult, threshold string) AuditVerdict {
 			v.ScanMediums++
 		case scanner.SeverityLow:
 			v.ScanLows++
+		case scanner.SeverityInfo:
+			v.ScanInfos++
 		}
 	}
 
 	if threshold == "" {
-		return v
+		return v, nil
 	}
 	switch strings.ToUpper(strings.TrimSpace(threshold)) {
 	case "CRITICAL":
@@ -256,16 +270,23 @@ func computeAuditVerdict(result *AuditResult, threshold string) AuditVerdict {
 			v.ThresholdExceeded = true
 		}
 	case "INFO":
-		// Any finding at all trips the gate.
-		if v.CheckCriticals+v.CheckWarnings > 0 ||
-			v.ScanCriticals+v.ScanHighs+v.ScanMediums+v.ScanLows > 0 {
+		// Any finding at all trips the gate, including INFO
+		// on either side. The earlier shape silently dropped
+		// INFO findings, so a custom INFO-only rule could
+		// have passed `--fail-on info` cleanly. That broke the
+		// "lowest threshold" contract; the explicit InfoCount
+		// fields above feed this gate now.
+		if v.CheckCriticals+v.CheckWarnings+v.CheckInfos > 0 ||
+			v.ScanCriticals+v.ScanHighs+v.ScanMediums+v.ScanLows+v.ScanInfos > 0 {
 			v.ThresholdExceeded = true
 		}
+	default:
+		return v, fmt.Errorf("invalid --fail-on %q: choose critical, warning, or info", threshold)
 	}
 	if v.ThresholdExceeded {
 		v.Status = "fail"
 	}
-	return v
+	return v, nil
 }
 
 func writeAuditJSON(result *AuditResult) error {

--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -1,0 +1,354 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+	"github.com/spf13/cobra"
+)
+
+var (
+	flagAuditPath       string
+	flagAuditCI         bool
+	flagAuditFailOn     string
+	flagAuditFresh      bool
+	flagAuditAllowStale bool
+)
+
+var auditCmd = &cobra.Command{
+	Use:   "audit [path]",
+	Short: "Run scan + check together and produce a single verdict",
+	Long: `Audit a project: run the supply-chain check (compromised packages /
+persistence artifacts) and the content scan (rule-based detection of
+prompt injection, credential leaks, etc.) together, and report a
+single combined verdict.
+
+Default audits stay offline -- they use the same embedded threat intel
+the standalone 'aguara check' uses. Pass --fresh to refresh OSV intel
+before the audit. Pass --ci to fail-on critical with no color (the
+default for unattended CI runs).`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runAudit,
+}
+
+func init() {
+	auditCmd.Flags().StringVar(&flagAuditPath, "path", "", "Path to audit (also accepted as a positional argument; defaults to '.')")
+	auditCmd.Flags().BoolVar(&flagAuditCI, "ci", false, "CI mode: --fail-on critical, no color")
+	auditCmd.Flags().StringVar(&flagAuditFailOn, "fail-on", "", "Exit code 1 when findings reach this severity (critical, warning, info)")
+	auditCmd.Flags().BoolVar(&flagAuditFresh, "fresh", false, "Refresh threat intel before the audit (network opt-in)")
+	auditCmd.Flags().BoolVar(&flagAuditAllowStale, "allow-stale", false, "Continue with cached/embedded intel if --fresh refresh fails")
+	rootCmd.AddCommand(auditCmd)
+}
+
+// AuditResult is the combined output of `aguara audit`. Both
+// sub-results retain their full shape so JSON consumers can drill
+// into either side; the verdict + summary fields are convenience
+// for terminal output and CI gates.
+type AuditResult struct {
+	Target  string                 `json:"target"`
+	Check   *incident.CheckResult  `json:"check"`
+	Scan    *scanner.ScanResult    `json:"scan"`
+	Verdict AuditVerdict           `json:"verdict"`
+	Intel   incident.IntelSummary  `json:"intel"`
+}
+
+// AuditVerdict is the single-line summary the CLI prints under
+// the two sub-result sections.
+type AuditVerdict struct {
+	Status            string `json:"status"` // "pass" | "fail"
+	CheckCriticals    int    `json:"check_criticals"`
+	CheckWarnings     int    `json:"check_warnings"`
+	ScanCriticals     int    `json:"scan_criticals"`
+	ScanHighs         int    `json:"scan_highs"`
+	ScanMediums       int    `json:"scan_mediums"`
+	ScanLows          int    `json:"scan_lows"`
+	ThresholdExceeded bool   `json:"threshold_exceeded"`
+}
+
+func runAudit(cmd *cobra.Command, args []string) error {
+	applyAuditCIDefaults()
+
+	target := flagAuditPath
+	if target == "" && len(args) == 1 {
+		target = args[0]
+	}
+	if target == "" {
+		target = "."
+	}
+
+	// Intel override: reuse the standalone check's resolution
+	// helper. We mirror audit's --fresh / --allow-stale flags
+	// onto the check-side globals so resolveCheckIntel reads the
+	// right intent. Restoring them on exit keeps the two surfaces
+	// from leaking state across commands in long-lived test runs.
+	prevFresh, prevAllowStale := flagCheckFresh, flagCheckAllowStale
+	flagCheckFresh, flagCheckAllowStale = flagAuditFresh, flagAuditAllowStale
+	defer func() { flagCheckFresh, flagCheckAllowStale = prevFresh, prevAllowStale }()
+
+	intelOverride, err := resolveCheckIntel(cmd.Context())
+	if err != nil {
+		return err
+	}
+
+	// 1. Run the supply-chain check.
+	checkEco, checkPath, err := resolveCheckTarget("", target)
+	if err != nil {
+		return err
+	}
+	checkOpts := incident.CheckOptions{Path: checkPath, Intel: intelOverride}
+	var checkResult *incident.CheckResult
+	switch checkEco {
+	case ecoPython:
+		checkResult, err = incident.Check(checkOpts)
+	case ecoNPM:
+		checkResult, err = incident.CheckNPM(checkOpts)
+	default:
+		return fmt.Errorf("audit: unresolved ecosystem %q", checkEco)
+	}
+	if err != nil {
+		return fmt.Errorf("audit: check phase: %w", err)
+	}
+
+	// 2. Run the content scan.
+	scanResult, err := auditRunScan(cmd, target)
+	if err != nil {
+		return fmt.Errorf("audit: scan phase: %w", err)
+	}
+
+	// 3. Compose result + verdict.
+	result := &AuditResult{
+		Target: target,
+		Check:  checkResult,
+		Scan:   scanResult,
+		Intel:  checkResult.Intel,
+	}
+	result.Verdict = computeAuditVerdict(result, flagAuditFailOn)
+
+	// 4. Emit.
+	if flagFormat == "json" {
+		if err := writeAuditJSON(result); err != nil {
+			return err
+		}
+	} else {
+		if err := writeAuditTerminal(result); err != nil {
+			return err
+		}
+	}
+
+	if result.Verdict.ThresholdExceeded {
+		return ErrThresholdExceeded
+	}
+	return nil
+}
+
+// applyAuditCIDefaults mirrors check / scan: --ci implies
+// --fail-on critical (unless the user set --fail-on explicitly)
+// and disables color. NO_COLOR also disables color so the flag
+// interacts cleanly with CI runners that set it by convention.
+func applyAuditCIDefaults() {
+	if flagAuditCI {
+		if flagAuditFailOn == "" {
+			flagAuditFailOn = "critical"
+		}
+		flagNoColor = true
+	}
+	if os.Getenv("NO_COLOR") != "" {
+		flagNoColor = true
+	}
+}
+
+// auditRunScan invokes the scanner against the target path using
+// the same helpers runScan uses. Kept as a thin shim so the audit
+// command does not duplicate scanner-construction logic; if the
+// scan pipeline grows new flags, audit picks them up automatically.
+//
+// Note we do NOT honour --severity for audit: the audit's job is
+// to be a strict gate, so we always run with SeverityInfo and let
+// the verdict / --fail-on threshold filter what matters.
+func auditRunScan(cmd *cobra.Command, targetPath string) (*scanner.ScanResult, error) {
+	cfg := loadScanConfig(cmd, targetPath)
+
+	compiled, err := loadAndCompileRules(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	s, store := buildScanner(compiled, cfg, scanner.SeverityInfo)
+	sp := startSpinnerIfTerminal(s, "Auditing content...")
+
+	ctx, cancel := contextWithInterrupt()
+	defer cancel()
+
+	result, err := executeScan(ctx, s, targetPath)
+	stopSpinner(sp)
+	if err != nil {
+		return nil, err
+	}
+	result.RulesLoaded = len(compiled)
+	result.Target = targetPath
+
+	if store != nil {
+		if err := store.Save(); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: saving state: %v\n", err)
+		}
+	}
+
+	if !flagNoRedact {
+		types.RedactCredentialFindings(result.Findings)
+	}
+	return result, nil
+}
+
+// computeAuditVerdict tallies per-section severities and decides
+// whether the --fail-on threshold trips. The threshold mapping
+// between audit's vocabulary (critical / warning / info) and
+// scan's numeric Severity is intentionally simple:
+//
+//	critical -> check critical, scan critical
+//	warning  -> check warning,  scan high
+//	info     -> check info,     scan info
+//
+// A finer-grained mapping (e.g. warning matches medium) would
+// surprise users who expect "warning" to mean "the loudest of the
+// non-critical buckets" in both vocabularies. The simple mapping
+// also means a single --fail-on flag is unambiguous in CI logs.
+func computeAuditVerdict(result *AuditResult, threshold string) AuditVerdict {
+	v := AuditVerdict{Status: "pass"}
+
+	for _, f := range result.Check.Findings {
+		switch strings.ToUpper(f.Severity) {
+		case incident.SevCritical:
+			v.CheckCriticals++
+		case incident.SevWarning:
+			v.CheckWarnings++
+		}
+	}
+	for _, f := range result.Scan.Findings {
+		switch f.Severity {
+		case scanner.SeverityCritical:
+			v.ScanCriticals++
+		case scanner.SeverityHigh:
+			v.ScanHighs++
+		case scanner.SeverityMedium:
+			v.ScanMediums++
+		case scanner.SeverityLow:
+			v.ScanLows++
+		}
+	}
+
+	if threshold == "" {
+		return v
+	}
+	switch strings.ToUpper(strings.TrimSpace(threshold)) {
+	case "CRITICAL":
+		if v.CheckCriticals > 0 || v.ScanCriticals > 0 {
+			v.ThresholdExceeded = true
+		}
+	case "WARNING":
+		if v.CheckCriticals > 0 || v.CheckWarnings > 0 ||
+			v.ScanCriticals > 0 || v.ScanHighs > 0 {
+			v.ThresholdExceeded = true
+		}
+	case "INFO":
+		// Any finding at all trips the gate.
+		if v.CheckCriticals+v.CheckWarnings > 0 ||
+			v.ScanCriticals+v.ScanHighs+v.ScanMediums+v.ScanLows > 0 {
+			v.ThresholdExceeded = true
+		}
+	}
+	if v.ThresholdExceeded {
+		v.Status = "fail"
+	}
+	return v
+}
+
+func writeAuditJSON(result *AuditResult) error {
+	w := os.Stdout
+	if flagOutput != "" {
+		f, err := os.Create(flagOutput)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+		w = f
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func writeAuditTerminal(result *AuditResult) error {
+	bold := "\033[1m"
+	dim := "\033[2m"
+	red := "\033[31m"
+	green := "\033[32m"
+	yellow := "\033[33m"
+	reset := "\033[0m"
+	if flagNoColor {
+		bold, dim, red, green, yellow, reset = "", "", "", "", "", ""
+	}
+
+	fmt.Printf("\n%sAguara audit: %s%s\n\n", bold, result.Target, reset)
+
+	fmt.Printf("%sSupply chain%s\n", bold, reset)
+	if len(result.Check.Findings) == 0 {
+		fmt.Printf("  %s✔ No compromised packages or artifacts found.%s\n", green, reset)
+	} else {
+		for _, f := range result.Check.Findings {
+			sev := red
+			if f.Severity == incident.SevWarning {
+				sev = yellow
+			}
+			fmt.Printf("  %s%-10s%s %s\n", sev, f.Severity, reset, f.Title)
+			if f.Path != "" {
+				fmt.Printf("           %sPath: %s%s\n", dim, f.Path, reset)
+			}
+		}
+	}
+
+	fmt.Printf("\n%sContent scan%s\n", bold, reset)
+	if len(result.Scan.Findings) == 0 {
+		fmt.Printf("  %s✔ No content findings.%s\n", green, reset)
+	} else {
+		// Cap the verbose listing -- a noisy repo can dump
+		// hundreds of low-severity findings into the audit
+		// output. Showing all of them buries the verdict.
+		const maxList = 10
+		shown := 0
+		for _, f := range result.Scan.Findings {
+			if shown >= maxList {
+				break
+			}
+			fmt.Printf("  %s%-9s%s %s (%s)\n", red, f.Severity.String(), reset, f.RuleName, f.RuleID)
+			if f.FilePath != "" {
+				fmt.Printf("           %s%s:%d%s\n", dim, f.FilePath, f.Line, reset)
+			}
+			shown++
+		}
+		if len(result.Scan.Findings) > maxList {
+			fmt.Printf("  %s... +%d more (full list in --format json)%s\n",
+				dim, len(result.Scan.Findings)-maxList, reset)
+		}
+	}
+
+	fmt.Printf("\n%sIntel:%s mode=%s snapshot=%s sources=%v generated=%s\n",
+		bold, reset, result.Intel.Mode, result.Intel.Snapshot,
+		result.Intel.Sources, result.Intel.GeneratedAt.Format(time.DateOnly))
+
+	verdictColor := green
+	if result.Verdict.ThresholdExceeded {
+		verdictColor = red
+	}
+	fmt.Printf("\n%s%sVerdict: %s%s (check: %d critical / %d warning, scan: %d critical / %d high)\n",
+		verdictColor, bold, strings.ToUpper(result.Verdict.Status), reset,
+		result.Verdict.CheckCriticals, result.Verdict.CheckWarnings,
+		result.Verdict.ScanCriticals, result.Verdict.ScanHighs)
+	return nil
+}
+

--- a/cmd/aguara/commands/audit_test.go
+++ b/cmd/aguara/commands/audit_test.go
@@ -1,0 +1,185 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+	"github.com/stretchr/testify/require"
+)
+
+// auditToFile runs `aguara audit` with the given args, writes JSON
+// output to a temp file via `-o`, and returns the parsed result.
+// Same pattern as scanToFile / checkToFile.
+func auditToFile(t *testing.T, args ...string) *AuditResult {
+	t.Helper()
+	resetFlags()
+	outFile := filepath.Join(t.TempDir(), "audit.json")
+	fullArgs := append([]string{"audit"}, args...)
+	fullArgs = append(fullArgs, "-o", outFile, "--format", "json", "--no-update-check")
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs(fullArgs)
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		resetFlags()
+	})
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	var result AuditResult
+	require.NoError(t, json.Unmarshal(data, &result))
+	return &result
+}
+
+func TestAuditCleanProject(t *testing.T) {
+	// An empty project audit must succeed cleanly: check passes
+	// (no compromised packages), scan passes (no findings), and
+	// the verdict is "pass" with zero counts.
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# clean"), 0o644))
+
+	result := auditToFile(t, dir)
+	require.NotNil(t, result.Check)
+	require.NotNil(t, result.Scan)
+	require.Equal(t, "pass", result.Verdict.Status)
+	require.False(t, result.Verdict.ThresholdExceeded)
+	require.Empty(t, result.Check.Findings)
+}
+
+func TestAuditDetectsCompromisedNPMPackage(t *testing.T) {
+	// Audit on a project with a known-compromised npm package
+	// surfaces it in the Check sub-result and the verdict
+	// reflects the critical count. The supply-chain side carries
+	// IntelSummary so the JSON consumer sees provenance.
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	require.NoError(t, os.MkdirAll(filepath.Join(nm, "event-stream"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(nm, "event-stream", "package.json"),
+		[]byte(`{"name":"event-stream","version":"3.3.6"}`),
+		0o644,
+	))
+
+	result := auditToFile(t, dir)
+	require.NotEmpty(t, result.Check.Findings, "compromised event-stream@3.3.6 must surface in audit")
+	require.Greater(t, result.Verdict.CheckCriticals, 0)
+}
+
+func TestAuditCIFailsOnCritical(t *testing.T) {
+	// audit --ci with a compromised package must exit non-zero
+	// so a release pipeline gates on it. Subprocess pattern:
+	// ErrThresholdExceeded is the sentinel main.go maps to
+	// os.Exit(1).
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	require.NoError(t, os.MkdirAll(filepath.Join(nm, "event-stream"), 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(nm, "event-stream", "package.json"),
+		[]byte(`{"name":"event-stream","version":"3.3.6"}`),
+		0o644,
+	))
+
+	cmd := exec.Command("go", "test", "-race", "-count=1",
+		"-run", "TestAuditCIFailsOnCriticalHelper",
+		"./cmd/aguara/commands/",
+	)
+	cmd.Dir = filepath.Join("..", "..", "..")
+	cmd.Env = append(os.Environ(), "AGUARA_TEST_AUDIT_CI_DIR="+dir)
+
+	out, err := cmd.CombinedOutput()
+	require.Error(t, err, "expected non-zero exit: %s", string(out))
+}
+
+// TestAuditCIFailsOnCriticalHelper is invoked by TestAuditCIFailsOnCritical
+// in a subprocess; skipped when not.
+func TestAuditCIFailsOnCriticalHelper(t *testing.T) {
+	dir := os.Getenv("AGUARA_TEST_AUDIT_CI_DIR")
+	if dir == "" {
+		t.Skip("only runs as subprocess of TestAuditCIFailsOnCritical")
+	}
+	resetFlags()
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{
+		"audit", dir,
+		"--ci",
+		"--format", "json",
+		"-o", filepath.Join(t.TempDir(), "out.json"),
+		"--no-update-check",
+	})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		resetFlags()
+	})
+
+	if err := rootCmd.Execute(); errors.Is(err, ErrThresholdExceeded) {
+		os.Exit(1)
+	}
+}
+
+func TestAuditVerdictWarningTrips(t *testing.T) {
+	// computeAuditVerdict's warning threshold must trip on
+	// either a check warning OR a scan high. Direct unit test
+	// because building a fixture that emits a scan-high finding
+	// from the audit pipeline is expensive.
+	result := &AuditResult{
+		Check: nil,
+		Scan:  nil,
+	}
+	// Use the public-but-internal helper via reflection of the
+	// computed fields. Simpler: stub the result + call the
+	// helper directly.
+	v := computeAuditVerdict(stubAuditResult(t, 0, 1, 0, 0), "warning")
+	require.True(t, v.ThresholdExceeded)
+	require.Equal(t, "fail", v.Status)
+	require.Equal(t, 1, v.CheckWarnings)
+
+	v = computeAuditVerdict(stubAuditResult(t, 0, 0, 0, 1), "warning")
+	require.True(t, v.ThresholdExceeded, "scan high must trip warning threshold")
+	_ = result
+}
+
+func TestAuditVerdictCriticalPassesOnWarningOnly(t *testing.T) {
+	v := computeAuditVerdict(stubAuditResult(t, 0, 1, 0, 0), "critical")
+	require.False(t, v.ThresholdExceeded, "single warning must not trip critical gate")
+	require.Equal(t, "pass", v.Status)
+}
+
+// stubAuditResult builds a minimal AuditResult with the requested
+// finding counts. checkC/W are check criticals/warnings;
+// scanC/H are scan criticals/highs. Used in the verdict unit
+// tests.
+func stubAuditResult(t *testing.T, checkC, checkW, scanC, scanH int) *AuditResult {
+	t.Helper()
+	check := &incident.CheckResult{}
+	for i := 0; i < checkC; i++ {
+		check.Findings = append(check.Findings, incident.Finding{Severity: incident.SevCritical})
+	}
+	for i := 0; i < checkW; i++ {
+		check.Findings = append(check.Findings, incident.Finding{Severity: incident.SevWarning})
+	}
+	scan := &scanner.ScanResult{}
+	for i := 0; i < scanC; i++ {
+		scan.Findings = append(scan.Findings, types.Finding{Severity: scanner.SeverityCritical})
+	}
+	for i := 0; i < scanH; i++ {
+		scan.Findings = append(scan.Findings, types.Finding{Severity: scanner.SeverityHigh})
+	}
+	return &AuditResult{Check: check, Scan: scan}
+}

--- a/cmd/aguara/commands/audit_test.go
+++ b/cmd/aguara/commands/audit_test.go
@@ -138,34 +138,54 @@ func TestAuditVerdictWarningTrips(t *testing.T) {
 	// either a check warning OR a scan high. Direct unit test
 	// because building a fixture that emits a scan-high finding
 	// from the audit pipeline is expensive.
-	result := &AuditResult{
-		Check: nil,
-		Scan:  nil,
-	}
-	// Use the public-but-internal helper via reflection of the
-	// computed fields. Simpler: stub the result + call the
-	// helper directly.
-	v := computeAuditVerdict(stubAuditResult(t, 0, 1, 0, 0), "warning")
+	v, err := computeAuditVerdict(stubAuditResult(t, 0, 1, 0, 0, 0, 0), "warning")
+	require.NoError(t, err)
 	require.True(t, v.ThresholdExceeded)
 	require.Equal(t, "fail", v.Status)
 	require.Equal(t, 1, v.CheckWarnings)
 
-	v = computeAuditVerdict(stubAuditResult(t, 0, 0, 0, 1), "warning")
+	v, err = computeAuditVerdict(stubAuditResult(t, 0, 0, 0, 1, 0, 0), "warning")
+	require.NoError(t, err)
 	require.True(t, v.ThresholdExceeded, "scan high must trip warning threshold")
-	_ = result
 }
 
 func TestAuditVerdictCriticalPassesOnWarningOnly(t *testing.T) {
-	v := computeAuditVerdict(stubAuditResult(t, 0, 1, 0, 0), "critical")
+	v, err := computeAuditVerdict(stubAuditResult(t, 0, 1, 0, 0, 0, 0), "critical")
+	require.NoError(t, err)
 	require.False(t, v.ThresholdExceeded, "single warning must not trip critical gate")
 	require.Equal(t, "pass", v.Status)
 }
 
+func TestAuditVerdictInfoTripsOnInfoFindings(t *testing.T) {
+	// Codex P2 regression (PR 5 review): --fail-on info must
+	// trip on INFO-level findings from either side. The earlier
+	// shape only summed critical/warning for check and
+	// critical/high/medium/low for scan, so an INFO-only
+	// finding could pass --fail-on info cleanly. That broke the
+	// "lowest threshold" contract.
+	v, err := computeAuditVerdict(stubAuditResult(t, 0, 0, 0, 0, 1, 0), "info")
+	require.NoError(t, err)
+	require.True(t, v.ThresholdExceeded, "check INFO must trip --fail-on info")
+
+	v, err = computeAuditVerdict(stubAuditResult(t, 0, 0, 0, 0, 0, 1), "info")
+	require.NoError(t, err)
+	require.True(t, v.ThresholdExceeded, "scan INFO must trip --fail-on info")
+}
+
+func TestAuditVerdictRejectsInvalidThreshold(t *testing.T) {
+	// Codex P2 regression (PR 5 review): a typo in --fail-on
+	// previously fell through the switch without setting
+	// ThresholdExceeded and the audit exited green. scan and
+	// check both reject invalid thresholds; audit must do the
+	// same so a CI typo cannot silently disable the gate.
+	_, err := computeAuditVerdict(stubAuditResult(t, 1, 0, 0, 0, 0, 0), "critcal") // intentional typo
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid --fail-on")
+}
+
 // stubAuditResult builds a minimal AuditResult with the requested
-// finding counts. checkC/W are check criticals/warnings;
-// scanC/H are scan criticals/highs. Used in the verdict unit
-// tests.
-func stubAuditResult(t *testing.T, checkC, checkW, scanC, scanH int) *AuditResult {
+// finding counts. Used in the verdict unit tests.
+func stubAuditResult(t *testing.T, checkC, checkW, scanC, scanH, checkI, scanI int) *AuditResult {
 	t.Helper()
 	check := &incident.CheckResult{}
 	for i := 0; i < checkC; i++ {
@@ -174,12 +194,18 @@ func stubAuditResult(t *testing.T, checkC, checkW, scanC, scanH int) *AuditResul
 	for i := 0; i < checkW; i++ {
 		check.Findings = append(check.Findings, incident.Finding{Severity: incident.SevWarning})
 	}
+	for i := 0; i < checkI; i++ {
+		check.Findings = append(check.Findings, incident.Finding{Severity: incident.SevInfo})
+	}
 	scan := &scanner.ScanResult{}
 	for i := 0; i < scanC; i++ {
 		scan.Findings = append(scan.Findings, types.Finding{Severity: scanner.SeverityCritical})
 	}
 	for i := 0; i < scanH; i++ {
 		scan.Findings = append(scan.Findings, types.Finding{Severity: scanner.SeverityHigh})
+	}
+	for i := 0; i < scanI; i++ {
+		scan.Findings = append(scan.Findings, types.Finding{Severity: scanner.SeverityInfo})
 	}
 	return &AuditResult{Check: check, Scan: scan}
 }

--- a/cmd/aguara/commands/scan_test.go
+++ b/cmd/aguara/commands/scan_test.go
@@ -43,6 +43,11 @@ func resetFlags() {
 	flagUpdateTimeout = intel.DefaultHTTPTimeout
 	flagUpdateEcosystems = nil
 	flagUpdateAllowEmpty = false
+	flagAuditPath = ""
+	flagAuditCI = false
+	flagAuditFailOn = ""
+	flagAuditFresh = false
+	flagAuditAllowStale = false
 }
 
 // scanToFile runs aguara scan and writes output to a temp file, returning the content.


### PR DESCRIPTION
## Summary

Step 5 (final) of the native-threat-intel roadmap. Stacks on #88 --
please land #86, #87, #88 first.

`aguara audit [path]` runs the supply-chain check and the content scan
against the same path and prints a single verdict. No new analyzer
logic; this PR orchestrates the existing two pipelines.

### New `aguara audit` command

- Auto-detects npm vs Python for the check side (uses
  `resolveCheckTarget`), then runs the same scanner pipeline `aguara
  scan` uses.
- Flags mirror check / scan: `--path`, `--fresh`, `--allow-stale`,
  `--ci`, `--fail-on`, `--format`. `--ci` implies `--fail-on critical`,
  no color.
- `--fresh` flows through `resolveCheckIntel` (same code path as
  `aguara check --fresh`), so the audit consults a freshly-refreshed
  snapshot when explicitly requested.

### `AuditResult` shape

```json
{
  "target": ".",
  "check": { ... full incident.CheckResult ... },
  "scan":  { ... full scanner.ScanResult ... },
  "verdict": {
    "status": "pass" | "fail",
    "check_criticals": 0, "check_warnings": 0, "check_infos": 0,
    "scan_criticals": 0,  "scan_highs": 0, "scan_mediums": 0,
    "scan_lows": 0,       "scan_infos": 0,
    "threshold_exceeded": false
  },
  "intel": { ... IntelSummary ... }
}
```

Terminal output sectioned: Supply chain, Content scan, Intel,
Verdict. Scan listing capped at 10 findings so a noisy repo does
not bury the verdict; full list in `--format json`.

### Threshold mapping

The single `--fail-on` flag maps to both sub-pipelines'
vocabularies:

| Audit threshold | Check trip | Scan trip |
|-----------------|------------|-----------|
| `critical`      | critical   | critical  |
| `warning`       | warning+   | high+     |
| `info`          | any        | any       |

Simple by design so CI logs are unambiguous.
`ErrThresholdExceeded` is the shared sentinel; main.go's exit
code path stays uniform across scan / check / audit.

## Codex pre-PR review (1 round, 2 fixes -- stopped on the same axis)

- R1 P2: `--fail-on critcal` (typo) silently passed because the
  switch fell through without tripping the gate. Now errors with
  the same message scan / check use.
- R1 P2: `--fail-on info` advertised "any finding trips" but the
  verdict only counted critical/warning/high/medium/low. An
  INFO-only finding on either side passed cleanly. Added
  CheckInfos + ScanInfos counters and routed them through the
  info gate.

Both findings were on the same gate-validation axis; stopped here
per the tightened stop rule.

## Test plan

- [x] `go test -race -count=1 ./...`
- [x] `make vet`
- [x] `make lint` (0 issues)
- [x] Clean project audit returns pass.
- [x] Compromised `event-stream@3.3.6` fixture trips the check
      side and produces a non-zero verdict.
- [x] `audit --ci` exits non-zero on the same fixture (subprocess
      pattern; mirrors TestScanFailOn / TestCheckCIExitsNonZero).
- [x] Verdict unit tests: warning trips on check warning OR scan
      high; critical does not trip on warning-only; INFO trips on
      either side; invalid `--fail-on` is rejected.