### PR TITLE
fix(check): reject explicit missing or non-directory --path before autodiscovery

### DIFF
--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -122,7 +122,16 @@ func applyCheckCIDefaults() {
 // --ecosystem is empty does auto-detection run. An empty --path remains
 // empty for Python (so the legacy site-packages auto-discovery still
 // works) and resolves to "." for npm probing only.
+//
+// An EXPLICIT --path that does not exist (or points at a regular file)
+// is an error: a typo in CI -- e.g. `--path /opt/venv/lib/pyhton...` --
+// must not look like a clean check result. The validator only fires
+// when path != ""; empty path keeps the legacy Python autodiscovery
+// contract intact.
 func resolveCheckTarget(eco, path string) (string, string, error) {
+	if err := validateExplicitCheckPath(path); err != nil {
+		return "", "", err
+	}
 	switch strings.ToLower(strings.TrimSpace(eco)) {
 	case "python", "pypi":
 		return ecoPython, path, nil
@@ -133,6 +142,30 @@ func resolveCheckTarget(eco, path string) (string, string, error) {
 	default:
 		return "", "", fmt.Errorf("unsupported ecosystem %q: choose python or npm", eco)
 	}
+}
+
+// validateExplicitCheckPath enforces that an explicit --path (when
+// non-empty) refers to an existing directory. Returns nil when path
+// is empty so the autodiscovery branch keeps working. A missing path
+// is the typical typo case ("/opt/venv/lib/pyhton..." vs "python");
+// returning a clean error here means CI surfaces the typo as exit 2
+// instead of advertising a green check on a path the operator never
+// asked to scan.
+func validateExplicitCheckPath(path string) error {
+	if path == "" {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return fmt.Errorf("check: --path %s: no such file or directory", path)
+		}
+		return fmt.Errorf("check: --path %s: %w", path, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("check: --path %s: not a directory", path)
+	}
+	return nil
 }
 
 // autoDetectCheckTarget chooses an ecosystem from the filesystem shape

--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -337,6 +337,98 @@ func TestResolveCheckTargetExplicitFlags(t *testing.T) {
 	require.True(t, strings.Contains(err.Error(), "unsupported"))
 }
 
+func TestResolveCheckTargetRejectsMissingPath(t *testing.T) {
+	// QA regression on v0.16.0: `aguara check --path /no/existe`
+	// returned exit 0 with an empty result, masking a typo as a
+	// clean check. Every code path that takes a non-empty --path
+	// must surface a clear error before any check pipeline runs.
+	missing := filepath.Join(t.TempDir(), "definitely-does-not-exist")
+
+	for _, eco := range []string{"", "python", "pypi", "npm"} {
+		eco := eco
+		t.Run("ecosystem="+eco, func(t *testing.T) {
+			_, _, err := resolveCheckTarget(eco, missing)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "no such file or directory",
+				"missing --path must surface the canonical filesystem error")
+			require.Contains(t, err.Error(), missing,
+				"error must echo the bad path so the user can spot the typo")
+		})
+	}
+}
+
+func TestResolveCheckTargetRejectsFilePath(t *testing.T) {
+	// --path pointing at a regular file is a typo too: the user
+	// likely meant a sibling directory. Surface a distinct error
+	// from missing-path so logs are unambiguous.
+	f, err := os.CreateTemp(t.TempDir(), "not-a-dir-*")
+	require.NoError(t, err)
+	require.NoError(t, f.Close())
+
+	for _, eco := range []string{"", "python", "pypi", "npm"} {
+		eco := eco
+		t.Run("ecosystem="+eco, func(t *testing.T) {
+			_, _, err := resolveCheckTarget(eco, f.Name())
+			require.Error(t, err)
+			require.Contains(t, err.Error(), "not a directory")
+			require.Contains(t, err.Error(), f.Name())
+		})
+	}
+}
+
+func TestResolveCheckTargetEmptyPathStillAutodiscovers(t *testing.T) {
+	// Guardrail: the new validator must NOT fire on empty --path.
+	// The legacy Python autodiscovery contract (`aguara check`
+	// with no flags falls back to site-packages) MUST keep
+	// working; nobody should suddenly have to pass --path on a
+	// host where the prior release found Python automatically.
+	eco, path, err := resolveCheckTarget("", "")
+	require.NoError(t, err)
+	// Either ecoPython (no node_modules in cwd) or ecoNPM (if the
+	// test host happens to have one). Both are acceptable. What
+	// matters is no error and the path remains as auto-detect
+	// wants it.
+	require.Contains(t, []string{ecoPython, ecoNPM}, eco)
+	_ = path
+}
+
+func TestRunCheckExplicitMissingPathProducesError(t *testing.T) {
+	// End-to-end via cobra: a missing --path on the CLI surface
+	// produces a non-nil error from rootCmd.Execute (which
+	// main.go maps to os.Exit(2)) and -o never writes a JSON
+	// file. Locks the "no false clean JSON" contract.
+	resetFlags()
+	outFile := filepath.Join(t.TempDir(), "check.json")
+	missing := filepath.Join(t.TempDir(), "missing")
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{
+		"check",
+		"--path", missing,
+		"--format", "json",
+		"-o", outFile,
+		"--no-update-check",
+	})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		resetFlags()
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err, "missing --path must surface a non-nil error from Execute")
+	require.Contains(t, err.Error(), missing)
+
+	// And -o must NOT have been written -- the cardinal sin is
+	// producing a green check.json on a path the user never
+	// asked to scan.
+	_, statErr := os.Stat(outFile)
+	require.True(t, os.IsNotExist(statErr),
+		"no JSON output file should exist on a missing-path error; got stat err %v", statErr)
+}
+
 func TestResolveCheckTargetAutoDetectFromInsideNodeModules(t *testing.T) {
 	// Regression for codex P2 (PR review, 2026-05-15): when the
 	// probe is "." -- e.g. the user runs `aguara check` from inside


### PR DESCRIPTION
## Summary

QA on v0.16.0 caught a P2/P3 UX gap: `aguara check --path /no/existe
--format json` returned **exit 0 with an empty result**. A CI typo
in the `--path` argument advertised itself as a clean check.
`aguara scan` and `aguara audit` already fail on missing paths;
`check` was the outlier -- likely because the empty-path branch
falls through to Python's silent autodiscovery and the validator
never ran for explicit-but-bogus paths.

PR 1 of the v0.16 QA backlog.

## Change

`resolveCheckTarget` now validates non-empty `--path` via `os.Stat`
before the ecosystem dispatcher runs:

| Input | Result |
|-------|--------|
| `--path` empty | unchanged: legacy Python autodiscovery falls through |
| `--path /no/existe` | `check: --path /no/existe: no such file or directory` (exit 2) |
| `--path some-file.txt` | `check: --path some-file.txt: not a directory` (exit 2) |
| `--path some-dir` | unchanged: dispatches to ecosystem normally |

The validator only fires on `path != ""`, so `aguara check` with
no flags continues to autodiscover Python site-packages exactly
as before.

`main.go` maps any non-`ErrThresholdExceeded` error to `exit 2`;
`checkCmd.SilenceUsage = true` (set in #91) suppresses Cobra's
Usage block. A typo now reads as a single clean error line in
CI logs.

## Regression lock

Four tests:

- `TestResolveCheckTargetRejectsMissingPath` -- every ecosystem
  (auto-detect, python, pypi, npm).
- `TestResolveCheckTargetRejectsFilePath` -- every ecosystem.
- `TestResolveCheckTargetEmptyPathStillAutodiscovers` -- guard
  against accidentally tightening empty-path behaviour, which
  would break the legacy `aguara check` contract.
- `TestRunCheckExplicitMissingPathProducesError` -- e2e via
  `rootCmd.Execute`: missing `--path` produces a non-nil error
  AND **`-o` file is NEVER written**, so no false-green JSON is
  ever emitted under any condition.

## Codex pre-PR review

CLEAN PASS on the first round.

## Out of scope

PRs 2-4 of the QA backlog ship separately per the spec:
- `aguara explain JS_DNS_TXT_EXFIL_001 --format json` for
  analyzer-emitted rules.
- `aguara update --format json` honouring the format flag.
- Release-prep guardrail against `init` template version drift.

## Test plan

- [x] `go test -race -count=1 ./...`
- [x] `make vet` / `make lint` (0 issues)
- [x] Manual: `--path /no/existe`, `--path <file>`, `--path <dir>`,
      `--path ""`, each with explicit `--ecosystem` and
      auto-detect -- all behave per the table above.