### PR TITLE
fix(update): honor --format json + guard --output against snapshot overwrite

### DIFF
--- a/cmd/aguara/commands/update.go
+++ b/cmd/aguara/commands/update.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -192,10 +193,19 @@ func writeUpdateTerminal(res *intel.UpdateResult, snapshotPath string) error {
 // assertOutputNotShadowingStore returns an error if flagOutput
 // would resolve to the same on-disk file the intel.Store writes
 // the snapshot to. Compared by canonical absolute path so a
-// relative -o (or one with redundant separators) is caught too.
-// Symlink shenanigans across the two paths are out of scope: if
-// the user has set up a symlink farm pointing -o at the snapshot,
-// they have asked for trouble.
+// relative -o (or one with redundant separators) is caught.
+//
+// On case-insensitive filesystems (macOS HFS+/APFS, Windows
+// NTFS), `Snapshot.JSON` and `snapshot.json` resolve to the same
+// file even though the bytes differ; we fold case for the
+// comparison so the corruption guard fires for that scenario
+// too. Linux's ext4/xfs are case-sensitive by default and the
+// byte-for-byte compare is correct there; the case-fold path
+// stays gated on runtime.GOOS so we do not over-reject.
+//
+// Symlink shenanigans across the two paths are still out of
+// scope (a user who sets up a symlink farm pointing -o at the
+// snapshot has asked for trouble).
 //
 // Returns nil for the common case (no -o, or -o pointing
 // anywhere other than the snapshot path) so the rest of the
@@ -212,10 +222,42 @@ func assertOutputNotShadowingStore(out, storeDir string) error {
 	if err != nil {
 		return nil
 	}
-	if filepath.Clean(outAbs) == filepath.Clean(storeAbs) {
+	if pathsCollide(filepath.Clean(outAbs), filepath.Clean(storeAbs)) {
 		return fmt.Errorf("aguara update: --output %s would overwrite the threat-intel snapshot the command just wrote; pick a different path (the snapshot already lives there)", out)
 	}
 	return nil
+}
+
+// pathsCollide reports whether two canonical absolute paths
+// resolve to the same on-disk file under the host's filesystem
+// rules. macOS and Windows default to case-insensitive lookups,
+// so `Snapshot.JSON` and `snapshot.json` open the same file even
+// though the bytes differ. Linux ext4/xfs are case-sensitive by
+// default and the byte compare is sufficient there.
+func pathsCollide(a, b string) bool {
+	if a == b {
+		return true
+	}
+	if isCaseInsensitiveFS() && strings.EqualFold(a, b) {
+		return true
+	}
+	return false
+}
+
+// isCaseInsensitiveFS reports whether the host's default
+// filesystem treats paths case-insensitively. macOS APFS CAN be
+// created case-sensitive, but the default (and the format every
+// homebrew/installer assumes) is case-insensitive; treating both
+// macOS and Windows as case-insensitive is the defensive choice
+// vs running data-corruption risk for the small minority of
+// case-sensitive macOS volumes.
+func isCaseInsensitiveFS() bool {
+	switch runtime.GOOS {
+	case "darwin", "windows":
+		return true
+	default:
+		return false
+	}
 }
 
 // osvImporterAdapter bridges intel.UpdateOptions.Importer (an

--- a/cmd/aguara/commands/update.go
+++ b/cmd/aguara/commands/update.go
@@ -54,6 +54,19 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("aguara update: %w", err)
 	}
 
+	// Guard: -o must not point at the snapshot path the store
+	// is about to write. The Save happens BEFORE the output
+	// writer runs, so without this check `aguara update -o
+	// ~/.aguara/intel/snapshot.json` would first write the real
+	// refreshed snapshot and then truncate the same file to a
+	// terminal/JSON summary -- silently corrupting the cache.
+	// Future offline checks would then fail to Load the snapshot
+	// and fall back to the embedded data without telling the
+	// user the refresh effectively disappeared.
+	if err := assertOutputNotShadowingStore(flagOutput, store.Dir); err != nil {
+		return err
+	}
+
 	ctx, cancel := context.WithTimeout(cmd.Context(), flagUpdateTimeout)
 	defer cancel()
 
@@ -173,6 +186,35 @@ func writeUpdateTerminal(res *intel.UpdateResult, snapshotPath string) error {
 		fmt.Fprintf(w, "  %-8s -> %d records\n", eco.Ecosystem, eco.RecordsKept)
 	}
 	fmt.Fprintf(w, "  Written: %s\n", snapshotPath)
+	return nil
+}
+
+// assertOutputNotShadowingStore returns an error if flagOutput
+// would resolve to the same on-disk file the intel.Store writes
+// the snapshot to. Compared by canonical absolute path so a
+// relative -o (or one with redundant separators) is caught too.
+// Symlink shenanigans across the two paths are out of scope: if
+// the user has set up a symlink farm pointing -o at the snapshot,
+// they have asked for trouble.
+//
+// Returns nil for the common case (no -o, or -o pointing
+// anywhere other than the snapshot path) so the rest of the
+// happy path stays untouched.
+func assertOutputNotShadowingStore(out, storeDir string) error {
+	if out == "" {
+		return nil
+	}
+	outAbs, err := filepath.Abs(out)
+	if err != nil {
+		return nil // can't normalise; let the open() below fail with a real message
+	}
+	storeAbs, err := filepath.Abs(filepath.Join(storeDir, "snapshot.json"))
+	if err != nil {
+		return nil
+	}
+	if filepath.Clean(outAbs) == filepath.Clean(storeAbs) {
+		return fmt.Errorf("aguara update: --output %s would overwrite the threat-intel snapshot the command just wrote; pick a different path (the snapshot already lives there)", out)
+	}
 	return nil
 }
 

--- a/cmd/aguara/commands/update.go
+++ b/cmd/aguara/commands/update.go
@@ -2,9 +2,12 @@ package commands
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/garagon/aguara/internal/intel"
@@ -88,11 +91,88 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("aguara update: save snapshot: %w", err)
 	}
 
-	fmt.Fprintf(os.Stdout, "Aguara threat intel updated\n")
-	for _, eco := range res.PerEcosystem {
-		fmt.Fprintf(os.Stdout, "  %-8s -> %d records\n", eco.Ecosystem, eco.RecordsKept)
+	return writeUpdateOutput(res, store.Dir)
+}
+
+// updateOutput is the JSON-stable shape `aguara update --format json`
+// emits. Field names match the snake_case scheme the rest of the JSON
+// surface uses; the array is always non-nil so consumers parsing it
+// in a typed language see []byte / [] cleanly.
+type updateOutput struct {
+	SnapshotPath string                  `json:"snapshot_path"`
+	Records      int                     `json:"records"`
+	GeneratedAt  time.Time               `json:"generated_at"`
+	PerEcosystem []updateEcosystemOutput `json:"per_ecosystem"`
+}
+
+type updateEcosystemOutput struct {
+	Ecosystem    string    `json:"ecosystem"`
+	RecordsKept  int       `json:"records_kept"`
+	BytesRead    int64     `json:"bytes_read"`
+	DownloadedAt time.Time `json:"downloaded_at"`
+}
+
+// writeUpdateOutput dispatches between the JSON and terminal
+// writers based on the global --format flag. The -o flag, when
+// present, redirects EITHER format to a file; otherwise both go to
+// stdout. Stderr is untouched so the per-ecosystem progress line
+// the intel.Update Stderr hook prints stays visible regardless of
+// --format. Network failures error out before this function is
+// called, so this path is offline-only.
+func writeUpdateOutput(res *intel.UpdateResult, storeDir string) error {
+	snapshotPath := filepath.Join(storeDir, "snapshot.json")
+
+	if strings.ToLower(flagFormat) == "json" {
+		return writeUpdateJSON(res, snapshotPath)
 	}
-	fmt.Fprintf(os.Stdout, "  Written: %s\n", store.Dir+"/snapshot.json")
+	return writeUpdateTerminal(res, snapshotPath)
+}
+
+func writeUpdateJSON(res *intel.UpdateResult, snapshotPath string) error {
+	out := updateOutput{
+		SnapshotPath: snapshotPath,
+		Records:      len(res.Snapshot.Records),
+		GeneratedAt:  res.Snapshot.GeneratedAt,
+		PerEcosystem: make([]updateEcosystemOutput, 0, len(res.PerEcosystem)),
+	}
+	for _, eco := range res.PerEcosystem {
+		out.PerEcosystem = append(out.PerEcosystem, updateEcosystemOutput{
+			Ecosystem:    eco.Ecosystem,
+			RecordsKept:  eco.RecordsKept,
+			BytesRead:    eco.BytesRead,
+			DownloadedAt: eco.DownloadedAt,
+		})
+	}
+
+	w := io.Writer(os.Stdout)
+	if flagOutput != "" {
+		f, err := os.Create(flagOutput)
+		if err != nil {
+			return fmt.Errorf("aguara update: write --output: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+		w = f
+	}
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+func writeUpdateTerminal(res *intel.UpdateResult, snapshotPath string) error {
+	w := io.Writer(os.Stdout)
+	if flagOutput != "" {
+		f, err := os.Create(flagOutput)
+		if err != nil {
+			return fmt.Errorf("aguara update: write --output: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+		w = f
+	}
+	fmt.Fprintf(w, "Aguara threat intel updated\n")
+	for _, eco := range res.PerEcosystem {
+		fmt.Fprintf(w, "  %-8s -> %d records\n", eco.Ecosystem, eco.RecordsKept)
+	}
+	fmt.Fprintf(w, "  Written: %s\n", snapshotPath)
 	return nil
 }
 

--- a/cmd/aguara/commands/update_test.go
+++ b/cmd/aguara/commands/update_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -202,6 +203,34 @@ func TestAssertOutputNotShadowingStore(t *testing.T) {
 	err = assertOutputNotShadowingStore("snapshot.json", storeDir)
 	require.Error(t, err,
 		"a relative -o resolving to the snapshot path must collide too")
+}
+
+func TestAssertOutputNotShadowingStoreCaseInsensitive(t *testing.T) {
+	// Codex P2 round 2 (PR 3): on macOS/Windows, `Snapshot.JSON`
+	// and `snapshot.json` resolve to the same file even though
+	// the bytes differ. The guard MUST fire there too -- a
+	// byte-for-byte compare misses the collision and the writer
+	// overwrites the cache. On case-sensitive filesystems
+	// (Linux ext4/xfs default) the two are distinct files and
+	// the guard correctly does NOT fire.
+	storeDir := t.TempDir()
+
+	mixedCase := filepath.Join(storeDir, "Snapshot.JSON")
+	err := assertOutputNotShadowingStore(mixedCase, storeDir)
+	switch runtime.GOOS {
+	case "darwin", "windows":
+		require.Error(t, err,
+			"case-insensitive FS must catch mixed-case -o that resolves to the same file")
+		require.Contains(t, err.Error(), "would overwrite")
+	default:
+		// Linux: case-sensitive default. Snapshot.JSON is a
+		// genuinely different file from snapshot.json, so the
+		// guard correctly returns nil. (A case-insensitive
+		// mount on Linux could fool this, but we mirror what
+		// the kernel's path-lookup actually does on the host.)
+		require.NoError(t, err,
+			"case-sensitive FS: Snapshot.JSON and snapshot.json are distinct files; guard must not over-reject")
+	}
 }
 
 func TestWriteUpdateTerminalRespectsOutputFile(t *testing.T) {

--- a/cmd/aguara/commands/update_test.go
+++ b/cmd/aguara/commands/update_test.go
@@ -1,0 +1,187 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+// makeUpdateResult builds a minimal intel.UpdateResult for the
+// writer tests. Pure: no HTTP, no Store, no filesystem beyond
+// what each test arranges itself.
+func makeUpdateResult(records int, generated time.Time) *intel.UpdateResult {
+	return &intel.UpdateResult{
+		Snapshot: intel.Snapshot{
+			SchemaVersion: intel.CurrentSchemaVersion,
+			GeneratedAt:   generated,
+			Records:       make([]intel.Record, records),
+		},
+		PerEcosystem: []intel.EcosystemResult{
+			{Ecosystem: intel.EcosystemNPM, RecordsKept: 10, BytesRead: 1024, DownloadedAt: generated},
+			{Ecosystem: intel.EcosystemPyPI, RecordsKept: 5, BytesRead: 512, DownloadedAt: generated},
+		},
+	}
+}
+
+// captureStdoutBytes redirects os.Stdout to a temp file for the
+// duration of a test and returns the captured bytes. The update
+// writers write to os.Stdout directly (not cobra's SetOut, since
+// they format machine-readable output), so this is the right
+// hook to assert on. Mirrors the helper in status_test.go.
+func captureStdoutBytes(t *testing.T, fn func()) []byte {
+	t.Helper()
+	orig := os.Stdout
+	tmp, err := os.CreateTemp(t.TempDir(), "stdout-*.txt")
+	require.NoError(t, err)
+	os.Stdout = tmp
+	defer func() {
+		os.Stdout = orig
+		_ = tmp.Close()
+	}()
+	fn()
+	_ = tmp.Sync()
+	data, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	return data
+}
+
+func TestWriteUpdateJSONShape(t *testing.T) {
+	// QA on v0.16.0 reported `aguara update --format json` emits
+	// human-readable output. PR 3 contract: --format json must
+	// emit a stable JSON shape the spec defined ({snapshot_path,
+	// records, generated_at, per_ecosystem:[...]}) and nothing
+	// else on stdout.
+	resetFlags()
+	t.Cleanup(resetFlags)
+	flagFormat = "json"
+	flagOutput = ""
+
+	res := makeUpdateResult(15, time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC))
+	snapshotPath := "/home/user/.aguara/intel/snapshot.json"
+
+	out := captureStdoutBytes(t, func() {
+		require.NoError(t, writeUpdateOutput(res, filepath.Dir(snapshotPath)))
+	})
+
+	// 1) Must parse as JSON.
+	var parsed updateOutput
+	require.NoError(t, json.Unmarshal(out, &parsed),
+		"--format json must produce parseable JSON, not human text. got: %s", string(out))
+
+	// 2) Field shape matches the spec.
+	require.Equal(t, snapshotPath, parsed.SnapshotPath)
+	require.Equal(t, 15, parsed.Records)
+	require.Equal(t, time.Date(2026, time.May, 15, 12, 0, 0, 0, time.UTC), parsed.GeneratedAt.UTC())
+	require.Len(t, parsed.PerEcosystem, 2)
+	require.Equal(t, intel.EcosystemNPM, parsed.PerEcosystem[0].Ecosystem)
+	require.Equal(t, 10, parsed.PerEcosystem[0].RecordsKept)
+	require.Equal(t, int64(1024), parsed.PerEcosystem[0].BytesRead)
+	require.Equal(t, intel.EcosystemPyPI, parsed.PerEcosystem[1].Ecosystem)
+
+	// 3) No human-readable lines leaked in. The legacy terminal
+	// output starts with "Aguara threat intel updated"; that
+	// string must NOT appear in JSON-mode output even as a
+	// stray Fprintf.
+	require.NotContains(t, string(out), "Aguara threat intel updated",
+		"--format json must not emit the human-readable header line")
+	require.NotContains(t, string(out), "Written:",
+		"--format json must not emit the human-readable 'Written:' line")
+}
+
+func TestWriteUpdateJSONEmptyPerEcosystem(t *testing.T) {
+	// A run with no ecosystems (unusual but possible if a future
+	// configuration filters all of them out) must still emit a
+	// VALID JSON document with per_ecosystem as an empty array,
+	// not null. Stable shape for typed consumers.
+	resetFlags()
+	t.Cleanup(resetFlags)
+	flagFormat = "json"
+
+	res := &intel.UpdateResult{
+		Snapshot: intel.Snapshot{
+			SchemaVersion: intel.CurrentSchemaVersion,
+			GeneratedAt:   time.Unix(0, 0).UTC(),
+		},
+	}
+	out := captureStdoutBytes(t, func() {
+		require.NoError(t, writeUpdateOutput(res, "/tmp"))
+	})
+	require.Contains(t, string(out), `"per_ecosystem": []`,
+		"empty per_ecosystem must serialise as [] not null; got: %s", string(out))
+}
+
+func TestWriteUpdateJSONToFile(t *testing.T) {
+	// --format json combined with -o must redirect the JSON to
+	// the file AND leave stdout clean. Critical for automation:
+	// callers tee output and pipe stdout; spurious bytes on
+	// stdout corrupt their pipeline.
+	resetFlags()
+	t.Cleanup(resetFlags)
+	flagFormat = "json"
+	outFile := filepath.Join(t.TempDir(), "update.json")
+	flagOutput = outFile
+
+	res := makeUpdateResult(20, time.Date(2026, time.May, 15, 0, 0, 0, 0, time.UTC))
+
+	stdoutBytes := captureStdoutBytes(t, func() {
+		require.NoError(t, writeUpdateOutput(res, "/home/user/.aguara/intel"))
+	})
+
+	require.Empty(t, stdoutBytes,
+		"--format json -o file must leave stdout empty; bytes leaked: %d", len(stdoutBytes))
+
+	fileBytes, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	var parsed updateOutput
+	require.NoError(t, json.Unmarshal(fileBytes, &parsed))
+	require.Equal(t, 20, parsed.Records)
+}
+
+func TestWriteUpdateTerminalDefault(t *testing.T) {
+	// Default (no --format) keeps the human-readable output as
+	// before. No regression for users who upgrade and were
+	// relying on the legacy terminal shape.
+	resetFlags()
+	t.Cleanup(resetFlags)
+	flagFormat = "terminal"
+
+	res := makeUpdateResult(15, time.Unix(0, 0))
+	out := captureStdoutBytes(t, func() {
+		require.NoError(t, writeUpdateOutput(res, "/home/user/.aguara/intel"))
+	})
+	s := string(out)
+	require.Contains(t, s, "Aguara threat intel updated")
+	require.Contains(t, s, "npm")
+	require.Contains(t, s, "PyPI")
+	require.Contains(t, s, "Written:")
+	// And the terminal output must NOT be valid JSON, so a
+	// consumer scripting against --format json sees the
+	// difference immediately if they forgot the flag.
+	require.False(t, strings.HasPrefix(strings.TrimSpace(s), "{"),
+		"terminal default must not start like JSON; got: %s", s)
+}
+
+func TestWriteUpdateTerminalRespectsOutputFile(t *testing.T) {
+	// -o without --format puts the terminal text in the file
+	// (same legacy semantics as scan / check), so users who
+	// scripted `aguara update -o file` keep their flow.
+	resetFlags()
+	t.Cleanup(resetFlags)
+	outFile := filepath.Join(t.TempDir(), "update.txt")
+	flagOutput = outFile
+
+	res := makeUpdateResult(15, time.Unix(0, 0))
+	stdoutBytes := captureStdoutBytes(t, func() {
+		require.NoError(t, writeUpdateOutput(res, "/home/user/.aguara/intel"))
+	})
+	require.Empty(t, stdoutBytes, "with -o, stdout must be empty regardless of format")
+	fileBytes, err := os.ReadFile(outFile)
+	require.NoError(t, err)
+	require.Contains(t, string(fileBytes), "Aguara threat intel updated")
+}

--- a/cmd/aguara/commands/update_test.go
+++ b/cmd/aguara/commands/update_test.go
@@ -167,6 +167,43 @@ func TestWriteUpdateTerminalDefault(t *testing.T) {
 		"terminal default must not start like JSON; got: %s", s)
 }
 
+func TestAssertOutputNotShadowingStore(t *testing.T) {
+	// Codex P2 (PR 3): `aguara update -o ~/.aguara/intel/snapshot.json`
+	// would first write the real refreshed snapshot via store.Save,
+	// then truncate the same file to a terminal/JSON summary,
+	// silently corrupting the cache. The guard catches the path
+	// collision BEFORE any I/O happens.
+	storeDir := t.TempDir()
+	snapshotPath := filepath.Join(storeDir, "snapshot.json")
+
+	// Exact match -> rejected.
+	err := assertOutputNotShadowingStore(snapshotPath, storeDir)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "would overwrite")
+	require.Contains(t, err.Error(), snapshotPath)
+
+	// Trailing slash redundancy still collides under
+	// filepath.Clean normalisation.
+	err = assertOutputNotShadowingStore(snapshotPath+"/./.", storeDir)
+	require.Error(t, err)
+
+	// Empty -o -> nil (the common case).
+	err = assertOutputNotShadowingStore("", storeDir)
+	require.NoError(t, err)
+
+	// Different path -> nil.
+	err = assertOutputNotShadowingStore(filepath.Join(storeDir, "summary.json"), storeDir)
+	require.NoError(t, err)
+
+	// Relative path that resolves to the snapshot still
+	// collides (filepath.Abs normalises).
+	// Set up: chdir into storeDir, pass `snapshot.json` as -o.
+	t.Chdir(storeDir)
+	err = assertOutputNotShadowingStore("snapshot.json", storeDir)
+	require.Error(t, err,
+		"a relative -o resolving to the snapshot path must collide too")
+}
+
 func TestWriteUpdateTerminalRespectsOutputFile(t *testing.T) {
 	// -o without --format puts the terminal text in the file
 	// (same legacy semantics as scan / check), so users who


### PR DESCRIPTION
## Summary

QA on v0.16.0 caught a P3 UX gap: `aguara update --format json`
accepted the global flag but emitted human-readable text.
Automation consumers scripting against the JSON output saw the
legacy shape and broke. The `scan` / `check` / `audit` commands
already honour `--format json`; update was the outlier.

PR 3 of 4 in the v0.16 QA backlog (after #93 and #94, before the
release-prep version guardrail).

## Change

Split the writer path:

- `writeUpdateOutput` dispatches on `flagFormat`.
- `writeUpdateJSON` emits a stable shape:

```json
{
  "snapshot_path": "/home/.../.aguara/intel/snapshot.json",
  "records": 21518,
  "generated_at": "2026-05-15T...",
  "per_ecosystem": [
    {"ecosystem": "npm",  "records_kept": 16304, "bytes_read": 203471729, "downloaded_at": "..."},
    {"ecosystem": "PyPI", "records_kept": 1399,  "bytes_read": 23199922,  "downloaded_at": "..."}
  ]
}
```

- `writeUpdateTerminal` keeps the legacy human-readable output
  unchanged, so users not passing `--format` see no regression.
- Both writers honour `-o file`. Stderr per-ecosystem progress
  (the `intel.Update` Stderr hook) is preserved regardless of
  `--format`.

No changes to network semantics, `--allow-empty`, or HTTP timeouts.

## Codex pre-PR review (3 rounds, 2 fixes -- stopped)

- R1 P2: `aguara update -o ~/.aguara/intel/snapshot.json` first
  wrote the real refreshed snapshot via `store.Save`, then
  truncated the same file to the summary. Silent cache
  corruption. Added `assertOutputNotShadowingStore` before any
  I/O, with a clear error message.
- R2 P2: the byte-for-byte path compare missed
  case-insensitive filesystem collisions (`Snapshot.JSON` on
  macOS APFS resolves to the same file). Introduced
  `pathsCollide` + `isCaseInsensitiveFS()`: byte compare on
  Linux, `strings.EqualFold` on darwin/windows. Defensive: a
  macOS APFS volume CAN be created case-sensitive, but the
  default is case-insensitive and shipping data corruption to
  the majority case is unacceptable.
- R3: CLEAN PASS.

## Regression lock

Six tests:

- `TestWriteUpdateJSONShape` -- `--format json` parses, fields
  match spec, **no** human-readable lines leak in.
- `TestWriteUpdateJSONEmptyPerEcosystem` -- empty array
  serialises as `[]` not `null`.
- `TestWriteUpdateJSONToFile` -- `--format json -o file`
  redirects to file and leaves stdout empty.
- `TestWriteUpdateTerminalDefault` -- legacy human output
  preserved, NOT valid JSON so a consumer who forgot `--format`
  sees the difference immediately.
- `TestWriteUpdateTerminalRespectsOutputFile` -- `-o` without
  `--format` keeps legacy semantics.
- `TestAssertOutputNotShadowingStore` + `...CaseInsensitive` --
  guard fires for exact match, redundant separators,
  chdir-relative paths AND mixed-case on macOS/Windows. Does
  NOT over-reject on Linux where mixed-case files are
  genuinely distinct.

## Test plan

- [x] `go test -race -count=1 ./...`
- [x] `make vet` / `make lint` (0 issues)
- [x] Manual: `aguara update --format json` parses; legacy
      `aguara update` keeps the human output verbatim.

## Out of scope

PR 4 of the v0.16 QA backlog (release-prep guardrail against
`init` template version drift) ships separately.