### PR TITLE
feat(packagecheck): Maven + NuGet parsers

### DIFF
--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -34,6 +34,8 @@ const (
 	ecoCargo    = "cargo"
 	ecoComposer = "composer"
 	ecoRuby     = "ruby"
+	ecoMaven    = "maven"
+	ecoNuGet    = "nuget"
 )
 
 // packagecheckEcosystems maps CLI dispatch tokens to the
@@ -46,6 +48,8 @@ var packagecheckEcosystems = map[string]string{
 	ecoCargo:    intel.EcosystemCargo,
 	ecoComposer: intel.EcosystemPackagist,
 	ecoRuby:     intel.EcosystemRubyGems,
+	ecoMaven:    intel.EcosystemMaven,
+	ecoNuGet:    intel.EcosystemNuGet,
 }
 
 var checkCmd = &cobra.Command{
@@ -63,6 +67,8 @@ a specific check:
   cargo  (alias: rust)
   composer (alias: php)
   ruby   (aliases: gem, rubygems)
+  maven  (alias: java)
+  nuget  (aliases: dotnet, csharp)
 
 The known-bad list ships embedded with the binary.`,
 	RunE: runCheck,
@@ -70,7 +76,7 @@ The known-bad list ships embedded with the binary.`,
 
 func init() {
 	checkCmd.Flags().StringVar(&flagCheckPath, "path", "", "Path to project root, node_modules, or Python site-packages")
-	checkCmd.Flags().StringVar(&flagCheckEcosystem, "ecosystem", "", "Package ecosystem (auto-detect by default): python, npm, go, cargo, composer, ruby")
+	checkCmd.Flags().StringVar(&flagCheckEcosystem, "ecosystem", "", "Package ecosystem (auto-detect by default): python, npm, go, cargo, composer, ruby, maven, nuget")
 	checkCmd.Flags().StringVar(&flagCheckFailOn, "fail-on", "", "Exit with code 1 if findings reach this severity: critical, warning, info")
 	checkCmd.Flags().BoolVar(&flagCheckCI, "ci", false, "CI mode: equivalent to --fail-on critical --no-color")
 	checkCmd.Flags().BoolVar(&flagCheckFresh, "fresh", false, "Refresh threat intel before checking (network opt-in)")
@@ -175,10 +181,14 @@ func resolveCheckTarget(eco, path string) (string, string, error) {
 		return ecoComposer, path, nil
 	case "ruby", "gem", "rubygems":
 		return ecoRuby, path, nil
+	case "maven", "java":
+		return ecoMaven, path, nil
+	case "nuget", "dotnet", "csharp":
+		return ecoNuGet, path, nil
 	case "":
 		return autoDetectCheckTarget(path)
 	default:
-		return "", "", fmt.Errorf("unsupported ecosystem %q: choose python, npm, go, cargo, composer, or ruby", eco)
+		return "", "", fmt.Errorf("unsupported ecosystem %q: choose python, npm, go, cargo, composer, ruby, maven, or nuget", eco)
 	}
 }
 
@@ -347,6 +357,12 @@ func ecosystemFindingText(ecoToken string, hit packagecheck.Hit) (title, remedia
 	case ecoRuby:
 		return fmt.Sprintf("%s %s is a known compromised RubyGem (%s)", name, version, id),
 			fmt.Sprintf("Run `bundle update %s` or pin a fixed version in Gemfile. Rotate secrets reachable from builds that used the compromised gem.", name)
+	case ecoMaven:
+		return fmt.Sprintf("%s %s is a known compromised Maven package (%s)", name, version, id),
+			fmt.Sprintf("Update %s to a fixed version in pom.xml / Gradle lockfile and rebuild the lockfile. Rotate secrets reachable from builds that used the compromised package.", name)
+	case ecoNuGet:
+		return fmt.Sprintf("%s %s is a known compromised NuGet package (%s)", name, version, id),
+			fmt.Sprintf("Update %s to a fixed version in the project file or packages.lock.json and restore. Rotate secrets reachable from builds that used the compromised package.", name)
 	default:
 		// Defensive: a packagecheck ecosystem without a wording
 		// entry still produces a usable finding rather than a
@@ -385,12 +401,16 @@ func writeCheckTerminal(result *incident.CheckResult, ecosystem string) error {
 		envLabel = "Composer packages"
 	case ecoRuby:
 		envLabel = "RubyGems"
+	case ecoMaven:
+		envLabel = "Maven / Gradle dependencies"
+	case ecoNuGet:
+		envLabel = "NuGet packages"
 	}
 	fmt.Printf("\nScanning %s: %s\n", envLabel, result.Environment)
 	switch ecosystem {
 	case ecoNPM:
 		fmt.Printf("Packages read: %d\n\n", result.PackagesRead)
-	case ecoGo, ecoCargo, ecoComposer, ecoRuby:
+	case ecoGo, ecoCargo, ecoComposer, ecoRuby, ecoMaven, ecoNuGet:
 		fmt.Printf("Packages read: %d  |  Lockfiles found: %d\n\n", result.PackagesRead, len(result.Ecosystems))
 	default:
 		fmt.Printf("Packages read: %d  |  .pth files scanned: %d\n\n", result.PackagesRead, result.PthScanned)

--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -161,7 +161,7 @@ func TestCheckRejectsUnsupportedEcosystem(t *testing.T) {
 	// recover from the typo without reading source. PR #1
 	// established the same contract on `aguara update`; we
 	// mirror it here.
-	for _, eco := range []string{"python", "npm", "go", "cargo", "composer", "ruby"} {
+	for _, eco := range []string{"python", "npm", "go", "cargo", "composer", "ruby", "maven", "nuget"} {
 		require.Contains(t, err.Error(), eco, "error must list %s", eco)
 	}
 }
@@ -697,6 +697,53 @@ func TestCheckNewEcosystemsReturnEmptyEcosystemsOnEmptyPath(t *testing.T) {
 	tmp := t.TempDir()
 	require.NoError(t, os.WriteFile(filepath.Join(tmp, "README.md"), []byte("# nothing\n"), 0o644))
 	for _, eco := range []string{"cargo", "rust", "composer", "php", "ruby", "gem", "rubygems"} {
+		t.Run(eco, func(t *testing.T) {
+			raw := checkToFileRaw(t, "--ecosystem", eco, "--path", tmp)
+			require.Contains(t, string(raw), `"ecosystems": []`)
+			require.NotContains(t, string(raw), `"ecosystems": null`)
+		})
+	}
+}
+
+// --- PR #4: Maven / NuGet CLI paths ---
+
+func TestCheckMavenExplicitEcosystemEmitsEcosystemsSlice(t *testing.T) {
+	result := checkToFile(t, "--ecosystem", "maven", "--path", "../../../internal/packagecheck/testdata/maven-clean")
+	require.Len(t, result.Ecosystems, 1)
+	require.Equal(t, "Maven", result.Ecosystems[0].Ecosystem)
+	require.Equal(t, "pom.xml", result.Ecosystems[0].Source)
+	require.Equal(t, 1, result.Ecosystems[0].PackagesRead)
+	require.Equal(t, 0, result.Ecosystems[0].FindingsCount)
+}
+
+func TestCheckMavenAliasJavaResolves(t *testing.T) {
+	result := checkToFile(t, "--ecosystem", "java", "--path", "../../../internal/packagecheck/testdata/maven-clean")
+	require.Len(t, result.Ecosystems, 1)
+	require.Equal(t, "Maven", result.Ecosystems[0].Ecosystem)
+}
+
+func TestCheckNuGetExplicitEcosystemEmitsEcosystemsSlice(t *testing.T) {
+	result := checkToFile(t, "--ecosystem", "nuget", "--path", "../../../internal/packagecheck/testdata/nuget-clean")
+	require.Len(t, result.Ecosystems, 1)
+	require.Equal(t, "NuGet", result.Ecosystems[0].Ecosystem)
+	require.Equal(t, "csproj", result.Ecosystems[0].Source)
+	require.Equal(t, 1, result.Ecosystems[0].PackagesRead)
+}
+
+func TestCheckNuGetAliasesDotnetAndCsharpResolve(t *testing.T) {
+	for _, alias := range []string{"dotnet", "csharp"} {
+		t.Run(alias, func(t *testing.T) {
+			result := checkToFile(t, "--ecosystem", alias, "--path", "../../../internal/packagecheck/testdata/nuget-clean")
+			require.Len(t, result.Ecosystems, 1)
+			require.Equal(t, "NuGet", result.Ecosystems[0].Ecosystem)
+		})
+	}
+}
+
+func TestCheckMavenAndNuGetEmptyPathEmitsEmptyArray(t *testing.T) {
+	tmp := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(tmp, "README.md"), []byte("# nothing\n"), 0o644))
+	for _, eco := range []string{"maven", "java", "nuget", "dotnet", "csharp"} {
 		t.Run(eco, func(t *testing.T) {
 			raw := checkToFileRaw(t, "--ecosystem", eco, "--path", tmp)
 			require.Contains(t, string(raw), `"ecosystems": []`)

--- a/internal/packagecheck/discovery.go
+++ b/internal/packagecheck/discovery.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/garagon/aguara/internal/intel"
 )
@@ -12,22 +13,42 @@ import (
 // node_modules is intentionally skipped here even when Discover is
 // asked for the npm ecosystem in the future; nested dependencies of
 // dependencies are not what the user is asking about. .git / vendor
-// / .aguara round out the "never read" set.
+// / .aguara round out the original "never read" set.
+//
+// PR #4 added the four build-output directories Maven / Gradle /
+// .NET emit by default. `target/` (Maven build output), `bin/` and
+// `obj/` (MSBuild output: stamped .csproj/.fsproj/.vbproj copies,
+// generated project.assets.json), and `.gradle/` (Gradle cache)
+// would otherwise drag stale or generated manifests into the
+// discovery output; skipping them keeps the user-visible
+// `ecosystems[]` aligned with what the developer actually
+// committed.
 var defaultSkipDirs = map[string]bool{
 	".git":         true,
 	"vendor":       true,
 	"node_modules": true,
 	".aguara":      true,
+	"target":       true,
+	"bin":          true,
+	"obj":          true,
+	".gradle":      true,
 }
 
 // lockfilePicker pairs an ecosystem with the function that probes
-// a directory for the matching lockfile (or fallback). One picker
-// per ecosystem keeps Discover linear in `len(lockfilePickers) *
-// dirs walked`; adding a new ecosystem is one entry in the slice
-// plus the picker implementation.
+// a directory for matching lockfiles. PR #4 widened the return
+// type from *Target to []Target because Maven and NuGet routinely
+// emit multiple lockfiles per directory (a Maven+Gradle project
+// has both pom.xml and gradle.lockfile; a .NET project directory
+// can host packages.lock.json plus one or more .csproj/.fsproj/
+// .vbproj files). Pickers for single-file ecosystems return a
+// one-element slice. Empty / nil = nothing of interest in this
+// directory.
+//
+// Adding a new ecosystem is one entry in the slice plus the
+// picker implementation.
 type lockfilePicker struct {
 	ecosystem string
-	pick      func(dir string) *Target
+	pick      func(dir string) []Target
 }
 
 var lockfilePickers = []lockfilePicker{
@@ -35,6 +56,8 @@ var lockfilePickers = []lockfilePicker{
 	{intel.EcosystemCargo, pickCargoTarget},
 	{intel.EcosystemPackagist, pickComposerTarget},
 	{intel.EcosystemRubyGems, pickRubyTarget},
+	{intel.EcosystemMaven, pickMavenTargets},
+	{intel.EcosystemNuGet, pickNuGetTargets},
 }
 
 // Discover walks root and returns one Target per lockfile / discovery
@@ -82,9 +105,7 @@ func Discover(root string, ecosystems []string) ([]Target, error) {
 			if !want[p.ecosystem] {
 				continue
 			}
-			if t := p.pick(path); t != nil {
-				targets = append(targets, *t)
-			}
+			targets = append(targets, p.pick(path)...)
 		}
 		return nil
 	})
@@ -95,25 +116,25 @@ func Discover(root string, ecosystems []string) ([]Target, error) {
 }
 
 // pickGoTarget returns a Target for a Go module rooted at dir, or
-// nil when no go.sum / go.mod is present. go.sum wins when both
-// exist because it carries the resolved version set the matcher
-// needs; go.mod is the fallback for projects with `require` lines
-// but no checked-in go.sum (libraries that delegate locking to the
-// downstream consumer).
-func pickGoTarget(dir string) *Target {
+// an empty slice when no go.sum / go.mod is present. go.sum wins
+// when both exist because it carries the resolved version set the
+// matcher needs; go.mod is the fallback for projects with
+// `require` lines but no checked-in go.sum (libraries that delegate
+// locking to the downstream consumer).
+func pickGoTarget(dir string) []Target {
 	if statRegular(filepath.Join(dir, "go.sum")) {
-		return &Target{
+		return []Target{{
 			Ecosystem: intel.EcosystemGo,
 			Path:      filepath.Join(dir, "go.sum"),
 			Source:    "go.sum",
-		}
+		}}
 	}
 	if statRegular(filepath.Join(dir, "go.mod")) {
-		return &Target{
+		return []Target{{
 			Ecosystem: intel.EcosystemGo,
 			Path:      filepath.Join(dir, "go.mod"),
 			Source:    "go.mod",
-		}
+		}}
 	}
 	return nil
 }
@@ -123,13 +144,13 @@ func pickGoTarget(dir string) *Target {
 // directories are intentionally skipped: without a lockfile the
 // resolved version set is whatever `cargo update` would produce
 // today, which the offline parser cannot determine.
-func pickCargoTarget(dir string) *Target {
+func pickCargoTarget(dir string) []Target {
 	if statRegular(filepath.Join(dir, "Cargo.lock")) {
-		return &Target{
+		return []Target{{
 			Ecosystem: intel.EcosystemCargo,
 			Path:      filepath.Join(dir, "Cargo.lock"),
 			Source:    "Cargo.lock",
-		}
+		}}
 	}
 	return nil
 }
@@ -138,28 +159,129 @@ func pickCargoTarget(dir string) *Target {
 // dir, or nil when no composer.lock is present. composer.json
 // alone (no lockfile) is skipped for the same reason as Cargo.toml
 // without Cargo.lock.
-func pickComposerTarget(dir string) *Target {
+func pickComposerTarget(dir string) []Target {
 	if statRegular(filepath.Join(dir, "composer.lock")) {
-		return &Target{
+		return []Target{{
 			Ecosystem: intel.EcosystemPackagist,
 			Path:      filepath.Join(dir, "composer.lock"),
 			Source:    "composer.lock",
-		}
+		}}
 	}
 	return nil
 }
 
 // pickRubyTarget returns a Target for a Ruby/Bundler project
 // rooted at dir, or nil when no Gemfile.lock is present.
-func pickRubyTarget(dir string) *Target {
+func pickRubyTarget(dir string) []Target {
 	if statRegular(filepath.Join(dir, "Gemfile.lock")) {
-		return &Target{
+		return []Target{{
 			Ecosystem: intel.EcosystemRubyGems,
 			Path:      filepath.Join(dir, "Gemfile.lock"),
 			Source:    "Gemfile.lock",
-		}
+		}}
 	}
 	return nil
+}
+
+// pickMavenTargets returns every Maven-family manifest in dir:
+//
+//   - pom.xml          (Maven proper)
+//   - gradle.lockfile  (Gradle single-lockfile mode, project root)
+//   - *.lockfile inside dir when dir basename is "dependency-locks"
+//     and its parent is "gradle" (Gradle per-configuration mode)
+//
+// Each match becomes its own Target so a polyglot project with
+// both Maven and Gradle locks shows every manifest in the
+// ecosystems[] output. Source labels: "pom.xml" for Maven,
+// "gradle.lockfile" for both Gradle modes (they share the parser).
+func pickMavenTargets(dir string) []Target {
+	var out []Target
+	if statRegular(filepath.Join(dir, "pom.xml")) {
+		out = append(out, Target{
+			Ecosystem: intel.EcosystemMaven,
+			Path:      filepath.Join(dir, "pom.xml"),
+			Source:    "pom.xml",
+		})
+	}
+	if statRegular(filepath.Join(dir, "gradle.lockfile")) {
+		out = append(out, Target{
+			Ecosystem: intel.EcosystemMaven,
+			Path:      filepath.Join(dir, "gradle.lockfile"),
+			Source:    "gradle.lockfile",
+		})
+	}
+	// Per-configuration lockfiles live in `gradle/dependency-locks/`.
+	// We detect that exact path by checking the current directory's
+	// basename plus its parent's basename to keep the picker from
+	// firing on a stray `*.lockfile` somewhere else in the tree.
+	parent := filepath.Base(filepath.Dir(dir))
+	base := filepath.Base(dir)
+	if base == "dependency-locks" && parent == "gradle" {
+		entries, err := os.ReadDir(dir)
+		if err == nil {
+			for _, e := range entries {
+				if e.IsDir() {
+					continue
+				}
+				if !strings.HasSuffix(e.Name(), ".lockfile") {
+					continue
+				}
+				out = append(out, Target{
+					Ecosystem: intel.EcosystemMaven,
+					Path:      filepath.Join(dir, e.Name()),
+					Source:    "gradle.lockfile",
+				})
+			}
+		}
+	}
+	return out
+}
+
+// pickNuGetTargets returns every NuGet manifest in dir:
+//
+//   - packages.lock.json (NuGet central package management
+//     lockfile; the resolved-version source of truth)
+//   - *.csproj / *.fsproj / *.vbproj (project files with
+//     PackageReference items; the version source when no
+//     lockfile is in use)
+//
+// A directory with BOTH a lockfile AND a project file emits both
+// targets; the lockfile and the project files cover different
+// resolution paths and the matcher's per-(ref, advisory) dedup
+// keeps double-counted hits from inflating FindingsCount.
+//
+// Source labels: "packages.lock.json" for the lockfile,
+// "csproj"/"fsproj"/"vbproj" (no leading dot) for project files
+// so EcosystemResult entries distinguish them when several land
+// in the same dir.
+func pickNuGetTargets(dir string) []Target {
+	var out []Target
+	if statRegular(filepath.Join(dir, "packages.lock.json")) {
+		out = append(out, Target{
+			Ecosystem: intel.EcosystemNuGet,
+			Path:      filepath.Join(dir, "packages.lock.json"),
+			Source:    "packages.lock.json",
+		})
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return out
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		ext := strings.ToLower(filepath.Ext(e.Name()))
+		switch ext {
+		case ".csproj", ".fsproj", ".vbproj":
+			out = append(out, Target{
+				Ecosystem: intel.EcosystemNuGet,
+				Path:      filepath.Join(dir, e.Name()),
+				Source:    strings.TrimPrefix(ext, "."),
+			})
+		}
+	}
+	return out
 }
 
 func statRegular(path string) bool {

--- a/internal/packagecheck/discovery_test.go
+++ b/internal/packagecheck/discovery_test.go
@@ -179,3 +179,99 @@ func TestDiscover_DefaultNilCoversAllPackagecheckEcosystems(t *testing.T) {
 		}
 	}
 }
+
+func TestDiscover_MavenAndNuGetMonorepoSkipsBuildDirs(t *testing.T) {
+	// Monorepo fixture has:
+	//   api/pom.xml             (Maven)
+	//   web/Web.csproj          (NuGet)
+	//   vendor/should-skip.csproj   (skipped: vendor/)
+	//   target/skip/pom.xml         (skipped: target/)
+	//   .gradle/skip/gradle.lockfile (skipped: .gradle/)
+	//   web/bin/Skip.csproj         (skipped: bin/)
+	//   web/obj/Skip.csproj         (skipped: obj/)
+	root := filepath.Join("testdata", "multi-mvn-nuget")
+	targets, err := Discover(root, []string{intel.EcosystemMaven, intel.EcosystemNuGet})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if got, want := len(targets), 2; got != want {
+		t.Fatalf("targets = %d, want %d (targets=%+v)", got, want, targets)
+	}
+	var sawMaven, sawNuGet bool
+	for _, target := range targets {
+		switch target.Ecosystem {
+		case intel.EcosystemMaven:
+			sawMaven = true
+			if target.Source != "pom.xml" {
+				t.Errorf("Maven source = %q, want pom.xml", target.Source)
+			}
+			if !strings.Contains(target.Path, "/api/") {
+				t.Errorf("Maven path %q not under api/", target.Path)
+			}
+		case intel.EcosystemNuGet:
+			sawNuGet = true
+			if target.Source != "csproj" {
+				t.Errorf("NuGet source = %q, want csproj", target.Source)
+			}
+		}
+	}
+	if !sawMaven || !sawNuGet {
+		t.Errorf("expected both Maven + NuGet targets, got %+v", targets)
+	}
+	for _, target := range targets {
+		for _, skipDir := range []string{"/vendor/", "/target/", "/.gradle/", "/bin/", "/obj/"} {
+			if strings.Contains(target.Path, skipDir) {
+				t.Errorf("Discover walked into %s: %q", skipDir, target.Path)
+			}
+		}
+	}
+}
+
+func TestDiscover_GradleDependencyLocksDirectoryEmitsPerFileTarget(t *testing.T) {
+	// gradle/dependency-locks/*.lockfile must emit one Target
+	// per file, NOT one per directory. The maven-gradle fixture
+	// has compileClasspath.lockfile + runtimeClasspath.lockfile
+	// under gradle/dependency-locks/ AND a root-level
+	// gradle.lockfile, so total = 3 Maven targets in the
+	// directory tree.
+	root := filepath.Join("testdata", "maven-gradle")
+	targets, err := Discover(root, []string{intel.EcosystemMaven})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(targets) != 3 {
+		t.Fatalf("targets = %d, want 3 (gradle.lockfile + 2 dependency-locks files); got %+v", len(targets), targets)
+	}
+	for _, target := range targets {
+		if target.Ecosystem != intel.EcosystemMaven {
+			t.Errorf("ecosystem = %q, want Maven", target.Ecosystem)
+		}
+		if target.Source != "gradle.lockfile" {
+			t.Errorf("source = %q, want gradle.lockfile", target.Source)
+		}
+	}
+}
+
+func TestDiscover_NuGetMultipleProjectFilesPerDirectory(t *testing.T) {
+	// A directory with both a packages.lock.json AND a .csproj
+	// emits both targets (different parser source-of-truth: the
+	// lockfile carries resolved versions, the .csproj carries
+	// the declared version that may differ).
+	root := filepath.Join("testdata", "nuget-compromised")
+	targets, err := Discover(root, []string{intel.EcosystemNuGet})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(targets) != 2 {
+		t.Fatalf("targets = %d, want 2 (packages.lock.json + MyApp.csproj); got %+v", len(targets), targets)
+	}
+	sources := map[string]bool{}
+	for _, target := range targets {
+		sources[target.Source] = true
+	}
+	for _, want := range []string{"packages.lock.json", "csproj"} {
+		if !sources[want] {
+			t.Errorf("missing source %q in %+v", want, sources)
+		}
+	}
+}

--- a/internal/packagecheck/maven.go
+++ b/internal/packagecheck/maven.go
@@ -1,0 +1,235 @@
+package packagecheck
+
+import (
+	"bufio"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/garagon/aguara/internal/intel"
+)
+
+// ParseMaven reads a Maven-family manifest and returns the declared
+// `groupId:artifactId` dependencies. The parser dispatches on
+// target.Source to the right reader:
+//
+//   - "pom.xml"          -> parsePomXML  (Maven proper)
+//   - "gradle.lockfile"  -> parseGradleLockfile (both
+//                            single-lockfile mode at project root
+//                            and per-configuration mode under
+//                            gradle/dependency-locks/)
+//
+// No external commands (`mvn`, `gradle`). No network. Parent POMs,
+// BOMs, dependencyManagement-only declarations, profiles, and the
+// full Gradle dependency graph are out of scope for PR #4; only
+// explicit `<dependency>` blocks in this POM and resolved entries
+// in the Gradle lockfile produce PackageRefs.
+func ParseMaven(target Target) ([]PackageRef, error) {
+	switch target.Source {
+	case "pom.xml":
+		return parsePomXML(target)
+	case "gradle.lockfile":
+		return parseGradleLockfile(target)
+	default:
+		return nil, fmt.Errorf("packagecheck: ParseMaven: unsupported source %q (want pom.xml or gradle.lockfile)", target.Source)
+	}
+}
+
+// parsePomXML decodes a Maven POM and returns one PackageRef per
+// `<dependency>` whose scope is included (default / compile /
+// runtime) and whose `<version>` is either literal or resolvable
+// against the SAME pom.xml's `<properties>` block.
+//
+// Property resolution covers only same-file declarations:
+// `${foo.version}` looks up `<properties><foo.version>...
+// </foo.version></properties>`. Maven built-ins (project.version,
+// project.groupId, env.X) and external dependencyManagement
+// inheritance are out of scope; unresolved placeholders skip the
+// dependency rather than emit a half-formed PackageRef the
+// matcher could mis-attribute.
+func parsePomXML(target Target) ([]PackageRef, error) {
+	data, err := os.ReadFile(target.Path)
+	if err != nil {
+		return nil, fmt.Errorf("open pom.xml: %w", err)
+	}
+	var pom pomProject
+	if err := xml.Unmarshal(data, &pom); err != nil {
+		return nil, fmt.Errorf("parse pom.xml: %w", err)
+	}
+
+	// Build the in-file property map. Entries arrive as a slice of
+	// (tagname, chardata) pairs because the property names are
+	// user-defined and not known at decode time.
+	props := make(map[string]string, len(pom.Properties.Entries))
+	for _, p := range pom.Properties.Entries {
+		props[p.XMLName.Local] = strings.TrimSpace(p.Value)
+	}
+
+	var refs []PackageRef
+	for _, dep := range pom.Dependencies.Dependency {
+		if mavenScopeExcluded(dep.Scope) {
+			continue
+		}
+		group := strings.TrimSpace(dep.GroupID)
+		artifact := strings.TrimSpace(dep.ArtifactID)
+		version := strings.TrimSpace(dep.Version)
+		if group == "" || artifact == "" || version == "" {
+			continue
+		}
+		if v, ok := resolveMavenProperty(version, props); ok {
+			version = v
+		} else if mavenIsPropertyPlaceholder(version) {
+			// Unresolved ${...} placeholder. Skip rather than
+			// emit a literal `${...}` string the matcher would
+			// silently miss.
+			continue
+		}
+		refs = append(refs, PackageRef{
+			Ecosystem: intel.EcosystemMaven,
+			Name:      group + ":" + artifact,
+			Version:   version,
+			Path:      target.Path,
+			Source:    "pom.xml",
+		})
+	}
+	return refs, nil
+}
+
+// pomProject mirrors the minimal subset of the Maven POM schema
+// the parser consumes. The Properties slice uses xml:",any" to
+// capture user-defined property names that are not known at
+// decode time.
+type pomProject struct {
+	XMLName      xml.Name        `xml:"project"`
+	Properties   pomProperties   `xml:"properties"`
+	Dependencies pomDependencies `xml:"dependencies"`
+}
+
+type pomProperties struct {
+	Entries []pomProperty `xml:",any"`
+}
+
+type pomProperty struct {
+	XMLName xml.Name
+	Value   string `xml:",chardata"`
+}
+
+type pomDependencies struct {
+	Dependency []pomDependency `xml:"dependency"`
+}
+
+type pomDependency struct {
+	GroupID    string `xml:"groupId"`
+	ArtifactID string `xml:"artifactId"`
+	Version    string `xml:"version"`
+	Scope      string `xml:"scope"`
+}
+
+// mavenExcludedScopes are POM dependency scopes excluded from the
+// emitted refs. test / provided / system / import dependencies do
+// not ship in the build output and should not be matched against
+// runtime supply-chain advisories. The empty scope defaults to
+// `compile`, which is included.
+var mavenExcludedScopes = map[string]bool{
+	"test":     true,
+	"provided": true,
+	"system":   true,
+	"import":   true,
+}
+
+func mavenScopeExcluded(scope string) bool {
+	return mavenExcludedScopes[strings.ToLower(strings.TrimSpace(scope))]
+}
+
+// mavenIsPropertyPlaceholder reports whether the version string is
+// a `${...}` reference. Used to distinguish "literal version that
+// happens to contain a `$`" from "unresolved property reference".
+func mavenIsPropertyPlaceholder(v string) bool {
+	v = strings.TrimSpace(v)
+	return strings.HasPrefix(v, "${") && strings.HasSuffix(v, "}")
+}
+
+// resolveMavenProperty looks up a `${name}` placeholder in the
+// in-file property map. Returns (value, true) on hit, ("", false)
+// on miss OR when the input is not a property placeholder at all.
+// Callers that already know the input is a placeholder use the
+// false return as the "unresolved, skip" signal.
+func resolveMavenProperty(version string, props map[string]string) (string, bool) {
+	if !mavenIsPropertyPlaceholder(version) {
+		// Literal version: return as-is so the caller does not
+		// have to special-case the non-placeholder path.
+		return version, true
+	}
+	name := strings.TrimSuffix(strings.TrimPrefix(version, "${"), "}")
+	value, ok := props[name]
+	if !ok || value == "" {
+		return "", false
+	}
+	return value, true
+}
+
+// parseGradleLockfile reads a Gradle dependency lockfile (both the
+// project-root `gradle.lockfile` and per-configuration files under
+// `gradle/dependency-locks/*.lockfile`). Format per line:
+//
+//	group:name:version=config1,config2,...
+//
+// Comments (`#` prefix) and the special `empty=...` marker are
+// skipped. Lines whose left side does not split cleanly into
+// (group, name, version) on `:` are skipped silently — being
+// conservative here trades coverage of exotic classifier shapes
+// (`group:name:version:classifier`) for a zero-FP guarantee on the
+// common case.
+func parseGradleLockfile(target Target) ([]PackageRef, error) {
+	f, err := os.Open(target.Path)
+	if err != nil {
+		return nil, fmt.Errorf("open gradle.lockfile: %w", err)
+	}
+	defer func() { _ = f.Close() }()
+
+	var refs []PackageRef
+	seen := make(map[string]bool)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		eq := strings.IndexByte(line, '=')
+		if eq < 0 {
+			continue
+		}
+		left := strings.TrimSpace(line[:eq])
+		if left == "" || left == "empty" {
+			continue
+		}
+		parts := strings.Split(left, ":")
+		if len(parts) != 3 {
+			// Lines like `group:name:version:classifier` or
+			// any other multi-colon shape land here. Skip
+			// rather than risk emitting a wrong identifier.
+			continue
+		}
+		group, name, version := parts[0], parts[1], parts[2]
+		if group == "" || name == "" || version == "" {
+			continue
+		}
+		key := group + ":" + name + ":" + version
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		refs = append(refs, PackageRef{
+			Ecosystem: intel.EcosystemMaven,
+			Name:      group + ":" + name,
+			Version:   version,
+			Path:      target.Path,
+			Source:    "gradle.lockfile",
+		})
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("read gradle.lockfile: %w", err)
+	}
+	return refs, nil
+}

--- a/internal/packagecheck/maven_test.go
+++ b/internal/packagecheck/maven_test.go
@@ -1,0 +1,199 @@
+package packagecheck
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+)
+
+func TestParseMaven_PomXMLResolvesPropertiesExcludesScopes(t *testing.T) {
+	target := Target{
+		Ecosystem: intel.EcosystemMaven,
+		Path:      filepath.Join("testdata", "maven-compromised", "pom.xml"),
+		Source:    "pom.xml",
+	}
+	refs, err := ParseMaven(target)
+	if err != nil {
+		t.Fatalf("ParseMaven: %v", err)
+	}
+	// Expected: 3 emitted (jackson via property, commons-lang3
+	// literal, log4j via property). test/provided/system scopes
+	// drop their respective deps; the unresolved-placeholder
+	// dependency is also dropped.
+	want := map[string]string{
+		"com.fasterxml.jackson.core:jackson-databind": "2.16.1",
+		"org.apache.commons:commons-lang3":            "3.14.0",
+		"org.apache.logging.log4j:log4j-core":         "2.22.1",
+	}
+	if len(refs) != len(want) {
+		t.Fatalf("refs = %d, want %d (refs=%+v)", len(refs), len(want), refs)
+	}
+	for _, r := range refs {
+		if r.Ecosystem != intel.EcosystemMaven {
+			t.Errorf("ref %q: ecosystem = %q, want Maven", r.Name, r.Ecosystem)
+		}
+		if r.Source != "pom.xml" {
+			t.Errorf("ref %q: source = %q, want pom.xml", r.Name, r.Source)
+		}
+		v, ok := want[r.Name]
+		if !ok {
+			t.Errorf("unexpected dep %q (excluded scope or unresolved property leaked)", r.Name)
+			continue
+		}
+		if r.Version != v {
+			t.Errorf("dep %q: version = %q, want %q", r.Name, r.Version, v)
+		}
+	}
+}
+
+func TestParseMaven_ExcludesTestProvidedSystemImportScopes(t *testing.T) {
+	refs, _ := ParseMaven(Target{
+		Ecosystem: intel.EcosystemMaven,
+		Path:      filepath.Join("testdata", "maven-compromised", "pom.xml"),
+		Source:    "pom.xml",
+	})
+	for _, r := range refs {
+		switch r.Name {
+		case "org.junit.jupiter:junit-jupiter":
+			t.Errorf("test-scope dep leaked: %+v", r)
+		case "jakarta.servlet:jakarta.servlet-api":
+			t.Errorf("provided-scope dep leaked: %+v", r)
+		case "com.local:local-jar":
+			t.Errorf("system-scope dep leaked: %+v", r)
+		}
+	}
+}
+
+func TestParseMaven_SkipsUnresolvedPropertyPlaceholder(t *testing.T) {
+	refs, _ := ParseMaven(Target{
+		Ecosystem: intel.EcosystemMaven,
+		Path:      filepath.Join("testdata", "maven-compromised", "pom.xml"),
+		Source:    "pom.xml",
+	})
+	for _, r := range refs {
+		if r.Name == "com.unresolved:missing-prop" {
+			t.Errorf("unresolved ${not.defined.anywhere} leaked: %+v", r)
+		}
+		if r.Version == "${not.defined.anywhere}" {
+			t.Errorf("literal property placeholder leaked as version: %+v", r)
+		}
+	}
+}
+
+func TestParseMaven_MalformedXMLReturnsError(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "pom.xml")
+	writeFile(t, path, "<project><unclosed")
+	_, err := ParseMaven(Target{Ecosystem: intel.EcosystemMaven, Path: path, Source: "pom.xml"})
+	if err == nil {
+		t.Fatal("expected error for malformed XML")
+	}
+}
+
+func TestParseMaven_GradleLockfileBasic(t *testing.T) {
+	target := Target{
+		Ecosystem: intel.EcosystemMaven,
+		Path:      filepath.Join("testdata", "maven-gradle", "gradle.lockfile"),
+		Source:    "gradle.lockfile",
+	}
+	refs, err := ParseMaven(target)
+	if err != nil {
+		t.Fatalf("ParseMaven: %v", err)
+	}
+	// Expected: commons-lang3, guava. The `empty=...` marker
+	// skips; the classifier-shaped line (group:name:version:
+	// classifier=...) has 4 colon-parts and is also skipped per
+	// PR #4 conservatism.
+	want := map[string]string{
+		"org.apache.commons:commons-lang3": "3.14.0",
+		"com.google.guava:guava":           "33.0.0-jre",
+	}
+	if len(refs) != len(want) {
+		t.Fatalf("refs = %d, want %d (refs=%+v)", len(refs), len(want), refs)
+	}
+	for _, r := range refs {
+		v, ok := want[r.Name]
+		if !ok {
+			t.Errorf("unexpected dep %q", r.Name)
+			continue
+		}
+		if r.Version != v {
+			t.Errorf("dep %q: version = %q, want %q", r.Name, r.Version, v)
+		}
+		if r.Source != "gradle.lockfile" {
+			t.Errorf("dep %q: source = %q, want gradle.lockfile", r.Name, r.Source)
+		}
+	}
+}
+
+func TestParseMaven_GradleDependencyLocksDirectory(t *testing.T) {
+	// Per-configuration lockfiles live under
+	// gradle/dependency-locks/<config>.lockfile. Discovery
+	// emits one Target per file; the parser handles each
+	// independently and the same parser path as gradle.lockfile.
+	target := Target{
+		Ecosystem: intel.EcosystemMaven,
+		Path:      filepath.Join("testdata", "maven-gradle", "gradle", "dependency-locks", "compileClasspath.lockfile"),
+		Source:    "gradle.lockfile",
+	}
+	refs, err := ParseMaven(target)
+	if err != nil {
+		t.Fatalf("ParseMaven: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("refs = %d, want 2 (refs=%+v)", len(refs), refs)
+	}
+}
+
+func TestParseMaven_GradleSkipsMalformedLines(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "gradle.lockfile")
+	writeFile(t, path, "# comment\nempty=foo\nnot-a-coord=foo\nfoo:bar=foo\nfoo:bar:1.0:classifier=foo\nfoo:bar:1.0=compileClasspath\n")
+	refs, err := ParseMaven(Target{Ecosystem: intel.EcosystemMaven, Path: path, Source: "gradle.lockfile"})
+	if err != nil {
+		t.Fatalf("ParseMaven: %v", err)
+	}
+	// Only `foo:bar:1.0` survives: comment skipped, `empty=`
+	// skipped, two-colon `not-a-coord` skipped, two-colon
+	// `foo:bar` skipped, four-colon classifier line skipped.
+	if len(refs) != 1 || refs[0].Name != "foo:bar" || refs[0].Version != "1.0" {
+		t.Errorf("expected one foo:bar 1.0 ref, got %+v", refs)
+	}
+}
+
+func TestParseMaven_RejectsUnknownSource(t *testing.T) {
+	_, err := ParseMaven(Target{Ecosystem: intel.EcosystemMaven, Path: "/dev/null", Source: "Cargo.lock"})
+	if err == nil {
+		t.Fatal("expected error for unsupported source")
+	}
+}
+
+func TestResolveMavenProperty(t *testing.T) {
+	props := map[string]string{"foo.version": "1.2.3", "empty.prop": ""}
+
+	t.Run("literal version returns unchanged", func(t *testing.T) {
+		v, ok := resolveMavenProperty("4.5.6", props)
+		if !ok || v != "4.5.6" {
+			t.Errorf("got (%q, %v), want (4.5.6, true)", v, ok)
+		}
+	})
+	t.Run("known placeholder resolves", func(t *testing.T) {
+		v, ok := resolveMavenProperty("${foo.version}", props)
+		if !ok || v != "1.2.3" {
+			t.Errorf("got (%q, %v), want (1.2.3, true)", v, ok)
+		}
+	})
+	t.Run("unknown placeholder fails", func(t *testing.T) {
+		_, ok := resolveMavenProperty("${unknown}", props)
+		if ok {
+			t.Errorf("expected unresolved property to fail")
+		}
+	})
+	t.Run("known placeholder with empty value fails", func(t *testing.T) {
+		_, ok := resolveMavenProperty("${empty.prop}", props)
+		if ok {
+			t.Errorf("expected empty property to fail")
+		}
+	})
+}

--- a/internal/packagecheck/nuget.go
+++ b/internal/packagecheck/nuget.go
@@ -1,0 +1,213 @@
+package packagecheck
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/garagon/aguara/internal/intel"
+)
+
+// ParseNuGet reads a NuGet manifest and returns the declared
+// dependencies. Dispatches on target.Source:
+//
+//   - "packages.lock.json" -> parseNuGetLockfile (Direct +
+//                              Transitive entries; the
+//                              resolved-version source of truth
+//                              when central package management is
+//                              enabled)
+//   - "csproj" / "fsproj" / "vbproj" -> parseNuGetProjectFile
+//                              (PackageReference items; the
+//                              version source when no lockfile
+//                              is in use)
+//
+// No external commands (`dotnet restore`, `nuget`). No network.
+// obj/project.assets.json is out of scope; the build cache lives
+// under skip-listed `obj/` anyway. Project.assets.json parsing
+// can land in a follow-up if user demand justifies it.
+func ParseNuGet(target Target) ([]PackageRef, error) {
+	switch target.Source {
+	case "packages.lock.json":
+		return parseNuGetLockfile(target)
+	case "csproj", "fsproj", "vbproj":
+		return parseNuGetProjectFile(target)
+	default:
+		return nil, fmt.Errorf("packagecheck: ParseNuGet: unsupported source %q (want packages.lock.json, csproj, fsproj, or vbproj)", target.Source)
+	}
+}
+
+// parseNuGetLockfile decodes packages.lock.json and emits one
+// PackageRef per resolved dependency across every target
+// framework. Entries without a `resolved` version are skipped:
+// the `type: "Project"` marker uses that field to point at a
+// sibling project rather than a registry package, and the matcher
+// can only act on registry versions.
+//
+// Cross-framework dedup: if the same (name, version) appears
+// under both net8.0 and net7.0 we emit one PackageRef — the
+// matcher would otherwise count and report the same compromise
+// twice when only the framework differs.
+func parseNuGetLockfile(target Target) ([]PackageRef, error) {
+	data, err := os.ReadFile(target.Path)
+	if err != nil {
+		return nil, fmt.Errorf("open packages.lock.json: %w", err)
+	}
+	var lock nugetLockfile
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return nil, fmt.Errorf("parse packages.lock.json: %w", err)
+	}
+	var refs []PackageRef
+	seen := make(map[string]bool)
+	for _, byPkg := range lock.Dependencies {
+		for name, dep := range byPkg {
+			if name == "" || dep.Resolved == "" {
+				continue
+			}
+			key := name + "@" + dep.Resolved
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			refs = append(refs, PackageRef{
+				Ecosystem: intel.EcosystemNuGet,
+				Name:      name,
+				Version:   dep.Resolved,
+				Path:      target.Path,
+				Source:    "packages.lock.json",
+			})
+		}
+	}
+	return refs, nil
+}
+
+type nugetLockfile struct {
+	// Dependencies is keyed by target framework
+	// (e.g. "net8.0") then by package ID.
+	Dependencies map[string]map[string]nugetLockDep `json:"dependencies"`
+}
+
+type nugetLockDep struct {
+	Type     string `json:"type"`
+	Resolved string `json:"resolved"`
+}
+
+// parseNuGetProjectFile decodes a .csproj / .fsproj / .vbproj and
+// emits one PackageRef per <PackageReference>. Both the
+// attribute form (`Version="X"`) and the child-element form
+// (`<Version>X</Version>`) are supported; `Update="..."` items
+// (PR transitive version pins) are treated the same as
+// `Include="..."` items.
+//
+// Property resolution covers same-file <PropertyGroup> entries:
+// `$(SerilogVersion)` looks up the SerilogVersion child of any
+// PropertyGroup. Unresolved properties skip the reference rather
+// than emit a literal `$(...)` the matcher would silently miss.
+// MSBuild built-ins (TargetFramework, Configuration) and external
+// imports are out of scope.
+func parseNuGetProjectFile(target Target) ([]PackageRef, error) {
+	data, err := os.ReadFile(target.Path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", target.Source, err)
+	}
+	var proj csProject
+	if err := xml.Unmarshal(data, &proj); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", target.Source, err)
+	}
+
+	props := map[string]string{}
+	for _, pg := range proj.PropertyGroups {
+		for _, p := range pg.Properties {
+			props[p.XMLName.Local] = strings.TrimSpace(p.Value)
+		}
+	}
+
+	var refs []PackageRef
+	seen := map[string]bool{}
+	for _, ig := range proj.ItemGroups {
+		for _, pr := range ig.PackageRefs {
+			name := strings.TrimSpace(pr.Include)
+			if name == "" {
+				name = strings.TrimSpace(pr.Update)
+			}
+			if name == "" {
+				continue
+			}
+			version := strings.TrimSpace(pr.VersionAttr)
+			if version == "" {
+				version = strings.TrimSpace(pr.VersionChild)
+			}
+			if version == "" {
+				continue
+			}
+			if v, ok := resolveMSBuildProperty(version, props); ok {
+				version = v
+			} else if msbuildIsPropertyPlaceholder(version) {
+				continue
+			}
+			key := name + "@" + version
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			refs = append(refs, PackageRef{
+				Ecosystem: intel.EcosystemNuGet,
+				Name:      name,
+				Version:   version,
+				Path:      target.Path,
+				Source:    target.Source,
+			})
+		}
+	}
+	return refs, nil
+}
+
+type csProject struct {
+	XMLName        xml.Name          `xml:"Project"`
+	PropertyGroups []csPropertyGroup `xml:"PropertyGroup"`
+	ItemGroups     []csItemGroup     `xml:"ItemGroup"`
+}
+
+type csPropertyGroup struct {
+	Properties []csProperty `xml:",any"`
+}
+
+type csProperty struct {
+	XMLName xml.Name
+	Value   string `xml:",chardata"`
+}
+
+type csItemGroup struct {
+	PackageRefs []csPackageRef `xml:"PackageReference"`
+}
+
+type csPackageRef struct {
+	Include      string `xml:"Include,attr"`
+	Update       string `xml:"Update,attr"`
+	VersionAttr  string `xml:"Version,attr"`
+	VersionChild string `xml:"Version"`
+}
+
+// msbuildIsPropertyPlaceholder reports whether the version string
+// is an MSBuild `$(...)` reference.
+func msbuildIsPropertyPlaceholder(v string) bool {
+	v = strings.TrimSpace(v)
+	return strings.HasPrefix(v, "$(") && strings.HasSuffix(v, ")")
+}
+
+// resolveMSBuildProperty resolves a `$(name)` placeholder against
+// the in-file PropertyGroup map. Returns ("value", true) on hit,
+// ("", false) on miss or empty value. Literal versions return
+// unchanged so callers do not branch on the placeholder shape.
+func resolveMSBuildProperty(version string, props map[string]string) (string, bool) {
+	if !msbuildIsPropertyPlaceholder(version) {
+		return version, true
+	}
+	name := strings.TrimSuffix(strings.TrimPrefix(version, "$("), ")")
+	value, ok := props[name]
+	if !ok || value == "" {
+		return "", false
+	}
+	return value, true
+}

--- a/internal/packagecheck/nuget_test.go
+++ b/internal/packagecheck/nuget_test.go
@@ -1,0 +1,187 @@
+package packagecheck
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+)
+
+func TestParseNuGet_LockfileDirectAndTransitiveCrossFramework(t *testing.T) {
+	target := Target{
+		Ecosystem: intel.EcosystemNuGet,
+		Path:      filepath.Join("testdata", "nuget-compromised", "packages.lock.json"),
+		Source:    "packages.lock.json",
+	}
+	refs, err := ParseNuGet(target)
+	if err != nil {
+		t.Fatalf("ParseNuGet: %v", err)
+	}
+	// Expected: 3 unique (name, version) pairs after cross-
+	// framework dedup. SiblingProject (type: Project) is
+	// skipped because it has no `resolved`.
+	want := map[string]string{
+		"Newtonsoft.Json": "13.0.3",
+		"Serilog":         "3.1.1",
+		"Microsoft.Extensions.Logging.Abstractions": "8.0.0",
+	}
+	if len(refs) != len(want) {
+		t.Fatalf("refs = %d, want %d (refs=%+v)", len(refs), len(want), refs)
+	}
+	for _, r := range refs {
+		v, ok := want[r.Name]
+		if !ok {
+			t.Errorf("unexpected package %q", r.Name)
+			continue
+		}
+		if r.Version != v {
+			t.Errorf("package %q: version = %q, want %q", r.Name, r.Version, v)
+		}
+		if r.Source != "packages.lock.json" {
+			t.Errorf("package %q: source = %q, want packages.lock.json", r.Name, r.Source)
+		}
+	}
+}
+
+func TestParseNuGet_LockfileSkipsEntriesWithoutResolved(t *testing.T) {
+	refs, _ := ParseNuGet(Target{
+		Ecosystem: intel.EcosystemNuGet,
+		Path:      filepath.Join("testdata", "nuget-compromised", "packages.lock.json"),
+		Source:    "packages.lock.json",
+	})
+	for _, r := range refs {
+		if r.Name == "SiblingProject" {
+			t.Errorf("type:Project entry without `resolved` leaked: %+v", r)
+		}
+	}
+}
+
+func TestParseNuGet_LockfileMalformedJSONErrors(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "packages.lock.json")
+	writeFile(t, path, "{not json")
+	_, err := ParseNuGet(Target{Ecosystem: intel.EcosystemNuGet, Path: path, Source: "packages.lock.json"})
+	if err == nil {
+		t.Fatal("expected error for malformed JSON")
+	}
+}
+
+func TestParseNuGet_CsprojAttributeAndChildVersion(t *testing.T) {
+	target := Target{
+		Ecosystem: intel.EcosystemNuGet,
+		Path:      filepath.Join("testdata", "nuget-compromised", "MyApp.csproj"),
+		Source:    "csproj",
+	}
+	refs, err := ParseNuGet(target)
+	if err != nil {
+		t.Fatalf("ParseNuGet: %v", err)
+	}
+	// Expected: 4 emitted (3 Include + 1 Update). The
+	// Unresolved.Prop entry skips because $(UndefinedVersion)
+	// has no PropertyGroup binding.
+	want := map[string]string{
+		"Newtonsoft.Json":               "13.0.3",
+		"Serilog":                       "3.1.1",
+		"Microsoft.Extensions.Logging":  "8.0.0",
+		"Polly":                         "8.2.0",
+	}
+	if len(refs) != len(want) {
+		t.Fatalf("refs = %d, want %d (refs=%+v)", len(refs), len(want), refs)
+	}
+	for _, r := range refs {
+		v, ok := want[r.Name]
+		if !ok {
+			t.Errorf("unexpected package %q (probably unresolved property leak)", r.Name)
+			continue
+		}
+		if r.Version != v {
+			t.Errorf("package %q: version = %q, want %q", r.Name, r.Version, v)
+		}
+		if r.Source != "csproj" {
+			t.Errorf("package %q: source = %q, want csproj", r.Name, r.Source)
+		}
+	}
+}
+
+func TestParseNuGet_CsprojSkipsUnresolvedProperty(t *testing.T) {
+	refs, _ := ParseNuGet(Target{
+		Ecosystem: intel.EcosystemNuGet,
+		Path:      filepath.Join("testdata", "nuget-compromised", "MyApp.csproj"),
+		Source:    "csproj",
+	})
+	for _, r := range refs {
+		if r.Name == "Unresolved.Prop" {
+			t.Errorf("unresolved $(UndefinedVersion) leaked: %+v", r)
+		}
+	}
+}
+
+func TestParseNuGet_FsprojAndVbprojShareParser(t *testing.T) {
+	for _, c := range []struct{ dir, file, source, name, version string }{
+		{"nuget-fsproj", "FsApp.fsproj", "fsproj", "FSharp.Core", "8.0.100"},
+		{"nuget-vbproj", "VbApp.vbproj", "vbproj", "Microsoft.VisualBasic", "10.3.0"},
+	} {
+		t.Run(c.source, func(t *testing.T) {
+			refs, err := ParseNuGet(Target{
+				Ecosystem: intel.EcosystemNuGet,
+				Path:      filepath.Join("testdata", c.dir, c.file),
+				Source:    c.source,
+			})
+			if err != nil {
+				t.Fatalf("ParseNuGet: %v", err)
+			}
+			if len(refs) != 1 || refs[0].Name != c.name || refs[0].Version != c.version {
+				t.Errorf("got %+v, want one %s %s ref", refs, c.name, c.version)
+			}
+			if refs[0].Source != c.source {
+				t.Errorf("source = %q, want %q", refs[0].Source, c.source)
+			}
+		})
+	}
+}
+
+func TestParseNuGet_CsprojMalformedXMLErrors(t *testing.T) {
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "Bad.csproj")
+	writeFile(t, path, "<Project><Unclosed")
+	_, err := ParseNuGet(Target{Ecosystem: intel.EcosystemNuGet, Path: path, Source: "csproj"})
+	if err == nil {
+		t.Fatal("expected error for malformed XML")
+	}
+}
+
+func TestParseNuGet_RejectsUnknownSource(t *testing.T) {
+	_, err := ParseNuGet(Target{Ecosystem: intel.EcosystemNuGet, Path: "/dev/null", Source: "Cargo.lock"})
+	if err == nil {
+		t.Fatal("expected error for unsupported source")
+	}
+}
+
+func TestResolveMSBuildProperty(t *testing.T) {
+	props := map[string]string{"SerilogVersion": "3.1.1", "EmptyProp": ""}
+
+	t.Run("literal returns unchanged", func(t *testing.T) {
+		v, ok := resolveMSBuildProperty("8.0.0", props)
+		if !ok || v != "8.0.0" {
+			t.Errorf("got (%q, %v), want (8.0.0, true)", v, ok)
+		}
+	})
+	t.Run("known property resolves", func(t *testing.T) {
+		v, ok := resolveMSBuildProperty("$(SerilogVersion)", props)
+		if !ok || v != "3.1.1" {
+			t.Errorf("got (%q, %v), want (3.1.1, true)", v, ok)
+		}
+	})
+	t.Run("unknown property fails", func(t *testing.T) {
+		_, ok := resolveMSBuildProperty("$(Unknown)", props)
+		if ok {
+			t.Errorf("expected unresolved property to fail")
+		}
+	})
+	t.Run("empty property fails", func(t *testing.T) {
+		_, ok := resolveMSBuildProperty("$(EmptyProp)", props)
+		if ok {
+			t.Errorf("expected empty property to fail")
+		}
+	})
+}

--- a/internal/packagecheck/runner.go
+++ b/internal/packagecheck/runner.go
@@ -106,6 +106,10 @@ func parseTarget(t Target) ([]PackageRef, error) {
 		return ParseComposer(t)
 	case intel.EcosystemRubyGems:
 		return ParseRuby(t)
+	case intel.EcosystemMaven:
+		return ParseMaven(t)
+	case intel.EcosystemNuGet:
+		return ParseNuGet(t)
 	default:
 		return nil, fmt.Errorf("no parser for ecosystem %q", t.Ecosystem)
 	}

--- a/internal/packagecheck/runner_test.go
+++ b/internal/packagecheck/runner_test.go
@@ -247,3 +247,63 @@ func TestRunner_ComposerAliasDoesNotDoubleCountFinding(t *testing.T) {
 		t.Errorf("findings_count = %d, want 1", res.Ecosystems[0].FindingsCount)
 	}
 }
+
+func TestRunner_MavenSyntheticHit(t *testing.T) {
+	snap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		Records: []intel.Record{{
+			ID:        "MAL-MAVEN",
+			Ecosystem: intel.EcosystemMaven,
+			Name:      "com.fasterxml.jackson.core:jackson-databind",
+			Kind:      intel.KindMalicious,
+			Versions:  []string{"2.16.1"},
+		}},
+	}
+	runner := &Runner{Matcher: intel.NewMatcher(snap)}
+	targets, _ := Discover(filepath.Join("testdata", "maven-compromised"), []string{intel.EcosystemMaven})
+	res, err := runner.Run(targets)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Hits) != 1 {
+		t.Fatalf("hits = %d, want 1 (hits=%+v)", len(res.Hits), res.Hits)
+	}
+	if res.Hits[0].Ref.Name != "com.fasterxml.jackson.core:jackson-databind" {
+		t.Errorf("hit ref name = %q, want com.fasterxml.jackson.core:jackson-databind", res.Hits[0].Ref.Name)
+	}
+	if res.Ecosystems[0].FindingsCount != 1 {
+		t.Errorf("findings_count = %d, want 1", res.Ecosystems[0].FindingsCount)
+	}
+}
+
+func TestRunner_NuGetSyntheticHit(t *testing.T) {
+	snap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		Records: []intel.Record{{
+			ID:        "MAL-NUGET",
+			Ecosystem: intel.EcosystemNuGet,
+			Name:      "newtonsoft.json", // case-folded by intel.normalizeName
+			Kind:      intel.KindMalicious,
+			Versions:  []string{"13.0.3"},
+		}},
+	}
+	runner := &Runner{Matcher: intel.NewMatcher(snap)}
+	targets, _ := Discover(filepath.Join("testdata", "nuget-compromised"), []string{intel.EcosystemNuGet})
+	res, err := runner.Run(targets)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Hits) == 0 {
+		t.Fatal("expected at least one hit (Newtonsoft.Json 13.0.3 in lockfile + csproj)")
+	}
+	// Both packages.lock.json and the .csproj declare
+	// Newtonsoft.Json 13.0.3; the per-(ref, advisory) dedup is
+	// per-target, so each lockfile gets one hit. With two
+	// targets that means up to 2 hits — but the lockfile and
+	// the csproj produce different PackageRef paths.
+	for _, h := range res.Hits {
+		if h.Record.ID != "MAL-NUGET" {
+			t.Errorf("hit record ID = %q, want MAL-NUGET", h.Record.ID)
+		}
+	}
+}

--- a/internal/packagecheck/testdata/maven-clean/pom.xml
+++ b/internal/packagecheck/testdata/maven-clean/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>clean</artifactId>
+  <version>0.0.1</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-core</artifactId>
+      <version>6.1.4</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/internal/packagecheck/testdata/maven-compromised/pom.xml
+++ b/internal/packagecheck/testdata/maven-compromised/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>my-app</artifactId>
+  <version>0.1.0</version>
+
+  <properties>
+    <jackson.version>2.16.1</jackson.version>
+    <log4j.version>2.22.1</log4j.version>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>${jackson.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.14.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+      <version>${log4j.version}</version>
+    </dependency>
+
+    <!-- test scope: must be excluded -->
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <version>5.10.0</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- provided scope: must be excluded -->
+    <dependency>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
+      <version>6.0.0</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- system scope: must be excluded -->
+    <dependency>
+      <groupId>com.local</groupId>
+      <artifactId>local-jar</artifactId>
+      <version>1.0.0</version>
+      <scope>system</scope>
+    </dependency>
+
+    <!-- unresolved placeholder: must be skipped -->
+    <dependency>
+      <groupId>com.unresolved</groupId>
+      <artifactId>missing-prop</artifactId>
+      <version>${not.defined.anywhere}</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/internal/packagecheck/testdata/maven-gradle/gradle.lockfile
+++ b/internal/packagecheck/testdata/maven-gradle/gradle.lockfile
@@ -1,0 +1,7 @@
+# This is a Gradle generated file for dependency locking.
+# Manual edits can break the build and are not advised.
+# This file is expected to be part of source control.
+empty=annotationProcessor,testAnnotationProcessor
+org.apache.commons:commons-lang3:3.14.0=compileClasspath,runtimeClasspath
+com.google.guava:guava:33.0.0-jre=compileClasspath,runtimeClasspath
+com.example:with-classifier:1.0.0:linux-x86_64=compileClasspath

--- a/internal/packagecheck/testdata/maven-gradle/gradle/dependency-locks/compileClasspath.lockfile
+++ b/internal/packagecheck/testdata/maven-gradle/gradle/dependency-locks/compileClasspath.lockfile
@@ -1,0 +1,2 @@
+org.slf4j:slf4j-api:2.0.12=compileClasspath
+ch.qos.logback:logback-classic:1.4.14=compileClasspath

--- a/internal/packagecheck/testdata/maven-gradle/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/internal/packagecheck/testdata/maven-gradle/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -1,0 +1,2 @@
+org.slf4j:slf4j-api:2.0.12=runtimeClasspath
+ch.qos.logback:logback-core:1.4.14=runtimeClasspath

--- a/internal/packagecheck/testdata/multi-mvn-nuget/.gradle/skip/gradle.lockfile
+++ b/internal/packagecheck/testdata/multi-mvn-nuget/.gradle/skip/gradle.lockfile
@@ -1,0 +1,1 @@
+should.not:be-scanned:1.0.0=compileClasspath

--- a/internal/packagecheck/testdata/multi-mvn-nuget/api/pom.xml
+++ b/internal/packagecheck/testdata/multi-mvn-nuget/api/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>com.example</groupId>
+  <artifactId>api</artifactId>
+  <version>0.1.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.16.1</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/internal/packagecheck/testdata/multi-mvn-nuget/target/skip/pom.xml
+++ b/internal/packagecheck/testdata/multi-mvn-nuget/target/skip/pom.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project>
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>should.not</groupId>
+  <artifactId>be-scanned</artifactId>
+  <version>1.0.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>should.not</groupId>
+      <artifactId>be-emitted</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+  </dependencies>
+</project>

--- a/internal/packagecheck/testdata/multi-mvn-nuget/vendor/should-skip.csproj
+++ b/internal/packagecheck/testdata/multi-mvn-nuget/vendor/should-skip.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Should.NotBeScanned" Version="1.0.0" />
+  </ItemGroup>
+</Project>

--- a/internal/packagecheck/testdata/multi-mvn-nuget/web/Web.csproj
+++ b/internal/packagecheck/testdata/multi-mvn-nuget/web/Web.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.0" />
+  </ItemGroup>
+</Project>

--- a/internal/packagecheck/testdata/multi-mvn-nuget/web/bin/Skip.csproj
+++ b/internal/packagecheck/testdata/multi-mvn-nuget/web/bin/Skip.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Should.Not.Be.Emitted" Version="1.0.0" />
+  </ItemGroup>
+</Project>

--- a/internal/packagecheck/testdata/multi-mvn-nuget/web/obj/Skip.csproj
+++ b/internal/packagecheck/testdata/multi-mvn-nuget/web/obj/Skip.csproj
@@ -1,0 +1,5 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <ItemGroup>
+    <PackageReference Include="Should.Not.Be.Emitted" Version="1.0.0" />
+  </ItemGroup>
+</Project>

--- a/internal/packagecheck/testdata/nuget-clean/Clean.csproj
+++ b/internal/packagecheck/testdata/nuget-clean/Clean.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Text.Json" Version="8.0.2" />
+  </ItemGroup>
+</Project>

--- a/internal/packagecheck/testdata/nuget-compromised/MyApp.csproj
+++ b/internal/packagecheck/testdata/nuget-compromised/MyApp.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <SerilogVersion>3.1.1</SerilogVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Serilog" Version="$(SerilogVersion)" />
+    <PackageReference Include="Microsoft.Extensions.Logging">
+      <Version>8.0.0</Version>
+    </PackageReference>
+    <PackageReference Update="Polly" Version="8.2.0" />
+    <PackageReference Include="Unresolved.Prop" Version="$(UndefinedVersion)" />
+  </ItemGroup>
+</Project>

--- a/internal/packagecheck/testdata/nuget-compromised/packages.lock.json
+++ b/internal/packagecheck/testdata/nuget-compromised/packages.lock.json
@@ -1,0 +1,28 @@
+{
+  "version": 1,
+  "dependencies": {
+    "net8.0": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "resolved": "13.0.3"
+      },
+      "Serilog": {
+        "type": "Direct",
+        "resolved": "3.1.1"
+      },
+      "Microsoft.Extensions.Logging.Abstractions": {
+        "type": "Transitive",
+        "resolved": "8.0.0"
+      },
+      "SiblingProject": {
+        "type": "Project"
+      }
+    },
+    "net7.0": {
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "resolved": "13.0.3"
+      }
+    }
+  }
+}

--- a/internal/packagecheck/testdata/nuget-fsproj/FsApp.fsproj
+++ b/internal/packagecheck/testdata/nuget-fsproj/FsApp.fsproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="FSharp.Core" Version="8.0.100" />
+  </ItemGroup>
+</Project>

--- a/internal/packagecheck/testdata/nuget-vbproj/VbApp.vbproj
+++ b/internal/packagecheck/testdata/nuget-vbproj/VbApp.vbproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VisualBasic" Version="10.3.0" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary

PR #4 of the v0.17.0 multi-ecosystem expansion. Adds the last two parsers on the `packagecheck` substrate, completing the six v0.17 ecosystems (npm and PyPI keep using the legacy `incident.Check` / `incident.CheckNPM` paths). Range matcher, recursive autodetect, README / CHANGELOG, and release framing all stay for PR #5.

## Parsers

| File | Sources | Notes |
|---|---|---|
| `maven.go` | `pom.xml`, `gradle.lockfile`, `gradle/dependency-locks/*.lockfile` | `encoding/xml` decoder for pom.xml; in-file `<properties>` resolution; excludes `test`, `provided`, `system`, `import` scopes; unresolved `${...}` placeholders skipped (no half-formed refs). Gradle lockfile line parser for `group:name:version=configs`. Per-configuration files under `gradle/dependency-locks/` get one Target each. Parent POMs / BOMs / dependencyManagement inheritance / profiles out of scope. |
| `nuget.go` | `packages.lock.json`, `*.csproj`, `*.fsproj`, `*.vbproj` | Lockfile JSON walks every target framework; **per-file dedup by `(name, version)`** so the same package resolved under both `net8.0` and `net7.0` only emits one PackageRef from the lockfile. Entries without `resolved` (e.g. `type: "Project"` sibling refs) skipped. Project XML supports both attribute `Version="X"` and child `<Version>X</Version>` forms; both `Include=` and `Update=` items; same-file `<PropertyGroup>` resolution for `$(name)` placeholders; unresolved placeholders skipped. **No cross-target dedup**: a package that appears in both `packages.lock.json` and a `.csproj` shows up in each Target's `packages_read` independently — `ecosystems[]` reflects per-file visibility, and the runner's per-(ref, advisory ID) dedup is per-PackageRef, not global. `obj/project.assets.json` out of scope. |

### Discovery changes

- `lockfilePicker` signature widened from `func(dir string) *Target` to `[]Target`. Maven and NuGet routinely emit multiple lockfiles per directory; old single-file pickers (Go / Cargo / Composer / Ruby) now return one-element slices.
- `defaultSkipDirs` extended with `target/`, `bin/`, `obj/`, `.gradle/`. These are the standard build-output directories Maven / Gradle / .NET emit by default; walking them would drag stale or generated manifests into `ecosystems[]`.
- `pickMavenTargets` detects `gradle/dependency-locks/` by checking the current dir's basename (`dependency-locks`) AND its parent's basename (`gradle`) so a stray `*.lockfile` elsewhere does not trip the picker.
- `pickNuGetTargets` emits a Target for `packages.lock.json` AND for every project file in the dir. Source label is `csproj` / `fsproj` / `vbproj` (no leading dot) so `EcosystemResult` entries distinguish parser types when several land in the same dir.

## CLI

- New `ecoMaven`, `ecoNuGet` constants; `packagecheckEcosystems` map gains both.
- `resolveCheckTarget` accepts `maven`/`java`, `nuget`/`dotnet`/`csharp`.
- `ecosystemFindingText` for both with ecosystem-specific remediation copy:
  - Maven: `Update <pkg> to a fixed version in pom.xml / Gradle lockfile and rebuild the lockfile.`
  - NuGet: `Update <pkg> to a fixed version in the project file or packages.lock.json and restore.`
- Help text + `--ecosystem` flag enumerate the new choices.
- `TestCheckRejectsUnsupportedEcosystem` error message now lists every supported choice including `maven` and `nuget`.

## CLI smoke (manual)

```
$ aguara check --ecosystem maven --path internal/packagecheck/testdata/maven-compromised --format json
  ecosystems[ Maven  pom.xml             packages_read=3 ]
    (jackson via property + commons-lang3 literal + log4j via property;
     test/provided/system scopes + unresolved ${not.defined.anywhere} skipped)

$ aguara check --ecosystem nuget --path internal/packagecheck/testdata/nuget-compromised --format json
  ecosystems[ NuGet  packages.lock.json  packages_read=3 ]   (Direct + Transitive; type:Project skipped; in-file cross-framework dedup)
  ecosystems[ NuGet  csproj              packages_read=4 ]   (attribute + child <Version> + $(SerilogVersion); $(UndefinedVersion) skipped)
```

Both targets carry their own `packages_read`. The lockfile and the `.csproj` declare `Newtonsoft.Json 13.0.3`; that is intentional per-target visibility, not duplication. A future PR can add cross-target collapsing if user feedback warrants it.

```
$ aguara check --ecosystem csharp --path <empty-dir> --format json | grep ecosystems
  "ecosystems": []
```

## Out of scope (per user spec)

- Range matcher (separate v0.17.x / v0.18 follow-up).
- Maven parent / BOM / profile resolution.
- Gradle full dependency graph (only the lockfile is parsed).
- NuGet `obj/project.assets.json`.
- Cross-target dedup between lockfile and project file (per-target visibility kept on purpose).
- Executing `mvn`, `gradle`, `dotnet`.
- Default recursive autodetect for `aguara check .` (PR #5).
- README / CHANGELOG / public-claim wording changes (PR #5).
- Migrating `incident.Check` / `incident.CheckNPM` onto packagecheck.

## Acceptance

- [x] `go test ./internal/packagecheck/... ./cmd/aguara/commands/... ./internal/intel/...`
- [x] `go test ./...`
- [x] `make vet` clean
- [x] `make lint` 0 issues
- [x] CLI smoke (above): all 5 spec cases match expected output, including literal `"ecosystems": []` on empty-dir.
- [x] No regression: existing TestCheckAutoDetectsNPM*, Go / Cargo / Composer / Ruby paths, npm/PyPI paths all green.