### PR TITLE
fix(init): scaffolded workflow uses the official action with pinned binary version

### DIFF
--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -235,6 +235,12 @@ jobs:
         with:
           path: .
           fail-on: high
+          # Pin the actual Aguara BINARY version too. Without this,
+          # the action's install step calls install.sh with no
+          # version override and fetches whatever release is
+          # "latest" at run time -- so the scanner code can drift
+          # away from the action ref above without notice.
+          version: v0.16.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -192,6 +192,24 @@ aguara scan . --fail-on high --no-color
 exit $?
 `
 
+// workflowTemplateV2 is the GitHub Actions workflow scaffolded by
+// `aguara init`. It uses the official `garagon/aguara` action so
+// the workflow gets:
+//
+//   - install.sh-backed binary install with mandatory checksum
+//     verification (no manual curl + 404 risk),
+//   - SARIF upload to Code Scanning out of the box,
+//   - automatic version pinning matching whatever tag the user
+//     pins the `uses:` ref to.
+//
+// The action ref is pinned to the v0.16.0 tag rather than `@v1`
+// (which exists but lags significantly behind point releases). New
+// projects get a reproducible, dependabot-friendly pin; users who
+// want floating-major can edit the ref themselves.
+//
+// The 'Comment on PR' step is kept so the workflow feels complete
+// out of the box; it reads from the action's default SARIF output
+// path (aguara-results.sarif).
 const workflowTemplateV2 = `name: Aguara Security Scan
 
 on:
@@ -211,37 +229,23 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Aguara binary
-        uses: actions/cache@v4
-        with:
-          path: ./aguara
-          key: aguara-linux-amd64
-
-      - name: Install Aguara
-        run: |
-          if [ ! -f ./aguara ]; then
-            curl -sSL https://github.com/garagon/aguara/releases/latest/download/aguara-linux-amd64 -o aguara
-            chmod +x aguara
-          fi
-
-      - name: Run Aguara scan
+      - name: Run Aguara security scan
         id: scan
-        continue-on-error: true
-        run: ./aguara scan . --format sarif --output results.sarif --fail-on high
-
-      - name: Upload SARIF results
-        if: always()
-        uses: github/codeql-action/upload-sarif@v3
+        uses: garagon/aguara@v0.16.0
         with:
-          sarif_file: results.sarif
+          path: .
+          fail-on: high
+          # SARIF results land at aguara-results.sarif and are
+          # uploaded to GitHub Code Scanning automatically. Set
+          # upload-sarif: 'false' to disable that upload.
 
-      - name: Comment on PR
-        if: github.event_name == 'pull_request' && always()
+      - name: Comment summary on PR
+        if: github.event_name == 'pull_request' && always() && hashFiles('aguara-results.sarif') != ''
         uses: actions/github-script@v7
         with:
           script: |
             const fs = require('fs');
-            const sarif = JSON.parse(fs.readFileSync('results.sarif', 'utf8'));
+            const sarif = JSON.parse(fs.readFileSync('aguara-results.sarif', 'utf8'));
             const results = sarif.runs[0].results || [];
             const counts = {};
             results.forEach(r => { counts[r.level] = (counts[r.level] || 0) + 1; });
@@ -260,8 +264,4 @@ jobs:
               issue_number: context.issue.number,
               body: lines.join('\n')
             });
-
-      - name: Fail on findings
-        if: steps.scan.outcome == 'failure'
-        run: exit 1
 `

--- a/cmd/aguara/commands/init_test.go
+++ b/cmd/aguara/commands/init_test.go
@@ -57,6 +57,14 @@ func TestInitWorkflowUsesActionNotBrokenAsset(t *testing.T) {
 		"workflow must not curl release assets directly; the action handles install + checksum")
 	require.True(t, strings.Contains(body, "uses: garagon/aguara@"),
 		"workflow must invoke the official garagon/aguara action so version pin + checksum verify are guaranteed")
+
+	// Codex P2 follow-up: the action ref alone does NOT pin the
+	// binary version (the action's `version` input defaults to
+	// empty -> install.sh fetches whatever is latest at run time).
+	// The scaffold MUST also set the `version:` input so the
+	// installed CLI is reproducible across runs.
+	require.True(t, strings.Contains(body, "version: v"),
+		"workflow must pin the Aguara binary version (action ref alone does not pin the install)")
 }
 
 func TestInitSkipsExisting(t *testing.T) {

--- a/cmd/aguara/commands/init_test.go
+++ b/cmd/aguara/commands/init_test.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -28,6 +29,34 @@ func TestInitCreatesFiles(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, data, "expected %s to have content", name)
 	}
+}
+
+func TestInitWorkflowUsesActionNotBrokenAsset(t *testing.T) {
+	// QA regression on v0.16.0: the scaffolded workflow downloaded
+	// `aguara-linux-amd64` from /releases/latest/download/, an asset
+	// shape that does not exist (release assets are tar.gz archives
+	// like `aguara_0.16.0_linux_amd64.tar.gz`). The curl 404'd and
+	// every new-user CI job broke at install.
+	//
+	// The workflow must now:
+	//   1. NOT reference the broken `aguara-linux-amd64` asset,
+	//   2. NOT manually curl install.sh in the workflow itself
+	//      (the action does that with checksum verification),
+	//   3. USE the official `garagon/aguara` action so version pin
+	//      + checksum verify happen via the action's contract.
+	dir := t.TempDir()
+	require.NoError(t, runInit(nil, []string{dir}))
+
+	wf, err := os.ReadFile(filepath.Join(dir, ".github", "workflows", "aguara.yml"))
+	require.NoError(t, err)
+	body := string(wf)
+
+	require.NotContains(t, body, "aguara-linux-amd64",
+		"workflow must not reference the non-existent aguara-linux-amd64 asset (release assets are tar.gz archives)")
+	require.NotContains(t, body, "/releases/latest/download/aguara",
+		"workflow must not curl release assets directly; the action handles install + checksum")
+	require.True(t, strings.Contains(body, "uses: garagon/aguara@"),
+		"workflow must invoke the official garagon/aguara action so version pin + checksum verify are guaranteed")
 }
 
 func TestInitSkipsExisting(t *testing.T) {


### PR DESCRIPTION
## Summary

QA on v0.16.0 caught a **P1 onboarding bug**: `aguara init`
produced a GitHub Actions workflow whose install step did:

```yaml
- run: |
    curl -sSL https://github.com/garagon/aguara/releases/latest/download/aguara-linux-amd64 -o aguara
    chmod +x aguara
```

That asset shape does not exist. Release assets are tarballs like
`aguara_0.16.0_linux_amd64.tar.gz`. The curl 404'd and every new-
user CI job broke at install -- the first contact most teams have
with Aguara in CI.

## Change

The scaffolded workflow now uses the official `garagon/aguara`
action with **two pins** (action ref AND binary version):

```yaml
- uses: garagon/aguara@v0.16.0
  with:
    path: .
    fail-on: high
    version: v0.16.0
```

Why both pins: the action ref alone (`@v0.16.0`) only pins the
composite action and its install script. The action's `version:`
input defaults to empty, so install.sh fetches whatever release
is "latest" at run time -- scanner code could drift away from the
action ref without notice. Setting both makes the scaffold
reproducible and dependabot-friendly (the bot updates both
together when v0.16.1 lands).

Workflow drops from ~45 lines of manual curl + cache + run +
upload + fail steps to a single `uses:` step plus the optional
PR-comment summary that reads from the action's default SARIF
output path (`aguara-results.sarif`).

Pinning to the exact tag `v0.16.0` instead of the floating-major
`v1`: the `v1` tag exists but lags significantly behind point
releases. New projects get a reproducible pin; users who want
floating-major can edit the ref themselves.

## Regression lock

`TestInitWorkflowUsesActionNotBrokenAsset` asserts four contract
points:

1. NO `aguara-linux-amd64` reference (the missing asset).
2. NO direct curl of `/releases/latest/download/aguara` (the
   action handles install + checksum).
3. Workflow MUST invoke `garagon/aguara@`.
4. Workflow MUST set `version: v...` (binary pin, not just action
   pin).

A future template change that drops any of those loses the test.

## Codex pre-PR review

- R1 P2: action ref alone doesn't pin the binary version. Added
  explicit `version: v0.16.0` input.
- R2: CLEAN PASS.

## Out of scope (deferred to separate follow-ups)

QA reported three more findings on v0.16.0:
- **P2 explainability:** `aguara explain JS_DNS_TXT_EXFIL_001
  --format json` fails with "rule not found" because analyzer-
  emitted rules aren't in the `explain` index.
- **P2/P3 UX:** `aguara check --path /nonexistent` returns exit 0
  with an empty result instead of erroring (scan and audit fail
  correctly).
- **P3 UX:** `aguara update --format json` accepts the flag but
  emits human-readable output.

None of those block onboarding the way the broken `init` did, so
they ship as separate small PRs rather than getting bundled here.

## Test plan

- [x] `go test -race -count=1 ./...`
- [x] `make vet` / `make lint` (0 issues)
- [x] Generated workflow inspected manually: action ref + binary
      version both pinned to `v0.16.0`, PR comment step reads from
      the right SARIF path.