### PR TITLE
feat(intel): measure-intel tool + OSV bucket sizing for v0.17.0

### DIFF
--- a/tools/measure-intel/classify.go
+++ b/tools/measure-intel/classify.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/garagon/aguara/internal/intel"
+)
+
+// classifyStatus enumerates the exact filter funnel
+// osvimport.convertOSVRecord walks: ecosystem-miss -> withdrawn ->
+// ranges-only -> signal-or-keyword pass -> kept. Each record lands
+// in exactly one bucket so the per-ecosystem totals add up.
+type classifyStatus int
+
+const (
+	statusEcosystemMiss classifyStatus = iota
+	statusWithdrawn
+	statusRangesOnly
+	statusNeither
+	statusKeptSignal
+	statusKeptKeyword
+)
+
+// classifyRecord parses one OSV JSON record and returns the
+// produced intel.Record plus the status bucket. The logic mirrors
+// osvimport.convertOSVRecord exactly with one intentional
+// difference: ecosystem matching is case-sensitive against the raw
+// OSV string (e.g. "Go", "crates.io"), not against
+// osvimport.canonicaliseEcosystem which today rejects everything
+// except npm / pypi. Once PR #1 widens the canonicaliser, this
+// mirror can be deleted in favour of a direct osvimport call.
+//
+// SYNC TARGET: internal/intel/osvimport/osvimport.go::convertOSVRecord
+// Any change to the production filter must be mirrored here, or the
+// measurement numbers diverge from what the importer will actually
+// produce.
+func classifyRecord(raw []byte, targetEcosystem string) (intel.Record, classifyStatus) {
+	var osv osvJSON
+	if err := json.Unmarshal(raw, &osv); err != nil {
+		return intel.Record{}, statusEcosystemMiss
+	}
+	if osv.ID == "" || len(osv.Affected) == 0 {
+		return intel.Record{}, statusEcosystemMiss
+	}
+
+	// Find the FIRST affected[] entry that targets the ecosystem of
+	// interest. OSV records can list multiple ecosystems
+	// (e.g. a GHSA aliased across npm + RubyGems); we treat each
+	// (record, ecosystem) pair independently, mirroring
+	// convertOSVRecord's loop body.
+	var aff *osvAffectedJSON
+	for i := range osv.Affected {
+		if osv.Affected[i].Package.Ecosystem == targetEcosystem {
+			aff = &osv.Affected[i]
+			break
+		}
+	}
+	if aff == nil {
+		return intel.Record{}, statusEcosystemMiss
+	}
+
+	withdrawn := osv.Withdrawn != ""
+	if withdrawn {
+		// Withdrawn passes through as a tombstone, NOT a kept
+		// record. The renderer / merge layer would emit it so the
+		// runtime matcher can retract a previously-live copy.
+		return intel.Record{}, statusWithdrawn
+	}
+
+	if len(aff.Versions) == 0 {
+		return intel.Record{}, statusRangesOnly
+	}
+
+	signal := hasSignal(&osv)
+	keyword := hasKeyword(&osv)
+	if !signal && !keyword {
+		return intel.Record{}, statusNeither
+	}
+
+	rec := intel.Record{
+		ID:        osv.ID,
+		Aliases:   append([]string(nil), osv.Aliases...),
+		Ecosystem: targetEcosystem,
+		Name:      aff.Package.Name,
+		Kind:      intel.KindMalicious,
+		Summary:   pickSummary(&osv),
+		Versions:  append([]string(nil), aff.Versions...),
+	}
+	for _, ref := range osv.References {
+		if ref.URL != "" {
+			rec.References = append(rec.References, ref.URL)
+		}
+	}
+
+	if signal {
+		return rec, statusKeptSignal
+	}
+	return rec, statusKeptKeyword
+}
+
+// osvJSON mirrors osvimport's private osvRecord. We keep it private
+// here too because PR #1 will widen the importer and this file can
+// then call into osvimport directly.
+type osvJSON struct {
+	ID               string             `json:"id"`
+	Aliases          []string           `json:"aliases,omitempty"`
+	Withdrawn        string             `json:"withdrawn,omitempty"`
+	Summary          string             `json:"summary,omitempty"`
+	Details          string             `json:"details,omitempty"`
+	Affected         []osvAffectedJSON  `json:"affected,omitempty"`
+	References       []osvReferenceJSON `json:"references,omitempty"`
+	DatabaseSpecific json.RawMessage    `json:"database_specific,omitempty"`
+}
+
+type osvAffectedJSON struct {
+	Package  osvPackageJSON `json:"package"`
+	Versions []string       `json:"versions,omitempty"`
+}
+
+type osvPackageJSON struct {
+	Name      string `json:"name"`
+	Ecosystem string `json:"ecosystem"`
+}
+
+type osvReferenceJSON struct {
+	Type string `json:"type,omitempty"`
+	URL  string `json:"url,omitempty"`
+}
+
+// highConfidenceKeywords mirrors osvimport.highConfidenceKeywords.
+// SYNC TARGET: internal/intel/osvimport/osvimport.go.
+var highConfidenceKeywords = []string{
+	"malicious package",
+	"malicious npm package",
+	"malicious python package",
+	"compromised package",
+	"credential stealing",
+	"credential exfiltration",
+	"typosquat malware",
+	"install script malware",
+}
+
+func hasSignal(osv *osvJSON) bool {
+	if strings.HasPrefix(osv.ID, "MAL-") {
+		return true
+	}
+	// OpenSSF Malicious Packages records embed an
+	// `malicious-packages-origins` key inside database_specific.
+	// A substring check on the raw JSON is good enough here; the
+	// importer does the same.
+	if len(osv.DatabaseSpecific) > 0 && strings.Contains(string(osv.DatabaseSpecific), "malicious-packages-origins") {
+		return true
+	}
+	return false
+}
+
+func hasKeyword(osv *osvJSON) bool {
+	hay := strings.ToLower(osv.Summary + " " + osv.Details)
+	for _, kw := range highConfidenceKeywords {
+		if strings.Contains(hay, kw) {
+			return true
+		}
+	}
+	return false
+}
+
+func pickSummary(osv *osvJSON) string {
+	if osv.Summary != "" {
+		return osv.Summary
+	}
+	if osv.Details != "" {
+		// One-line preview only; the renderer cares about source
+		// bytes, so a long Details would inflate the size estimate.
+		if i := strings.IndexAny(osv.Details, "\r\n"); i > 0 {
+			return osv.Details[:i]
+		}
+		return osv.Details
+	}
+	return ""
+}

--- a/tools/measure-intel/classify_test.go
+++ b/tools/measure-intel/classify_test.go
@@ -1,0 +1,160 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func mkRaw(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+func TestClassifyRecord_KeptViaMALSignal(t *testing.T) {
+	raw := mkRaw(t, map[string]any{
+		"id": "MAL-2024-0001",
+		"affected": []any{map[string]any{
+			"package":  map[string]any{"name": "evil-crate", "ecosystem": "crates.io"},
+			"versions": []string{"1.2.3"},
+		}},
+	})
+	rec, status := classifyRecord(raw, "crates.io")
+	if status != statusKeptSignal {
+		t.Fatalf("status = %v, want statusKeptSignal", status)
+	}
+	if rec.Name != "evil-crate" || rec.Ecosystem != "crates.io" {
+		t.Errorf("record: %+v", rec)
+	}
+}
+
+func TestClassifyRecord_KeptViaKeyword(t *testing.T) {
+	raw := mkRaw(t, map[string]any{
+		"id":      "GHSA-xxxx-yyyy-zzzz",
+		"summary": "Malicious package distributing credential stealing payload",
+		"affected": []any{map[string]any{
+			"package":  map[string]any{"name": "rogue-gem", "ecosystem": "RubyGems"},
+			"versions": []string{"0.0.1"},
+		}},
+	})
+	_, status := classifyRecord(raw, "RubyGems")
+	if status != statusKeptKeyword {
+		t.Fatalf("status = %v, want statusKeptKeyword", status)
+	}
+}
+
+func TestClassifyRecord_DropsRangesOnly(t *testing.T) {
+	// MAL- signal would normally pass but ranges-only is the hard
+	// drop because the matcher cannot consume ranges.
+	raw := mkRaw(t, map[string]any{
+		"id": "MAL-2024-9999",
+		"affected": []any{map[string]any{
+			"package": map[string]any{"name": "ranged-pkg", "ecosystem": "Go"},
+		}},
+	})
+	_, status := classifyRecord(raw, "Go")
+	if status != statusRangesOnly {
+		t.Fatalf("status = %v, want statusRangesOnly", status)
+	}
+}
+
+func TestClassifyRecord_DropsNeitherSignalNorKeyword(t *testing.T) {
+	// Plain CVE record with exact versions, no MAL- prefix, no
+	// keyword hit. This is the path that keeps Aguara out of
+	// general-CVE territory.
+	raw := mkRaw(t, map[string]any{
+		"id":      "CVE-2024-1111",
+		"summary": "Vulnerability in the parser allows remote code execution",
+		"affected": []any{map[string]any{
+			"package":  map[string]any{"name": "innocent-pkg", "ecosystem": "Maven"},
+			"versions": []string{"1.0.0"},
+		}},
+	})
+	_, status := classifyRecord(raw, "Maven")
+	if status != statusNeither {
+		t.Fatalf("status = %v, want statusNeither", status)
+	}
+}
+
+func TestClassifyRecord_WithdrawnPassesAsTombstone(t *testing.T) {
+	raw := mkRaw(t, map[string]any{
+		"id":        "MAL-2024-2222",
+		"withdrawn": "2024-01-15T00:00:00Z",
+		"affected": []any{map[string]any{
+			"package":  map[string]any{"name": "retracted", "ecosystem": "Packagist"},
+			"versions": []string{"1.0.0"},
+		}},
+	})
+	_, status := classifyRecord(raw, "Packagist")
+	if status != statusWithdrawn {
+		t.Fatalf("status = %v, want statusWithdrawn", status)
+	}
+}
+
+func TestClassifyRecord_EcosystemMissDoesNotMatch(t *testing.T) {
+	raw := mkRaw(t, map[string]any{
+		"id": "MAL-2024-3333",
+		"affected": []any{map[string]any{
+			"package":  map[string]any{"name": "wrong-eco", "ecosystem": "npm"},
+			"versions": []string{"1.0.0"},
+		}},
+	})
+	// Asking for crates.io but the record affects npm.
+	_, status := classifyRecord(raw, "crates.io")
+	if status != statusEcosystemMiss {
+		t.Fatalf("status = %v, want statusEcosystemMiss", status)
+	}
+}
+
+func TestClassifyRecord_OpenSSFOriginsCountAsSignal(t *testing.T) {
+	// OpenSSF Malicious Packages records embed an
+	// `malicious-packages-origins` key under database_specific.
+	// The signal scan is a substring check on the raw JSON.
+	raw := mkRaw(t, map[string]any{
+		"id": "GHSA-with-openssf-origin",
+		"affected": []any{map[string]any{
+			"package":  map[string]any{"name": "openssf-pkg", "ecosystem": "NuGet"},
+			"versions": []string{"2.0.0"},
+		}},
+		"database_specific": map[string]any{
+			"malicious-packages-origins": []any{map[string]any{"source": "ossf"}},
+		},
+	})
+	_, status := classifyRecord(raw, "NuGet")
+	if status != statusKeptSignal {
+		t.Fatalf("status = %v, want statusKeptSignal", status)
+	}
+}
+
+func TestClassifyRecord_MultipleAffectedPicksFirstEcosystemMatch(t *testing.T) {
+	// A GHSA aliased across npm + crates.io should be classified
+	// per-ecosystem. Asking for crates.io must NOT pick up the
+	// npm entry's versions.
+	raw := mkRaw(t, map[string]any{
+		"id":      "GHSA-multi",
+		"summary": "Compromised package shipped credential stealing payload across registries",
+		"affected": []any{
+			map[string]any{
+				"package":  map[string]any{"name": "shared-name", "ecosystem": "npm"},
+				"versions": []string{"9.9.9"},
+			},
+			map[string]any{
+				"package":  map[string]any{"name": "rust-twin", "ecosystem": "crates.io"},
+				"versions": []string{"1.0.0"},
+			},
+		},
+	})
+	rec, status := classifyRecord(raw, "crates.io")
+	if status != statusKeptKeyword {
+		t.Fatalf("status = %v, want statusKeptKeyword", status)
+	}
+	if rec.Name != "rust-twin" {
+		t.Errorf("name = %q, want rust-twin (the crates.io entry, not the npm twin)", rec.Name)
+	}
+	if len(rec.Versions) != 1 || rec.Versions[0] != "1.0.0" {
+		t.Errorf("versions = %v, want [1.0.0]", rec.Versions)
+	}
+}

--- a/tools/measure-intel/main.go
+++ b/tools/measure-intel/main.go
@@ -1,0 +1,447 @@
+// Command measure-intel reports the size, record yield, and embed
+// cost of each OSV ecosystem dump.
+//
+// Background. PR #0 of the v0.17.0 multi-ecosystem expansion. Before
+// committing to embedding Go / crates.io / Packagist / RubyGems /
+// Maven / NuGet OSV snapshots in the Aguara binary by default, the
+// maintainer needs concrete numbers per ecosystem:
+//
+//   - compressed all.zip size (network + GHA artifact cost)
+//   - total records OSV publishes for the ecosystem
+//   - records this importer would actually KEEP (after the
+//     "exact-versions present AND signal-or-keyword pass" filter)
+//   - records dropped because they only carry ranges (the runtime
+//     matcher cannot consume ranges today)
+//   - generated Go source size (proxy for binary growth; embedding
+//     a 30 MB Go source roughly 3x the source as committed file +
+//     ~1-2x in the stripped binary).
+//
+// The numbers feed the embed-vs-opt-in decision for PR #4. If an
+// ecosystem ships 50k OSV records but 95% are ranges-only that the
+// matcher cannot use, we do NOT advertise it as covered yet; if
+// Maven / NuGet snapshots are too large, they ship as `aguara update
+// --ecosystem maven` opt-in rather than embedded default.
+//
+// The tool is dev-only. It is NOT shipped in any distribution
+// channel and is not invoked from `make test` / `make lint`. The
+// maintainer runs it manually:
+//
+//	# Download all 6 buckets then measure
+//	go run ./tools/measure-intel --download
+//
+//	# Measure from already-downloaded local zips
+//	go run ./tools/measure-intel \
+//	    --from-zip ./osv-cache/Go.zip --ecosystem Go \
+//	    --from-zip ./osv-cache/crates.io.zip --ecosystem crates.io
+//
+//	# Emit JSON instead of the Markdown table (for the PR body
+//	# generator or a follow-up architecture decision doc).
+//	go run ./tools/measure-intel --download --format json
+//
+// Filter logic. The per-record gate mirrors osvimport.convertOSVRecord
+// (exact-versions present + signal-or-keyword pass). The mirror is
+// intentional: this tool must NOT depend on osvimport's hardcoded
+// canonicaliseEcosystem (which today rejects everything except npm /
+// pypi) but it MUST produce the same counts the importer would
+// produce once PR #1 widens canonicaliseEcosystem. The two filter
+// implementations are kept in sync by review; any change to the
+// importer's filter rules must reproduce here.
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/garagon/aguara/internal/intel/osvimport"
+)
+
+// defaultEcosystems is the set PR #0 measures: the 6 ecosystems
+// proposed for v0.17.0 multi-ecosystem expansion. npm / PyPI are
+// excluded because they already ship embedded; measuring them would
+// add noise without changing any decision.
+var defaultEcosystems = []string{
+	"Go",
+	"crates.io",
+	"Packagist",
+	"RubyGems",
+	"Maven",
+	"NuGet",
+}
+
+// osvURLTemplate is the OSV.dev public bucket layout. The {{eco}}
+// placeholder is substituted at fetch time with the ecosystem name
+// exactly as OSV publishes it (case-sensitive). The path follows the
+// pattern OSV documents at https://google.github.io/osv.dev/data/.
+const osvURLTemplate = "https://osv-vulnerabilities.storage.googleapis.com/{{eco}}/all.zip"
+
+// downloadTimeout caps a single zip fetch. Maven and NuGet dumps
+// can be hundreds of MB; the cap protects against a stalled CDN
+// without aborting a healthy multi-minute download.
+const downloadTimeout = 10 * time.Minute
+
+type multiFlag []string
+
+func (m *multiFlag) String() string     { return strings.Join(*m, ", ") }
+func (m *multiFlag) Set(v string) error { *m = append(*m, v); return nil }
+
+func main() {
+	if err := run(os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}
+
+func run(args []string, stdout, stderr io.Writer) error {
+	var (
+		ecosystems multiFlag
+		zips       multiFlag
+		zipEcos    multiFlag
+		download   bool
+		cacheDir   string
+		format     string
+		urlTmpl    string
+	)
+
+	fs := flag.NewFlagSet("measure-intel", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	fs.Var(&ecosystems, "ecosystem", "Ecosystem to measure (repeatable; OSV string e.g. Go, crates.io, Maven). Default: all 6 v0.17.0 candidates.")
+	fs.Var(&zips, "from-zip", "Path to a local OSV all.zip (repeatable; pair positionally with --from-zip-ecosystem).")
+	fs.Var(&zipEcos, "from-zip-ecosystem", "Ecosystem string for the matching --from-zip (repeatable).")
+	fs.BoolVar(&download, "download", false, "Fetch OSV all.zip for each ecosystem into --cache-dir. Required to make network calls.")
+	fs.StringVar(&cacheDir, "cache-dir", ".intel-cache", "Directory to read/write cached OSV zips.")
+	fs.StringVar(&format, "format", "markdown", "Output format: markdown or json.")
+	fs.StringVar(&urlTmpl, "url-template", osvURLTemplate, "OSV bucket URL template; {{eco}} is replaced with the ecosystem string.")
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+
+	if format != "markdown" && format != "json" {
+		return fmt.Errorf("--format must be markdown or json, got %q", format)
+	}
+
+	jobs, err := resolveJobs(ecosystems, zips, zipEcos, download, cacheDir, urlTmpl, stderr)
+	if err != nil {
+		return err
+	}
+	if len(jobs) == 0 {
+		return errors.New("no ecosystems to measure; pass --ecosystem or --from-zip / --from-zip-ecosystem")
+	}
+
+	reports := make([]ecosystemReport, 0, len(jobs))
+	for _, job := range jobs {
+		fmt.Fprintf(stderr, ">> measuring %s (%s)...\n", job.ecosystem, job.zipPath)
+		r, err := measure(job)
+		if err != nil {
+			return fmt.Errorf("measure %s: %w", job.ecosystem, err)
+		}
+		reports = append(reports, r)
+	}
+
+	sort.Slice(reports, func(i, j int) bool { return reports[i].Ecosystem < reports[j].Ecosystem })
+
+	switch format {
+	case "json":
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(struct {
+			GeneratedAt time.Time         `json:"generated_at"`
+			Reports     []ecosystemReport `json:"reports"`
+		}{
+			GeneratedAt: time.Now().UTC(),
+			Reports:     reports,
+		})
+	default:
+		return renderMarkdown(stdout, reports)
+	}
+}
+
+// measureJob pairs an ecosystem string with the local zip path the
+// tool will read. resolveJobs is the single source of truth for
+// where the zip comes from (explicit --from-zip, cache hit, or
+// network download); measure() does not touch the network or cache
+// logic.
+type measureJob struct {
+	ecosystem string
+	zipPath   string
+}
+
+func resolveJobs(ecosystems, zips, zipEcos multiFlag, download bool, cacheDir, urlTmpl string, stderr io.Writer) ([]measureJob, error) {
+	// Explicit --from-zip wins. The pair --from-zip/--from-zip-ecosystem
+	// is positional; mismatched pair counts is a typo we must surface
+	// (silent fallthrough would mis-tag a dump).
+	if len(zips) != len(zipEcos) {
+		return nil, fmt.Errorf("--from-zip count (%d) must match --from-zip-ecosystem count (%d)", len(zips), len(zipEcos))
+	}
+	var jobs []measureJob
+	for i, z := range zips {
+		jobs = append(jobs, measureJob{ecosystem: zipEcos[i], zipPath: z})
+	}
+
+	// --ecosystem fills in any ecosystems the user did not provide
+	// via --from-zip. The default set kicks in only when both
+	// --ecosystem and --from-zip are empty.
+	ecoTargets := []string(ecosystems)
+	if len(ecoTargets) == 0 && len(zips) == 0 {
+		ecoTargets = append(ecoTargets, defaultEcosystems...)
+	}
+
+	for _, eco := range ecoTargets {
+		// Skip ecosystems already covered by --from-zip so we do
+		// not double-measure the same input.
+		if containsEco(zipEcos, eco) {
+			continue
+		}
+		zipPath := filepath.Join(cacheDir, eco+".zip")
+		if _, err := os.Stat(zipPath); err == nil {
+			jobs = append(jobs, measureJob{ecosystem: eco, zipPath: zipPath})
+			continue
+		}
+		if !download {
+			return nil, fmt.Errorf(
+				"no local zip for %s at %s and --download not set; pass --download to fetch, or supply --from-zip",
+				eco, zipPath,
+			)
+		}
+		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+			return nil, fmt.Errorf("create cache dir: %w", err)
+		}
+		url := strings.ReplaceAll(urlTmpl, "{{eco}}", eco)
+		fmt.Fprintf(stderr, "  downloading %s -> %s\n", url, zipPath)
+		if err := fetchZip(url, zipPath); err != nil {
+			return nil, fmt.Errorf("download %s: %w", eco, err)
+		}
+		jobs = append(jobs, measureJob{ecosystem: eco, zipPath: zipPath})
+	}
+	return jobs, nil
+}
+
+func containsEco(xs []string, target string) bool {
+	for _, x := range xs {
+		if x == target {
+			return true
+		}
+	}
+	return false
+}
+
+func fetchZip(url, dest string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("HTTP %d for %s", resp.StatusCode, url)
+	}
+	// Write through a temp file so a torn download does not leave a
+	// corrupt zip in the cache that subsequent invocations would
+	// pick up. Rename is atomic on the same filesystem.
+	tmp, err := os.CreateTemp(filepath.Dir(dest), "intel-zip-*")
+	if err != nil {
+		return err
+	}
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+	}()
+	if _, err := io.Copy(tmp, resp.Body); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	return os.Rename(tmp.Name(), dest)
+}
+
+// ecosystemReport is the per-ecosystem counter set the tool emits.
+// JSON tags are lower_snake so the report is consumable by a
+// downstream architecture-decision script without name munging.
+type ecosystemReport struct {
+	Ecosystem string `json:"ecosystem"`
+	ZipPath   string `json:"zip_path"`
+	// Sizes
+	ZipCompressedBytes   int64 `json:"zip_compressed_bytes"`
+	ZipDecompressedBytes int64 `json:"zip_decompressed_bytes"`
+	GeneratedSourceBytes int64 `json:"generated_source_bytes"`
+	// Record counts: read top-to-bottom for the funnel.
+	TotalRecords             int `json:"total_records"`
+	EcosystemMatchedRecords  int `json:"ecosystem_matched_records"`
+	WithdrawnRecords         int `json:"withdrawn_records"`
+	RangesOnlyDroppedRecords int `json:"ranges_only_dropped_records"`
+	SignalOrKeywordKept      int `json:"signal_or_keyword_kept_records"`
+	NeitherDroppedRecords    int `json:"neither_dropped_records"`
+	FinalKeptRecords         int `json:"final_kept_records"`
+	// Timing
+	ParseDurationMS    int64 `json:"parse_duration_ms"`
+	RenderDurationMS   int64 `json:"render_duration_ms"`
+}
+
+func measure(job measureJob) (ecosystemReport, error) {
+	r := ecosystemReport{Ecosystem: job.ecosystem, ZipPath: job.zipPath}
+
+	info, err := os.Stat(job.zipPath)
+	if err != nil {
+		return r, fmt.Errorf("stat zip: %w", err)
+	}
+	r.ZipCompressedBytes = info.Size()
+
+	f, err := os.Open(job.zipPath)
+	if err != nil {
+		return r, fmt.Errorf("open zip: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	zr, err := zip.NewReader(f, info.Size())
+	if err != nil {
+		return r, fmt.Errorf("open zip reader: %w", err)
+	}
+
+	parseStart := time.Now()
+	var kept []intel.Record
+	for _, entry := range zr.File {
+		if !strings.HasSuffix(entry.Name, ".json") {
+			continue
+		}
+		data, err := readZipEntry(entry)
+		if err != nil {
+			// Skip malformed entries rather than abort; OSV
+			// dumps occasionally include bookkeeping files that
+			// fail to parse but should not invalidate the run.
+			continue
+		}
+		r.ZipDecompressedBytes += int64(len(data))
+		r.TotalRecords++
+
+		rec, status := classifyRecord(data, job.ecosystem)
+		switch status {
+		case statusEcosystemMiss:
+			// nothing to count beyond TotalRecords
+		case statusWithdrawn:
+			r.EcosystemMatchedRecords++
+			r.WithdrawnRecords++
+		case statusRangesOnly:
+			r.EcosystemMatchedRecords++
+			r.RangesOnlyDroppedRecords++
+		case statusNeither:
+			r.EcosystemMatchedRecords++
+			r.NeitherDroppedRecords++
+		case statusKeptSignal, statusKeptKeyword:
+			r.EcosystemMatchedRecords++
+			r.SignalOrKeywordKept++
+			r.FinalKeptRecords++
+			kept = append(kept, rec)
+		}
+	}
+	r.ParseDurationMS = time.Since(parseStart).Milliseconds()
+
+	// Sort kept records into the canonical (ecosystem, name, ID)
+	// order osvimport.RenderGoSource expects so the size estimate
+	// matches a real generated file byte-for-byte.
+	osvimport.SortRecords(kept)
+
+	renderStart := time.Now()
+	snap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		GeneratedAt:   time.Date(2026, time.May, 16, 0, 0, 0, 0, time.UTC),
+		Sources: []intel.SourceMeta{{
+			Name:        "osv.dev/" + strings.ToLower(job.ecosystem),
+			Kind:        intel.SourceOSV,
+			URL:         "https://osv.dev",
+			RetrievedAt: time.Date(2026, time.May, 16, 0, 0, 0, 0, time.UTC),
+			License:     "CC-BY-4.0",
+		}},
+		Records: kept,
+	}
+	src, err := osvimport.RenderGoSource(snap, osvimport.RenderConfig{
+		Package: "incident",
+		VarName: "EmbeddedIntelSnapshot_" + sanitizeForGoIdent(job.ecosystem),
+	})
+	if err != nil {
+		return r, fmt.Errorf("render snapshot: %w", err)
+	}
+	r.GeneratedSourceBytes = int64(len(src))
+	r.RenderDurationMS = time.Since(renderStart).Milliseconds()
+
+	return r, nil
+}
+
+// readZipEntry caps a single decompressed entry at 4 MiB (OSV
+// records are typically a few KiB). Beyond the cap the entry is
+// almost certainly malformed; skipping it keeps the rest of the
+// run useful instead of aborting on one bad row.
+func readZipEntry(entry *zip.File) ([]byte, error) {
+	rc, err := entry.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = rc.Close() }()
+	const cap = 4 * 1024 * 1024
+	return io.ReadAll(io.LimitReader(rc, cap))
+}
+
+// sanitizeForGoIdent turns an OSV ecosystem string into something
+// usable as a Go identifier suffix. OSV publishes "crates.io" with
+// a dot, "RubyGems" with mixed case; the renderer needs a plain
+// identifier so the variable name compiles.
+func sanitizeForGoIdent(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('_')
+		}
+	}
+	return b.String()
+}
+
+func renderMarkdown(w io.Writer, reports []ecosystemReport) error {
+	var buf bytes.Buffer
+	fmt.Fprintln(&buf, "| Ecosystem | Zip (MB) | Total | Matched | Withdrawn | Ranges-only | Neither | Kept (final) | Gen. source (MB) | Parse (s) |")
+	fmt.Fprintln(&buf, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+	for _, r := range reports {
+		fmt.Fprintf(&buf, "| %s | %.1f | %d | %d | %d | %d | %d | **%d** | %.2f | %.1f |\n",
+			r.Ecosystem,
+			float64(r.ZipCompressedBytes)/1024/1024,
+			r.TotalRecords,
+			r.EcosystemMatchedRecords,
+			r.WithdrawnRecords,
+			r.RangesOnlyDroppedRecords,
+			r.NeitherDroppedRecords,
+			r.FinalKeptRecords,
+			float64(r.GeneratedSourceBytes)/1024/1024,
+			float64(r.ParseDurationMS)/1000,
+		)
+	}
+	fmt.Fprintln(&buf)
+	fmt.Fprintln(&buf, "Columns:")
+	fmt.Fprintln(&buf, "- **Total**: every JSON record in the zip.")
+	fmt.Fprintln(&buf, "- **Matched**: records whose `affected[].package.ecosystem` matches the target.")
+	fmt.Fprintln(&buf, "- **Withdrawn**: OSV-retracted; counted in Matched, passed through as tombstones (not in Kept).")
+	fmt.Fprintln(&buf, "- **Ranges-only**: matched records dropped because the runtime matcher cannot consume version ranges yet.")
+	fmt.Fprintln(&buf, "- **Neither**: matched, has exact versions, but fails BOTH the signal (MAL- prefix / OpenSSF origins) and the keyword gate. These are CVE-flavoured records that do not belong in a malicious-package snapshot.")
+	fmt.Fprintln(&buf, "- **Kept (final)**: what would actually become `intel.Record` entries in the embedded snapshot.")
+	fmt.Fprintln(&buf, "- **Gen. source**: gofmt'd generated Go source size; a rough upper bound on commit-time bloat. Binary impact is typically smaller after the linker drops unused intermediates.")
+	_, err := w.Write(buf.Bytes())
+	return err
+}


### PR DESCRIPTION
## Summary

PR #0 of the v0.17.0 multi-ecosystem expansion. Before deciding which new ecosystems to embed by default, this PR adds the measurement tool and reports the numbers per ecosystem. No production code changes.

## Tool

`tools/measure-intel/` walks an OSV ecosystem `all.zip`, mirrors the `osvimport.convertOSVRecord` filter (exact-versions + signal-or-keyword), and reports the funnel per ecosystem.

```
# Fetch + measure all 6 v0.17 candidates
go run ./tools/measure-intel --download

# Measure pre-downloaded zips (reproducible)
go run ./tools/measure-intel \
  --from-zip ./osv-Go.zip       --from-zip-ecosystem Go \
  --from-zip ./osv-Maven.zip    --from-zip-ecosystem Maven \
  --format json
```

`classify.go` mirrors `osvimport.convertOSVRecord` with `SYNC TARGET` comments. Once PR #1 widens `canonicaliseEcosystem` to know all 8 ecosystems, the mirror can be deleted in favour of a direct osvimport call.

## Measurement (2026-05-16 against current OSV)

| Ecosystem | Zip (MB) | Total | Matched | Withdrawn | Ranges-only (dropped) | Exact-version | CVE-flavoured (dropped) | **Kept** | Gen. source | Recommendation |
|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---|
| Go | 8.1 | 6,946 | 6,946 | 104 | 6,765 (97%) | 77 | 77 | **0** | 0 B | parser-now / range-required |
| crates.io | 2.8 | 2,443 | 2,443 | 63 | 2,331 (95%) | 49 | 42 | **7** | 2.7 KB | parser-now / range-required |
| Packagist | 8.5 | 6,342 | 5,881 | 75 | 612 | 5,194 | 5,188 | **6** | 7.2 KB | parser-now / range-required |
| Maven | 8.9 | 6,576 | 6,576 | 108 | 751 | 5,717 | 5,712 | **5** | 5.2 KB | parser-now / range-required |
| RubyGems | 2.2 | 2,027 | 2,027 | 66 | 18 | 1,943 | 974 | **969** | 309 KB | embed-now |
| NuGet | 2.0 | 1,712 | 1,712 | 33 | 46 | 1,633 | 860 | **773** | 270 KB | embed-now |
| **Total** | **32.5** | **26,046** | | | | | | **1,760** | **~595 KB** | |

Column notes:
- **Exact-version** = Matched − Withdrawn − Ranges-only. These are the records the matcher *could* consume; CVE-flavoured + Kept add up to this column.
- **CVE-flavoured (dropped)** = exact-version records that fail BOTH the signal gate (MAL- prefix / OpenSSF malicious-packages origins) AND the keyword gate. These are real CVEs that don't belong in a malicious-package snapshot.
- **Kept** = what actually becomes `intel.Record` entries in the embedded snapshot.
- **Update duration**: the tool emits per-job `download_duration_ms` when `--download` is used. This report used pre-fetched zips for parallel curl (each bucket finished in roughly 5-30 s; total wall-clock under one minute for all six). The numbers fit comfortably in CI / GHA artifact limits.

## Interpretation

**The big takeaway: binary size is not the limiting factor for this expansion. The limiting factor is usable detection coverage.**

All six additional OSV buckets are cheap enough to embed (~595 KB Go source total, negligible binary impact), but not equally useful with Aguara's current exact-version matcher. RubyGems and NuGet provide strong malicious-package coverage today (969 and 773 records, mostly MAL- and OSSF-origin). Go, crates.io, Packagist, and Maven are much more CVE / range-shaped, so v0.17 can ship parsers and OSV ingestion for them, but the public claim must be explicit: full value for those ecosystems lands when range matching is implemented.

## Architecture decision

- **Embed all six new ecosystems in the release snapshot.** Size argument doesn't hold; the per-ecosystem cost is negligible.
- **Treat ecosystem support as two levels:**
  1. Installed parser + exact-version malicious-package matching available now.
  2. Range-aware vulnerability matching deferred.
- **README must distinguish "supported parser" from "strong current detection coverage."** Wording from the spec is the right baseline ("detecta paquetes maliciosos o comprometidos en múltiples ecosistemas usando threat intel de OSV/OpenSSF y advisories propios"); for Go / crates.io / Packagist / Maven we add the level-2 disclaimer.
- **Open a follow-up for the range matcher**, likely v0.18 or a quick v0.17.x. Filing once PR #4 lands.

## Acceptance criteria (PR #0)

- [x] Tool emits, per ecosystem: compressed size, records kept, exact-version records, ranges-only dropped, estimated generated source size, update duration field (recorded when `--download` is used).
- [x] Report committed in PR body with explicit per-ecosystem recommendation: `embed-now` / `parser-now` / `range-required`.
- [x] Numbers reproduced from a clean run against real OSV buckets.

## Limitations / follow-ups

- The mirror in `classify.go` is technical debt (PR #1 deletes it).
- Binary size estimate not computed; gen-source size is a proxy. If precise binary impact matters, PR #4 can build a probe binary with the snapshot linked in and `wc -c` the result.
- Tool is dev-only; not invoked from `make test`. Maintainer-run, output captured in the vault.
- Range-matcher follow-up issue to be opened after this PR lands.

## Test plan

- [x] `make test`
- [x] `make vet`
- [x] `make lint`
- [x] Unit tests cover signal-kept / keyword-kept / ranges-only / Neither / withdrawn / ecosystem-miss / OpenSSF origins / multi-ecosystem
- [x] Smoke run against all 6 real OSV buckets reproduced the table above