### PR TITLE
ci(release): guard release-prep against version-pin drift

### DIFF
--- a/.github/scripts/check-version-pins.sh
+++ b/.github/scripts/check-version-pins.sh
@@ -1,0 +1,123 @@
+#!/bin/sh
+#
+# check-version-pins.sh -- verify that every release-pinned tag
+# reference in the repository points at the version about to be
+# tagged. Run as a release-prep step BEFORE `git tag vX.Y.Z`:
+#
+#   VERSION=v0.17.0 .github/scripts/check-version-pins.sh
+#
+# Why this script exists
+# ----------------------
+# Several files hardcode the current release tag so that consumers
+# get a reproducible default rather than a floating ref:
+#
+#   cmd/aguara/commands/init.go    scaffolded GHA workflow:
+#                                  uses: garagon/aguara@vX.Y.Z
+#                                  version: vX.Y.Z
+#   action.yml                     DEFAULT_REF="vX.Y.Z" (fallback
+#                                  for consumers who do not pin)
+#   Makefile                       INSTALL_SH_TEST_VERSION ?= vX.Y.Z
+#                                  (install.sh acceptance test target)
+#   README.md                      curl-pipe install snippets:
+#                                  VERSION=vX.Y.Z sh
+#
+# Bumping ONLY the git tag while leaving any of these on the old
+# version ships a release whose first-touch UX (init scaffold, action
+# default) still points at the prior version. PR #92 was the
+# fallout from exactly that pattern; this script makes the same
+# class of mistake fail loud BEFORE the tag is pushed.
+#
+# This script is intentionally NOT wired into `make test`. It is a
+# release-prep gate the maintainer runs alongside `verify-release.sh`
+# (verify-release.sh runs POST-tag against the published artifacts;
+# this one runs PRE-tag against the working tree).
+#
+# Exit codes:
+#   0   every pin matches $VERSION
+#   1   one or more pins drifted; the report lists each location and
+#       what is currently there vs. what was expected
+#   2   missing or malformed $VERSION env var
+set -eu
+
+if [ -z "${VERSION:-}" ]; then
+  echo "check-version-pins: VERSION env var is required (e.g. VERSION=v0.17.0)" >&2
+  exit 2
+fi
+
+# Validate semver shape. The version MUST look like vMAJOR.MINOR.PATCH;
+# anything else would be a typo (or a pre-release the release flow
+# does not handle yet).
+case "$VERSION" in
+  v[0-9]*.[0-9]*.[0-9]*) ;;
+  *)
+    echo "check-version-pins: VERSION must be a semver tag like vX.Y.Z, got: $VERSION" >&2
+    exit 2
+    ;;
+esac
+
+REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$REPO_ROOT"
+
+drift_count=0
+report() {
+  printf 'DRIFT: %s\n' "$1" >&2
+  drift_count=$((drift_count + 1))
+}
+
+# Each check below prints a DRIFT: line on failure and increments
+# drift_count. We do NOT exit on the first failure -- the maintainer
+# wants the full list in one run so they can fix everything in one
+# commit.
+
+# 1. cmd/aguara/commands/init.go: scaffolded GHA workflow action ref.
+if ! grep -Fq "uses: garagon/aguara@$VERSION" cmd/aguara/commands/init.go; then
+  report "cmd/aguara/commands/init.go: scaffolded workflow does not pin 'uses: garagon/aguara@$VERSION'"
+fi
+
+# 2. cmd/aguara/commands/init.go: scaffolded workflow binary version.
+if ! grep -Fq "version: $VERSION" cmd/aguara/commands/init.go; then
+  report "cmd/aguara/commands/init.go: scaffolded workflow does not pin 'version: $VERSION' (action input)"
+fi
+
+# 3. action.yml: DEFAULT_REF fallback for consumers who do not pin
+#    `uses: garagon/aguara@<ref>`. Lives in the install-script ref
+#    selection block.
+if ! grep -Eq "DEFAULT_REF=\"$VERSION\"" action.yml; then
+  report "action.yml: DEFAULT_REF is not \"$VERSION\""
+fi
+
+# 4. Makefile: INSTALL_SH_TEST_VERSION default for the install.sh
+#    acceptance target. The variable is ?=-assigned, so the literal
+#    must be on the right of '?='.
+if ! grep -Eq "^INSTALL_SH_TEST_VERSION[[:space:]]*\?=[[:space:]]*$VERSION\$" Makefile; then
+  report "Makefile: INSTALL_SH_TEST_VERSION does not default to $VERSION"
+fi
+
+# 5+6. README.md: curl-pipe install snippets that document
+#      VERSION=<tag> sh. There are two of these (quick install +
+#      pin-to-version examples); both must match.
+readme_hits=$(grep -c "VERSION=$VERSION sh" README.md || true)
+if [ "$readme_hits" -lt 2 ]; then
+  report "README.md: expected >=2 install snippets with 'VERSION=$VERSION sh' (found $readme_hits)"
+fi
+
+# Report stale README snippets too -- if VERSION=v0.15.0 still
+# appears, the user will know which line to fix.
+if grep -nE "VERSION=v[0-9]+\.[0-9]+\.[0-9]+ sh" README.md | grep -vE "VERSION=$VERSION sh"; then
+  : # the grep above prints the offending lines on stderr-equivalent;
+    # increment the counter via a sentinel marker.
+  if grep -nqE "VERSION=v[0-9]+\.[0-9]+\.[0-9]+ sh" README.md && \
+     ! grep -nq "VERSION=$VERSION sh" README.md; then
+    report "README.md: install snippets reference a different VERSION than $VERSION (see lines above)"
+  fi
+fi
+
+if [ "$drift_count" -gt 0 ]; then
+  echo "" >&2
+  echo "check-version-pins: $drift_count location(s) drifted from $VERSION" >&2
+  echo "  Fix each DRIFT: line above and re-run before tagging." >&2
+  exit 1
+fi
+
+echo "check-version-pins: all release pins agree on $VERSION"
+exit 0

--- a/.github/scripts/check-version-pins.sh
+++ b/.github/scripts/check-version-pins.sh
@@ -44,16 +44,19 @@ if [ -z "${VERSION:-}" ]; then
   exit 2
 fi
 
-# Validate semver shape. The version MUST look like vMAJOR.MINOR.PATCH;
-# anything else would be a typo (or a pre-release the release flow
-# does not handle yet).
-case "$VERSION" in
-  v[0-9]*.[0-9]*.[0-9]*) ;;
-  *)
-    echo "check-version-pins: VERSION must be a semver tag like vX.Y.Z, got: $VERSION" >&2
-    exit 2
-    ;;
-esac
+# Validate semver shape. The version MUST look exactly like
+# vMAJOR.MINOR.PATCH; anything else (pre-release suffixes,
+# trailing junk like 'v0.17.0foo') is a typo the release flow
+# does not handle yet.
+#
+# `case "$VERSION" in v[0-9]*.[0-9]*.[0-9]*)` is NOT strict
+# enough -- the trailing `*` in a shell glob consumes any
+# characters, so 'v0.17.0foo' would match. Use a grep -E anchor
+# instead, which is POSIX and enforces exact end-of-string.
+if ! printf '%s' "$VERSION" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "check-version-pins: VERSION must be a semver tag like vX.Y.Z, got: $VERSION" >&2
+  exit 2
+fi
 
 REPO_ROOT=$(cd "$(dirname "$0")/../.." && pwd)
 cd "$REPO_ROOT"
@@ -93,23 +96,31 @@ if ! grep -Eq "^INSTALL_SH_TEST_VERSION[[:space:]]*\?=[[:space:]]*$VERSION\$" Ma
   report "Makefile: INSTALL_SH_TEST_VERSION does not default to $VERSION"
 fi
 
-# 5+6. README.md: curl-pipe install snippets that document
-#      VERSION=<tag> sh. There are two of these (quick install +
-#      pin-to-version examples); both must match.
-readme_hits=$(grep -c "VERSION=$VERSION sh" README.md || true)
-if [ "$readme_hits" -lt 2 ]; then
-  report "README.md: expected >=2 install snippets with 'VERSION=$VERSION sh' (found $readme_hits)"
+# 5. README.md: curl-pipe install snippets that document
+#    VERSION=<tag> sh. Every snippet matching the shape
+#    `VERSION=vX.Y.Z sh` MUST pin to $VERSION; anything else is a
+#    stale snippet a maintainer forgot to bump.
+#
+# Walking the matches line-by-line (rather than counting +
+# negative-grep) means a README with two updated + one stale
+# snippet fails too. The previous count-based check passed in
+# that scenario because the count threshold was satisfied.
+stale_readme=$(grep -nE "VERSION=v[0-9]+\.[0-9]+\.[0-9]+ sh" README.md | grep -v "VERSION=$VERSION sh" || true)
+if [ -n "$stale_readme" ]; then
+  printf '%s\n' "$stale_readme" | while IFS= read -r line; do
+    report "README.md:$line (must pin to $VERSION)"
+  done
+  # The pipeline above runs in a subshell; drift_count increments
+  # there do not propagate to the parent. Add a single sentinel
+  # bump here so the overall exit reflects the README drift.
+  drift_count=$((drift_count + 1))
 fi
 
-# Report stale README snippets too -- if VERSION=v0.15.0 still
-# appears, the user will know which line to fix.
-if grep -nE "VERSION=v[0-9]+\.[0-9]+\.[0-9]+ sh" README.md | grep -vE "VERSION=$VERSION sh"; then
-  : # the grep above prints the offending lines on stderr-equivalent;
-    # increment the counter via a sentinel marker.
-  if grep -nqE "VERSION=v[0-9]+\.[0-9]+\.[0-9]+ sh" README.md && \
-     ! grep -nq "VERSION=$VERSION sh" README.md; then
-    report "README.md: install snippets reference a different VERSION than $VERSION (see lines above)"
-  fi
+# Sanity: if README has ZERO matching snippets at all, even after
+# the stale-snippets check, that's also a drift (someone removed
+# the example entirely or the convention changed).
+if ! grep -Fq "VERSION=$VERSION sh" README.md; then
+  report "README.md: no install snippet pins 'VERSION=$VERSION sh' (the canonical example)"
 fi
 
 if [ "$drift_count" -gt 0 ]; then

--- a/.github/scripts/check-version-pins.sh
+++ b/.github/scripts/check-version-pins.sh
@@ -107,13 +107,19 @@ fi
 # that scenario because the count threshold was satisfied.
 stale_readme=$(grep -nE "VERSION=v[0-9]+\.[0-9]+\.[0-9]+ sh" README.md | grep -v "VERSION=$VERSION sh" || true)
 if [ -n "$stale_readme" ]; then
-  printf '%s\n' "$stale_readme" | while IFS= read -r line; do
+  # Use a here-doc to feed the while loop instead of a pipe. A
+  # pipe spawns the right-hand side in a subshell, so 'report'
+  # would bump a copy of drift_count that vanishes when the
+  # subshell exits -- the parent's count then under-reports the
+  # number of locations the maintainer has to fix. The here-doc
+  # keeps the loop in the current shell so each stale snippet
+  # increments drift_count for real.
+  while IFS= read -r line; do
+    [ -z "$line" ] && continue
     report "README.md:$line (must pin to $VERSION)"
-  done
-  # The pipeline above runs in a subshell; drift_count increments
-  # there do not propagate to the parent. Add a single sentinel
-  # bump here so the overall exit reflects the README drift.
-  drift_count=$((drift_count + 1))
+  done <<EOF
+$stale_readme
+EOF
 fi
 
 # Sanity: if README has ZERO matching snippets at all, even after

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -144,7 +144,13 @@ CI currently does not gate on self-scan output; rule coverage is asserted by the
 
 ## Release Process
 
-After merging the release PR (`release/vX.Y.Z`) and tagging:
+**Before** tagging, run the pin-check script against the new version. Several files hardcode the current release tag (the scaffolded `aguara init` workflow, the action's `DEFAULT_REF`, the install.sh acceptance target, and the README install snippets). Bumping ONLY the git tag while leaving any of these on the old version ships a release whose first-touch UX still points at the prior version — PR #92 was that exact regression.
+
+```bash
+VERSION=vX.Y.Z .github/scripts/check-version-pins.sh
+```
+
+The script exits non-zero with a per-location `DRIFT:` report listing every file that still references the prior version. Fix each one in the release commit, re-run until it exits 0, then tag:
 
 ```bash
 git tag vX.Y.Z && git push origin vX.Y.Z


### PR DESCRIPTION
## Summary

PR 4 of 4 in the v0.16 QA backlog (after #93 / #94 / #95). Closes
the release hygiene gap captured in
`feedback_init_template_version_drift.md`: several files
hardcode the current release tag, and bumping ONLY the git tag
while leaving any of them on the old version ships a release
whose first-touch UX still points at the prior version. PR #92
was that exact regression -- `aguara init` from v0.16.0 pinned
v0.15.0 to `/releases/latest/`, which 404'd.

Scope cap honoured: bash-only release-prep gate, **no detection,
runtime, or UX behaviour changes**.

## What ships

### `.github/scripts/check-version-pins.sh`

Takes `VERSION=vX.Y.Z` env input and greps four pin locations
against it:

| Location | Pin shape |
|----------|-----------|
| `cmd/aguara/commands/init.go` | `uses: garagon/aguara@VERSION` |
| `cmd/aguara/commands/init.go` | `version: VERSION` (action input) |
| `action.yml` | `DEFAULT_REF="VERSION"` |
| `Makefile` | `INSTALL_SH_TEST_VERSION ?= VERSION` |
| `README.md` (x2) | `VERSION=VERSION sh` install snippets |

Each drift prints a `DRIFT:` line naming the file (and offending
README line numbers); the script collects ALL failures in one
run so a maintainer can fix everything in one commit. Exit
codes:

| Exit | Meaning |
|------|---------|
| `0` | every pin matches `$VERSION` |
| `1` | one or more pins drifted (DRIFT report on stderr) |
| `2` | missing or malformed `VERSION` env var |

Intentionally NOT wired into `make test`. It is a release-prep
gate the maintainer runs alongside `verify-release.sh`:

```bash
# pre-tag (this PR)
VERSION=vX.Y.Z .github/scripts/check-version-pins.sh

# post-tag (existing)
VERSION=vX.Y.Z .github/scripts/verify-release.sh
```

### CONTRIBUTING.md

The "Release Process" section now leads with the pre-tag step
and cites PR #92 as the historical fallout, so future
maintainers see *why* the gate exists, not just *how* to run it.

## Codex pre-PR review (3 rounds, 2 fixes -- stopped)

- R1 P3: `case "$VERSION" in v[0-9]*.[0-9]*.[0-9]*` accepted
  `v0.17.0foo` (trailing shell-glob `*` consumes anything).
  Replaced with `grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+$'` -- anchored
  both ends, rejects pre-release suffixes too.
- R1 P2: count-based README check (`>=2 matching snippets`)
  passed when 2 updated + 1 stale snippet co-existed. Switched
  to per-line scan: every `VERSION=vX.Y.Z sh` that doesn't match
  `$VERSION` gets its own DRIFT line.
- R2 P3: the pipe-to-while loop ran in a subshell, so
  `drift_count` increments vanished; the parent under-reported
  multi-line README drift. Switched to a here-doc input so the
  loop runs in the current shell. POSIX-portable.
- R3: CLEAN PASS -- "self-contained, executable, correctly
  reports drift; CONTRIBUTING update accurately documents the
  workflow".

## Smoke matrix (every row currently passes)

| Input | Expected | Got |
|-------|----------|-----|
| `VERSION=v0.16.0` (current state) | exit 0 | exit 0 |
| `VERSION=v0.17.0` (drift) | exit 1, 7 DRIFT lines | exit 1, 7 DRIFT lines, "7 location(s) drifted" |
| no `VERSION` | exit 2 + clear message | OK |
| `VERSION=v0.17` (too few segments) | exit 2 | OK |
| `VERSION=v0.17.0foo` (trailing junk) | exit 2 | OK |
| `VERSION=v0.17.0-rc1` (pre-release) | exit 2 | OK |
| README with 2 updated + 2 extra stale snippets | exit 1, count matches DRIFT lines | 8 / 8 |

## Test plan

- [x] All four smoke scenarios pass against the working tree.
- [x] `make vet` / `make lint` (0 issues).
- [x] `go test -race -count=1 ./...` (no Go changes, but kept
      green for sanity).

## Out of scope

- README `garagon/aguara@v1` floating-major references (lines
  279/285) -- that is a *separate* hygiene issue (whether to
  move the `v1` tag forward, deprecate it, or leave it frozen),
  not version-pin drift. Tracked elsewhere if it comes up
  again.
- Wiring the gate into `make test` or CI -- the script is
  release-prep only, deliberately. Maintainers run it before
  tagging, not on every PR.

## Round close

Backlog QA v0.16.0:

| PR | Item | Status |
|----|------|--------|
| #93 | `check --path` inexistente | MERGED |
| #94 | explain/list-rules analyzer catalog | MERGED |
| #95 | `update --format json` + overwrite guard | MERGED |
| **(this)** | release-prep version-pin guardrail | **OPEN** |

After this lands, the v0.16 QA backlog is fully resolved.