### PR TITLE
release: v0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-05-16
+
+Patch release. Closes the P1 secret-leak found in the v0.16.1 security audit.
+
+### Fixed
+
+- Aguara previously redacted findings only when `Category == "credential-leak"`. That missed credential-bearing findings emitted under other categories: `MCP_007` (mcp-attack), `NLP_CRED_EXFIL_COMBO` (exfiltration), toxic-flow credential-bound pairs (`TOXIC_001/002`, `TOXIC_CROSS_001/002`), and selected exfiltration / supply-chain exfil pattern rules. Those findings could copy raw secrets into `matched_text`, `context`, and SARIF `message.text`, so CI logs or GitHub Code Scanning artifacts became a second copy of the secret. (#97)
+- Cross-finding context bleed: a non-sensitive finding whose context window overlapped a sensitive sibling's match line no longer serializes that line raw.
+- Dedup-survivor leak: when a non-sensitive finding outranks a sensitive one on the same line at dedup time, the survivor now inherits the redaction obligation.
+
+### Changed
+
+- `types.Finding` gains an optional `Sensitive bool` (`"sensitive"` in JSON, emitted only when true).
+- YAML rules can opt in to redaction via `sensitive: true`. Analyzer emit sites (`NLP_CRED_EXFIL_COMBO`, `NLP_OVERRIDE_DANGEROUS` when credentials contribute, `TOXIC_*` cred-bound) mark findings sensitive inline.
+- `types.RedactCredentialFindings` is renamed to `RedactSensitiveFindings`; the old name is kept as a deprecated alias so library consumers keep compiling. Backward compatible: `Category == "credential-leak"` still triggers redaction even without the new flag.
+- `--no-redact` / `WithRedaction(false)` remain the explicit raw-output escape hatch.
+
+### Known follow-ups (v0.16.3)
+
+- `match_mode: all` rules whose secondary pattern hit lands more than ~3 lines from the anchor: that line is outside the recorded sensitive set. Will need `Finding.MatchedLines []int` plumbing.
+- Sensitive findings dropped by the `--severity` filter before redaction can leave their secret lines unmarked in surviving findings' context windows. Will need to collect sensitive lines inside `scanner.postProcess` before the severity filter.
+
 ## [0.16.1] - 2026-05-16
 
 Patch release for v0.16.0 focused on onboarding, CLI output contracts, and release hygiene.

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.16.1
+INSTALL_SH_TEST_VERSION ?= v0.16.2
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
 Installs the latest binary to `~/.local/bin`. Customize with environment variables:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.16.1 sh
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.16.2 sh
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | INSTALL_DIR=/usr/local/bin sh
 ```
 
@@ -73,7 +73,7 @@ To update an existing install, rerun the installer. It downloads the selected re
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
 
 # Update/pin to a specific release
-curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.16.1 sh
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.16.2 sh
 ```
 
 ### Alternative methods
@@ -276,29 +276,29 @@ aguara scan --auto
 #### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.16.1
+- uses: garagon/aguara@v0.16.2
   with:
     path: .
     fail-on: high
-    version: v0.16.1
+    version: v0.16.2
 ```
 
 Both pins (the action ref AND the `version:` input) are required. The
 action ref alone pins only the composite action and its install
 script; `version:` pins the Aguara binary the action installs. Setting
 both makes the workflow reproducible and dependabot-friendly: when
-v0.16.2 lands, the bot updates both together.
+v0.16.3 lands, the bot updates both together.
 
 Scans your repository, uploads findings to GitHub Code Scanning, and
 optionally fails the build:
 
 ```yaml
-- uses: garagon/aguara@v0.16.1
+- uses: garagon/aguara@v0.16.2
   with:
     path: ./mcp-server/
     severity: medium
     fail-on: high
-    version: v0.16.1
+    version: v0.16.2
 ```
 
 All inputs are optional. See [`action.yml`](action.yml) for the full list.

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.16.1"
+        DEFAULT_REF="v0.16.2"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.16.1 tag rather than `@v1`
+// The action ref is pinned to the v0.16.2 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.16.1
+        uses: garagon/aguara@v0.16.2
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.16.1
+          version: v0.16.2
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
## Summary

Prepare `v0.16.2`, a security patch release for the redaction-boundary fix merged in #97.

This release closes the P1 found in the v0.16.1 final security audit: findings outside `category: credential-leak` could still carry raw secrets into JSON, terminal output, Markdown, or SARIF. The fix introduces sensitivity-based redaction and keeps the legacy credential-leak fallback for custom rules.

## Release Contents

- Adds `CHANGELOG.md` entry for `0.16.2 - 2026-05-16`.
- Bumps release-pinned references from `v0.16.1` to `v0.16.2`:
  - `cmd/aguara/commands/init.go`
  - `action.yml`
  - `README.md`
  - `Makefile` install.sh Docker acceptance default
- Documents known follow-ups deferred to `v0.16.3`:
  - `MatchedLines []int` for distant secondary matches in `match_mode: all`.
  - redaction-line collection before severity filtering.

## Why This Release Exists

`v0.16.1` fixed onboarding and output-contract bugs, but the final audit found a real output-boundary issue:

- `MCP_007` (`mcp-attack`)
- `NLP_CRED_EXFIL_COMBO` (`exfiltration`)
- toxic-flow credential-bound findings
- selected exfiltration / supply-chain exfil rules

could copy a secret into `matched_text`, `context`, or SARIF `message.text` because redaction was category-gated. #97 moves that boundary to explicit sensitivity metadata.

## Test Plan

- [x] `VERSION=v0.16.2 .github/scripts/check-version-pins.sh`
- [x] `go test ./...`
- [x] `make vet`
- [x] `make lint`
- [x] redaction smoke: JSON/SARIF no longer contain the fake audit secret
- [x] `--no-redact` / `WithRedaction(false)` still preserves raw output when explicitly requested