### PR TITLE
release: v0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,22 +5,32 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-05-17
+
+`aguara check .` now walks the dependency surface of a modern repo
+instead of stopping at npm/Python. v0.17 adds offline malicious-package
+checks across npm, PyPI, Go, Rust, PHP/Composer, Ruby/Bundler,
+Java/Maven/Gradle, and .NET/NuGet, built from OSV.dev + OpenSSF
+Malicious Packages records.
+
 ### Added
 
 - Recursive multi-ecosystem `aguara check`. Running `aguara check .` from a repo root walks the path for npm `node_modules`, Python `site-packages`, plus lockfiles for Go (`go.sum`/`go.mod`), Rust (`Cargo.lock`, crates.io registry only), PHP (`composer.lock`), Ruby (`Gemfile.lock`), Java (`pom.xml`, `gradle.lockfile`, `gradle/dependency-locks/*.lockfile`), and .NET (`packages.lock.json`, `*.csproj`/`*.fsproj`/`*.vbproj`). One `EcosystemResult` entry per discovered lockfile; top-level `findings[]` stays flat.
 - `--ecosystem` now accepts multiple values, comma-separated (`--ecosystem go,ruby`) or repeated (`--ecosystem go --ecosystem ruby`). Aliases: `python`, `pypi`, `golang`, `cargo`, `rust`, `php`, `composer`, `gem`, `rubygems`, `java`, `dotnet`, `csharp`.
 - `aguara audit` now uses the same multi-ecosystem check plan as `aguara check`, so `audit --path . --format json` includes the recursive `ecosystems[]` slice.
+- Embedded threat-intel snapshot now ships records for all 8 ecosystems (23,926 records total, up from ~21,500 in v0.16). Strong embedded coverage today on npm, PyPI, RubyGems, NuGet; parser-ready coverage on Go, crates.io, Packagist, Maven (range-aware OSV matching deferred to a follow-up).
 
 ### Changed
 
 - `aguara update` default refreshes every supported ecosystem (npm, PyPI, Go, crates.io, Packagist, RubyGems, Maven, NuGet) instead of only npm + PyPI. Use `--ecosystem` to scope a refresh.
-- `aguara check --fresh` now refreshes only the ecosystems the plan actually touches. `aguara check --fresh --ecosystem maven` no longer pulls npm + PyPI as a side effect of the legacy default.
+- `aguara check --fresh` now refreshes only the ecosystems the plan actually touches. `aguara check --fresh --ecosystem maven` no longer pulls npm + PyPI as a side effect of the legacy default. `--fresh` on an empty plan skips the network entirely.
 - `aguara check` terminal output for multi-ecosystem runs frames the scan as "project dependencies" and reports `Targets found:` instead of the single-ecosystem `Lockfiles found:` line. Action guidance for packagecheck-routed ecosystems no longer recommends `aguara clean` (which only knows Python persistence artifacts).
 - Default `aguara check` on an explicit `--path` with no signals returns a clean result with `"ecosystems": []` instead of silently falling back to the host's global Python `site-packages`.
+- README "Aguara Watch" section: previous public observatory is stale; section now states Watch is being reworked and points users at the scanner / CLI / Docker image / signed release artifacts as the supported v0.17 surfaces.
 
 ### Known limitations
 
-- Range-aware OSV matching is deferred. Go / crates.io / Packagist / Maven ship parsers with limited current coverage today because their OSV streams are CVE/range-shaped and the matcher only consumes exact versions. Tracking issue: see follow-up filed at PR #5 merge.
+- Range-aware OSV matching is deferred. Go / crates.io / Packagist / Maven ship parsers with limited current coverage today because their OSV streams are CVE/range-shaped and the matcher only consumes exact versions. Tracking issue: [#105](https://github.com/garagon/aguara/issues/105).
 
 ## [0.16.2] - 2026-05-16
 

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.16.2
+INSTALL_SH_TEST_VERSION ?= v0.17.0
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
 Installs the latest binary to `~/.local/bin`. Customize with environment variables:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.16.2 sh
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.17.0 sh
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | INSTALL_DIR=/usr/local/bin sh
 ```
 
@@ -73,7 +73,7 @@ To update an existing install, rerun the installer. It downloads the selected re
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
 
 # Update/pin to a specific release
-curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.16.2 sh
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.17.0 sh
 ```
 
 ### Alternative methods
@@ -94,7 +94,7 @@ docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara scan /scan
 docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara scan /scan --severity high --format json
 
 # Use a specific version
-docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara:0.16.1 scan /scan
+docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara:0.17.0 scan /scan
 ```
 
 **From source** (requires Go 1.25+):
@@ -278,29 +278,29 @@ aguara scan --auto
 #### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.16.2
+- uses: garagon/aguara@v0.17.0
   with:
     path: .
     fail-on: high
-    version: v0.16.2
+    version: v0.17.0
 ```
 
 Both pins (the action ref AND the `version:` input) are required. The
 action ref alone pins only the composite action and its install
 script; `version:` pins the Aguara binary the action installs. Setting
 both makes the workflow reproducible and dependabot-friendly: when
-v0.16.3 lands, the bot updates both together.
+v0.17.1 lands, the bot updates both together.
 
 Scans your repository, uploads findings to GitHub Code Scanning, and
 optionally fails the build:
 
 ```yaml
-- uses: garagon/aguara@v0.16.2
+- uses: garagon/aguara@v0.17.0
   with:
     path: ./mcp-server/
     severity: medium
     fail-on: high
-    version: v0.16.2
+    version: v0.17.0
 ```
 
 All inputs are optional. See [`action.yml`](action.yml) for the full list.
@@ -480,6 +480,9 @@ aguara scan .claude/skills/ --rules ./my-rules/
 ```
 
 ## Supply-Chain Check
+
+In v0.17, `aguara check .` walks the dependency surface of a modern repo
+instead of stopping at npm/Python.
 
 Aguara ships with native threat intel built from [OSV.dev](https://osv.dev)'s
 public vulnerability database and OpenSSF Malicious Packages records, plus a
@@ -661,7 +664,7 @@ Your agent gets 4 tools: `scan_content`, `check_mcp_config`, `list_rules`, and `
 
 ## Aguara Watch
 
-[Aguara Watch](https://watch.aguarascan.com/) continuously scans **28,000+ AI agent skills** across 6 public registries to track the real-world threat landscape for AI agents. All scans are powered by Aguara.
+Aguara Watch is being reworked. The previous public observatory is stale, so we are not using it as a product signal for this release. The scanner, CLI, Docker image, and signed release artifacts remain the supported surfaces for v0.17.0.
 
 ## Go Library
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.16.2"
+        DEFAULT_REF="v0.17.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.16.2 tag rather than `@v1`
+// The action ref is pinned to the v0.17.0 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.16.2
+        uses: garagon/aguara@v0.17.0
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.16.2
+          version: v0.17.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.

--- a/internal/intel/update.go
+++ b/internal/intel/update.go
@@ -234,13 +234,12 @@ func fetchAndImport(ctx context.Context, client *http.Client, urlTmpl, ecosystem
 // and so callers reading the file can see where the CLI-level
 // alias resolution happens before the URL is built.
 //
-// The default ecosystem list ([npm, PyPI]) is intentionally NOT
-// widened to all 8 in this PR. The embedded snapshot still ships
-// only npm + PyPI; flipping the update default before the embedded
-// snapshot covers the new ecosystems would create an asymmetric
-// experience (`aguara update` pulls 8 buckets but `aguara check`
-// has embedded matches for 2). The default flip lands in the
-// release PR that regenerates the embedded snapshot.
+// The default ecosystem list widened to SupportedEcosystems() in
+// v0.17 (PR #106) when the embedded snapshot grew to cover all 8
+// OSV buckets; see Update() above for the empty-Ecosystems
+// default. `aguara update` and `aguara check --fresh` now share
+// the same refresh surface, scoped per call via --ecosystem when
+// the caller wants a narrower refresh.
 func canonicaliseEcosystemForUpdate(raw string) string {
 	return CanonicaliseEcosystem(raw)
 }


### PR DESCRIPTION
## Summary

Release prep for v0.17.0.

This PR does not change runtime behavior. It aligns version pins, README examples, release docs, and the stale internal update comment with the v0.17.0 multi-ecosystem supply-chain release.

## Changes

- Bumps init/action/install test pins to `v0.17.0`.
- Updates README install, Docker, and GitHub Action examples to `v0.17.0`.
- Rewrites the Aguara Watch section to avoid stale observatory claims.
- Adds the v0.17 user-facing supply-chain framing: `aguara check .` now walks the dependency surface of a modern repo instead of stopping at npm/Python.
- Updates the stale `update.go` comment to match the 8-ecosystem refresh behavior.
- Moves CHANGELOG `[Unreleased]` entries to `[0.17.0] - 2026-05-17`.

## Verification

- [x] `VERSION=v0.17.0 .github/scripts/check-version-pins.sh`
- [x] `go test ./...`
- [x] `make vet`
- [x] `make lint`
- [x] `make verify-docker`
- [x] `aguara init --ci` scaffold smoke: `garagon/aguara@v0.17.0` + `version: v0.17.0`
- [x] README forbidden-string smoke: no old v0.16 pins or stale Watch claim