### PR TITLE
fix(rules): mark MCPCFG_003 sensitive so its matched_text is redacted

### DIFF
--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -590,6 +590,69 @@ func TestJSONFormatterRedactsSensitiveMatch(t *testing.T) {
 	require.Contains(t, out, "[REDACTED]")
 }
 
+// TestJSONFormatterRedactsMCPCFG003 locks the YAML -> runtime -> output
+// chain for MCPCFG_003. The rule's `match_mode: all` requires the env
+// block pattern AND the secret-bearing key/value pattern to fire, so
+// the resulting MatchedText literally contains the value side of the
+// env binding. With sensitive: true on the rule, the runtime emits
+// Finding.Sensitive=true and RedactSensitiveFindings scrubs MatchedText
+// before any output formatter sees it. The fixture value is obviously
+// synthetic padding (no resemblance to a real credential) and the test
+// asserts it never reaches the JSON output.
+func TestJSONFormatterRedactsMCPCFG003(t *testing.T) {
+	const fixtureValue = "not-a-real-key-just-test-padding-XYZ-0123456789"
+	findings := []types.Finding{
+		{
+			RuleID:      "MCPCFG_003",
+			RuleName:    "Hardcoded secrets in MCP env block",
+			Severity:    types.SeverityLow,
+			Category:    "mcp-config",
+			FilePath:    "mcp.json",
+			Line:        4,
+			MatchedText: `"env":{ + "API_KEY":"` + fixtureValue + `"`,
+			Sensitive:   true,
+		},
+	}
+	types.RedactSensitiveFindings(findings)
+
+	f := &output.JSONFormatter{}
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(&buf, &types.ScanResult{Findings: findings}))
+
+	out := buf.String()
+	require.NotContains(t, out, fixtureValue, "MCPCFG_003 captured value leaked into JSON output")
+	require.Contains(t, out, "[REDACTED]", "JSON output should embed the redaction placeholder")
+}
+
+// TestSARIFFormatterRedactsMCPCFG003 is the SARIF counterpart. The
+// SARIF formatter embeds MatchedText into message.text which gets
+// published to GitHub Code Scanning, so the redaction must run before
+// SARIF serialization.
+func TestSARIFFormatterRedactsMCPCFG003(t *testing.T) {
+	const fixtureValue = "not-a-real-key-just-test-padding-XYZ-0123456789"
+	findings := []types.Finding{
+		{
+			RuleID:      "MCPCFG_003",
+			RuleName:    "Hardcoded secrets in MCP env block",
+			Severity:    types.SeverityLow,
+			Category:    "mcp-config",
+			FilePath:    "mcp.json",
+			Line:        4,
+			MatchedText: `"env":{ + "API_KEY":"` + fixtureValue + `"`,
+			Sensitive:   true,
+		},
+	}
+	types.RedactSensitiveFindings(findings)
+
+	f := &output.SARIFFormatter{}
+	var buf bytes.Buffer
+	require.NoError(t, f.Format(&buf, &types.ScanResult{Findings: findings}))
+
+	out := buf.String()
+	require.NotContains(t, out, fixtureValue, "MCPCFG_003 captured value leaked into SARIF output")
+	require.Contains(t, out, "[REDACTED]", "SARIF output should embed the redaction placeholder")
+}
+
 // TestSARIFFormatterPreservesNonSensitiveMatch is the negative case: a
 // non-sensitive finding (e.g. a prompt-injection signature) must keep its
 // MatchedText so reviewers can see what tripped the rule.

--- a/internal/rules/builtin/mcp-config.yaml
+++ b/internal/rules/builtin/mcp-config.yaml
@@ -47,6 +47,7 @@ severity: LOW
 category: mcp-config
 targets: ["*.json", "*.md", "*.txt"]
 match_mode: all
+sensitive: true
 remediation: "Use environment variable references (e.g., $ENV_VAR) or a secrets manager instead of hardcoding credentials."
 patterns:
   - type: regex

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -75,6 +75,34 @@ func TestCompileMissingID(t *testing.T) {
 	require.Error(t, err)
 }
 
+// TestSensitiveFlag_MCPCFG003 pins that MCPCFG_003 carries the
+// sensitive flag through YAML -> compiled rule. The rule's `match_mode:
+// all` requires both the env-block pattern AND the secret-bearing
+// key/value pattern to fire, so the resulting MatchedText literally
+// contains the value side of the env binding. Without the flag,
+// types.RedactSensitiveFindings does not scrub that text and the
+// value flows un-redacted into JSON / SARIF / terminal output. Peer
+// rules with the same shape (MCP_007, all CRED_* via category) set
+// this; MCPCFG_003 was missed in the original sensitive-flag rollout
+// and is restored here.
+func TestSensitiveFlag_MCPCFG003(t *testing.T) {
+	rawRules, err := rules.LoadFromFS(builtin.FS())
+	require.NoError(t, err)
+	compiled, errs := rules.CompileAll(rawRules)
+	require.Empty(t, errs)
+
+	var rule *rules.CompiledRule
+	for i := range compiled {
+		if compiled[i].ID == "MCPCFG_003" {
+			rule = compiled[i]
+			break
+		}
+	}
+	require.NotNil(t, rule, "MCPCFG_003 not found in built-in rules")
+	require.True(t, rule.Sensitive,
+		"MCPCFG_003 must be sensitive: true; otherwise its matched_text flows un-redacted through output formatters")
+}
+
 func TestLoadBuiltinRules(t *testing.T) {
 	rawRules, err := rules.LoadFromFS(builtin.FS())
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

MCPCFG_003 ("Hardcoded secrets in MCP env block") was missed in the sensitive-flag rollout that landed across the credential / cred+exfil rule family. Its \`match_mode: all\` requires both the env-block pattern and the secret-bearing key/value pattern to fire, so the resulting MatchedText literally contains the value side of the env binding.

Peer rules with the same shape all flow through \`types.RedactSensitiveFindings\`:

- MCP_007 in \`mcp-attack.yaml\` (\`sensitive: true\`)
- the seven \`sensitive: true\` rules in \`exfiltration.yaml\` / \`supply-chain-exfil.yaml\`
- the CRED_* family via category-based redaction (\`Category == "credential-leak"\`)

MCPCFG_003 did not. The in-place scrub in \`types.RedactSensitiveFindings\` only fires on \`Sensitive=true\` or \`Category=="credential-leak"\`; MCPCFG_003 is \`mcp-config\` (not credential-leak) and lacked the flag, so it bypassed both gates and the matched_text flowed verbatim through JSON, SARIF, and terminal output formatters.

## Patch

- **\`internal/rules/builtin/mcp-config.yaml\`**: add \`sensitive: true\` to MCPCFG_003. One-line YAML change; the flag propagates through the existing chain (\`compiler.go:44\` → \`CompiledRule.Sensitive\` → pattern matcher \`Finding.Sensitive\` → \`RedactSensitiveFindings\`). No engine changes.

## Regression tests

- **\`internal/rules/rules_test.go\`** → \`TestSensitiveFlag_MCPCFG003\`: loads the built-in rules, finds MCPCFG_003, asserts \`CompiledRule.Sensitive == true\`. Catches any future YAML change that drops the flag.
- **\`internal/output/output_test.go\`** → \`TestJSONFormatterRedactsMCPCFG003\` and \`TestSARIFFormatterRedactsMCPCFG003\`: build a Finding with the MCPCFG_003 shape, run through \`types.RedactSensitiveFindings\`, render, assert the fixture value never appears in output while \`[REDACTED]\` does. Fixture value is obviously synthetic padding (no resemblance to a real credential) so the tests can ship in the public repo without smuggling a credential-shaped string into git history.

## Codex review trail

1 round. Codex flagged a P2 in \`README.md\` (\`aguara check .\` examples documented usage that doesn't work because the command ignores positional arguments and only reads \`--path\`). That finding is REAL but **out of scope** for this PR, which is focused on the MCPCFG_003 redaction flag. It is a pre-existing documentation gap, not a regression introduced by this commit. Filed as a separate follow-up.

## Test plan

- [x] \`go test -race -count=1 ./internal/rules/\`: \`TestSensitiveFlag_MCPCFG003\` PASS
- [x] \`go test -race -count=1 ./internal/output/\`: \`TestJSONFormatterRedactsMCPCFG003\` + \`TestSARIFFormatterRedactsMCPCFG003\` PASS
- [x] \`go test -race -count=1 ./...\`: full suite PASS
- [x] \`go vet ./...\` and \`make lint\`: clean (0 issues)
- [ ] CI green