### PR TITLE
release-prep(v0.16): real OSV intel + user-intent docs + Docker content-claims

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,98 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
-### Added
+### Native threat-intel round (v0.16-track)
+
+`aguara check` grows from a niche incident-response command into the
+project's offline supply-chain pipeline. Five stacked PRs (#85-#89)
+land the UX, the in-memory snapshot core, the OSV importer + CLI, the
+runtime refresh path, and a single-verdict audit aggregator. The
+embedded snapshot in this release carries 21,518 high-confidence
+malicious-package records (20,703 `MAL-*` from the OpenSSF Malicious
+Packages namespace, plus selected `GHSA-` / `PYSEC-` / `OSV-`
+records) sourced from osv.dev dumps generated 2026-05-15.
+
+Sources used for the embedded OSV snapshot (paste to reproduce):
+
+```
+osv-npm.zip   sha256: 3d5a8e00d69c170a4ba138cde35cfa4f6c21258e7d9227b5b300998f6e91b9cb
+osv-pypi.zip  sha256: 1156159eac3ae589a7cc95c12fc99e022df653dc727dfd85a210227782b9360b
+```
+
+#### New commands and flags
+
+- `aguara check` auto-detects npm vs Python from the current directory
+  (a `node_modules` child wins; otherwise Python site-packages
+  discovery falls through). Explicit `--ecosystem python` /
+  `--ecosystem npm` still wins when passed.
+- `aguara check --ci` shorthand for `--fail-on critical --no-color`;
+  matches the convention `aguara scan --ci` already uses. Does not
+  clobber an explicit `--fail-on`.
+- `aguara check --fail-on critical|warning|info` returns exit code 1
+  via the same `ErrThresholdExceeded` sentinel `scan` uses.
+- `aguara check --fresh` refreshes threat intel from OSV before
+  checking. The only check mode that uses the network.
+  `--allow-stale` lets the run fall back to cached/embedded intel
+  on refresh failure.
+- `aguara update` — new top-level command. Refreshes the local
+  threat-intel cache at `~/.aguara/intel/snapshot.json`. Subsequent
+  offline checks layer the local cache over the embedded snapshot
+  automatically.
+- `aguara status` — new. Prints binary version, embedded snapshot
+  age and record count, and local cache state. No network.
+- `aguara audit` — new. Runs the supply-chain check plus the content
+  scan in one shot and produces a single verdict (per-section
+  severity counts plus a threshold-exceeded flag). JSON output
+  carries both sub-results.
+
+#### Library API
+
+- `internal/intel/` package: `Snapshot`, `Record`, `SourceMeta`,
+  `IOC`, `Matcher`, `Store`. `intel.NewMatcher(snapshots...)` gives
+  O(1)-per-package lookup keyed by ecosystem + normalised name (npm
+  case-sensitive scope-preserving, PyPI PEP 503), with cross-snapshot
+  version merge for the same advisory ID and order-independent
+  withdrawn-record tombstone. `intel.Store` writes the local cache
+  atomically (temp file + fsync + rename) with a 64 MiB size cap,
+  schema-version gate, and 0600 file perms.
+- `incident.CheckResult` grows an `Intel IntelSummary` field
+  describing the snapshot the run consulted (`mode = offline|online`,
+  `snapshot = embedded|local|remote-fresh`, sources, generated-at).
+  Always populated by `Check` and `CheckNPM`.
+- `incident.CheckOptions.Intel *IntelOverride` lets external callers
+  inject a custom snapshot set (e.g. embedded + local cache) without
+  mutating package-level state. The CLI uses this to surface
+  refreshed intel without rebuilding the cached default matcher.
+
+#### Generator
+
+- `tools/update-intel` CLI: produces
+  `internal/incident/generated_intel.go` from local OSV `all.zip`
+  dumps. Accepts repeated `--from-zip` / `--ecosystem` pairs in
+  lockstep, `--generated-at` for reproducible builds,
+  `--allow-empty` for the bootstrap stub. Refuses zero-record
+  imports by default so a mistagged ecosystem cannot silently ship
+  empty intel.
+- High-confidence filter only: MAL-* IDs, OpenSSF
+  `malicious-packages-origins` records, or keyword-qualified records
+  ("malicious package", "credential exfiltration", "typosquat
+  malware", ...) that carry at least one exact affected version.
+  Generic CVE / DoS entries are dropped at import time so the
+  snapshot stays focused on malicious packages, not general SCA.
+
+#### Performance
+
+- `checkCaches` filename heuristic rebuilt from a per-file
+  substring scan (O(files × records)) to a precomputed name index
+  with structural wheel/sdist parsing (`<name>-<version>-...`). On a
+  host with active pip/uv caches (~40k+ files is common), this
+  drops the cache phase from 30s+ to under a second once the
+  embedded OSV snapshot started carrying real records. Also removes
+  the substring false-positive class where short record names
+  ("4123", typosquat prefixes) matched hex hash filenames or
+  legitimate package prefixes.
+
+### Other v0.16-track changes carried over from the prior round
 
 - `aguara check --ecosystem npm` now flags the May 2026 node-ipc compromise (versions 9.1.6, 9.2.3, 12.0.1; advisory `SOCKET-2026-05-14-node-ipc`). The package-metadata check catches the compromised versions by name and version against an installed `node_modules` tree (which is what `check --ecosystem npm` walks; `scan` itself ignores `node_modules` by default). The historical 2022 RIAEvangelist / "peacenotwar" versions (10.1.1, 10.1.2, 11.0.0, 11.1.0) are tracked as a separate `SOCKET-node-ipc-historical-malicious` entry so the two incidents stay legible.
 - New `jsrisk` rule `JS_DNS_TXT_EXFIL_001`. Detects credential exfiltration via DNS TXT queries. The detector requires a real `resolveTxt` invocation (inline `require('dns').resolveTxt`, a discovered `dns` / `dns/promises` module alias, a `new dns.Resolver()` instance, or a destructured `{ resolveTxt }` import) and at least one further chain signal: CI/cloud secret read, on-disk `envs.txt` credential stage, tar.gz archive staged under `os.tmpdir()`, install-time daemonization, or a known IOC string from the 2026 node-ipc compromise (`bt.node.js`, `sh.azurestaticprovider.net`, `__ntw`, `__ntRun`). Fires HIGH on a single partner; CRITICAL on three-plus partners or a known IOC.

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,10 @@ RACE_ARTIFACTS := go-test-race.txt provenance-race.json
 SMOKE_ARTIFACTS := smoke-npm-compromised.json smoke-npm-clean.json \
 	smoke-npm-fixture.json smoke-npm-bare.txt \
 	smoke-npm-node-ipc.json \
-	smoke-supply-chain.json smoke-supply-chain-clean.json
+	smoke-supply-chain.json smoke-supply-chain-clean.json \
+	smoke-v016-autodetect.json smoke-v016-ci.json \
+	smoke-v016-ci-clean.json smoke-v016-status.txt \
+	smoke-v016-audit.json smoke-v016-audit-clean.json
 
 .PHONY: build test lint run clean fmt vet wasm wasm-serve bench \
 	bench-docker-image race-docker-image \
@@ -83,6 +86,9 @@ smoke-docker: bench-docker-image
 		-v "$(CURDIR)/.bench:/out" $(DOCKER_BENCH_IMAGE)
 	docker run $(DOCKER_RUN_FLAGS) \
 		--entrypoint /src/benchmarks/smoke-supply-chain.sh \
+		-v "$(CURDIR)/.bench:/out" $(DOCKER_BENCH_IMAGE)
+	docker run $(DOCKER_RUN_FLAGS) \
+		--entrypoint /src/benchmarks/smoke-v016-commands.sh \
 		-v "$(CURDIR)/.bench:/out" $(DOCKER_BENCH_IMAGE)
 
 verify-docker: bench-docker test-race-docker smoke-docker

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   <a href="#how-it-works">How It Works</a> &bull;
   <a href="#usage">Usage</a> &bull;
   <a href="#rules">Rules</a> &bull;
-  <a href="#incident-response">Incident Response</a> &bull;
+  <a href="#supply-chain-check">Supply-Chain Check</a> &bull;
   <a href="#aguara-mcp">Aguara MCP</a> &bull;
   <a href="#aguara-watch">Aguara Watch</a> &bull;
   <a href="#contributing">Contributing</a>
@@ -37,7 +37,7 @@ https://github.com/user-attachments/assets/851333be-048f-48fa-aaf3-f8cc1d4aa594
 AI agents and MCP servers run code on your behalf. A single malicious skill file can exfiltrate credentials, inject prompts, or install backdoors. Aguara catches these threats **before deployment** with static analysis that requires no API keys, no cloud, and no LLM.
 
 - **193 detection rules across 13 categories** — prompt injection, data exfiltration, credential leaks, supply-chain attacks, MCP-specific threats, command execution, SSRF, unicode attacks, and more.
-- **7 scan analyzers** — pattern matching, GitHub Actions trust-chain detection (ci-trust), npm package metadata (pkgmeta), JavaScript payload risk (jsrisk), NLP analysis, taint tracking, and rug-pull detection work together to catch threats that any single technique would miss. A separate `aguara check --ecosystem {python,npm}` command flags installed package trees against known-compromised version sets.
+- **7 scan analyzers** — pattern matching, GitHub Actions trust-chain detection (ci-trust), npm package metadata (pkgmeta), JavaScript payload risk (jsrisk), NLP analysis, taint tracking, and rug-pull detection work together to catch threats that any single technique would miss. Separate `aguara check` / `aguara audit` commands flag installed package trees against the embedded threat-intel snapshot (manual emergency advisories + OSV malicious-packages records, auto-detects npm vs Python, offline by default).
 - **8 decoders for encoded evasion** — base64, hex, URL encoding, Unicode escapes, HTML entities, hex escapes, base32, and C-style octal escapes. Obfuscated payloads are decoded and re-scanned automatically.
 - **NLP on markdown, JSON, and YAML** — goldmark AST analysis for markdown files, plus string extraction and classification for JSON/YAML tool descriptions. Catches MCP tool poisoning in structured configs.
 - **Cross-file toxic flow analysis** — detects dangerous capability combinations split across files in the same MCP server directory (e.g., one tool reads credentials, another sends to a webhook).
@@ -160,33 +160,42 @@ docker buildx imagetools inspect ghcr.io/garagon/aguara:${VERSION#v} \
 ## Quick Start
 
 ```bash
-# Auto-discover and scan all MCP configs on your machine
-aguara scan --auto
-
-# Discover which MCP clients are configured (no scanning)
-aguara discover
-
-# Scan a skills directory
-aguara scan .claude/skills/
-
-# Scan a single file
-aguara scan .claude/skills/deploy/SKILL.md
-
-# Only high and critical findings
-aguara scan . --severity high
-
-# CI mode (exit 1 on high+, no color)
-aguara scan .claude/skills/ --ci
-
-# Verbose mode (show descriptions, confidence scores, remediation)
-aguara scan . --verbose
-
-# Check for compromised Python packages (litellm, etc.)
+# Am I exposed to a compromised package?
 aguara check
 
-# Clean up compromised packages and persistence artifacts
-aguara clean
+# Same, but refresh threat intel from OSV first
+aguara check --fresh
+
+# CI gate: fail if a compromised package is installed
+aguara check --ci
+
+# Audit: scan code + check packages, single verdict
+aguara audit
+
+# Is Aguara's threat intel fresh?
+aguara status
+
+# Pull the latest threat intel for future offline checks
+aguara update
 ```
+
+```bash
+# Discover which MCP clients are configured on this machine
+aguara discover
+
+# Scan a skills directory (or any path) for content threats
+aguara scan .claude/skills/
+
+# CI mode for content scan: --fail-on high, no color
+aguara scan .claude/skills/ --ci
+
+# Auto-discover and scan all MCP configs on this machine
+aguara scan --auto
+```
+
+Both `aguara check` and `aguara audit` run offline by default using the
+threat intel baked into the binary. The network is used only when you
+opt in with `--fresh` or `aguara update`.
 
 ## How It Works
 
@@ -202,7 +211,10 @@ Aguara runs 6 scan analyzers sequentially on every file by default; a 7th (Rug-P
 | **Taint Tracker** | Source-to-sink flow analysis | Dangerous capability combinations within a single file and across files in the same directory. Detects credential reads paired with webhook sends, env vars flowing to shell execution, destructive plus exec combos across MCP server tools. |
 | **Rug-Pull Detector** | SHA256 hash tracking | Tool descriptions that change between scans. CLI: `--monitor` flag. Library: `WithStateDir()` for persistent consumers. |
 
-A separate `aguara check --ecosystem {python,npm}` command inspects installed package trees (`site-packages` for Python, `node_modules` for npm including the pnpm `.pnpm` store) for known-compromised package versions.
+Separate `aguara check` and `aguara audit` commands inspect installed package
+trees (Python `site-packages`, npm `node_modules` including the pnpm `.pnpm`
+store) against the embedded threat-intel snapshot. See
+[Supply-Chain Check](#supply-chain-check) for the full surface.
 
 All content is NFKC-normalized before scanning to prevent Unicode evasion attacks. All layers report findings with severity, dynamic confidence score (0.50-0.95), matched text, file location with context lines, and remediation guidance. An aggregate risk score (0-100) summarizes overall threat level.
 
@@ -453,48 +465,125 @@ Custom rules are validated at load time: unknown YAML fields are rejected, and a
 aguara scan .claude/skills/ --rules ./my-rules/
 ```
 
-## Incident Response
+## Supply-Chain Check
 
-Aguara can detect and clean compromised Python packages. Built in response to the [litellm supply chain attack](https://github.com/garagon/aguara/releases/tag/v0.11.0) (March 2026), where malicious `.pth` files exfiltrated credentials and installed K8s backdoors.
+Aguara ships with native threat intel: a hand-curated list of high-priority
+emergency advisories (event-stream, node-ipc 2022 and 2026, litellm) plus an
+OSV-derived snapshot regenerated each release from
+[osv.dev](https://osv.dev). Both run **offline by default** — the binary
+carries the snapshot. Runtime updates are opt-in.
 
-### `aguara check`
+The check commands are organised by user intent.
 
-Scans installed Python environments for compromised packages, malicious `.pth` files, and persistence artifacts.
+### `aguara check` — am I exposed?
 
 ```bash
-# Auto-discover Python environment and check
+# Default: auto-detect npm vs Python in the current directory, run offline
 aguara check
 
-# Check a specific virtualenv
-aguara check --path /opt/venv/lib/python3.12/site-packages/
+# Refresh threat intel from OSV first, then check. The only check mode that
+# uses the network; the rest stay offline.
+aguara check --fresh
 
-# Machine-readable output
+# CI gate: --fail-on critical, no color, exit 1 on compromised packages
+aguara check --ci
+
+# Machine-readable
 aguara check --format json
 ```
 
 What it checks:
-- **Known compromised versions** (embedded database, updated with each release)
-- **`.pth` files with executable code** (import, subprocess, exec, eval)
-- **pip/uv/npx caches** (scanned automatically, finds compromised packages even without a virtualenv)
-- **Persistence backdoors** (systemd user services, sysmon artifacts)
-- **Credential files at risk** (SSH, AWS, K8s, git, npm, PyPI, databases)
+- **Known compromised package versions** (manual advisories + OSV
+  malicious-package records).
+- **`.pth` files with executable code** (import, subprocess, exec, eval).
+- **pip/uv/npx caches** so a compromised package in the cache surfaces
+  even without a virtualenv.
+- **Persistence backdoors** (systemd user services, sysmon artifacts).
+- **Credential files at risk** (SSH, AWS, K8s, git, npm, PyPI, databases).
 
-### `aguara clean`
+Auto-detection rules (least to most specific):
+- If the current directory contains `node_modules`, run an npm check.
+- If `--path` points at a `node_modules` directory, run an npm check.
+- Otherwise, fall back to Python site-packages discovery.
 
-Removes compromised packages and quarantines malicious files for forensics.
+### `aguara audit` — code AND packages, one verdict
 
 ```bash
-# Remove everything (shows what will be removed, asks confirmation)
-aguara clean
-
-# Non-interactive, also purge pip/uv caches
-aguara clean --yes --purge-caches
-
-# Preview only
-aguara clean --dry-run
+aguara audit          # check + scan on the current directory
+aguara audit --ci     # CI gate: --fail-on critical, no color
+aguara audit --fresh  # refresh intel, then audit
 ```
 
-Files are quarantined to `/tmp/aguara-quarantine/`, not deleted. After cleaning, Aguara prints a credential rotation checklist for every credential file that exists on the system.
+`aguara audit` composes the supply-chain check and the content scan into a
+single verdict. JSON output carries both sub-results (`.check` and `.scan`)
+plus per-section counts so a dashboard can drill into either side.
+
+### `aguara status` — is my threat intel fresh?
+
+```bash
+aguara status
+```
+
+Prints the Aguara version, the embedded snapshot's generated-at date and
+record count, and whether a local cached snapshot exists from a prior
+`aguara update` run. Does no network I/O.
+
+### `aguara update` — refresh intel for future offline checks
+
+```bash
+aguara update                     # fetch latest OSV dumps (npm + PyPI), cache locally
+aguara update --ecosystem npm     # just npm
+```
+
+`aguara update` and `--fresh` are the only commands that use the network.
+The refreshed cache lives at `~/.aguara/intel/snapshot.json`; subsequent
+`aguara check` runs layer it over the embedded snapshot automatically and
+stay offline.
+
+If a refresh returns zero records (upstream outage, schema shift), the
+update is refused so cached intel cannot be silently wiped. Pass
+`--allow-empty` to override during initial bootstrap.
+
+### `aguara clean` — quarantine compromised packages
+
+```bash
+aguara clean                       # interactive confirmation
+aguara clean --yes --purge-caches  # non-interactive, also purge pip/uv caches
+aguara clean --dry-run             # preview
+```
+
+Files are quarantined to `/tmp/aguara-quarantine/`, not deleted. After
+cleaning, Aguara prints a credential rotation checklist for every
+credential file present on the system.
+
+### Advanced: explicit ecosystem and path
+
+Use these when auto-detection cannot find the environment you want to check:
+
+```bash
+aguara check --ecosystem python --path /opt/venv/lib/python3.12/site-packages/
+aguara check --ecosystem npm --path ./node_modules
+```
+
+### Threat-intel sources
+
+The embedded snapshot is built from two sources:
+
+- **Manual** — a short hand-curated list of high-priority emergency
+  advisories. Takes display precedence when an advisory ID also appears
+  in OSV.
+- **OSV.dev** — high-confidence records only: OpenSSF Malicious Packages
+  IDs (the `MAL-` namespace), records with
+  `database_specific.malicious-packages-origins`, plus keyword-qualified
+  records that carry exact affected versions. Generic CVE / DoS records
+  are filtered out at import time so Aguara stays focused on malicious
+  packages, not general SCA.
+
+Built originally in response to the
+[litellm supply chain attack](https://github.com/garagon/aguara/releases/tag/v0.11.0)
+(March 2026), where malicious `.pth` files exfiltrated credentials and
+installed K8s backdoors. The toolset grew from that incident into the
+broader check + audit + update + status surface above.
 
 ## Aguara MCP
 

--- a/benchmarks/smoke-v016-commands.sh
+++ b/benchmarks/smoke-v016-commands.sh
@@ -1,0 +1,160 @@
+#!/bin/sh
+#
+# Behavioral smoke test for the v0.16 native-threat-intel commands.
+# Exercises each command documented in the README under the
+# Supply-Chain Check section so docs and binary cannot drift:
+#
+#   aguara check              (auto-detect; offline)
+#   aguara check --ci         (--fail-on critical, exit code)
+#   aguara status             (no network; offline by definition)
+#   aguara audit              (check + scan, single verdict)
+#
+# The --fresh / update paths are intentionally NOT exercised here.
+# Both reach osv.dev over the network, and the smoke harness must
+# stay hermetic (the bench image runs --read-only --network host
+# only for go-build access). Coverage for those paths lives in
+# internal/intel/update_test.go using httptest.NewServer.
+#
+# Exits non-zero on the first failed assertion so `make smoke-docker`
+# surfaces the regression immediately.
+set -eu
+
+OUT="${BENCH_OUT:-/out}"
+mkdir -p /tmp/go-build /tmp/go-tmp "$OUT"
+
+FIX_ROOT="/tmp/smoke-v016"
+rm -rf "$FIX_ROOT"
+mkdir -p "$FIX_ROOT"
+
+PKG="github.com/garagon/aguara/cmd/aguara/commands"
+LDFLAGS="-s -w -X ${PKG}.Version=${AGUARA_VERSION:-dev} -X ${PKG}.Commit=${AGUARA_COMMIT:-none}"
+go build -trimpath -ldflags "$LDFLAGS" -o /tmp/aguara ./cmd/aguara
+
+fail() {
+  echo "SMOKE FAIL: $1" >&2
+  exit 1
+}
+ok() {
+  printf 'SMOKE OK  : %s\n' "$1"
+}
+
+# --- Case 1: aguara check (no flags, auto-detect npm) ---------------
+# The README's Quick Start leads with `aguara check`. The contract:
+# (a) it must auto-detect node_modules when present without
+# requiring --ecosystem, and (b) it must surface compromised
+# packages with the manual SOCKET advisory ID.
+case1="$FIX_ROOT/autodetect-npm"
+mkdir -p "$case1/node_modules/event-stream"
+printf '{"name":"event-stream","version":"3.3.6"}\n' \
+  > "$case1/node_modules/event-stream/package.json"
+
+case1_json="$OUT/smoke-v016-autodetect.json"
+/tmp/aguara --no-update-check check --path "$case1" --format json > "$case1_json"
+
+if ! grep -Eq '"severity":[[:space:]]*"CRITICAL"' "$case1_json"; then
+  cat "$case1_json"
+  fail "aguara check (auto-detect) missed event-stream 3.3.6 as CRITICAL"
+fi
+if ! grep -q 'GHSA-mh6f-8j2x-4483' "$case1_json"; then
+  cat "$case1_json"
+  fail "aguara check (auto-detect) missing event-stream advisory"
+fi
+ok "aguara check auto-detected node_modules and flagged event-stream@3.3.6"
+
+# --- Case 2: aguara check --ci exits non-zero on compromised --------
+# The README's CI usage promises `--ci` returns a non-zero exit code
+# when a compromised package is present. Same fixture as Case 1.
+case2_json="$OUT/smoke-v016-ci.json"
+if /tmp/aguara --no-update-check check --path "$case1" --ci \
+     --format json > "$case2_json" 2>&1; then
+  cat "$case2_json"
+  fail "aguara check --ci must exit non-zero when a compromised package is present"
+fi
+ok "aguara check --ci exited non-zero on compromised package"
+
+# --- Case 3: aguara check --ci on a clean tree exits zero ----------
+# Symmetric assertion: --ci must NOT trip on a clean project, or
+# every CI build of every consumer's project breaks.
+case3="$FIX_ROOT/clean"
+mkdir -p "$case3/node_modules/lodash"
+printf '{"name":"lodash","version":"4.17.21"}\n' \
+  > "$case3/node_modules/lodash/package.json"
+
+case3_json="$OUT/smoke-v016-ci-clean.json"
+if ! /tmp/aguara --no-update-check check --path "$case3" --ci \
+       --format json > "$case3_json"; then
+  cat "$case3_json"
+  fail "aguara check --ci on a clean tree must exit 0"
+fi
+if grep -Eq '"severity":[[:space:]]*"CRITICAL"' "$case3_json"; then
+  cat "$case3_json"
+  fail "aguara check --ci on a clean tree must produce no critical findings"
+fi
+ok "aguara check --ci on a clean tree exited 0 with no critical findings"
+
+# --- Case 4: aguara status (no network) ----------------------------
+# `aguara status` must work offline and produce a human-readable
+# block with the embedded snapshot line. We do not assert the exact
+# record count -- the snapshot regenerates each release -- only the
+# structural markers.
+status_out="$OUT/smoke-v016-status.txt"
+/tmp/aguara --no-update-check status > "$status_out"
+
+if ! grep -q "Threat intel:" "$status_out"; then
+  cat "$status_out"
+  fail "aguara status missing 'Threat intel:' header"
+fi
+if ! grep -q "Embedded" "$status_out"; then
+  cat "$status_out"
+  fail "aguara status missing 'Embedded' line"
+fi
+if ! grep -q "Default checks do not use the network" "$status_out"; then
+  cat "$status_out"
+  fail "aguara status missing offline-by-default disclosure"
+fi
+ok "aguara status produced the expected offline disclosure block"
+
+# --- Case 5: aguara audit on the compromised fixture ---------------
+# audit composes check + scan. With a known compromised package +
+# no scan-side findings, the verdict status must be 'fail' and
+# check_criticals must be > 0. JSON shape stable so dashboards can
+# parse it.
+audit_json="$OUT/smoke-v016-audit.json"
+if /tmp/aguara --no-update-check audit "$case1" --ci \
+     --format json -o "$audit_json"; then
+  cat "$audit_json"
+  fail "aguara audit --ci must exit non-zero on a compromised package"
+fi
+if ! grep -Eq '"status":[[:space:]]*"fail"' "$audit_json"; then
+  cat "$audit_json"
+  fail "aguara audit verdict.status must be 'fail' on the compromised fixture"
+fi
+if ! grep -Eq '"check_criticals":[[:space:]]*[1-9]' "$audit_json"; then
+  cat "$audit_json"
+  fail "aguara audit verdict.check_criticals must be >=1 on the compromised fixture"
+fi
+if ! grep -q '"check":' "$audit_json"; then
+  cat "$audit_json"
+  fail "aguara audit JSON missing .check sub-result"
+fi
+if ! grep -q '"scan":' "$audit_json"; then
+  cat "$audit_json"
+  fail "aguara audit JSON missing .scan sub-result"
+fi
+ok "aguara audit --ci surfaced compromised package, exited non-zero, JSON shape stable"
+
+# --- Case 6: aguara audit on a clean tree --------------------------
+clean_audit_json="$OUT/smoke-v016-audit-clean.json"
+if ! /tmp/aguara --no-update-check audit "$case3" \
+       --format json -o "$clean_audit_json"; then
+  cat "$clean_audit_json"
+  fail "aguara audit on a clean tree must exit 0"
+fi
+if ! grep -Eq '"status":[[:space:]]*"pass"' "$clean_audit_json"; then
+  cat "$clean_audit_json"
+  fail "aguara audit verdict.status must be 'pass' on the clean fixture"
+fi
+ok "aguara audit on a clean tree passed cleanly"
+
+echo
+echo "all v0.16 command smokes passed"

--- a/internal/incident/checker.go
+++ b/internal/incident/checker.go
@@ -411,6 +411,16 @@ func checkCaches(opts CheckOptions) []Finding {
 
 	matcher := matcherFor(opts)
 	snaps := snapshotsFor(opts)
+	// Precompute the PyPI filename-heuristic index ONCE outside
+	// the per-file WalkDir loop. Before this, every cache file
+	// re-iterated all snapshots' records and ran a fresh
+	// strings.ToLower on each rec.Name. With v0.16's regenerated
+	// OSV stub carrying ~1,400 PyPI records, a host with active
+	// pip/uv caches (40k+ files is common) saw aguara check spike
+	// to 30s+ scanning caches. The precompute moves the lower-case
+	// and ecosystem filter out of the hot loop so per-file cost
+	// scales with the substring matcher, not the snapshot size.
+	pypiIndex := buildPyPIFilenameIndex(snaps)
 	seen := make(map[string]bool) // deduplicate findings by path
 	for _, dir := range cacheDirs {
 		if _, err := os.Stat(dir); err != nil {
@@ -471,27 +481,39 @@ func checkCaches(opts CheckOptions) []Finding {
 			// advisory trips the heuristic without having to wait
 			// for the next release.
 			base := strings.ToLower(name)
-			for _, snap := range snaps {
-				for _, rec := range snap.Records {
-					if rec.Ecosystem != intel.EcosystemPyPI {
-						continue
-					}
-					if rec.Withdrawn {
-						continue
-					}
-					if !strings.Contains(base, strings.ToLower(rec.Name)) {
-						continue
-					}
-					for _, v := range rec.Versions {
-						if strings.Contains(base, v) && !seen[path] {
-							seen[path] = true
-							findings = append(findings, Finding{
-								Severity:    SevWarning,
-								Title:       fmt.Sprintf("Cached compromised artifact: %s %s (%s)", rec.Name, v, rec.ID),
-								Path:        path,
-								Remediation: "Run 'aguara clean --purge-caches' to remove cached packages",
-							})
-						}
+			candidateName, rest := parsePyPIWheelName(base)
+			if candidateName == "" {
+				// Filename is not a wheel/sdist shape (pip's
+				// content-hash cache entries fall here). Skip
+				// rather than substring-scan, which v0.15
+				// false-positived on hex hashes that happened
+				// to contain a record name.
+				return nil
+			}
+			entries, ok := pypiIndex[intel.PEP503Normalize(candidateName)]
+			if !ok {
+				return nil
+			}
+			for _, entry := range entries {
+				if seen[path] {
+					break
+				}
+				for _, v := range entry.versions {
+					// Require version to appear in the suffix
+					// after the name. Without that constraint
+					// `numpy-1.26.4.whl` could spuriously match
+					// a record whose version string lives only
+					// inside `numpy` itself (1-digit versions
+					// like "1" would explode otherwise).
+					if strings.Contains(rest, v) {
+						seen[path] = true
+						findings = append(findings, Finding{
+							Severity:    SevWarning,
+							Title:       fmt.Sprintf("Cached compromised artifact: %s %s (%s)", entry.displayName, v, entry.id),
+							Path:        path,
+							Remediation: "Run 'aguara clean --purge-caches' to remove cached packages",
+						})
+						break
 					}
 				}
 			}
@@ -499,4 +521,77 @@ func checkCaches(opts CheckOptions) []Finding {
 		})
 	}
 	return findings
+}
+
+// pypiFilenameEntry is one row in the precomputed PyPI filename-
+// heuristic index. displayName preserves the original casing for
+// the finding title; id is the OSV/manual advisory ID.
+type pypiFilenameEntry struct {
+	displayName string
+	id          string
+	versions    []string
+}
+
+// pypiFilenameIndex maps a PEP 503-normalised package name to the
+// list of (id, displayName, versions) entries for that name. The
+// per-file matcher parses the wheel/sdist filename, extracts the
+// `<name>-<version>` prefix, normalises the name, and does an
+// O(1) map lookup. This avoids the v0.15-era substring scan that
+// false-positived on hash filenames (`...4123932...` matching a
+// MAL record named "4123") and on typosquat prefixes ("nump"
+// matching "numpy-1.26.4.whl"); both were observed regressions
+// once the OSV stub started carrying real records.
+type pypiFilenameIndex map[string][]pypiFilenameEntry
+
+// buildPyPIFilenameIndex builds the precomputed heuristic index
+// once per check run. Filters out withdrawn records, anything not
+// tagged PyPI, and records with no Versions (filename heuristic
+// needs at least one version to anchor a cache finding). Names
+// are normalised via intel.PEP503Normalize so the lookup matches
+// the canonical wheel-filename casing.
+func buildPyPIFilenameIndex(snaps []intel.Snapshot) pypiFilenameIndex {
+	idx := make(pypiFilenameIndex)
+	for _, snap := range snaps {
+		for _, rec := range snap.Records {
+			if rec.Ecosystem != intel.EcosystemPyPI {
+				continue
+			}
+			if rec.Withdrawn {
+				continue
+			}
+			if len(rec.Versions) == 0 {
+				continue
+			}
+			key := intel.PEP503Normalize(rec.Name)
+			if key == "" {
+				continue
+			}
+			idx[key] = append(idx[key], pypiFilenameEntry{
+				displayName: rec.Name,
+				id:          rec.ID,
+				versions:    rec.Versions,
+			})
+		}
+	}
+	return idx
+}
+
+// parsePyPIWheelName extracts the (name, rest) pair from a PyPI
+// cache filename. Returns ("", "") for filenames that do not
+// match a wheel/sdist shape (e.g. pip's content-hash cache entries
+// in http-v2/) so the caller can skip them cleanly.
+//
+// Wheel: `<name>-<version>-<python>-<abi>-<platform>.whl`
+// Sdist: `<name>-<version>.tar.gz` (or .zip)
+//
+// Both forms put the name first, followed by `-`. We do not
+// require any specific suffix because pip caches sometimes drop
+// the extension; the lookup-by-version step below catches false
+// hits anyway.
+func parsePyPIWheelName(base string) (name, rest string) {
+	idx := strings.IndexByte(base, '-')
+	if idx <= 0 {
+		return "", ""
+	}
+	return base[:idx], base[idx+1:]
 }

--- a/internal/incident/checker.go
+++ b/internal/incident/checker.go
@@ -481,8 +481,8 @@ func checkCaches(opts CheckOptions) []Finding {
 			// advisory trips the heuristic without having to wait
 			// for the next release.
 			base := strings.ToLower(name)
-			candidateName, rest := parsePyPIWheelName(base)
-			if candidateName == "" {
+			candidates := parsePyPIWheelName(base)
+			if len(candidates) == 0 {
 				// Filename is not a wheel/sdist shape (pip's
 				// content-hash cache entries fall here). Skip
 				// rather than substring-scan, which v0.15
@@ -490,30 +490,41 @@ func checkCaches(opts CheckOptions) []Finding {
 				// to contain a record name.
 				return nil
 			}
-			entries, ok := pypiIndex[intel.PEP503Normalize(candidateName)]
-			if !ok {
-				return nil
-			}
-			for _, entry := range entries {
+			// Try every (name, rest) split. Hyphenated sdist names
+			// (e.g. `233-misc-0.0.3.tar.gz`) have multiple
+			// candidate boundaries; we accept the FIRST that hits
+			// the index. The intel index is PEP 503 normalised so
+			// we normalise the candidate before lookup.
+			for _, cand := range candidates {
 				if seen[path] {
 					break
 				}
-				for _, v := range entry.versions {
-					// Require version to appear in the suffix
-					// after the name. Without that constraint
-					// `numpy-1.26.4.whl` could spuriously match
-					// a record whose version string lives only
-					// inside `numpy` itself (1-digit versions
-					// like "1" would explode otherwise).
-					if strings.Contains(rest, v) {
-						seen[path] = true
-						findings = append(findings, Finding{
-							Severity:    SevWarning,
-							Title:       fmt.Sprintf("Cached compromised artifact: %s %s (%s)", entry.displayName, v, entry.id),
-							Path:        path,
-							Remediation: "Run 'aguara clean --purge-caches' to remove cached packages",
-						})
+				entries, ok := pypiIndex[intel.PEP503Normalize(cand.name)]
+				if !ok {
+					continue
+				}
+				for _, entry := range entries {
+					if seen[path] {
 						break
+					}
+					for _, v := range entry.versions {
+						// Version must appear in the suffix
+						// after the name. Without that constraint
+						// `numpy-1.26.4.whl` could spuriously
+						// match a record whose version string
+						// lives only inside `numpy` itself
+						// (1-digit versions like "1" would
+						// explode otherwise).
+						if strings.Contains(cand.rest, v) {
+							seen[path] = true
+							findings = append(findings, Finding{
+								Severity:    SevWarning,
+								Title:       fmt.Sprintf("Cached compromised artifact: %s %s (%s)", entry.displayName, v, entry.id),
+								Path:        path,
+								Remediation: "Run 'aguara clean --purge-caches' to remove cached packages",
+							})
+							break
+						}
 					}
 				}
 			}
@@ -576,22 +587,51 @@ func buildPyPIFilenameIndex(snaps []intel.Snapshot) pypiFilenameIndex {
 	return idx
 }
 
-// parsePyPIWheelName extracts the (name, rest) pair from a PyPI
-// cache filename. Returns ("", "") for filenames that do not
-// match a wheel/sdist shape (e.g. pip's content-hash cache entries
-// in http-v2/) so the caller can skip them cleanly.
+// parsePyPIWheelName extracts (name, rest) candidates from a PyPI
+// cache filename. Returns the EMPTY slice for filenames that do
+// not match a wheel/sdist shape (e.g. pip's content-hash cache
+// entries in http-v2/) so the caller can skip them cleanly.
 //
 // Wheel: `<name>-<version>-<python>-<abi>-<platform>.whl`
-// Sdist: `<name>-<version>.tar.gz` (or .zip)
+//   - PEP 491: non-alphanumeric chars in name are normalised to `_`
+//     in wheel filenames, so the wheel name never contains `-`.
 //
-// Both forms put the name first, followed by `-`. We do not
-// require any specific suffix because pip caches sometimes drop
-// the extension; the lookup-by-version step below catches false
-// hits anyway.
-func parsePyPIWheelName(base string) (name, rest string) {
-	idx := strings.IndexByte(base, '-')
-	if idx <= 0 {
-		return "", ""
+// Sdist: `<name>-<version>.tar.gz` (or .zip)
+//   - Name may contain `-` (e.g. `233-misc-0.0.3.tar.gz` has name
+//     `233-misc`, version `0.0.3`).
+//
+// We resolve the ambiguity by emitting a candidate at every `-`
+// position whose next byte is a digit (PEP 440 versions always
+// start with a digit, possibly preceded by an epoch which itself
+// starts with a digit). Callers try each candidate in order; the
+// first that resolves in the intel index wins. For wheels there
+// is exactly one such boundary; for hyphenated sdists there are
+// typically two (the inner ones don't match the index but the
+// last one does).
+func parsePyPIWheelName(base string) []nameCandidate {
+	var out []nameCandidate
+	for i := 0; i < len(base); i++ {
+		if base[i] != '-' {
+			continue
+		}
+		if i+1 >= len(base) {
+			break
+		}
+		if base[i+1] < '0' || base[i+1] > '9' {
+			continue
+		}
+		if i == 0 {
+			continue // leading '-' has no name part
+		}
+		out = append(out, nameCandidate{name: base[:i], rest: base[i+1:]})
 	}
-	return base[:idx], base[idx+1:]
+	return out
+}
+
+// nameCandidate is one possible (name, rest) split of a PyPI cache
+// filename. parsePyPIWheelName returns all candidates; the caller
+// tries each against the intel index until one resolves.
+type nameCandidate struct {
+	name string
+	rest string
 }

--- a/internal/incident/intel_adapter_test.go
+++ b/internal/incident/intel_adapter_test.go
@@ -104,10 +104,18 @@ func TestCheckResultIntelSummaryPopulated(t *testing.T) {
 	require.False(t, result.Intel.GeneratedAt.IsZero(),
 		"IntelSummary.GeneratedAt must be set from the embedded snapshot")
 	require.NotEmpty(t, result.Intel.Sources)
+	// The manual source must always be present; the generated OSV
+	// snapshot may or may not be (empty stub vs regenerated dump),
+	// so we assert manual-is-there rather than the prior
+	// only-manual contract which broke once real OSV records
+	// shipped in v0.16.
+	var sawManual bool
 	for _, src := range result.Intel.Sources {
-		require.Truef(t, strings.EqualFold(src, "manual"),
-			"embedded snapshot must carry only manual source, got %q", src)
+		if strings.EqualFold(src, "manual") {
+			sawManual = true
+		}
 	}
+	require.True(t, sawManual, "embedded IntelSummary must always list the manual source")
 }
 
 func TestCheckResultIntelSummaryPopulatedForPython(t *testing.T) {

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -195,6 +195,13 @@ func TestCheckNPM_DetectsNodeIPC2026Compromise(t *testing.T) {
 	// versions 9.1.6, 9.2.3, and 12.0.1 published an obfuscated
 	// CommonJS payload. Each must surface as CRITICAL with the
 	// SOCKET-2026-05-14 advisory.
+	//
+	// Since v0.16 the embedded OSV snapshot may carry an additional
+	// MAL- record for the same version, in which case BOTH advisories
+	// surface (distinct advisory IDs at the same tuple are kept
+	// separate by design -- see TestMatcherDistinctIDsAtSameTuple).
+	// The contract we lock is: at least one finding, CRITICAL, and
+	// the manual SOCKET advisory MUST be among them.
 	for _, ver := range []string{"9.1.6", "9.2.3", "12.0.1"} {
 		ver := ver
 		t.Run(ver, func(t *testing.T) {
@@ -206,15 +213,20 @@ func TestCheckNPM_DetectsNodeIPC2026Compromise(t *testing.T) {
 			if err != nil {
 				t.Fatalf("CheckNPM error: %v", err)
 			}
-			if len(result.Findings) != 1 {
-				t.Fatalf("expected 1 finding for node-ipc %s, got %d: %+v", ver, len(result.Findings), result.Findings)
+			if len(result.Findings) == 0 {
+				t.Fatalf("expected at least one finding for node-ipc %s, got none", ver)
 			}
-			f := result.Findings[0]
-			if f.Severity != incident.SevCritical {
-				t.Errorf("expected CRITICAL, got %q", f.Severity)
+			var sawSocket bool
+			for _, f := range result.Findings {
+				if f.Severity != incident.SevCritical {
+					t.Errorf("expected CRITICAL, got %q", f.Severity)
+				}
+				if strings.Contains(f.Title+f.Detail, "SOCKET-2026-05-14-node-ipc") {
+					sawSocket = true
+				}
 			}
-			if !strings.Contains(f.Title+f.Detail, "SOCKET-2026-05-14-node-ipc") {
-				t.Errorf("expected SOCKET-2026-05-14-node-ipc advisory reference, got title=%q detail=%q", f.Title, f.Detail)
+			if !sawSocket {
+				t.Errorf("expected SOCKET-2026-05-14-node-ipc advisory among findings for %s, got: %+v", ver, result.Findings)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Release-prep for v0.16.0 (native-threat-intel round). Five steps in
order, none of them bumping VERSION or tagging — that lands in a
separate commit once this PR is in main.

### 1. Real OSV intel (data blocker)

Regenerated `internal/incident/generated_intel.go` from OSV.dev
dumps (npm + PyPI, downloaded 2026-05-15, `--generated-at` pinned
for reproducibility). 21,518 high-confidence malicious-package
records:

- 20,703 `MAL-*` (OpenSSF Malicious Packages namespace)
- 503 `GHSA-*`, 311 `PYSEC-*`, 1 `OSV-*` (keyword-qualified)
- By ecosystem: ~9,624 npm, ~1,399 PyPI

Source SHA256s (paste to reproduce the snapshot):

```
osv-npm.zip   3d5a8e00d69c170a4ba138cde35cfa4f6c21258e7d9227b5b300998f6e91b9cb
osv-pypi.zip  1156159eac3ae589a7cc95c12fc99e022df653dc727dfd85a210227782b9360b
```

Perf + correctness fix on `checkCaches`: rebuilt the filename
heuristic from a per-file substring scan (O(files × records),
30s+ on hosts with active pip/uv caches once the OSV stub carried
real records) to a precomputed PyPI name index keyed by PEP 503
normalisation, with structural wheel/sdist parsing. Drops the
cache phase to ~1s on the same host. Also removes the false-
positive class where short record names like `4123` or typosquat
prefixes like `nump` matched hex hash filenames or legitimate
package prefixes. **Codex P2 follow-up:** the parser now emits a
candidate at every `-<digit>` boundary so hyphenated PyPI sdists
(e.g. `233-misc-0.0.3.tar.gz`) resolve through the index — the
first version of the parser split on the first `-` and missed
those.

### 2. README around user intent (product blocker)

Quick Start now leads with the supply-chain workflow:
`aguara check`, `check --fresh`, `check --ci`, `audit`, `status`,
`update`. The Incident Response section was renamed
"Supply-Chain Check" and reorganised by user intent (am I exposed
/ code AND packages / is intel fresh / refresh / clean /
advanced / sources).

### 3. CHANGELOG with user-facing changes (product blocker)

Documents PRs #85-#89 + the OSV regeneration as a single round
under `[Unreleased]`. Sub-sections: new commands and flags,
library API (intel package + IntelSummary + IntelOverride),
generator (update-intel CLI + high-confidence filter), performance
(cache filename rebuild). Tone follows the existing rule — feature
+ hardening framing, no CVE-style severity labels.

### 4. Docker content-claims (confidence blocker)

`benchmarks/smoke-v016-commands.sh` exercises every command the
README's Supply-Chain Check section documents:

| Command | Compromised fixture | Clean fixture |
|---------|---------------------|---------------|
| `aguara check` (auto-detect) | yes | yes |
| `aguara check --ci` | exit non-zero | exit 0 |
| `aguara status` | offline disclosure block | -- |
| `aguara audit` / `audit --ci` | verdict=fail, exit non-zero | verdict=pass, exit 0 |

`--fresh` / `aguara update` are intentionally not in the docker
harness (network reach to osv.dev breaks the hermetic contract);
network coverage lives in `internal/intel/update_test.go` via
`httptest.NewServer`.

`Makefile`: `SMOKE_ARTIFACTS` extended; `smoke-docker` runs the
new script alongside the existing npm-incident and supply-chain
smokes. `make verify-docker` end-to-end is green.

### 5. Test plan

- [x] `go test -race -count=1 ./...`
- [x] `make vet`
- [x] `make lint` (0 issues)
- [x] `make verify-docker` end-to-end (bench-docker + test-race-
      docker + smoke-docker)
- [x] Manual: `go run ./tools/update-intel --from-zip ...
      --ecosystem npm --from-zip ... --ecosystem PyPI` produces
      the committed `generated_intel.go` byte-for-byte (modulo
      timestamps, which `--generated-at` pins)

## Codex pre-PR review (1 round, 1 fix — stopped)

R1 P2: hyphenated PyPI sdist names (`233-misc-0.0.3.tar.gz`) lost
the match because the parser split on the first `-`. Fixed by
emitting candidates at every `-<digit>` boundary. No further
rounds; per the tightened stop rule, the finding was on the
cache-parser axis and isolated.

## Out of scope

- **No VERSION bump.** v0.16.0 lands in a separate commit after
  this PR is in main.
- **No tag.** GoReleaser fires on a clean tagged state; tagging
  before verifying main has real intel + verified docs is what
  has broken prior releases.
- **No `--source-hash` in update-intel.** Provenance currently lives
  in the commit message + CHANGELOG; auto-stamping the source
  SHA256 in `Snapshot.SHA256` is follow-up work.