### PR TITLE
feat(explain): include analyzer-emitted rules in rule catalog

### DIFF
--- a/aguara.go
+++ b/aguara.go
@@ -21,6 +21,7 @@ import (
 	"github.com/garagon/aguara/internal/engine/pkgmeta"
 	"github.com/garagon/aguara/internal/engine/rugpull"
 	"github.com/garagon/aguara/internal/engine/toxicflow"
+	"github.com/garagon/aguara/internal/rulecatalog"
 	"github.com/garagon/aguara/internal/rules"
 	"github.com/garagon/aguara/internal/rules/builtin"
 	"github.com/garagon/aguara/internal/scanner"
@@ -81,19 +82,32 @@ type RuleOverride struct {
 }
 
 // RuleInfo provides summary metadata about a detection rule.
+//
+// Analyzer is empty for pattern-matcher rules driven by YAML and
+// set to the analyzer name for analyzer-emitted rules (ci-trust,
+// pkgmeta, jsrisk, nlp, toxicflow). The omitempty tag keeps JSON
+// output compact for the common case.
 type RuleInfo struct {
 	ID       string `json:"id"`
 	Name     string `json:"name"`
 	Severity string `json:"severity"`
 	Category string `json:"category"`
+	Analyzer string `json:"analyzer,omitempty"`
 }
 
 // RuleDetail provides full information about a rule, including patterns and examples.
+//
+// Analyzer is empty for pattern-matcher rules driven by YAML and
+// set to the analyzer name for analyzer-emitted rules. Patterns,
+// TruePositives, and FalsePositives are typically empty for
+// analyzer-emitted rules because the analyzer logic itself is the
+// pattern.
 type RuleDetail struct {
 	ID             string   `json:"id"`
 	Name           string   `json:"name"`
 	Severity       string   `json:"severity"`
 	Category       string   `json:"category"`
+	Analyzer       string   `json:"analyzer,omitempty"`
 	Description    string   `json:"description"`
 	Remediation    string   `json:"remediation,omitempty"`
 	Patterns       []string `json:"patterns"`
@@ -165,83 +179,57 @@ func scanContentInternal(ctx context.Context, content string, filename string, t
 	return result, nil
 }
 
-// ListRules returns all available detection rules.
-// Use WithCategory to filter by category.
+// ListRules returns all available detection rules. Includes BOTH
+// YAML-driven pattern rules AND analyzer-emitted rules (ci-trust,
+// pkgmeta, jsrisk, nlp, toxicflow), so a finding's RuleID always
+// resolves through this function. Use WithCategory to filter.
 func ListRules(opts ...Option) []RuleInfo {
 	cfg := applyOpts(opts)
-	cr, _ := loadAndCompile(cfg)
-	if cr == nil {
+	cat, err := rulecatalog.Build(rulecatalog.Options{
+		CustomRulesDir: cfg.customRulesDir,
+		Category:       cfg.category,
+	})
+	if err != nil {
 		return nil
 	}
-	compiled := cr.compiled
-
-	sort.Slice(compiled, func(i, j int) bool {
-		return compiled[i].ID < compiled[j].ID
-	})
-
-	if cfg.category != "" {
-		var filtered []*rules.CompiledRule
-		for _, r := range compiled {
-			if strings.EqualFold(r.Category, cfg.category) {
-				filtered = append(filtered, r)
-			}
-		}
-		compiled = filtered
-	}
-
-	infos := make([]RuleInfo, len(compiled))
-	for i, r := range compiled {
+	infos := make([]RuleInfo, len(cat))
+	for i, r := range cat {
 		infos[i] = RuleInfo{
 			ID:       r.ID,
 			Name:     r.Name,
-			Severity: r.Severity.String(),
+			Severity: r.Severity,
 			Category: r.Category,
+			Analyzer: r.Analyzer,
 		}
 	}
 	return infos
 }
 
 // ExplainRule returns detailed information about a specific rule.
+// Resolves both YAML rules and analyzer-emitted rules (a finding
+// with RuleID "JS_DNS_TXT_EXFIL_001" or "GHA_PWN_REQUEST_001"
+// can be explained the same way as a pattern rule).
 func ExplainRule(id string, opts ...Option) (*RuleDetail, error) {
 	id = strings.ToUpper(strings.TrimSpace(id))
 	cfg := applyOpts(opts)
-	cr, _ := loadAndCompile(cfg)
-	if cr == nil {
-		return nil, fmt.Errorf("rule %q not found (rules failed to load)", id)
-	}
-	compiled := cr.compiled
-
-	var found *rules.CompiledRule
-	for _, r := range compiled {
-		if r.ID == id {
-			found = r
-			break
-		}
-	}
-	if found == nil {
+	r, err := rulecatalog.FindByID(rulecatalog.Options{
+		CustomRulesDir: cfg.customRulesDir,
+	}, id)
+	if err != nil {
 		return nil, fmt.Errorf("rule %q not found", id)
 	}
 
-	patterns := make([]string, len(found.Patterns))
-	for i, p := range found.Patterns {
-		switch p.Type {
-		case rules.PatternRegex:
-			patterns[i] = fmt.Sprintf("[regex] %s", p.Regex.String())
-		case rules.PatternContains:
-			patterns[i] = fmt.Sprintf("[contains] %s", p.Value)
-		}
-	}
-
 	return &RuleDetail{
-		ID:             found.ID,
-		Name:           found.Name,
-		Severity:       found.Severity.String(),
-		Category:       found.Category,
-		Description:    found.Description,
-		Remediation:    found.Remediation,
-		Patterns:       patterns,
-		TruePositives:  found.Examples.TruePositive,
-		FalsePositives: found.Examples.FalsePositive,
+		ID:             r.ID,
+		Name:           r.Name,
+		Severity:       r.Severity,
+		Category:       r.Category,
+		Analyzer:       r.Analyzer,
+		Description:    r.Description,
+		Remediation:    r.Remediation,
+		Patterns:       r.Patterns,
+		TruePositives:  r.TruePositives,
+		FalsePositives: r.FalsePositives,
 	}, nil
 }
 

--- a/aguara.go
+++ b/aguara.go
@@ -181,13 +181,17 @@ func scanContentInternal(ctx context.Context, content string, filename string, t
 
 // ListRules returns all available detection rules. Includes BOTH
 // YAML-driven pattern rules AND analyzer-emitted rules (ci-trust,
-// pkgmeta, jsrisk, nlp, toxicflow), so a finding's RuleID always
-// resolves through this function. Use WithCategory to filter.
+// pkgmeta, jsrisk, nlp, toxicflow, rugpull), so a finding's
+// RuleID always resolves through this function. WithCategory
+// filters; WithDisabledRules removes IDs from the listing so a
+// policy UI built on top of ListRules sees the same set the
+// scanner will consult.
 func ListRules(opts ...Option) []RuleInfo {
 	cfg := applyOpts(opts)
 	cat, err := rulecatalog.Build(rulecatalog.Options{
 		CustomRulesDir: cfg.customRulesDir,
 		Category:       cfg.category,
+		DisableRuleIDs: cfg.disabledRules,
 	})
 	if err != nil {
 		return nil

--- a/aguara.go
+++ b/aguara.go
@@ -179,19 +179,39 @@ func scanContentInternal(ctx context.Context, content string, filename string, t
 	return result, nil
 }
 
+// catalogOverridesFromCfg projects the public RuleOverride map
+// onto the catalog's narrower Override shape. Tool-scoping fields
+// (ApplyToTools / ExemptTools) are not relevant to list-rules /
+// explain output, so the projection drops them; the scanner still
+// sees them via the existing rule-overrides pipeline.
+func catalogOverridesFromCfg(in map[string]RuleOverride) map[string]rulecatalog.Override {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]rulecatalog.Override, len(in))
+	for id, o := range in {
+		out[id] = rulecatalog.Override{
+			Severity: o.Severity,
+			Disabled: o.Disabled,
+		}
+	}
+	return out
+}
+
 // ListRules returns all available detection rules. Includes BOTH
 // YAML-driven pattern rules AND analyzer-emitted rules (ci-trust,
 // pkgmeta, jsrisk, nlp, toxicflow, rugpull), so a finding's
 // RuleID always resolves through this function. WithCategory
-// filters; WithDisabledRules removes IDs from the listing so a
-// policy UI built on top of ListRules sees the same set the
-// scanner will consult.
+// filters; WithDisabledRules and WithRuleOverrides drop / mutate
+// rules so a policy UI built on top of ListRules sees the same
+// set the scanner will consult.
 func ListRules(opts ...Option) []RuleInfo {
 	cfg := applyOpts(opts)
 	cat, err := rulecatalog.Build(rulecatalog.Options{
 		CustomRulesDir: cfg.customRulesDir,
 		Category:       cfg.category,
 		DisableRuleIDs: cfg.disabledRules,
+		Overrides:      catalogOverridesFromCfg(cfg.ruleOverrides),
 	})
 	if err != nil {
 		return nil

--- a/aguara_test.go
+++ b/aguara_test.go
@@ -125,6 +125,91 @@ func TestListRules(t *testing.T) {
 	}
 }
 
+func TestListRulesIncludesAnalyzerRules(t *testing.T) {
+	// QA + codex regression: external library consumers (e.g.
+	// aguara-mcp) call aguara.ListRules to populate policy UIs.
+	// The list must include analyzer-emitted rule IDs alongside
+	// YAML rules; before the rulecatalog consolidation only YAML
+	// rules surfaced, so a finding from jsrisk / ci-trust / etc.
+	// had no listing for the UI to render.
+	rules := aguara.ListRules()
+	ids := make(map[string]string, len(rules))
+	for _, r := range rules {
+		ids[r.ID] = r.Analyzer
+	}
+	want := map[string]string{
+		"JS_DNS_TXT_EXFIL_001":  "jsrisk",
+		"GHA_PWN_REQUEST_001":   "ci-trust",
+		"NPM_LIFECYCLE_GIT_001": "pkgmeta",
+		"TOXIC_001":             "toxicflow",
+		"NLP_HIDDEN_INSTRUCTION": "nlp",
+		"RUGPULL_001":           "rugpull",
+	}
+	for id, analyzer := range want {
+		got, ok := ids[id]
+		if !ok {
+			t.Errorf("ListRules must include analyzer rule %s", id)
+			continue
+		}
+		if got != analyzer {
+			t.Errorf("ListRules %s: analyzer = %q, want %q", id, got, analyzer)
+		}
+	}
+}
+
+func TestListRulesHonoursDisabledRules(t *testing.T) {
+	// Codex P2: WithDisabledRules must filter the catalog the
+	// same way it filters the scanner. A policy UI built on top
+	// of ListRules has to agree with what the scanner actually
+	// runs; otherwise the UI shows rules that will never fire.
+	all := aguara.ListRules()
+	require := func(cond bool, msg string) {
+		if !cond {
+			t.Helper()
+			t.Fatal(msg)
+		}
+	}
+
+	target := "JS_DNS_TXT_EXFIL_001"
+	hasTarget := false
+	for _, r := range all {
+		if r.ID == target {
+			hasTarget = true
+			break
+		}
+	}
+	require(hasTarget, target+" must be in the unfiltered list")
+
+	filtered := aguara.ListRules(aguara.WithDisabledRules(target))
+	for _, r := range filtered {
+		if r.ID == target {
+			t.Errorf("WithDisabledRules(%s) must remove the rule from ListRules output", target)
+		}
+	}
+	if len(filtered) >= len(all) {
+		t.Errorf("WithDisabledRules did not reduce the list (filtered=%d, all=%d)", len(filtered), len(all))
+	}
+}
+
+func TestExplainRuleResolvesAnalyzerRule(t *testing.T) {
+	// QA regression: ExplainRule must resolve analyzer-emitted
+	// IDs the same way it resolves YAML IDs. The Analyzer field
+	// is set so the consumer can branch on engine origin.
+	d, err := aguara.ExplainRule("JS_DNS_TXT_EXFIL_001")
+	if err != nil {
+		t.Fatalf("ExplainRule(JS_DNS_TXT_EXFIL_001) failed: %v", err)
+	}
+	if d.Analyzer != "jsrisk" {
+		t.Errorf("ExplainRule: analyzer = %q, want jsrisk", d.Analyzer)
+	}
+	if d.Category != "supply-chain" {
+		t.Errorf("ExplainRule: category = %q, want supply-chain", d.Category)
+	}
+	if d.Remediation == "" {
+		t.Errorf("ExplainRule: analyzer rule must carry a non-empty remediation string")
+	}
+}
+
 func TestListRulesWithCategory(t *testing.T) {
 	all := aguara.ListRules()
 	pi := aguara.ListRules(aguara.WithCategory("prompt-injection"))

--- a/aguara_test.go
+++ b/aguara_test.go
@@ -157,6 +157,41 @@ func TestListRulesIncludesAnalyzerRules(t *testing.T) {
 	}
 }
 
+func TestListRulesHonoursRuleOverrides(t *testing.T) {
+	// Codex P2 round 2: WithRuleOverrides on ListRules must apply
+	// both the Disabled flag and the Severity remap, so a policy
+	// UI built on top of the catalog never disagrees with what the
+	// scanner actually runs. Two scenarios:
+	//
+	//  - Disabled:true drops the rule from the list.
+	//  - Severity:"low" remaps the rule's severity in the output.
+	target := "PROMPT_INJECTION_001"
+	overrides := map[string]aguara.RuleOverride{
+		target: {Disabled: true},
+	}
+	filtered := aguara.ListRules(aguara.WithRuleOverrides(overrides))
+	for _, r := range filtered {
+		if r.ID == target {
+			t.Errorf("WithRuleOverrides Disabled=true did not drop %s", target)
+		}
+	}
+
+	overrides = map[string]aguara.RuleOverride{
+		target: {Severity: "LOW"},
+	}
+	withSev := aguara.ListRules(aguara.WithRuleOverrides(overrides))
+	var got string
+	for _, r := range withSev {
+		if r.ID == target {
+			got = r.Severity
+			break
+		}
+	}
+	if got != "LOW" {
+		t.Errorf("WithRuleOverrides Severity remap: %s = %q, want LOW", target, got)
+	}
+}
+
 func TestListRulesHonoursDisabledRules(t *testing.T) {
 	// Codex P2: WithDisabledRules must filter the catalog the
 	// same way it filters the scanner. A policy UI built on top

--- a/cmd/aguara/commands/explain.go
+++ b/cmd/aguara/commands/explain.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,8 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/garagon/aguara/internal/rules"
-	"github.com/garagon/aguara/internal/rules/builtin"
+	"github.com/garagon/aguara/internal/rulecatalog"
+	"github.com/garagon/aguara/internal/rulemeta"
 )
 
 var explainCmd = &cobra.Command{
@@ -21,94 +22,46 @@ var explainCmd = &cobra.Command{
 }
 
 func init() {
+	// `rule not found` is a runtime user error (typo in the ID),
+	// not a flag-parse issue. Cobra's default behaviour would
+	// dump the Usage block on top of the error -- in CI logs that
+	// reads as command misuse rather than "you typed the ID
+	// wrong". Same SilenceUsage pattern PR #91 applied to scan /
+	// check / audit / update.
+	explainCmd.SilenceUsage = true
 	rootCmd.AddCommand(explainCmd)
-}
-
-type explainInfo struct {
-	ID             string   `json:"id"`
-	Name           string   `json:"name"`
-	Severity       string   `json:"severity"`
-	Category       string   `json:"category"`
-	Description    string   `json:"description"`
-	Remediation    string   `json:"remediation,omitempty"`
-	Patterns       []string `json:"patterns"`
-	TruePositives  []string `json:"true_positives"`
-	FalsePositives []string `json:"false_positives"`
 }
 
 func runExplain(cmd *cobra.Command, args []string) error {
 	ruleID := strings.ToUpper(strings.TrimSpace(args[0]))
 
-	found, err := findRule(ruleID)
+	found, err := rulecatalog.FindByID(rulecatalog.Options{
+		CustomRulesDir: flagRules,
+		Warn: func(format string, a ...any) {
+			fmt.Fprintf(cmd.ErrOrStderr(), format, a...)
+		},
+	}, ruleID)
 	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("rule %q not found", ruleID)
+		}
 		return err
 	}
 
-	patterns := describePatterns(found)
 	w := cmd.OutOrStdout()
-
 	if strings.ToLower(flagFormat) == "json" {
-		return writeExplainJSON(w, found, patterns)
+		return writeExplainJSON(w, found)
 	}
-	return writeExplainTerminal(w, found, patterns)
+	return writeExplainTerminal(w, found)
 }
 
-func findRule(ruleID string) (*rules.CompiledRule, error) {
-	rawRules, err := rules.LoadFromFS(builtin.FS())
-	if err != nil {
-		return nil, fmt.Errorf("loading built-in rules: %w", err)
-	}
-	if flagRules != "" {
-		customRules, err := rules.LoadFromDir(flagRules)
-		if err != nil {
-			return nil, fmt.Errorf("loading custom rules from %s: %w", flagRules, err)
-		}
-		rawRules = append(rawRules, customRules...)
-	}
-	compiled, compileErrs := rules.CompileAll(rawRules)
-	for _, e := range compileErrs {
-		fmt.Fprintf(os.Stderr, "warning: %v\n", e)
-	}
-
-	for _, r := range compiled {
-		if r.ID == ruleID {
-			return r, nil
-		}
-	}
-	return nil, fmt.Errorf("rule %q not found", ruleID)
-}
-
-func describePatterns(r *rules.CompiledRule) []string {
-	patterns := make([]string, len(r.Patterns))
-	for i, p := range r.Patterns {
-		switch p.Type {
-		case rules.PatternRegex:
-			patterns[i] = fmt.Sprintf("[regex] %s", p.Regex.String())
-		case rules.PatternContains:
-			patterns[i] = fmt.Sprintf("[contains] %s", p.Value)
-		}
-	}
-	return patterns
-}
-
-func writeExplainJSON(w io.Writer, r *rules.CompiledRule, patterns []string) error {
-	info := explainInfo{
-		ID:             r.ID,
-		Name:           r.Name,
-		Severity:       r.Severity.String(),
-		Category:       r.Category,
-		Description:    r.Description,
-		Remediation:    r.Remediation,
-		Patterns:       patterns,
-		TruePositives:  r.Examples.TruePositive,
-		FalsePositives: r.Examples.FalsePositive,
-	}
+func writeExplainJSON(w io.Writer, r *rulemeta.Rule) error {
 	enc := json.NewEncoder(w)
 	enc.SetIndent("", "  ")
-	return enc.Encode(info)
+	return enc.Encode(r)
 }
 
-func writeExplainTerminal(w io.Writer, found *rules.CompiledRule, patterns []string) error {
+func writeExplainTerminal(w io.Writer, found *rulemeta.Rule) error {
 	color := func(code, text string) string {
 		if flagNoColor {
 			return text
@@ -124,7 +77,7 @@ func writeExplainTerminal(w io.Writer, found *rules.CompiledRule, patterns []str
 	green := "\033[32m"
 
 	sevColor := cyan
-	switch found.Severity.String() {
+	switch found.Severity {
 	case "CRITICAL":
 		sevColor = red + bold
 	case "HIGH":
@@ -135,8 +88,11 @@ func writeExplainTerminal(w io.Writer, found *rules.CompiledRule, patterns []str
 
 	fmt.Fprintf(w, "\n%s %s\n", color(dim, "Rule:"), color(bold, found.ID))
 	fmt.Fprintf(w, "%s %s\n", color(dim, "Name:"), found.Name)
-	fmt.Fprintf(w, "%s %s\n", color(dim, "Severity:"), color(sevColor, found.Severity.String()))
+	fmt.Fprintf(w, "%s %s\n", color(dim, "Severity:"), color(sevColor, found.Severity))
 	fmt.Fprintf(w, "%s %s\n", color(dim, "Category:"), found.Category)
+	if found.Analyzer != "" {
+		fmt.Fprintf(w, "%s %s\n", color(dim, "Analyzer:"), found.Analyzer)
+	}
 
 	if found.Description != "" {
 		fmt.Fprintf(w, "\n%s\n%s\n", color(bold, "Description:"), found.Description)
@@ -146,24 +102,24 @@ func writeExplainTerminal(w io.Writer, found *rules.CompiledRule, patterns []str
 		fmt.Fprintf(w, "\n%s\n%s\n", color(bold, "Remediation:"), color(green, found.Remediation))
 	}
 
-	if len(patterns) > 0 {
+	if len(found.Patterns) > 0 {
 		fmt.Fprintf(w, "\n%s\n", color(bold, "Patterns:"))
-		for i, p := range patterns {
+		for i, p := range found.Patterns {
 			fmt.Fprintf(w, "  %d. %s\n", i+1, color(dim, p))
 		}
 	}
 
-	if len(found.Examples.TruePositive) > 0 {
+	if len(found.TruePositives) > 0 {
 		fmt.Fprintf(w, "\n%s\n", color(bold, "True Positives:"))
-		for _, ex := range found.Examples.TruePositive {
-			fmt.Fprintf(w, "  %s %s\n", color(red, "\u2716"), ex)
+		for _, ex := range found.TruePositives {
+			fmt.Fprintf(w, "  %s %s\n", color(red, "✖"), ex)
 		}
 	}
 
-	if len(found.Examples.FalsePositive) > 0 {
+	if len(found.FalsePositives) > 0 {
 		fmt.Fprintf(w, "\n%s\n", color(bold, "False Positives:"))
-		for _, ex := range found.Examples.FalsePositive {
-			fmt.Fprintf(w, "  %s %s\n", color(green, "\u2714"), ex)
+		for _, ex := range found.FalsePositives {
+			fmt.Fprintf(w, "  %s %s\n", color(green, "✔"), ex)
 		}
 	}
 

--- a/cmd/aguara/commands/explain.go
+++ b/cmd/aguara/commands/explain.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -42,7 +41,12 @@ func runExplain(cmd *cobra.Command, args []string) error {
 		},
 	}, ruleID)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		// Distinguish a clean miss (typo in the ID) from a
+		// catalog-build failure (e.g. --rules points at a
+		// missing directory). The latter must surface its real
+		// error so the user can diagnose, not get masked as
+		// "rule not found".
+		if errors.Is(err, rulecatalog.ErrRuleNotFound) {
 			return fmt.Errorf("rule %q not found", ruleID)
 		}
 		return err

--- a/cmd/aguara/commands/explain_test.go
+++ b/cmd/aguara/commands/explain_test.go
@@ -3,16 +3,18 @@ package commands
 import (
 	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
 
+	"github.com/garagon/aguara/internal/rulemeta"
 	"github.com/stretchr/testify/require"
 )
 
 func TestExplainKnownRule(t *testing.T) {
 	buf := new(bytes.Buffer)
-	flagFormat = "terminal"
+	resetFlags()
 	flagNoColor = true
-	flagRules = ""
+	t.Cleanup(resetFlags)
 
 	rootCmd.SetOut(buf)
 	rootCmd.SetArgs([]string{"explain", "PROMPT_INJECTION_001", "--no-color"})
@@ -32,8 +34,8 @@ func TestExplainKnownRule(t *testing.T) {
 
 func TestExplainJSON(t *testing.T) {
 	buf := new(bytes.Buffer)
-	flagFormat = "terminal"
-	flagRules = ""
+	resetFlags()
+	t.Cleanup(resetFlags)
 
 	rootCmd.SetOut(buf)
 	rootCmd.SetArgs([]string{"explain", "PROMPT_INJECTION_001", "--format", "json"})
@@ -43,19 +45,88 @@ func TestExplainJSON(t *testing.T) {
 	err := rootCmd.Execute()
 	require.NoError(t, err)
 
-	var info explainInfo
+	var info rulemeta.Rule
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &info))
 	require.Equal(t, "PROMPT_INJECTION_001", info.ID)
 	require.Equal(t, "CRITICAL", info.Severity)
 	require.Equal(t, "prompt-injection", info.Category)
+	require.Empty(t, info.Analyzer, "YAML pattern rules have no analyzer; omitempty must keep the field absent")
 	require.NotEmpty(t, info.Patterns)
 	require.NotEmpty(t, info.TruePositives)
 }
 
+func TestExplainAnalyzerRuleJSON(t *testing.T) {
+	// QA regression on v0.16.0: scan emitted JS_DNS_TXT_EXFIL_001
+	// but explain failed with "rule not found" because analyzer
+	// rules weren't in the catalog. This test locks the new path:
+	// the analyzer rule resolves AND its JSON shape carries the
+	// analyzer field so downstream tooling can branch on it.
+	buf := new(bytes.Buffer)
+	resetFlags()
+	t.Cleanup(resetFlags)
+
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"explain", "JS_DNS_TXT_EXFIL_001", "--format", "json"})
+	defer rootCmd.SetArgs(nil)
+	defer rootCmd.SetOut(nil)
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	var info rulemeta.Rule
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &info))
+	require.Equal(t, "JS_DNS_TXT_EXFIL_001", info.ID)
+	require.Equal(t, rulemeta.AnalyzerJSRisk, info.Analyzer)
+	require.Equal(t, "supply-chain", info.Category)
+	require.NotEmpty(t, info.Description)
+	require.NotEmpty(t, info.Remediation)
+}
+
+func TestExplainAnalyzerRuleTerminal(t *testing.T) {
+	// Terminal output for analyzer rules must print the new
+	// Analyzer: line so a human reading the explain block can
+	// see which engine owns the rule.
+	buf := new(bytes.Buffer)
+	resetFlags()
+	flagNoColor = true
+	t.Cleanup(resetFlags)
+
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"explain", "GHA_PWN_REQUEST_001", "--no-color"})
+	defer rootCmd.SetArgs(nil)
+	defer rootCmd.SetOut(nil)
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	out := buf.String()
+	require.Contains(t, out, "GHA_PWN_REQUEST_001")
+	require.True(t, strings.Contains(out, "Analyzer:") && strings.Contains(out, rulemeta.AnalyzerCITrust),
+		"analyzer rule terminal output must print the Analyzer: line; got: %s", out)
+}
+
+func TestExplainCaseInsensitive(t *testing.T) {
+	buf := new(bytes.Buffer)
+	resetFlags()
+	t.Cleanup(resetFlags)
+
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"explain", "js_dns_txt_exfil_001", "--format", "json"})
+	defer rootCmd.SetArgs(nil)
+	defer rootCmd.SetOut(nil)
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	var info rulemeta.Rule
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &info))
+	require.Equal(t, "JS_DNS_TXT_EXFIL_001", info.ID, "explain must be case-insensitive on the ID arg")
+}
+
 func TestExplainNotFound(t *testing.T) {
 	buf := new(bytes.Buffer)
-	flagFormat = "terminal"
-	flagRules = ""
+	resetFlags()
+	t.Cleanup(resetFlags)
 
 	rootCmd.SetOut(buf)
 	rootCmd.SetErr(buf)
@@ -67,4 +138,49 @@ func TestExplainNotFound(t *testing.T) {
 	err := rootCmd.Execute()
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "not found")
+	// SilenceUsage must prevent Cobra from dumping the --help
+	// block on rule-not-found. The buf captures stderr too, so a
+	// regression that re-enables Usage would appear here.
+	require.NotContains(t, buf.String(), "Usage:",
+		"rule-not-found must not print Cobra Usage block")
+	require.NotContains(t, buf.String(), "Flags:",
+		"rule-not-found must not print Cobra Flags block")
+}
+
+func TestListRulesIncludesAnalyzerRules(t *testing.T) {
+	// JSON list-rules must include analyzer-emitted rules
+	// alongside YAML rules so a CI integrator scripting against
+	// list-rules JSON sees every ID the scanner can emit.
+	buf := new(bytes.Buffer)
+	resetFlags()
+	t.Cleanup(resetFlags)
+
+	rootCmd.SetOut(buf)
+	rootCmd.SetArgs([]string{"list-rules", "--format", "json"})
+	defer rootCmd.SetArgs(nil)
+	defer rootCmd.SetOut(nil)
+
+	err := rootCmd.Execute()
+	require.NoError(t, err)
+
+	var entries []rulemeta.Rule
+	require.NoError(t, json.Unmarshal(buf.Bytes(), &entries))
+
+	ids := make(map[string]string, len(entries))
+	for _, e := range entries {
+		ids[e.ID] = e.Analyzer
+	}
+	for _, want := range []string{
+		"JS_DNS_TXT_EXFIL_001",
+		"GHA_PWN_REQUEST_001",
+		"NPM_LIFECYCLE_GIT_001",
+		"TOXIC_001",
+		"NLP_HIDDEN_INSTRUCTION",
+		"PROMPT_INJECTION_001",
+	} {
+		_, ok := ids[want]
+		require.Truef(t, ok, "list-rules JSON must include %s", want)
+	}
+	// And one specific analyzer pin to lock the shape.
+	require.Equal(t, rulemeta.AnalyzerJSRisk, ids["JS_DNS_TXT_EXFIL_001"])
 }

--- a/cmd/aguara/commands/list_rules.go
+++ b/cmd/aguara/commands/list_rules.go
@@ -3,14 +3,12 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/spf13/cobra"
 
-	"github.com/garagon/aguara/internal/rules"
-	"github.com/garagon/aguara/internal/rules/builtin"
+	"github.com/garagon/aguara/internal/rulecatalog"
 )
 
 var flagCategory string
@@ -26,85 +24,45 @@ func init() {
 	rootCmd.AddCommand(listRulesCmd)
 }
 
-type ruleInfo struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Severity string `json:"severity"`
-	Category string `json:"category"`
-}
-
 func runListRules(cmd *cobra.Command, args []string) error {
-	// Load built-in rules
-	rawRules, err := rules.LoadFromFS(builtin.FS())
-	if err != nil {
-		return fmt.Errorf("loading built-in rules: %w", err)
-	}
-
-	// Load custom rules if specified
-	if flagRules != "" {
-		customRules, err := rules.LoadFromDir(flagRules)
-		if err != nil {
-			return fmt.Errorf("loading custom rules from %s: %w", flagRules, err)
-		}
-		rawRules = append(rawRules, customRules...)
-	}
-
-	// Compile rules
-	compiled, compileErrs := rules.CompileAll(rawRules)
-	for _, e := range compileErrs {
-		fmt.Fprintf(cmd.ErrOrStderr(), "warning: %v\n", e)
-	}
-
-	// Apply --disable-rule flag
-	if len(flagDisableRules) > 0 {
-		disabled := make(map[string]bool)
-		for _, id := range flagDisableRules {
-			disabled[strings.TrimSpace(id)] = true
-		}
-		compiled = rules.FilterByIDs(compiled, disabled)
-	}
-
-	// Sort by rule ID
-	sort.Slice(compiled, func(i, j int) bool {
-		return compiled[i].ID < compiled[j].ID
+	// The catalog merges YAML-compiled pattern rules, custom rules
+	// from --rules, and every analyzer's RuleMetadata() into one
+	// sorted slice. Before this consolidation `list-rules` only
+	// surfaced YAML rules, so analyzer-emitted rules like
+	// JS_DNS_TXT_EXFIL_001 or GHA_PWN_REQUEST_001 appeared in
+	// findings but could not be listed or explained.
+	cat, err := rulecatalog.Build(rulecatalog.Options{
+		CustomRulesDir: flagRules,
+		DisableRuleIDs: flagDisableRules,
+		Category:       flagCategory,
+		Warn: func(format string, a ...any) {
+			fmt.Fprintf(cmd.ErrOrStderr(), format, a...)
+		},
 	})
-
-	// Filter by category
-	if flagCategory != "" {
-		var filtered []*rules.CompiledRule
-		for _, r := range compiled {
-			if strings.EqualFold(r.Category, flagCategory) {
-				filtered = append(filtered, r)
-			}
-		}
-		compiled = filtered
+	if err != nil {
+		return err
 	}
 
 	w := cmd.OutOrStdout()
 
 	if strings.ToLower(flagFormat) == "json" {
-		infos := make([]ruleInfo, len(compiled))
-		for i, r := range compiled {
-			infos[i] = ruleInfo{
-				ID:       r.ID,
-				Name:     r.Name,
-				Severity: r.Severity.String(),
-				Category: r.Category,
-			}
-		}
 		enc := json.NewEncoder(w)
 		enc.SetIndent("", "  ")
-		return enc.Encode(infos)
+		return enc.Encode(cat)
 	}
 
 	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
-	fmt.Fprintf(tw, "ID\tNAME\tSEVERITY\tCATEGORY\n")
-	fmt.Fprintf(tw, "--\t----\t--------\t--------\n")
-	for _, r := range compiled {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", r.ID, r.Name, r.Severity.String(), r.Category)
+	fmt.Fprintf(tw, "ID\tNAME\tSEVERITY\tCATEGORY\tANALYZER\n")
+	fmt.Fprintf(tw, "--\t----\t--------\t--------\t--------\n")
+	for _, r := range cat {
+		analyzer := r.Analyzer
+		if analyzer == "" {
+			analyzer = "-"
+		}
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n", r.ID, r.Name, r.Severity, r.Category, analyzer)
 	}
 	_ = tw.Flush()
-	fmt.Fprintf(w, "\n%d rules loaded\n", len(compiled))
+	fmt.Fprintf(w, "\n%d rules loaded\n", len(cat))
 
 	return nil
 }

--- a/cmd/aguara/commands/list_rules_test.go
+++ b/cmd/aguara/commands/list_rules_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/garagon/aguara/internal/rulemeta"
 	"github.com/stretchr/testify/require"
 )
 
@@ -46,7 +47,7 @@ func TestListRulesJSON(t *testing.T) {
 	err := rootCmd.Execute()
 	require.NoError(t, err)
 
-	var rules []ruleInfo
+	var rules []rulemeta.Rule
 	require.NoError(t, json.Unmarshal(buf.Bytes(), &rules))
 	require.GreaterOrEqual(t, len(rules), 70)
 	require.NotEmpty(t, rules[0].ID)
@@ -69,12 +70,25 @@ func TestListRulesCategoryFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	out := buf.String()
+	// Every listed rule that starts with a known prefix in the
+	// prompt-injection category must land in the right column.
+	// The set now includes NLP_* analyzer rules alongside the
+	// YAML PROMPT_INJECTION_* rules; both are prompt-injection.
 	lines := strings.SplitSeq(out, "\n")
 	for line := range lines {
-		if strings.HasPrefix(line, "PROMPT_INJECTION") {
-			require.Contains(t, line, "prompt-injection")
+		switch {
+		case strings.HasPrefix(line, "PROMPT_INJECTION"),
+			strings.HasPrefix(line, "NLP_"):
+			require.Contains(t, line, "prompt-injection",
+				"rule listed under --category prompt-injection must carry that category in the row: %s", line)
 		}
 	}
 	require.Contains(t, out, "rules loaded")
-	require.NotContains(t, out, "EXFIL_")
+	// Cross-category rules must NOT leak in. JS_DNS_TXT_EXFIL_001
+	// is supply-chain, not prompt-injection -- a regression
+	// that surfaces it here means the category filter is broken.
+	require.NotContains(t, out, "JS_DNS_TXT_EXFIL_001",
+		"supply-chain JS_DNS_TXT_EXFIL_001 must NOT appear under --category prompt-injection")
+	require.NotContains(t, out, "GHA_PWN_REQUEST_001",
+		"supply-chain GHA_PWN_REQUEST_001 must NOT appear under --category prompt-injection")
 }

--- a/internal/engine/ci/metadata.go
+++ b/internal/engine/ci/metadata.go
@@ -1,0 +1,75 @@
+package ci
+
+import "github.com/garagon/aguara/internal/rulemeta"
+
+// RuleMetadata returns the catalog entries for every rule this
+// analyzer can emit. Co-located with the analyzer so an engineer
+// adding a new GHA_* rule cannot forget the explain entry -- both
+// live in the same package.
+func RuleMetadata() []rulemeta.Rule {
+	return []rulemeta.Rule{
+		{
+			ID:       RulePwnRequest,
+			Name:     "Pull-request-target with PR-controlled checkout",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerCITrust,
+			Description: "GitHub Actions workflow triggered on `pull_request_target` " +
+				"that checks out PR-controlled code and runs install/build/test/interpreter " +
+				"steps in the same job. The `pull_request_target` trigger runs with the " +
+				"repository's secrets in scope, so untrusted PR code gains access to write " +
+				"tokens. Promoted to CRITICAL when the workflow also grants `contents: write` " +
+				"or similar write permissions.",
+			Remediation: "Use `pull_request` instead, or split the workflow so the " +
+				"`pull_request_target` job never executes PR-controlled code (no install/" +
+				"build/test/interpreter steps after the checkout). If write permissions are " +
+				"needed, gate them behind a manual review (`environment:` with required " +
+				"reviewers) rather than firing automatically on every PR.",
+		},
+		{
+			ID:       RuleCache,
+			Name:     "Pull-request-target cache poisoning chain",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerCITrust,
+			Description: "Same `pull_request_target` + PR-controlled checkout chain as " +
+				"GHA_PWN_REQUEST_001, additionally combined with an `actions/cache` write. " +
+				"PR-controlled code can populate the cache so subsequent runs (including on " +
+				"trusted branches) restore attacker-controlled artifacts. Promoted to " +
+				"CRITICAL when paired with code execution.",
+			Remediation: "Disable cache writes on PR-triggered jobs (`actions/cache/restore` " +
+				"is read-only) or scope the cache key to the PR's head SHA so cross-PR " +
+				"poisoning cannot land on `main`.",
+		},
+		{
+			ID:       RuleOIDC,
+			Name:     "OIDC token grant on install/build/test chain",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerCITrust,
+			Description: "Workflow grants `id-token: write` to a job that ALSO runs " +
+				"install/build/test steps. The OIDC token federates to cloud roles and " +
+				"trusted-publishing surfaces; pairing it with arbitrary install-time code " +
+				"execution lets a compromised dependency mint cloud credentials. Promoted " +
+				"to CRITICAL when the job also publishes (npm, PyPI, Docker, ...).",
+			Remediation: "Split the workflow: publish steps and id-token grants run in a " +
+				"separate job that does not execute install/build/test commands. The " +
+				"install job stays untrusted; the publish job receives a small, vetted " +
+				"artifact.",
+		},
+		{
+			ID:       RuleCheckout,
+			Name:     "Pull-request-target head-ref checkout without persist-credentials: false",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerCITrust,
+			Description: "Workflow uses `actions/checkout` against the PR head ref on a " +
+				"`pull_request_target` trigger without setting `persist-credentials: false`. " +
+				"The default behaviour leaves the workflow's GITHUB_TOKEN in the local git " +
+				"config, so any subsequent step (or PR-controlled hook) can push back to the " +
+				"repository.",
+			Remediation: "Add `with: persist-credentials: false` to the checkout step, or " +
+				"switch the trigger to `pull_request` (which runs without write tokens).",
+		},
+	}
+}

--- a/internal/engine/jsrisk/metadata.go
+++ b/internal/engine/jsrisk/metadata.go
@@ -39,9 +39,12 @@ func RuleMetadata() []rulemeta.Rule {
 				"behaviour in the package README and the lifecycle script comment.",
 		},
 		{
-			ID:       RuleCISecretHarvest,
-			Name:     "CI secret harvest: process.env read + network sink",
-			Severity: "HIGH",
+			ID:   RuleCISecretHarvest,
+			Name: "CI secret harvest: process.env read + network sink",
+			// Emit site (jsrisk.go) ships SeverityCritical for
+			// this rule; the catalog mirrors that so list-rules /
+			// explain triage stays aligned with scan findings.
+			Severity: "CRITICAL",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerJSRisk,
 			Description: "Script reads CI secret env vars (GITHUB_TOKEN, NPM_TOKEN, " +

--- a/internal/engine/jsrisk/metadata.go
+++ b/internal/engine/jsrisk/metadata.go
@@ -1,0 +1,102 @@
+package jsrisk
+
+import "github.com/garagon/aguara/internal/rulemeta"
+
+// RuleMetadata returns the catalog entries for every rule this
+// analyzer can emit. Adding a new JS_* / AGENT_* rule must also
+// add an entry here so `aguara explain <ID>` resolves; the
+// catalog test fails when an emit-site rule ID is missing from
+// this list.
+func RuleMetadata() []rulemeta.Rule {
+	return []rulemeta.Rule{
+		{
+			ID:       RuleObfuscation,
+			Name:     "Obfuscator-shape JavaScript payload",
+			Severity: "MEDIUM",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerJSRisk,
+			Description: "JavaScript file carries obfuscator-shape signals: dense hex " +
+				"identifiers (_0x...), dispatcher calls, `while(!![])` infinite loop wrappers, " +
+				"plus a size or line-length anomaly. Common in supply-chain payloads that " +
+				"hide credential-exfiltration logic. Promoted to HIGH when paired with " +
+				"env-var reads, child_process spawns, or network sinks.",
+			Remediation: "Treat the file as suspicious until source-mapped or hand-reviewed. " +
+				"If this is your own minified output, ship a sourcemap alongside; the " +
+				"detector does not penalise minified code that ALSO ships source.",
+		},
+		{
+			ID:       RuleDaemon,
+			Name:     "Install-time daemonization via child_process",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerJSRisk,
+			Description: "Script spawns a long-lived child process via `child_process.spawn` " +
+				"or `child_process.exec` with `detached: true` (or equivalent unref+setsid " +
+				"shape) during an install-time lifecycle hook. Pattern matches credential " +
+				"harvesters that stay resident after npm install completes.",
+			Remediation: "Move long-lived processes to explicit user-invoked commands. If " +
+				"a background process is genuinely needed at install time, document the " +
+				"behaviour in the package README and the lifecycle script comment.",
+		},
+		{
+			ID:       RuleCISecretHarvest,
+			Name:     "CI secret harvest: process.env read + network sink",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerJSRisk,
+			Description: "Script reads CI secret env vars (GITHUB_TOKEN, NPM_TOKEN, " +
+				"AWS_*, OIDC_*, etc.) AND sends them out via fetch/https/registry hooks " +
+				"in the same module. The detector requires a REAL process.env read against " +
+				"a known secret name plus a real network sink in the same control flow.",
+			Remediation: "If the script legitimately uploads CI artifacts, vendor the upload " +
+				"into a separate, audited script with no secret-reading code. The combined " +
+				"shape (secret read + network sink) is the canonical exfil pattern.",
+		},
+		{
+			ID:       RuleProcMemOIDC,
+			Name:     "Runner-process memory pivot to extract OIDC tokens",
+			Severity: "CRITICAL",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerJSRisk,
+			Description: "Script reads `/proc/<pid>/environ`, `/proc/<pid>/maps`, or similar " +
+				"runner-process introspection surfaces to extract OIDC tokens (or other " +
+				"secrets) from a sibling process. Specifically catches the " +
+				"GitHub-Actions runner pivot pattern where one package's install step " +
+				"reads tokens belonging to a parallel job.",
+			Remediation: "Remove the /proc walk. There is no legitimate reason for an npm " +
+				"install script to read another process's environment.",
+		},
+		{
+			ID:       RuleAgentPersistence,
+			Name:     "Claude Code / VS Code workspace persistence",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerJSRisk,
+			Description: "Script writes into `.claude/`, `.vscode/`, or the workspace " +
+				"`settings.json` from install code, establishing persistent agent or IDE " +
+				"hooks the user did not opt into. Common in supply-chain payloads that " +
+				"want to re-run on every editor session.",
+			Remediation: "Move workspace customisation to an explicit, user-opt-in flow " +
+				"(setup script, README instructions). Install-time writes into those paths " +
+				"are not legitimate behaviour for a published npm/PyPI package.",
+		},
+		{
+			ID:       RuleDNSTXTExfil,
+			Name:     "DNS TXT credential exfiltration chain",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerJSRisk,
+			Description: "Script calls `dns.resolveTxt` (or an equivalent destructured / " +
+				"dns/promises / new Resolver() shape) AND chains at least one signal: a " +
+				"CI/cloud secret read, an on-disk envs.txt credential stage, a tar.gz " +
+				"archive under os.tmpdir(), install-time daemonization, or a known IOC " +
+				"string from the 2026 node-ipc compromise (bt.node.js, " +
+				"sh.azurestaticprovider.net, __ntw, __ntRun). Fires HIGH on a single " +
+				"partner; CRITICAL on three+ partners or a known IOC.",
+			Remediation: "Treat the file as actively malicious. The DNS TXT exfil " +
+				"pattern has no legitimate use in package install code; remove the " +
+				"package, audit recent installs, and rotate every credential the host " +
+				"could reach.",
+		},
+	}
+}

--- a/internal/engine/nlp/metadata.go
+++ b/internal/engine/nlp/metadata.go
@@ -1,0 +1,95 @@
+package nlp
+
+import "github.com/garagon/aguara/internal/rulemeta"
+
+// RuleMetadata returns the catalog entries for every rule the NLP
+// injection analyzer can emit. Sourced from the rule IDs the
+// analyzer hands to scanner.Finding in injection.go; this file is
+// the canonical place users learn what each ID means.
+func RuleMetadata() []rulemeta.Rule {
+	return []rulemeta.Rule{
+		{
+			ID:       "NLP_HIDDEN_INSTRUCTION",
+			Name:     "Hidden instruction inside non-instructional structure",
+			Severity: "HIGH",
+			Category: "prompt-injection",
+			Analyzer: rulemeta.AnalyzerNLP,
+			Description: "Markdown / JSON / YAML payload places imperative instructions " +
+				"inside content the user reasonably reads as data (a table cell, an " +
+				"example block, a tool description). The classifier flags imperative " +
+				"verbs + role-switch language clustered inside structures that should " +
+				"never carry agent instructions.",
+			Remediation: "Move instructions to a section explicitly labelled as such, " +
+				"or remove them. If the content is illustrative, wrap it in a code block " +
+				"so the agent treats it as quoted text rather than directives.",
+		},
+		{
+			ID:       "NLP_CODE_MISMATCH",
+			Name:     "Code block contents diverge from surrounding instructions",
+			Severity: "MEDIUM",
+			Category: "prompt-injection",
+			Analyzer: rulemeta.AnalyzerNLP,
+			Description: "A markdown code block contains imperative instructions whose " +
+				"intent does not match the surrounding prose (the prose says 'this is " +
+				"an example of X', the code block actually says 'now do Y'). Pattern " +
+				"matches prompt-injection payloads that hide instructions in a code-fence " +
+				"to evade reviewer skim-reading.",
+			Remediation: "Reconcile the code block with the surrounding description, or " +
+				"escape the imperatives so they read as literal sample text.",
+		},
+		{
+			ID:       "NLP_HEADING_MISMATCH",
+			Name:     "Section heading does not match the section's instruction content",
+			Severity: "MEDIUM",
+			Category: "prompt-injection",
+			Analyzer: rulemeta.AnalyzerNLP,
+			Description: "Heading promises one topic (e.g. 'Configuration', 'Troubleshooting') " +
+				"but the section body issues imperatives unrelated to that topic. Classic " +
+				"injection structure: bury new directives under a benign-looking heading " +
+				"so casual reviewers skip past them.",
+			Remediation: "Align the heading with the section content, or remove the " +
+				"unrelated imperatives if they were not intentional.",
+		},
+		{
+			ID:       "NLP_AUTHORITY_CLAIM",
+			Name:     "Authority-claim language in untrusted content",
+			Severity: "MEDIUM",
+			Category: "prompt-injection",
+			Analyzer: rulemeta.AnalyzerNLP,
+			Description: "Content claims authority Aguara cannot verify ('the maintainer says...', " +
+				"'official policy...', 'as a system administrator...') and uses that claim to " +
+				"justify an action. Common in indirect injection via documents the agent reads.",
+			Remediation: "If the authority claim is real, route the instruction through a " +
+				"channel the agent can verify (signed message, vetted config file). " +
+				"Untrusted prose making authority claims is a prompt-injection vector.",
+		},
+		{
+			ID:       "NLP_CRED_EXFIL_COMBO",
+			Name:     "Credential reference + exfiltration verb in the same span",
+			Severity: "HIGH",
+			Category: "prompt-injection",
+			Analyzer: rulemeta.AnalyzerNLP,
+			Description: "Same proximity window contains a credential-reference token " +
+				"(API key, token, secret, password) AND an exfiltration verb (send, post, " +
+				"upload, exfiltrate, leak). The classifier requires both signals to be " +
+				"clustered, so generic security documentation does not trip.",
+			Remediation: "Remove the imperative phrasing or relocate the credential " +
+				"discussion into a code block / quoted example so the agent reads it as " +
+				"data, not instructions.",
+		},
+		{
+			ID:       "NLP_OVERRIDE_DANGEROUS",
+			Name:     "Instruction override paired with dangerous capability",
+			Severity: "CRITICAL",
+			Category: "prompt-injection",
+			Analyzer: rulemeta.AnalyzerNLP,
+			Description: "Text contains an explicit instruction override ('ignore previous', " +
+				"'forget your guidelines', 'new instructions') AND describes a dangerous " +
+				"capability (shell exec, file read, network call). Highest-confidence " +
+				"prompt-injection shape: an attacker telling the agent to drop its " +
+				"prior context AND giving it a specific destructive action.",
+			Remediation: "Treat the content as actively malicious. Remove the override + " +
+				"capability pair, and audit any agent runs that have processed this content.",
+		},
+	}
+}

--- a/internal/engine/nlp/metadata.go
+++ b/internal/engine/nlp/metadata.go
@@ -64,15 +64,20 @@ func RuleMetadata() []rulemeta.Rule {
 				"Untrusted prose making authority claims is a prompt-injection vector.",
 		},
 		{
-			ID:       "NLP_CRED_EXFIL_COMBO",
-			Name:     "Credential reference + exfiltration verb in the same span",
-			Severity: "HIGH",
-			Category: "prompt-injection",
+			ID:   "NLP_CRED_EXFIL_COMBO",
+			Name: "Text combines credential access with network transmission",
+			// Emit site: checkDangerousCombos in injection.go ->
+			// SeverityCritical + category "exfiltration". The
+			// catalog mirrors that exactly so list-rules and
+			// scan output agree on triage.
+			Severity: "CRITICAL",
+			Category: "exfiltration",
 			Analyzer: rulemeta.AnalyzerNLP,
 			Description: "Same proximity window contains a credential-reference token " +
-				"(API key, token, secret, password) AND an exfiltration verb (send, post, " +
-				"upload, exfiltrate, leak). The classifier requires both signals to be " +
-				"clustered, so generic security documentation does not trip.",
+				"(API key, token, secret, password) AND a network-transmission verb " +
+				"(send, post, upload, exfiltrate, leak). The classifier requires both " +
+				"signals to be clustered, so generic security documentation does not " +
+				"trip; when they cluster, the combination is the classic exfil shape.",
 			Remediation: "Remove the imperative phrasing or relocate the credential " +
 				"discussion into a code block / quoted example so the agent reads it as " +
 				"data, not instructions.",

--- a/internal/engine/pkgmeta/metadata.go
+++ b/internal/engine/pkgmeta/metadata.go
@@ -1,0 +1,57 @@
+package pkgmeta
+
+import "github.com/garagon/aguara/internal/rulemeta"
+
+// RuleMetadata returns the catalog entries for every rule this
+// analyzer can emit. Co-located with the analyzer so adding a new
+// NPM_* rule keeps the catalog and the emitter in sync.
+func RuleMetadata() []rulemeta.Rule {
+	return []rulemeta.Rule{
+		{
+			ID:       RuleLifecycleGit,
+			Name:     "npm install-time lifecycle script with git-sourced dependency",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPkgMeta,
+			Description: "package.json declares an install-time lifecycle script " +
+				"(preinstall, install, postinstall, prepublish, preprepare, prepare, " +
+				"postprepare) AND at least one dependency sourced from git (`git+`, " +
+				"`git://`, `git@`, `github:`). The combination lets a git ref the author " +
+				"controls execute arbitrary code on every install, bypassing npm's " +
+				"signature surface. Promoted to CRITICAL when the dep is in " +
+				"`optionalDependencies` AND carries a suspicious name (typosquat shape).",
+			Remediation: "Pin the dependency to a published npm version with a signed " +
+				"tarball. If the git dep is unavoidable, drop the install-time lifecycle " +
+				"script and run the equivalent work in a vetted CI step instead.",
+		},
+		{
+			ID:       RuleOptionalGit,
+			Name:     "git-sourced optionalDependency",
+			Severity: "MEDIUM",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPkgMeta,
+			Description: "package.json declares a git-sourced `optionalDependency`. " +
+				"`optionalDependencies` install silently on every host where they resolve, " +
+				"so a git ref the author controls becomes a stealthy install vector. " +
+				"Promoted to HIGH when the package name has a typosquat shape. Suppressed " +
+				"when NPM_LIFECYCLE_GIT_001 already covers the same dependency.",
+			Remediation: "Pin to a published npm version with a signed tarball, or make " +
+				"the dependency mandatory so its install behaviour is auditable.",
+		},
+		{
+			ID:       RulePublishSurface,
+			Name:     "publishConfig + install/build/test + trusted publishing reference",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPkgMeta,
+			Description: "package.json carries a `publishConfig` (or publish script) " +
+				"alongside install/build/test scripts AND a value-aware reference to " +
+				"trusted publishing (provenance, signed-publishes). The combined surface " +
+				"means an attacker who controls an install-time script can mint signed " +
+				"releases on the project's behalf.",
+			Remediation: "Move the publish surface into a separate package (or a separate " +
+				"CI job) that does not execute install/build/test scripts. Trusted " +
+				"publishing should only run from a vetted, minimal-scope environment.",
+		},
+	}
+}

--- a/internal/engine/rugpull/metadata.go
+++ b/internal/engine/rugpull/metadata.go
@@ -1,0 +1,31 @@
+package rugpull
+
+import "github.com/garagon/aguara/internal/rulemeta"
+
+// RuleMetadata returns the catalog entries the rug-pull analyzer
+// can emit. The analyzer only runs when --monitor is set (CLI) or
+// WithStateDir is configured (library); the rule is in the catalog
+// unconditionally so `aguara explain RUGPULL_001` works without
+// needing to enable the detector first.
+func RuleMetadata() []rulemeta.Rule {
+	return []rulemeta.Rule{
+		{
+			ID:       "RUGPULL_001",
+			Name:     "Tool description changed between scans",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerRugPull,
+			Description: "MCP tool description (or other tracked content) changed " +
+				"between this scan and the previous one. Detector compares SHA256 of " +
+				"the relevant content against the state stored in --state-path " +
+				"(default ~/.aguara/state.json). The classic 'rug-pull' shape: a " +
+				"tool ships with a benign description, gets installed and trusted, " +
+				"then a later update introduces malicious instructions while the " +
+				"surrounding metadata stays unchanged.",
+			Remediation: "Inspect the changed description against the prior version " +
+				"(stored in state). If the change is intentional and benign, re-run " +
+				"the scan to ack the new baseline. If unexpected, treat the tool as " +
+				"compromised and remove it.",
+		},
+	}
+}

--- a/internal/engine/rugpull/metadata.go
+++ b/internal/engine/rugpull/metadata.go
@@ -7,22 +7,28 @@ import "github.com/garagon/aguara/internal/rulemeta"
 // WithStateDir is configured (library); the rule is in the catalog
 // unconditionally so `aguara explain RUGPULL_001` works without
 // needing to enable the detector first.
+//
+// Severity + Category MUST match what rugpull.go sets on the
+// emitted Finding (currently CRITICAL + category rug-pull).
+// A future change to the emit site must update this metadata in
+// the same commit so list-rules / explain output stays consistent
+// with scan output.
 func RuleMetadata() []rulemeta.Rule {
 	return []rulemeta.Rule{
 		{
 			ID:       "RUGPULL_001",
-			Name:     "Tool description changed between scans",
-			Severity: "HIGH",
-			Category: "supply-chain",
+			Name:     "Tool description changed with dangerous content",
+			Severity: "CRITICAL",
+			Category: "rug-pull",
 			Analyzer: rulemeta.AnalyzerRugPull,
-			Description: "MCP tool description (or other tracked content) changed " +
-				"between this scan and the previous one. Detector compares SHA256 of " +
-				"the relevant content against the state stored in --state-path " +
-				"(default ~/.aguara/state.json). The classic 'rug-pull' shape: a " +
-				"tool ships with a benign description, gets installed and trusted, " +
-				"then a later update introduces malicious instructions while the " +
-				"surrounding metadata stays unchanged.",
-			Remediation: "Inspect the changed description against the prior version " +
+			Description: "File content changed since last scan and now contains " +
+				"suspicious patterns. The classic 'rug-pull' shape: a tool ships with " +
+				"a benign description, gets installed and trusted, then a later update " +
+				"introduces malicious instructions while the surrounding metadata stays " +
+				"unchanged. Detector compares SHA256 of the tracked content against " +
+				"the state stored in --state-path (default ~/.aguara/state.json) and " +
+				"only fires when the new content also matches dangerous-pattern signals.",
+			Remediation: "Inspect the changed content against the prior version " +
 				"(stored in state). If the change is intentional and benign, re-run " +
 				"the scan to ack the new baseline. If unexpected, treat the tool as " +
 				"compromised and remove it.",

--- a/internal/engine/toxicflow/metadata.go
+++ b/internal/engine/toxicflow/metadata.go
@@ -1,0 +1,95 @@
+package toxicflow
+
+import "github.com/garagon/aguara/internal/rulemeta"
+
+// RuleMetadata returns the catalog entries for every rule this
+// analyzer can emit. Single-file taint chains (TOXIC_*) and
+// cross-file correlation chains (TOXIC_CROSS_*) are surfaced
+// alongside so users can `aguara explain` either ID.
+func RuleMetadata() []rulemeta.Rule {
+	return []rulemeta.Rule{
+		{
+			ID:       "TOXIC_001",
+			Name:     "Credential read flows to network sink (same file)",
+			Severity: "HIGH",
+			Category: "supply-chain-exfil",
+			Analyzer: rulemeta.AnalyzerToxicFlow,
+			Description: "Single-file taint chain: a credential source (env-var read, " +
+				"file read of ~/.ssh/, ~/.aws/credentials, etc.) reaches a network sink " +
+				"(fetch, http.request, webhook URL) without sanitisation. Common shape " +
+				"in supply-chain exfil payloads disguised as benign utility scripts.",
+			Remediation: "Either remove the network sink or break the data flow: pass " +
+				"only non-credential identifiers across the boundary, and rotate any " +
+				"credential the host has already used while this code was reachable.",
+		},
+		{
+			ID:       "TOXIC_002",
+			Name:     "Environment variable flows to shell exec (same file)",
+			Severity: "HIGH",
+			Category: "command-execution",
+			Analyzer: rulemeta.AnalyzerToxicFlow,
+			Description: "Single-file taint chain: a process.env read (or os.environ in " +
+				"Python) flows into a shell exec (child_process.exec, subprocess with " +
+				"shell=True, os.system). User-controlled env vars become shell injection " +
+				"vectors; the scanner flags the data flow regardless of whether the " +
+				"specific env var name is sanitised at the source.",
+			Remediation: "Switch to the argv form of subprocess invocation (execFile, " +
+				"subprocess.run with a list and shell=False) so the env value cannot " +
+				"break out of an argument boundary.",
+		},
+		{
+			ID:       "TOXIC_003",
+			Name:     "Destructive operation paired with arbitrary exec (same file)",
+			Severity: "CRITICAL",
+			Category: "command-execution",
+			Analyzer: rulemeta.AnalyzerToxicFlow,
+			Description: "Single-file taint chain: a destructive operation (rm -rf, " +
+				"os.removedirs, fs.rmSync recursive) co-occurs with an arbitrary exec " +
+				"sink. The combination matches credential-wiper and ransom-style " +
+				"payloads that erase forensic traces after running.",
+			Remediation: "Treat as actively malicious. Remove the file and audit recent " +
+				"runs of any context that imported it.",
+		},
+		{
+			ID:       "TOXIC_CROSS_001",
+			Name:     "Cross-file credential exfiltration: one tool reads, another sends",
+			Severity: "HIGH",
+			Category: "supply-chain-exfil",
+			Analyzer: rulemeta.AnalyzerToxicFlow,
+			Description: "Cross-file correlation across MCP server tools in the same " +
+				"directory: one tool reads credentials, a sibling tool issues a network " +
+				"call. The split-across-files shape is a deliberate evasion of single-" +
+				"file detectors; this rule looks at the directory as one unit.",
+			Remediation: "Either remove the network sink in the sibling tool or move the " +
+				"credential read behind explicit user consent. Cross-tool data flow " +
+				"inside an MCP server should be auditable, not implicit.",
+		},
+		{
+			ID:       "TOXIC_CROSS_002",
+			Name:     "Cross-file env-to-exec chain across MCP tools",
+			Severity: "HIGH",
+			Category: "command-execution",
+			Analyzer: rulemeta.AnalyzerToxicFlow,
+			Description: "Cross-file correlation: one tool reads process environment, " +
+				"another tool exposes a shell exec surface, and the data flow between " +
+				"them is plausible (shared state, fs round-trip, ipc). Same evasion " +
+				"shape as TOXIC_CROSS_001 but with command execution as the sink.",
+			Remediation: "Decouple the read and exec surfaces. If one tool legitimately " +
+				"needs env state for the other, expose it as an explicit, audited " +
+				"parameter rather than relying on shared state.",
+		},
+		{
+			ID:       "TOXIC_CROSS_003",
+			Name:     "Cross-file destructive + exec combo across MCP tools",
+			Severity: "CRITICAL",
+			Category: "command-execution",
+			Analyzer: rulemeta.AnalyzerToxicFlow,
+			Description: "Cross-file correlation: one tool deletes / overwrites filesystem " +
+				"state, another tool runs commands. The combination supports ransom-style " +
+				"or evidence-wiping payloads distributed across the MCP server's tool surface.",
+			Remediation: "Treat the directory as actively malicious. The split shape is " +
+				"deliberate evasion; remove the server and audit any agent runs that " +
+				"have invoked its tools.",
+		},
+	}
+}

--- a/internal/engine/toxicflow/metadata.go
+++ b/internal/engine/toxicflow/metadata.go
@@ -6,55 +6,63 @@ import "github.com/garagon/aguara/internal/rulemeta"
 // analyzer can emit. Single-file taint chains (TOXIC_*) and
 // cross-file correlation chains (TOXIC_CROSS_*) are surfaced
 // alongside so users can `aguara explain` either ID.
+//
+// Severity + Category MUST match the values toxicflow.go and
+// crossfile.go set on the emitted Finding -- otherwise
+// `list-rules --category toxic-flow` disagrees with what scan
+// actually reports. Both emit sites currently use HIGH +
+// toxic-flow; this catalog mirrors that. A future change that
+// promotes one of these to CRITICAL must update BOTH the emit
+// site and this metadata.
 func RuleMetadata() []rulemeta.Rule {
 	return []rulemeta.Rule{
 		{
 			ID:       "TOXIC_001",
-			Name:     "Credential read flows to network sink (same file)",
+			Name:     "Private data read with public output",
 			Severity: "HIGH",
-			Category: "supply-chain-exfil",
+			Category: "toxic-flow",
 			Analyzer: rulemeta.AnalyzerToxicFlow,
-			Description: "Single-file taint chain: a credential source (env-var read, " +
-				"file read of ~/.ssh/, ~/.aws/credentials, etc.) reaches a network sink " +
-				"(fetch, http.request, webhook URL) without sanitisation. Common shape " +
-				"in supply-chain exfil payloads disguised as benign utility scripts.",
+			Description: "Skill can read private data (credentials, SSH keys, env vars) " +
+				"AND write to public channels (Slack, Discord, email). This combination " +
+				"enables data exfiltration -- the credential read and the network sink " +
+				"are independently benign, but co-occurring in the same skill they " +
+				"compose into an exfil chain.",
 			Remediation: "Either remove the network sink or break the data flow: pass " +
 				"only non-credential identifiers across the boundary, and rotate any " +
 				"credential the host has already used while this code was reachable.",
 		},
 		{
 			ID:       "TOXIC_002",
-			Name:     "Environment variable flows to shell exec (same file)",
+			Name:     "Private data read with code execution",
 			Severity: "HIGH",
-			Category: "command-execution",
+			Category: "toxic-flow",
 			Analyzer: rulemeta.AnalyzerToxicFlow,
-			Description: "Single-file taint chain: a process.env read (or os.environ in " +
-				"Python) flows into a shell exec (child_process.exec, subprocess with " +
-				"shell=True, os.system). User-controlled env vars become shell injection " +
-				"vectors; the scanner flags the data flow regardless of whether the " +
-				"specific env var name is sanitised at the source.",
-			Remediation: "Switch to the argv form of subprocess invocation (execFile, " +
-				"subprocess.run with a list and shell=False) so the env value cannot " +
-				"break out of an argument boundary.",
+			Description: "Skill can read private data AND execute arbitrary code. This " +
+				"combination enables credential theft via dynamic code: the read pulls " +
+				"the secret, the exec sends it anywhere the attacker chooses without " +
+				"needing a static network sink in the source.",
+			Remediation: "Drop one side of the chain. If the skill genuinely needs both, " +
+				"split into separate, audited tools so the data flow is auditable.",
 		},
 		{
 			ID:       "TOXIC_003",
-			Name:     "Destructive operation paired with arbitrary exec (same file)",
-			Severity: "CRITICAL",
-			Category: "command-execution",
+			Name:     "Destructive actions with code execution",
+			Severity: "HIGH",
+			Category: "toxic-flow",
 			Analyzer: rulemeta.AnalyzerToxicFlow,
-			Description: "Single-file taint chain: a destructive operation (rm -rf, " +
-				"os.removedirs, fs.rmSync recursive) co-occurs with an arbitrary exec " +
-				"sink. The combination matches credential-wiper and ransom-style " +
-				"payloads that erase forensic traces after running.",
-			Remediation: "Treat as actively malicious. Remove the file and audit recent " +
-				"runs of any context that imported it.",
+			Description: "Skill has destructive capabilities AND can execute arbitrary " +
+				"code. The combination enables ransomware-like attacks: the exec runs " +
+				"the destructive payload, and the destructive surface erases forensic " +
+				"traces afterwards.",
+			Remediation: "Remove the destructive surface, OR split the destructive and " +
+				"exec capabilities into separate skills so the agent's policy can refuse " +
+				"the combination explicitly.",
 		},
 		{
 			ID:       "TOXIC_CROSS_001",
-			Name:     "Cross-file credential exfiltration: one tool reads, another sends",
+			Name:     "Cross-file credential exfiltration across MCP tools",
 			Severity: "HIGH",
-			Category: "supply-chain-exfil",
+			Category: "toxic-flow",
 			Analyzer: rulemeta.AnalyzerToxicFlow,
 			Description: "Cross-file correlation across MCP server tools in the same " +
 				"directory: one tool reads credentials, a sibling tool issues a network " +
@@ -68,7 +76,7 @@ func RuleMetadata() []rulemeta.Rule {
 			ID:       "TOXIC_CROSS_002",
 			Name:     "Cross-file env-to-exec chain across MCP tools",
 			Severity: "HIGH",
-			Category: "command-execution",
+			Category: "toxic-flow",
 			Analyzer: rulemeta.AnalyzerToxicFlow,
 			Description: "Cross-file correlation: one tool reads process environment, " +
 				"another tool exposes a shell exec surface, and the data flow between " +
@@ -81,12 +89,13 @@ func RuleMetadata() []rulemeta.Rule {
 		{
 			ID:       "TOXIC_CROSS_003",
 			Name:     "Cross-file destructive + exec combo across MCP tools",
-			Severity: "CRITICAL",
-			Category: "command-execution",
+			Severity: "HIGH",
+			Category: "toxic-flow",
 			Analyzer: rulemeta.AnalyzerToxicFlow,
 			Description: "Cross-file correlation: one tool deletes / overwrites filesystem " +
 				"state, another tool runs commands. The combination supports ransom-style " +
-				"or evidence-wiping payloads distributed across the MCP server's tool surface.",
+				"or evidence-wiping payloads distributed across the MCP server's tool " +
+				"surface.",
 			Remediation: "Treat the directory as actively malicious. The split shape is " +
 				"deliberate evasion; remove the server and audit any agent runs that " +
 				"have invoked its tools.",

--- a/internal/rulecatalog/catalog.go
+++ b/internal/rulecatalog/catalog.go
@@ -13,8 +13,8 @@
 package rulecatalog
 
 import (
+	"errors"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -139,10 +139,18 @@ func Build(opts Options) ([]rulemeta.Rule, error) {
 	}
 
 	// 6. Per-rule overrides: drop disabled rules and apply
-	// severity overrides. Same surface aguara.WithRuleOverrides
-	// exposes -- without this, a policy UI built on ListRules
-	// disagrees with what scan runs (the scanner sees the
-	// override, list-rules did not).
+	// severity overrides. ONLY applied to YAML pattern rules
+	// (Analyzer == ""), matching the scanner contract: the
+	// scanner's rules.ApplyOverrides path operates over
+	// []*rules.CompiledRule only, so analyzer-owned findings
+	// (JS_*, GHA_*, TOXIC_*, ...) are emitted regardless of
+	// RuleOverride. If the catalog ALSO applied Overrides to
+	// analyzer rules, list-rules would claim a policy is in
+	// effect that Scan would not honour for those IDs.
+	//
+	// Users who want to suppress an analyzer rule should use
+	// WithDisabledRules / --disable-rule (the scanner DOES honour
+	// that via Scanner.SetDisabledRules).
 	if len(opts.Overrides) > 0 {
 		normalised := make(map[string]Override, len(opts.Overrides))
 		for id, o := range opts.Overrides {
@@ -151,7 +159,11 @@ func Build(opts Options) ([]rulemeta.Rule, error) {
 		filtered := out[:0]
 		for _, r := range out {
 			ovr, ok := normalised[strings.ToUpper(r.ID)]
-			if !ok {
+			// Pass analyzer rules through untouched -- their
+			// behaviour is governed by DisableRuleIDs, not by
+			// Overrides, so the catalog must not pretend
+			// otherwise.
+			if !ok || r.Analyzer != "" {
 				filtered = append(filtered, r)
 				continue
 			}
@@ -183,10 +195,27 @@ func Build(opts Options) ([]rulemeta.Rule, error) {
 	return out, nil
 }
 
+// ErrRuleNotFound is the sentinel FindByID returns when the
+// lookup completes successfully but no rule with that ID exists.
+// Distinguished from catalog-build errors (custom-rules dir
+// missing, malformed YAML, ...) so callers can map a typo to a
+// clean "rule X not found" message while surfacing real
+// configuration problems with their full context.
+var ErrRuleNotFound = errors.New("rule not found")
+
 // FindByID returns the catalog entry with the given ID (case-
-// insensitive) or os.ErrNotExist when nothing matches. Used by
-// explain.go and aguara.ExplainRule so both surfaces share one
-// lookup path.
+// insensitive). Used by explain.go and aguara.ExplainRule so
+// both surfaces share one lookup path.
+//
+// Two error shapes:
+//
+//   - errors.Is(err, ErrRuleNotFound) -> the catalog built
+//     successfully but no rule with that ID exists. Callers
+//     should surface a clean "rule X not found" message.
+//   - any other error -> the catalog failed to build (e.g.
+//     --rules pointed at a missing directory). Callers should
+//     surface the underlying error so the user can diagnose
+//     the configuration problem.
 func FindByID(opts Options, id string) (*rulemeta.Rule, error) {
 	id = strings.ToUpper(strings.TrimSpace(id))
 	cat, err := Build(opts)
@@ -198,7 +227,7 @@ func FindByID(opts Options, id string) (*rulemeta.Rule, error) {
 			return &cat[i], nil
 		}
 	}
-	return nil, fmt.Errorf("rule %q not found: %w", id, os.ErrNotExist)
+	return nil, fmt.Errorf("rule %q: %w", id, ErrRuleNotFound)
 }
 
 // fromCompiledRule projects a compiled YAML rule into the catalog

--- a/internal/rulecatalog/catalog.go
+++ b/internal/rulecatalog/catalog.go
@@ -22,6 +22,7 @@ import (
 	"github.com/garagon/aguara/internal/engine/jsrisk"
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pkgmeta"
+	"github.com/garagon/aguara/internal/engine/rugpull"
 	"github.com/garagon/aguara/internal/engine/toxicflow"
 	"github.com/garagon/aguara/internal/rulemeta"
 	"github.com/garagon/aguara/internal/rules"
@@ -90,12 +91,16 @@ func Build(opts Options) ([]rulemeta.Rule, error) {
 	}
 
 	// 4. Analyzer-emitted rules. Order doesn't matter; the sort
-	// at the end establishes the canonical ordering.
+	// at the end establishes the canonical ordering. rugpull is
+	// in the catalog unconditionally even though the analyzer
+	// only runs with --monitor / WithStateDir, so `aguara explain
+	// RUGPULL_001` works without first enabling the detector.
 	out = append(out, ci.RuleMetadata()...)
 	out = append(out, pkgmeta.RuleMetadata()...)
 	out = append(out, jsrisk.RuleMetadata()...)
 	out = append(out, nlp.RuleMetadata()...)
 	out = append(out, toxicflow.RuleMetadata()...)
+	out = append(out, rugpull.RuleMetadata()...)
 
 	// 5. --disable-rule filter. Applied AFTER merge so users can
 	// disable analyzer rules too (same UX as YAML rules).

--- a/internal/rulecatalog/catalog.go
+++ b/internal/rulecatalog/catalog.go
@@ -40,6 +40,14 @@ type Options struct {
 	// Matches the --disable-rule CLI flag and the config-file
 	// disable_rules list.
 	DisableRuleIDs []string
+	// Overrides apply per-rule severity changes and disables, the
+	// same surface aguara.WithRuleOverrides exposes. Keyed by
+	// rule ID (case-insensitive). An entry with Disabled=true
+	// drops the rule; an entry with a non-empty Severity replaces
+	// the metadata's severity in the output. Mirrors the
+	// scanner's RuleOverride path so a policy UI built on Build
+	// agrees with what the scanner actually runs.
+	Overrides map[string]Override
 	// Category, when non-empty, filters the result to rules whose
 	// Category matches case-insensitively.
 	Category string
@@ -47,6 +55,17 @@ type Options struct {
 	// loader. nil discards them; the CLI wires this to stderr so
 	// the user sees rule-author issues during `list-rules`.
 	Warn func(format string, args ...any)
+}
+
+// Override is the catalog-side projection of aguara.RuleOverride.
+// Kept here so the catalog package does not import the public
+// aguara API (which would create a cycle). The fields are a
+// strict subset: tool-scoping (ApplyToTools / ExemptTools) is a
+// scanner concern and does not change what list-rules / explain
+// show, so it is intentionally omitted from this struct.
+type Override struct {
+	Severity string // empty -> keep the catalog metadata severity
+	Disabled bool   // true  -> drop the rule from list-rules output
 }
 
 // Build returns the merged catalog. Errors come from the
@@ -119,7 +138,35 @@ func Build(opts Options) ([]rulemeta.Rule, error) {
 		out = filtered
 	}
 
-	// 6. --category filter. Case-insensitive on the Category
+	// 6. Per-rule overrides: drop disabled rules and apply
+	// severity overrides. Same surface aguara.WithRuleOverrides
+	// exposes -- without this, a policy UI built on ListRules
+	// disagrees with what scan runs (the scanner sees the
+	// override, list-rules did not).
+	if len(opts.Overrides) > 0 {
+		normalised := make(map[string]Override, len(opts.Overrides))
+		for id, o := range opts.Overrides {
+			normalised[strings.ToUpper(strings.TrimSpace(id))] = o
+		}
+		filtered := out[:0]
+		for _, r := range out {
+			ovr, ok := normalised[strings.ToUpper(r.ID)]
+			if !ok {
+				filtered = append(filtered, r)
+				continue
+			}
+			if ovr.Disabled {
+				continue
+			}
+			if ovr.Severity != "" {
+				r.Severity = strings.ToUpper(ovr.Severity)
+			}
+			filtered = append(filtered, r)
+		}
+		out = filtered
+	}
+
+	// 7. --category filter. Case-insensitive on the Category
 	// string; same UX as the legacy YAML-only list-rules.
 	if opts.Category != "" {
 		filtered := out[:0]
@@ -131,7 +178,7 @@ func Build(opts Options) ([]rulemeta.Rule, error) {
 		out = filtered
 	}
 
-	// 7. Canonical order.
+	// 8. Canonical order.
 	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
 	return out, nil
 }

--- a/internal/rulecatalog/catalog.go
+++ b/internal/rulecatalog/catalog.go
@@ -1,0 +1,178 @@
+// Package rulecatalog combines YAML-compiled pattern rules, custom
+// --rules-dir rules, and analyzer-emitted rule metadata into one
+// queryable []rulemeta.Rule. The CLI (explain, list-rules) and the
+// public Go API (aguara.ListRules / aguara.ExplainRule) both consume
+// the catalog, so a user can `aguara explain JS_DNS_TXT_EXFIL_001`
+// even though that rule originates from internal/engine/jsrisk
+// rather than from a YAML file.
+//
+// Catalog construction is pure: no file I/O beyond what the caller
+// asks for via Options. The pattern-rule load path is the same one
+// the scanner uses, so the catalog and the runtime see identical
+// rule sets.
+package rulecatalog
+
+import (
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/garagon/aguara/internal/engine/ci"
+	"github.com/garagon/aguara/internal/engine/jsrisk"
+	"github.com/garagon/aguara/internal/engine/nlp"
+	"github.com/garagon/aguara/internal/engine/pkgmeta"
+	"github.com/garagon/aguara/internal/engine/toxicflow"
+	"github.com/garagon/aguara/internal/rulemeta"
+	"github.com/garagon/aguara/internal/rules"
+	"github.com/garagon/aguara/internal/rules/builtin"
+)
+
+// Options controls Build. All fields are optional; the zero value
+// builds the full catalog (every YAML rule + every analyzer rule).
+type Options struct {
+	// CustomRulesDir, when non-empty, loads additional YAML rules
+	// from a directory and merges them in. Matches the --rules
+	// flag the CLI exposes.
+	CustomRulesDir string
+	// DisableRuleIDs filters by exact ID match before returning.
+	// Matches the --disable-rule CLI flag and the config-file
+	// disable_rules list.
+	DisableRuleIDs []string
+	// Category, when non-empty, filters the result to rules whose
+	// Category matches case-insensitively.
+	Category string
+	// Warn receives non-fatal compile warnings from the YAML rule
+	// loader. nil discards them; the CLI wires this to stderr so
+	// the user sees rule-author issues during `list-rules`.
+	Warn func(format string, args ...any)
+}
+
+// Build returns the merged catalog. Errors come from the
+// custom-rules directory path (missing dir, malformed YAML); built-
+// in rules are embedded and always succeed.
+//
+// Returned slice is sorted by ID so the CLI output is stable
+// across runs.
+func Build(opts Options) ([]rulemeta.Rule, error) {
+	warn := opts.Warn
+	if warn == nil {
+		warn = func(string, ...any) {}
+	}
+
+	// 1. Built-in pattern rules (embedded YAML files).
+	rawRules, err := rules.LoadFromFS(builtin.FS())
+	if err != nil {
+		return nil, fmt.Errorf("rulecatalog: load built-in rules: %w", err)
+	}
+
+	// 2. Custom rules dir, when configured.
+	if opts.CustomRulesDir != "" {
+		customRules, err := rules.LoadFromDir(opts.CustomRulesDir)
+		if err != nil {
+			return nil, fmt.Errorf("rulecatalog: load custom rules from %s: %w", opts.CustomRulesDir, err)
+		}
+		rawRules = append(rawRules, customRules...)
+	}
+
+	// Compile the YAML rules; compile warnings (regex too long,
+	// missing example, etc.) flow to the caller's warn func so
+	// the CLI surfaces them on stderr.
+	compiled, compileErrs := rules.CompileAll(rawRules)
+	for _, e := range compileErrs {
+		warn("warning: %v\n", e)
+	}
+
+	// 3. Convert compiled YAML rules into the catalog shape.
+	out := make([]rulemeta.Rule, 0, len(compiled)+32)
+	for _, r := range compiled {
+		out = append(out, fromCompiledRule(r))
+	}
+
+	// 4. Analyzer-emitted rules. Order doesn't matter; the sort
+	// at the end establishes the canonical ordering.
+	out = append(out, ci.RuleMetadata()...)
+	out = append(out, pkgmeta.RuleMetadata()...)
+	out = append(out, jsrisk.RuleMetadata()...)
+	out = append(out, nlp.RuleMetadata()...)
+	out = append(out, toxicflow.RuleMetadata()...)
+
+	// 5. --disable-rule filter. Applied AFTER merge so users can
+	// disable analyzer rules too (same UX as YAML rules).
+	if len(opts.DisableRuleIDs) > 0 {
+		disabled := make(map[string]struct{}, len(opts.DisableRuleIDs))
+		for _, id := range opts.DisableRuleIDs {
+			disabled[strings.ToUpper(strings.TrimSpace(id))] = struct{}{}
+		}
+		filtered := out[:0]
+		for _, r := range out {
+			if _, drop := disabled[strings.ToUpper(r.ID)]; drop {
+				continue
+			}
+			filtered = append(filtered, r)
+		}
+		out = filtered
+	}
+
+	// 6. --category filter. Case-insensitive on the Category
+	// string; same UX as the legacy YAML-only list-rules.
+	if opts.Category != "" {
+		filtered := out[:0]
+		for _, r := range out {
+			if strings.EqualFold(r.Category, opts.Category) {
+				filtered = append(filtered, r)
+			}
+		}
+		out = filtered
+	}
+
+	// 7. Canonical order.
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// FindByID returns the catalog entry with the given ID (case-
+// insensitive) or os.ErrNotExist when nothing matches. Used by
+// explain.go and aguara.ExplainRule so both surfaces share one
+// lookup path.
+func FindByID(opts Options, id string) (*rulemeta.Rule, error) {
+	id = strings.ToUpper(strings.TrimSpace(id))
+	cat, err := Build(opts)
+	if err != nil {
+		return nil, err
+	}
+	for i := range cat {
+		if strings.EqualFold(cat[i].ID, id) {
+			return &cat[i], nil
+		}
+	}
+	return nil, fmt.Errorf("rule %q not found: %w", id, os.ErrNotExist)
+}
+
+// fromCompiledRule projects a compiled YAML rule into the catalog
+// shape. Patterns are pre-formatted with the "[regex] ..." /
+// "[contains] ..." prefix the existing CLI uses; doing the
+// formatting here keeps explain.go free of internal/rules types.
+func fromCompiledRule(r *rules.CompiledRule) rulemeta.Rule {
+	patterns := make([]string, 0, len(r.Patterns))
+	for _, p := range r.Patterns {
+		switch p.Type {
+		case rules.PatternRegex:
+			patterns = append(patterns, fmt.Sprintf("[regex] %s", p.Regex.String()))
+		case rules.PatternContains:
+			patterns = append(patterns, fmt.Sprintf("[contains] %s", p.Value))
+		}
+	}
+	return rulemeta.Rule{
+		ID:             r.ID,
+		Name:           r.Name,
+		Severity:       r.Severity.String(),
+		Category:       r.Category,
+		Analyzer:       rulemeta.AnalyzerPattern, // empty -> JSON omits
+		Description:    r.Description,
+		Remediation:    r.Remediation,
+		Patterns:       patterns,
+		TruePositives:  r.Examples.TruePositive,
+		FalsePositives: r.Examples.FalsePositive,
+	}
+}

--- a/internal/rulecatalog/catalog_test.go
+++ b/internal/rulecatalog/catalog_test.go
@@ -2,7 +2,6 @@ package rulecatalog_test
 
 import (
 	"errors"
-	"os"
 	"testing"
 
 	"github.com/garagon/aguara/internal/rulecatalog"
@@ -114,14 +113,31 @@ func TestFindByIDCaseInsensitive(t *testing.T) {
 	require.Equal(t, "JS_DNS_TXT_EXFIL_001", rec.ID)
 }
 
-func TestFindByIDMissingReturnsErrNotExist(t *testing.T) {
-	// CLI maps os.ErrNotExist to a clean "rule X not found"
+func TestFindByIDMissingReturnsErrRuleNotFound(t *testing.T) {
+	// CLI maps ErrRuleNotFound to a clean "rule X not found"
 	// message. Other errors (load failure, malformed YAML) keep
-	// surfacing as wrapped errors.
+	// surfacing as wrapped errors so the user can diagnose them.
 	_, err := rulecatalog.FindByID(rulecatalog.Options{}, "DEFINITELY_NOT_A_RULE_999")
 	require.Error(t, err)
-	require.True(t, errors.Is(err, os.ErrNotExist),
-		"missing rule must wrap os.ErrNotExist for the CLI's error-mapping path")
+	require.True(t, errors.Is(err, rulecatalog.ErrRuleNotFound),
+		"missing rule must wrap ErrRuleNotFound (not the generic os.ErrNotExist)")
+}
+
+func TestFindByIDBuildErrorDistinctFromNotFound(t *testing.T) {
+	// Codex P3 round 3: when --rules points at a directory that
+	// does not exist, Build returns an error wrapping
+	// os.ErrNotExist (because LoadFromDir fails). The CLI must
+	// NOT collapse that into "rule not found" -- the underlying
+	// config typo would be hidden. Test: a missing custom-rules
+	// dir produces an error that is NOT ErrRuleNotFound, so
+	// explain.go's mapping (which only maps ErrRuleNotFound)
+	// surfaces the real error.
+	_, err := rulecatalog.FindByID(rulecatalog.Options{
+		CustomRulesDir: "/definitely/not/a/real/dir/" + t.Name(),
+	}, "PROMPT_INJECTION_001")
+	require.Error(t, err)
+	require.False(t, errors.Is(err, rulecatalog.ErrRuleNotFound),
+		"a missing custom-rules dir must NOT be mapped as ErrRuleNotFound; the CLI would mask the real error otherwise")
 }
 
 func TestAnalyzerMetadataMatchesEmittedSeverityAndCategory(t *testing.T) {
@@ -163,9 +179,16 @@ func TestAnalyzerMetadataMatchesEmittedSeverityAndCategory(t *testing.T) {
 	}
 }
 
-func TestBuildOverridesDisableAndSeverity(t *testing.T) {
+func TestBuildOverridesDisableAndSeverityYAMLOnly(t *testing.T) {
 	// Catalog-level test for the override path the aguara public
-	// API wires to. Disabled=true drops the rule; Severity remaps.
+	// API wires to. The scanner's rules.ApplyOverrides only
+	// operates on YAML compiled rules, so the catalog mirrors
+	// that contract: Overrides DROP / REMAP YAML rules but DO
+	// NOT touch analyzer rules. A divergence would mean a policy
+	// UI built on ListRules disagrees with what the scanner
+	// emits for analyzer findings.
+
+	// YAML rule -- Disabled drops it from the listing.
 	disabled, err := rulecatalog.Build(rulecatalog.Options{
 		Overrides: map[string]rulecatalog.Override{
 			"PROMPT_INJECTION_001": {Disabled: true},
@@ -174,9 +197,10 @@ func TestBuildOverridesDisableAndSeverity(t *testing.T) {
 	require.NoError(t, err)
 	for _, r := range disabled {
 		require.NotEqual(t, "PROMPT_INJECTION_001", r.ID,
-			"Overrides{Disabled:true} must drop the rule")
+			"Overrides{Disabled:true} must drop YAML rules")
 	}
 
+	// YAML rule -- Severity is remapped.
 	remapped, err := rulecatalog.Build(rulecatalog.Options{
 		Overrides: map[string]rulecatalog.Override{
 			"PROMPT_INJECTION_001": {Severity: "low"},
@@ -190,7 +214,29 @@ func TestBuildOverridesDisableAndSeverity(t *testing.T) {
 			break
 		}
 	}
-	require.Equal(t, "LOW", got, "Overrides{Severity: ...} must upper-case + apply")
+	require.Equal(t, "LOW", got, "Overrides{Severity: ...} must upper-case + apply to YAML rules")
+
+	// Analyzer rule -- Disabled is IGNORED. The scanner does not
+	// apply RuleOverrides to analyzer findings, so the catalog
+	// must not pretend it does. Users who want to suppress an
+	// analyzer rule should use WithDisabledRules instead.
+	notDropped, err := rulecatalog.Build(rulecatalog.Options{
+		Overrides: map[string]rulecatalog.Override{
+			"JS_DNS_TXT_EXFIL_001": {Disabled: true},
+		},
+	})
+	require.NoError(t, err)
+	var found bool
+	for _, r := range notDropped {
+		if r.ID == "JS_DNS_TXT_EXFIL_001" {
+			found = true
+			require.Equal(t, "HIGH", r.Severity,
+				"analyzer rule severity must NOT be touched by Overrides; scanner does not apply them to analyzer findings")
+			break
+		}
+	}
+	require.True(t, found,
+		"analyzer rule must survive Overrides{Disabled:true}; the scanner does not honour overrides for analyzer findings, so the catalog must not either")
 }
 
 func TestEveryAnalyzerEmittedIDHasCatalogEntry(t *testing.T) {

--- a/internal/rulecatalog/catalog_test.go
+++ b/internal/rulecatalog/catalog_test.go
@@ -124,6 +124,75 @@ func TestFindByIDMissingReturnsErrNotExist(t *testing.T) {
 		"missing rule must wrap os.ErrNotExist for the CLI's error-mapping path")
 }
 
+func TestAnalyzerMetadataMatchesEmittedSeverityAndCategory(t *testing.T) {
+	// Codex P2 round 2: the catalog metadata MUST match what the
+	// analyzers actually emit on Finding.Severity / Finding.Category.
+	// Without this lock, `list-rules --category X` shows rules the
+	// scanner reports under a different category, and triage
+	// agents calibrating to severity disagree with scan output.
+	//
+	// Source of truth (kept here as comments so a regression is
+	// debuggable from the test row alone):
+	//
+	//   toxicflow.go / crossfile.go append findings with
+	//     Severity = types.SeverityHigh, Category = "toxic-flow".
+	//   nlp/injection.go checkDangerousCombos:
+	//     NLP_CRED_EXFIL_COMBO -> CRITICAL + "exfiltration".
+	//   rugpull.go: RUGPULL_001 -> CRITICAL + "rug-pull".
+	type want struct {
+		Severity string
+		Category string
+	}
+	cases := map[string]want{
+		"TOXIC_001":             {Severity: "HIGH", Category: "toxic-flow"},
+		"TOXIC_002":             {Severity: "HIGH", Category: "toxic-flow"},
+		"TOXIC_003":             {Severity: "HIGH", Category: "toxic-flow"},
+		"TOXIC_CROSS_001":       {Severity: "HIGH", Category: "toxic-flow"},
+		"TOXIC_CROSS_002":       {Severity: "HIGH", Category: "toxic-flow"},
+		"TOXIC_CROSS_003":       {Severity: "HIGH", Category: "toxic-flow"},
+		"NLP_CRED_EXFIL_COMBO":  {Severity: "CRITICAL", Category: "exfiltration"},
+		"RUGPULL_001":           {Severity: "CRITICAL", Category: "rug-pull"},
+	}
+	for id, w := range cases {
+		rec, err := rulecatalog.FindByID(rulecatalog.Options{}, id)
+		require.NoErrorf(t, err, "%s must be in the catalog", id)
+		require.Equalf(t, w.Severity, rec.Severity,
+			"%s severity must match the analyzer emit-site", id)
+		require.Equalf(t, w.Category, rec.Category,
+			"%s category must match the analyzer emit-site", id)
+	}
+}
+
+func TestBuildOverridesDisableAndSeverity(t *testing.T) {
+	// Catalog-level test for the override path the aguara public
+	// API wires to. Disabled=true drops the rule; Severity remaps.
+	disabled, err := rulecatalog.Build(rulecatalog.Options{
+		Overrides: map[string]rulecatalog.Override{
+			"PROMPT_INJECTION_001": {Disabled: true},
+		},
+	})
+	require.NoError(t, err)
+	for _, r := range disabled {
+		require.NotEqual(t, "PROMPT_INJECTION_001", r.ID,
+			"Overrides{Disabled:true} must drop the rule")
+	}
+
+	remapped, err := rulecatalog.Build(rulecatalog.Options{
+		Overrides: map[string]rulecatalog.Override{
+			"PROMPT_INJECTION_001": {Severity: "low"},
+		},
+	})
+	require.NoError(t, err)
+	var got string
+	for _, r := range remapped {
+		if r.ID == "PROMPT_INJECTION_001" {
+			got = r.Severity
+			break
+		}
+	}
+	require.Equal(t, "LOW", got, "Overrides{Severity: ...} must upper-case + apply")
+}
+
 func TestEveryAnalyzerEmittedIDHasCatalogEntry(t *testing.T) {
 	// Belt-and-suspenders contract: the set of analyzer rule IDs
 	// that the codebase declares as constants must be a subset of
@@ -146,6 +215,8 @@ func TestEveryAnalyzerEmittedIDHasCatalogEntry(t *testing.T) {
 		// toxicflow emit sites (single-file + cross-file).
 		"TOXIC_001", "TOXIC_002", "TOXIC_003",
 		"TOXIC_CROSS_001", "TOXIC_CROSS_002", "TOXIC_CROSS_003",
+		// rug-pull analyzer (only fires with --monitor / WithStateDir).
+		"RUGPULL_001",
 	}
 	for _, id := range emitted {
 		_, err := rulecatalog.FindByID(rulecatalog.Options{}, id)

--- a/internal/rulecatalog/catalog_test.go
+++ b/internal/rulecatalog/catalog_test.go
@@ -1,0 +1,154 @@
+package rulecatalog_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/garagon/aguara/internal/rulecatalog"
+	"github.com/garagon/aguara/internal/rulemeta"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildIncludesYAMLAndAnalyzerRules locks the central contract:
+// every catalog source (pattern rules + ci-trust + pkgmeta + jsrisk
+// + nlp + toxicflow) must surface through Build. A regression in
+// any analyzer's RuleMetadata() loses one of these assertions and
+// fails loud, rather than silently breaking `aguara explain` for
+// the affected analyzer.
+func TestBuildIncludesYAMLAndAnalyzerRules(t *testing.T) {
+	cat, err := rulecatalog.Build(rulecatalog.Options{})
+	require.NoError(t, err)
+	require.NotEmpty(t, cat)
+
+	ids := make(map[string]rulemeta.Rule, len(cat))
+	for _, r := range cat {
+		ids[r.ID] = r
+	}
+
+	// One representative ID per analyzer.
+	want := map[string]string{
+		"JS_DNS_TXT_EXFIL_001":  rulemeta.AnalyzerJSRisk,
+		"GHA_PWN_REQUEST_001":   rulemeta.AnalyzerCITrust,
+		"NPM_LIFECYCLE_GIT_001": rulemeta.AnalyzerPkgMeta,
+		"TOXIC_001":             rulemeta.AnalyzerToxicFlow,
+		"TOXIC_CROSS_001":       rulemeta.AnalyzerToxicFlow,
+		"NLP_HIDDEN_INSTRUCTION": rulemeta.AnalyzerNLP,
+		"AGENT_PERSISTENCE_001": rulemeta.AnalyzerJSRisk,
+		// And one pattern rule from the YAML catalog (analyzer
+		// stays empty for these).
+		"PROMPT_INJECTION_001": rulemeta.AnalyzerPattern,
+	}
+	for id, analyzer := range want {
+		rec, ok := ids[id]
+		require.Truef(t, ok, "catalog must include %s", id)
+		require.Equalf(t, analyzer, rec.Analyzer, "analyzer for %s", id)
+		require.NotEmptyf(t, rec.Severity, "%s severity must be set", id)
+		require.NotEmptyf(t, rec.Category, "%s category must be set", id)
+	}
+}
+
+func TestBuildSortsByID(t *testing.T) {
+	cat, err := rulecatalog.Build(rulecatalog.Options{})
+	require.NoError(t, err)
+	for i := 1; i < len(cat); i++ {
+		require.LessOrEqualf(t, cat[i-1].ID, cat[i].ID,
+			"catalog must be sorted by ID; %d=%s came before %d=%s", i-1, cat[i-1].ID, i, cat[i].ID)
+	}
+}
+
+func TestBuildCategoryFilter(t *testing.T) {
+	// --category filter applies to BOTH YAML rules and analyzer
+	// rules. Use "supply-chain" because ci-trust + pkgmeta + most
+	// jsrisk records share that category, so the filter has
+	// substantial output to assert against.
+	cat, err := rulecatalog.Build(rulecatalog.Options{Category: "supply-chain"})
+	require.NoError(t, err)
+	require.NotEmpty(t, cat)
+	for _, r := range cat {
+		require.Equal(t, "supply-chain", r.Category)
+	}
+}
+
+func TestBuildCategoryFilterCaseInsensitive(t *testing.T) {
+	upper, err := rulecatalog.Build(rulecatalog.Options{Category: "SUPPLY-CHAIN"})
+	require.NoError(t, err)
+	lower, err := rulecatalog.Build(rulecatalog.Options{Category: "supply-chain"})
+	require.NoError(t, err)
+	require.Equal(t, len(lower), len(upper), "category filter must be case-insensitive")
+}
+
+func TestBuildDisableRuleFiltersAnalyzerRules(t *testing.T) {
+	// --disable-rule must drop analyzer-emitted rules just like
+	// it drops YAML rules. Before this consolidation a user
+	// running `aguara list-rules --disable-rule JS_DNS_TXT_EXFIL_001`
+	// would see the rule anyway because list-rules only knew
+	// about YAML; this regression test locks the new behaviour.
+	cat, err := rulecatalog.Build(rulecatalog.Options{
+		DisableRuleIDs: []string{"JS_DNS_TXT_EXFIL_001"},
+	})
+	require.NoError(t, err)
+	for _, r := range cat {
+		require.NotEqual(t, "JS_DNS_TXT_EXFIL_001", r.ID,
+			"--disable-rule must remove analyzer rules from the catalog")
+	}
+}
+
+func TestFindByIDResolvesAnalyzerRule(t *testing.T) {
+	rec, err := rulecatalog.FindByID(rulecatalog.Options{}, "JS_DNS_TXT_EXFIL_001")
+	require.NoError(t, err)
+	require.Equal(t, "JS_DNS_TXT_EXFIL_001", rec.ID)
+	require.Equal(t, rulemeta.AnalyzerJSRisk, rec.Analyzer)
+}
+
+func TestFindByIDResolvesYAMLRule(t *testing.T) {
+	rec, err := rulecatalog.FindByID(rulecatalog.Options{}, "PROMPT_INJECTION_001")
+	require.NoError(t, err)
+	require.Equal(t, "PROMPT_INJECTION_001", rec.ID)
+	require.Equal(t, rulemeta.AnalyzerPattern, rec.Analyzer)
+}
+
+func TestFindByIDCaseInsensitive(t *testing.T) {
+	rec, err := rulecatalog.FindByID(rulecatalog.Options{}, "js_dns_txt_exfil_001")
+	require.NoError(t, err)
+	require.Equal(t, "JS_DNS_TXT_EXFIL_001", rec.ID)
+}
+
+func TestFindByIDMissingReturnsErrNotExist(t *testing.T) {
+	// CLI maps os.ErrNotExist to a clean "rule X not found"
+	// message. Other errors (load failure, malformed YAML) keep
+	// surfacing as wrapped errors.
+	_, err := rulecatalog.FindByID(rulecatalog.Options{}, "DEFINITELY_NOT_A_RULE_999")
+	require.Error(t, err)
+	require.True(t, errors.Is(err, os.ErrNotExist),
+		"missing rule must wrap os.ErrNotExist for the CLI's error-mapping path")
+}
+
+func TestEveryAnalyzerEmittedIDHasCatalogEntry(t *testing.T) {
+	// Belt-and-suspenders contract: the set of analyzer rule IDs
+	// that the codebase declares as constants must be a subset of
+	// the catalog. Specifically the rule IDs that the analyzer
+	// public consts (RuleObfuscation etc.) expose must each be
+	// findable. Tests the "co-locate metadata with the analyzer"
+	// invariant -- if someone adds a new const without a matching
+	// RuleMetadata() entry, this test fails.
+	emitted := []string{
+		// jsrisk public consts (internal/engine/jsrisk/jsrisk.go).
+		"JS_OBF_001", "JS_DAEMON_001", "JS_CI_SECRET_HARVEST_001",
+		"JS_PROC_MEM_OIDC_001", "AGENT_PERSISTENCE_001", "JS_DNS_TXT_EXFIL_001",
+		// ci-trust public consts.
+		"GHA_PWN_REQUEST_001", "GHA_CACHE_001", "GHA_OIDC_001", "GHA_CHECKOUT_001",
+		// pkgmeta public consts.
+		"NPM_LIFECYCLE_GIT_001", "NPM_OPTIONAL_GIT_001", "NPM_PUBLISH_SURFACE_001",
+		// nlp injection-analyzer emit sites.
+		"NLP_HIDDEN_INSTRUCTION", "NLP_CODE_MISMATCH", "NLP_HEADING_MISMATCH",
+		"NLP_AUTHORITY_CLAIM", "NLP_CRED_EXFIL_COMBO", "NLP_OVERRIDE_DANGEROUS",
+		// toxicflow emit sites (single-file + cross-file).
+		"TOXIC_001", "TOXIC_002", "TOXIC_003",
+		"TOXIC_CROSS_001", "TOXIC_CROSS_002", "TOXIC_CROSS_003",
+	}
+	for _, id := range emitted {
+		_, err := rulecatalog.FindByID(rulecatalog.Options{}, id)
+		require.NoErrorf(t, err, "analyzer-emitted ID %s must be in the catalog", id)
+	}
+}

--- a/internal/rulemeta/rule.go
+++ b/internal/rulemeta/rule.go
@@ -1,0 +1,66 @@
+// Package rulemeta is the single source of truth for "a rule the
+// user can explain or list". It defines a neutral Rule type that
+// every catalog source -- YAML-compiled pattern rules, --rules dir
+// custom rules, and analyzer-emitted rules (jsrisk, ci-trust,
+// pkgmeta, toxicflow, nlp-injection) -- conforms to.
+//
+// Keeping this surface independent of internal/rules.CompiledRule
+// and the various analyzer-internal rule types means:
+//
+//   - The CLI (explain, list-rules) can show every rule the scanner
+//     might emit, not just the YAML subset.
+//   - The Go API (aguara.ListRules / aguara.ExplainRule) returns a
+//     consistent shape regardless of which subsystem owns the rule.
+//   - New analyzer rules become explainable by adding a single
+//     RuleMetadata() entry in the analyzer package -- no plumbing
+//     through the YAML compile path.
+//
+// Patterns, TruePositives, FalsePositives are optional. Analyzer-
+// emitted rules carry no patterns because the analyzer logic itself
+// is the "pattern"; YAML rules carry concrete regex/contains
+// strings.
+package rulemeta
+
+// Rule is the neutral metadata shape for a detection rule.
+//
+// Field semantics:
+//
+//   - ID is the canonical rule identifier (e.g. "JS_DNS_TXT_EXFIL_001",
+//     "PROMPT_INJECTION_004"). Always upper-case, ASCII-only.
+//   - Analyzer names the engine that emits the rule. Empty for
+//     pattern-matcher rules driven by YAML; set for analyzer-owned
+//     rules ("ci-trust", "pkgmeta", "jsrisk", "nlp", "toxicflow").
+//     The empty case stays empty in JSON output (omitempty).
+//   - Severity is the canonical string ("CRITICAL", "HIGH", ...),
+//     matching what the scanner emits in findings.
+//   - Patterns is empty for analyzer rules -- the analyzer logic
+//     IS the pattern. YAML rules emit a "[regex] ..." / "[contains]
+//     ..." description per pattern.
+//   - TruePositives / FalsePositives are the YAML rules' self-test
+//     examples. Analyzer rules can include hand-curated fixtures
+//     here when useful, or leave them empty.
+type Rule struct {
+	ID             string   `json:"id"`
+	Name           string   `json:"name"`
+	Severity       string   `json:"severity"`
+	Category       string   `json:"category"`
+	Analyzer       string   `json:"analyzer,omitempty"`
+	Description    string   `json:"description,omitempty"`
+	Remediation    string   `json:"remediation,omitempty"`
+	Patterns       []string `json:"patterns,omitempty"`
+	TruePositives  []string `json:"true_positives,omitempty"`
+	FalsePositives []string `json:"false_positives,omitempty"`
+}
+
+// Analyzer name constants. Centralised here so a typo in one place
+// cannot make a record undiscoverable. The values are user-visible
+// (they show up in JSON output and in --filter args), so they're
+// short, lower-case, kebab-stable.
+const (
+	AnalyzerCITrust    = "ci-trust"
+	AnalyzerPkgMeta    = "pkgmeta"
+	AnalyzerJSRisk     = "jsrisk"
+	AnalyzerNLP        = "nlp"
+	AnalyzerToxicFlow  = "toxicflow"
+	AnalyzerPattern    = "" // YAML-driven rules; empty so JSON omits the field
+)

--- a/internal/rulemeta/rule.go
+++ b/internal/rulemeta/rule.go
@@ -57,10 +57,11 @@ type Rule struct {
 // (they show up in JSON output and in --filter args), so they're
 // short, lower-case, kebab-stable.
 const (
-	AnalyzerCITrust    = "ci-trust"
-	AnalyzerPkgMeta    = "pkgmeta"
-	AnalyzerJSRisk     = "jsrisk"
-	AnalyzerNLP        = "nlp"
-	AnalyzerToxicFlow  = "toxicflow"
-	AnalyzerPattern    = "" // YAML-driven rules; empty so JSON omits the field
+	AnalyzerCITrust   = "ci-trust"
+	AnalyzerPkgMeta   = "pkgmeta"
+	AnalyzerJSRisk    = "jsrisk"
+	AnalyzerNLP       = "nlp"
+	AnalyzerToxicFlow = "toxicflow"
+	AnalyzerRugPull   = "rugpull"
+	AnalyzerPattern   = "" // YAML-driven rules; empty so JSON omits the field
 )


### PR DESCRIPTION
## Summary

QA on v0.16.0 caught a P2 explainability gap: `aguara scan` emits
analyzer-owned rules like `JS_DNS_TXT_EXFIL_001`,
`GHA_PWN_REQUEST_001`, and `TOXIC_001`, but `aguara explain <ID>`
failed with `rule not found` on any of them because the explain
index only saw YAML pattern rules. A finding the scanner produced
could not be explained -- a transparency hole for the v0.16
analyzer round.

PR 2 of 4 in the v0.16 QA backlog (after #93, before `update --format
json` and the release-prep guardrail).

## Architecture

`internal/rulemeta`: neutral Rule type that every catalog source
conforms to (ID, Name, Severity, Category, Analyzer, Description,
Remediation, Patterns, TruePositives, FalsePositives).

`internal/engine/{ci,pkgmeta,jsrisk,nlp,toxicflow,rugpull}/metadata.go`:
each analyzer co-locates a `RuleMetadata()` function with its
source. Adding a new rule to an analyzer requires adding it to
that package's metadata.go in the same change -- a regression test
fails when an emit-site rule ID is missing from the catalog.

`internal/rulecatalog`: `Build` merges YAML compiled rules +
custom `--rules` dir + every analyzer's metadata into one sorted
`[]rulemeta.Rule`. `FindByID` is the single lookup the CLI and
the Go API share.

## CLI

`explain.go` now consumes the catalog. `explainCmd.SilenceUsage =
true` keeps a typo in the rule ID from dumping the `--help` block
in CI logs (same pattern PR #91 applied). Terminal output grows an
`Analyzer:` line for analyzer-owned rules.

`list_rules.go` table grows an ANALYZER column (`-` for YAML
rules). JSON output gains `analyzer,omitempty`.

## Public API (aguara.go)

`RuleInfo` and `RuleDetail` grow `Analyzer string` json:"analyzer,omitempty".
`ListRules` and `ExplainRule` now route through `rulecatalog`, so
external library consumers (e.g. `aguara-mcp`) get the same
expanded catalog as the CLI.

`ListRules` honours `WithCategory`, `WithDisabledRules`, AND
`WithRuleOverrides`. Override semantics mirror the scanner exactly:
YAML rules see the override; analyzer rules pass through untouched
(the scanner's `rules.ApplyOverrides` only operates on
`[]*rules.CompiledRule`, so the catalog must not pretend it does
for analyzer findings). Users who want to suppress an analyzer
rule should use `WithDisabledRules`, which the scanner DOES honour.

## Codex pre-PR review (4 rounds, all on the same axis -- stopped)

- R1: catalog presence (rugpull missing) + ListRules ignored
  WithDisabledRules. Fixed.
- R2: metadata accuracy -- toxicflow / nlp / rugpull catalog
  severities + categories didn't match what the analyzers emit.
  Fixed: catalog now mirrors the emit-site exactly.
- R3: overrides applied to analyzer rules (scanner doesn't) +
  JS_CI_SECRET_HARVEST_001 metadata HIGH but emit ships CRITICAL
  + explain.go masked custom-rules-dir errors as "rule not found".
  Fixed: catalog overrides scoped to YAML only; severity aligned;
  `rulecatalog.ErrRuleNotFound` typed sentinel.

Stopped iterating per the tightened stop rule. The findings clustered
on the catalog-shape axis; a fourth round would either re-validate
(likely CLEAN) or surface another metadata-drift instance that is
better handled by the source-of-truth tests we now have.

## Test plan

- [x] `go test -race -count=1 ./...`
- [x] `make vet` / `make lint` (0 issues)
- [x] `TestAnalyzerMetadataMatchesEmittedSeverityAndCategory` --
      catalog severity + category must match what each analyzer's
      emit site sets. Regression that flips one without the other
      fails this single table-driven test.
- [x] `TestEveryAnalyzerEmittedIDHasCatalogEntry` -- every rule ID
      the analyzers declare as a public const must resolve in the
      catalog.
- [x] `TestBuildOverridesDisableAndSeverityYAMLOnly` -- Overrides
      drop/remap YAML rules, leave analyzer rules untouched.
- [x] `TestFindByIDBuildErrorDistinctFromNotFound` -- a missing
      `--rules` dir does NOT mask as `rule not found`.
- [x] `TestListRulesHonoursRuleOverrides` /
      `TestListRulesHonoursDisabledRules` /
      `TestListRulesIncludesAnalyzerRules` /
      `TestExplainRuleResolvesAnalyzerRule` -- public API contracts.
- [x] CLI: `aguara explain JS_DNS_TXT_EXFIL_001 --format json`
      resolves with `analyzer:"jsrisk"`; `list-rules --format json`
      includes analyzer rules; `--category prompt-injection` now
      legitimately includes `NLP_*` alongside `PROMPT_INJECTION_*`.

## Out of scope

No changes to detection logic, severities at emit sites, or FP
calibration. `ScanResult.RulesLoaded` continues to count compiled
YAML rules (the catalog is a separate, additive surface).