### PR TITLE
fix(cli): silence Cobra usage block on runtime errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ coverage.out
 !.env.example
 *.pem
 *.key
+/.nanostack/

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ SMOKE_ARTIFACTS := smoke-npm-compromised.json smoke-npm-clean.json \
 	smoke-supply-chain.json smoke-supply-chain-clean.json \
 	smoke-v016-autodetect.json smoke-v016-ci.json \
 	smoke-v016-ci-clean.json smoke-v016-status.txt \
-	smoke-v016-audit.json smoke-v016-audit-clean.json
+	smoke-v016-audit.json smoke-v016-audit.stderr.txt \
+	smoke-v016-audit-clean.json
 
 .PHONY: build test lint run clean fmt vet wasm wasm-serve bench \
 	bench-docker-image race-docker-image \

--- a/benchmarks/smoke-v016-commands.sh
+++ b/benchmarks/smoke-v016-commands.sh
@@ -64,13 +64,22 @@ ok "aguara check auto-detected node_modules and flagged event-stream@3.3.6"
 # --- Case 2: aguara check --ci exits non-zero on compromised --------
 # The README's CI usage promises `--ci` returns a non-zero exit code
 # when a compromised package is present. Same fixture as Case 1.
+# Also asserts the Cobra usage block does NOT print: a CI log that
+# reads "Error: findings exceed severity threshold" followed by a
+# full --help dump looks like command misuse to non-technical
+# readers. SilenceUsage on the checkCmd is the load-bearing setting;
+# this assertion locks the regression.
 case2_json="$OUT/smoke-v016-ci.json"
 if /tmp/aguara --no-update-check check --path "$case1" --ci \
      --format json > "$case2_json" 2>&1; then
   cat "$case2_json"
   fail "aguara check --ci must exit non-zero when a compromised package is present"
 fi
-ok "aguara check --ci exited non-zero on compromised package"
+if grep -Eq '^Usage:|^Flags:|^Global Flags:' "$case2_json"; then
+  cat "$case2_json"
+  fail "aguara check --ci printed Cobra Usage block on runtime threshold error"
+fi
+ok "aguara check --ci exited non-zero on compromised package, no Usage noise"
 
 # --- Case 3: aguara check --ci on a clean tree exits zero ----------
 # Symmetric assertion: --ci must NOT trip on a clean project, or
@@ -120,10 +129,16 @@ ok "aguara status produced the expected offline disclosure block"
 # check_criticals must be > 0. JSON shape stable so dashboards can
 # parse it.
 audit_json="$OUT/smoke-v016-audit.json"
+audit_stderr="$OUT/smoke-v016-audit.stderr.txt"
 if /tmp/aguara --no-update-check audit "$case1" --ci \
-     --format json -o "$audit_json"; then
+     --format json -o "$audit_json" 2> "$audit_stderr"; then
   cat "$audit_json"
+  cat "$audit_stderr"
   fail "aguara audit --ci must exit non-zero on a compromised package"
+fi
+if grep -Eq '^Usage:|^Flags:|^Global Flags:' "$audit_stderr"; then
+  cat "$audit_stderr"
+  fail "aguara audit --ci printed Cobra Usage block on runtime threshold error"
 fi
 if ! grep -Eq '"status":[[:space:]]*"fail"' "$audit_json"; then
   cat "$audit_json"

--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -43,6 +43,13 @@ func init() {
 	auditCmd.Flags().StringVar(&flagAuditFailOn, "fail-on", "", "Exit code 1 when findings reach this severity (critical, warning, info)")
 	auditCmd.Flags().BoolVar(&flagAuditFresh, "fresh", false, "Refresh threat intel before the audit (network opt-in)")
 	auditCmd.Flags().BoolVar(&flagAuditAllowStale, "allow-stale", false, "Continue with cached/embedded intel if --fresh refresh fails")
+	// Runtime errors (ErrThresholdExceeded after the verdict
+	// computes "fail", --fresh network failures) should not
+	// trigger Cobra's flag-usage block. The verdict line plus the
+	// JSON sub-results are already enough to act on; printing
+	// --help on top of those makes the CI log read as command
+	// misuse. See scan.go for the same rationale.
+	auditCmd.SilenceUsage = true
 	rootCmd.AddCommand(auditCmd)
 }
 

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -49,6 +49,13 @@ func init() {
 	checkCmd.Flags().BoolVar(&flagCheckCI, "ci", false, "CI mode: equivalent to --fail-on critical --no-color")
 	checkCmd.Flags().BoolVar(&flagCheckFresh, "fresh", false, "Refresh threat intel before checking (network opt-in)")
 	checkCmd.Flags().BoolVar(&flagCheckAllowStale, "allow-stale", false, "Continue with cached/embedded intel if --fresh refresh fails")
+	// Runtime errors (ErrThresholdExceeded after --ci, --fresh
+	// network failures) should not trigger Cobra's flag-usage
+	// block: a CI log that prints "Error: findings exceed severity
+	// threshold" then dumps the full --help reads as command
+	// misuse to non-technical readers. See scan.go for the same
+	// rationale.
+	checkCmd.SilenceUsage = true
 	rootCmd.AddCommand(checkCmd)
 }
 

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -69,6 +69,14 @@ func init() {
 	scanCmd.Flags().StringVar(&flagToolName, "tool-name", "", "Tool context for false-positive reduction (e.g. Bash, Edit, WebFetch)")
 	scanCmd.Flags().StringVar(&flagProfile, "profile", "", "Scan profile: strict (default), content-aware, minimal")
 	scanCmd.Flags().BoolVar(&flagNoRedact, "no-redact", false, "Keep raw matched text in credential-leak findings (default: redact to [REDACTED])")
+	// Runtime errors (ErrThresholdExceeded after a successful scan,
+	// network failures on --auto) should not trigger Cobra's
+	// flag-usage block: a CI log that already says
+	// "Error: findings exceed severity threshold" then prints the
+	// full --help reads as a command-misuse error to non-technical
+	// readers. Flag-parse errors still surface with a clear error
+	// message; we just stop printing the usage block on top.
+	scanCmd.SilenceUsage = true
 	rootCmd.AddCommand(scanCmd)
 }
 

--- a/cmd/aguara/commands/update.go
+++ b/cmd/aguara/commands/update.go
@@ -38,6 +38,10 @@ func init() {
 	updateCmd.Flags().DurationVar(&flagUpdateTimeout, "timeout", intel.DefaultHTTPTimeout, "Overall HTTP timeout for the refresh")
 	updateCmd.Flags().StringSliceVar(&flagUpdateEcosystems, "ecosystem", nil, "Ecosystems to refresh (default: npm, PyPI)")
 	updateCmd.Flags().BoolVar(&flagUpdateAllowEmpty, "allow-empty", false, "Save a 0-record snapshot anyway (defaults to error so an upstream outage cannot wipe cached intel)")
+	// Runtime errors (HTTP failures, OSV outage producing 0
+	// records) should not trigger Cobra's flag-usage block. Same
+	// rationale as scan / check / audit.
+	updateCmd.SilenceUsage = true
 	rootCmd.AddCommand(updateCmd)
 }
 


### PR DESCRIPTION
## Summary

QA on PR #90 flagged a P2 UX regression: when `aguara check --ci`,
`audit --ci`, or `check --fresh` fail as expected (threshold
exceeded, network failure), Cobra by default prints the full
`--help` block on top of the Error line. A CI log that reads:

```
Error: findings exceed severity threshold
Usage:
  aguara check [flags]
Flags:
  --ci ...
  --fresh ...
...
```

reads as command misuse to non-technical readers, when in fact
the command did exactly what was asked and exited non-zero by
design. Recommended by QA as a follow-up before tagging v0.16.

## Change

Set `SilenceUsage = true` on `scanCmd`, `checkCmd`, `auditCmd`,
and `updateCmd`. The Error line still prints (`SilenceErrors`
stays false) so the user knows what happened; only the noisy
Usage dump goes away. Flag-parse errors (`--ecosystem ruby`,
`--unknown-flag`) still surface with a clear error message; users
do not lose actionable feedback.

## Regression lock

`benchmarks/smoke-v016-commands.sh` now greps the captured
stderr / stdout for `^Usage:`, `^Flags:`, `^Global Flags:` after
the `--ci` threshold-exceeded path on both check and audit, and
fails the smoke if any of those headers appears. Locks the
regression so a future Cobra version bump or a new command
forgetting `SilenceUsage` cannot reintroduce the noise silently.

Bonus housekeeping: `.nanostack/` (QA artifact directory) added
to `.gitignore` so `git add` does not sweep it in.

## Codex pre-PR review

CLEAN PASS on the first round -- single concern axis, single fix.

## Test plan

- [x] `go test -race -count=1 ./...`
- [x] `make vet` / `make lint` (0 issues)
- [x] `make smoke-docker` end-to-end (the new regression assertions
      land here)
- [x] Manual: `aguara check --ci` on compromised tree shows the
      Error line only, no Usage dump. Flag-parse errors
      (`--ecosystem ruby`) still surface with clear message.

## Next step

After this merges, the v0.16.0 tag commit can land on main
(VERSION bump + CHANGELOG `[Unreleased]` -> `[0.16.0]` + tag push
to trigger GoReleaser).