### PR TITLE
feat(check): accept an optional positional path argument

### DIFF
--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -67,13 +67,25 @@ var osvIDToEcoToken = func() map[string]string {
 }()
 
 var checkCmd = &cobra.Command{
-	Use:   "check",
+	Use:   "check [path]",
 	Short: "Check for compromised packages and persistence artifacts",
 	Long: `Run from a project root. Aguara discovers installed npm /
 Python environments at the path AND lockfiles for Go, Rust,
 PHP/Composer, Ruby/Bundler, Java/Maven/Gradle, and .NET/NuGet
 recursively under the path, then matches every declared package
 against the embedded threat-intel snapshot.
+
+The scan target can be passed as a positional argument or via
+--path. The positional form is the natural one ('aguara check .'
+matches what users type first); --path stays for scripted callers
+and CI workflows that already use it.
+
+  aguara check .                # scan the current directory
+  aguara check ./myrepo         # scan a specific path
+  aguara check --path ./myrepo  # equivalent, flag form
+
+Passing both the positional argument and --path is an explicit
+error to avoid silent precedence: pick one, not both.
 
 Pass --ecosystem to constrain the scan. Multiple values supported,
 comma-separated or repeated:
@@ -93,11 +105,12 @@ Supported values (case-insensitive):
 
 The known-bad list ships embedded with the binary; --fresh refreshes
 only the ecosystems actually being checked.`,
+	Args: cobra.MaximumNArgs(1),
 	RunE: runCheck,
 }
 
 func init() {
-	checkCmd.Flags().StringVar(&flagCheckPath, "path", "", "Path to project root, node_modules, or Python site-packages")
+	checkCmd.Flags().StringVar(&flagCheckPath, "path", "", "Path to project root, node_modules, or Python site-packages (also accepted as a positional argument)")
 	checkCmd.Flags().StringSliceVar(&flagCheckEcosystems, "ecosystem", nil, "Package ecosystem (auto-detect by default; repeatable or comma-separated): python, npm, go, cargo, composer, ruby, maven, nuget")
 	checkCmd.Flags().StringVar(&flagCheckFailOn, "fail-on", "", "Exit with code 1 if findings reach this severity: critical, warning, info")
 	checkCmd.Flags().BoolVar(&flagCheckCI, "ci", false, "CI mode: equivalent to --fail-on critical --no-color")
@@ -116,7 +129,12 @@ func init() {
 func runCheck(cmd *cobra.Command, args []string) error {
 	applyCheckCIDefaults()
 
-	plan, err := buildCheckPlan(flagCheckEcosystems, flagCheckPath)
+	path, err := resolveCheckPathArg(args, flagCheckPath)
+	if err != nil {
+		return err
+	}
+
+	plan, err := buildCheckPlan(flagCheckEcosystems, path)
 	if err != nil {
 		return err
 	}
@@ -142,6 +160,37 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	}
 
 	return checkIncidentFailOnThreshold(result, flagCheckFailOn)
+}
+
+// resolveCheckPathArg picks the effective scan path from the positional
+// argument or the --path flag and rejects ambiguous combinations.
+//
+//   no positional, no --path  -> "" (legacy default: site-packages auto-discovery)
+//   no positional, --path X   -> X
+//   positional X, no --path   -> X
+//   positional X, --path Y    -> explicit error (ambiguity)
+//
+// The explicit-error case is the deliberate choice this command makes
+// vs the silent flag-wins semantics 'audit' uses. Picking one form
+// removes a class of "which one took effect?" mistakes that would
+// otherwise show up only when the two paths point at different
+// directories. The error message names both values so the operator
+// can drop one and re-run.
+//
+// cobra.MaximumNArgs(1) on the command spec already rejects two or
+// more positionals before this runs, so the only ambiguity we have
+// to handle here is "one positional plus --path".
+func resolveCheckPathArg(args []string, flagPath string) (string, error) {
+	if len(args) == 1 && flagPath != "" {
+		return "", fmt.Errorf(
+			"ambiguous path: pass either the positional argument or --path, not both (got positional %q and --path %q)",
+			args[0], flagPath,
+		)
+	}
+	if len(args) == 1 {
+		return args[0], nil
+	}
+	return flagPath, nil
 }
 
 // applyCheckCIDefaults wires --ci to the equivalent explicit flags.

--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -796,6 +796,121 @@ func TestCheckMultiEcosystemAutodetectFindsAllEcosystemsInFixture(t *testing.T) 
 	}
 }
 
+// --- Issue #111: aguara check [path] accepts an optional positional ---
+
+func TestCheck_PositionalPath_Dot(t *testing.T) {
+	// `aguara check .` must walk the current working directory.
+	// The fixture lives at a known path; the test cd's into the
+	// fixture root and calls `check .` so the positional `.`
+	// resolves to that root.
+	project := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(project, "node_modules"), 0o755))
+	writeFakeNPMPackage(t, filepath.Join(project, "node_modules"), "lodash", "4.17.21")
+
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	require.NoError(t, os.Chdir(project))
+	t.Cleanup(func() { _ = os.Chdir(wd) })
+
+	result := checkToFile(t, ".")
+
+	require.NotEmpty(t, result.Ecosystems, "positional '.' must resolve to the cwd and trigger the npm pipeline")
+	require.Equal(t, "npm", result.Ecosystems[0].Ecosystem)
+}
+
+func TestCheck_PositionalPath_RelativeWithEcosystemFlag(t *testing.T) {
+	// `aguara check ./fixtures --ecosystem npm` -- positional + flag
+	// on a different axis must coexist. The positional supplies the
+	// path; --ecosystem narrows the dispatch.
+	project := t.TempDir()
+	nm := filepath.Join(project, "node_modules")
+	require.NoError(t, os.MkdirAll(nm, 0o755))
+	writeFakeNPMPackage(t, nm, "lodash", "4.17.21")
+
+	result := checkToFile(t, project, "--ecosystem", "npm")
+
+	require.Len(t, result.Ecosystems, 1, "explicit --ecosystem npm with positional path must produce exactly one npm entry")
+	require.Equal(t, "npm", result.Ecosystems[0].Ecosystem)
+	require.Equal(t, 1, result.Ecosystems[0].PackagesRead)
+}
+
+func TestCheck_PositionalPath_PlusPathFlagIsAmbiguity(t *testing.T) {
+	// Both forms together must fail with a clear ambiguity error.
+	// The alternative ("flag wins silently") would surprise users
+	// whose two paths point at different directories.
+	a := t.TempDir()
+	b := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(b, "node_modules"), 0o755))
+
+	resetFlags()
+	rootCmd.SetArgs([]string{"check", a, "--path", b, "--no-update-check"})
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		resetFlags()
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err, "passing both positional and --path must error, not silently pick one")
+	require.Contains(t, err.Error(), "ambiguous path",
+		"error message must name the ambiguity so the operator can drop one")
+}
+
+func TestCheck_PositionalPath_TwoArgsRejected(t *testing.T) {
+	// `aguara check a b` must error via cobra.MaximumNArgs(1)
+	// rather than silently using the first arg and dropping the
+	// rest.
+	resetFlags()
+	rootCmd.SetArgs([]string{"check", "a", "b", "--no-update-check"})
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		resetFlags()
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err, "two positional args must error")
+	require.Contains(t, err.Error(), "accepts at most 1 arg",
+		"cobra's MaximumNArgs(1) error wording is the stable signal we lock against")
+}
+
+func TestCheck_ResolveCheckPathArg_TableSemantics(t *testing.T) {
+	// Unit-level coverage of the precedence table for resolveCheckPathArg.
+	// The CLI-level tests above exercise the full Cobra round-trip;
+	// this one pins the contract at the helper boundary so the table
+	// is reviewable in one place.
+	cases := []struct {
+		name      string
+		args      []string
+		flagPath  string
+		want      string
+		wantError bool
+	}{
+		{name: "empty/empty -> empty (legacy default)", args: nil, flagPath: "", want: ""},
+		{name: "empty/flag -> flag", args: nil, flagPath: "/x", want: "/x"},
+		{name: "positional/empty -> positional", args: []string{"/y"}, flagPath: "", want: "/y"},
+		{name: "positional/flag -> error", args: []string{"/y"}, flagPath: "/x", wantError: true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolveCheckPathArg(tc.args, tc.flagPath)
+			if tc.wantError {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "ambiguous path")
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 // --- Issue #109: npm and PyPI emit ecosystems[] entries on the incident path ---
 
 func TestCheckExplicitNPM_AppendsEcosystemsEntry(t *testing.T) {


### PR DESCRIPTION
Closes #111.

## Summary

\`aguara check .\` was the natural form users typed first, and the form the public v0.17 docs and CHANGELOG use to introduce the command. The command silently ignored positional arguments (only \`--path\` was consulted), so \`aguara check ../repo\` scanned the cwd instead of \`../repo\` with no warning. Issue #111 listed two fix options (support positional, or update docs to \`--path\`-only). This PR picks the user-facing one.

## Precedence (the table)

| Positional | \`--path\` | Effective path |
|---|---|---|
| absent | absent | \`""\` (legacy default: site-packages auto-discovery) |
| absent | present | \`--path\` value |
| present | absent | positional value |
| present | present | **explicit error** ("ambiguous path: ...") |

The \`audit\` command resolves the same conflict silently in favour of \`--path\`. \`check\` takes the stricter route here: the two paths could point at different directories, and "which one took effect?" is exactly the surprise this CLI should not produce. The error message names both values so the operator can drop one and re-run.

\`cobra.MaximumNArgs(1)\` on the command spec catches \`check a b\` before \`resolveCheckPathArg\` runs.

## Patch

- **\`cmd/aguara/commands/check.go\`**:
  - \`Use: "check [path]"\`
  - \`Args: cobra.MaximumNArgs(1)\`
  - New \`resolveCheckPathArg(args, flagPath)\` helper that encodes the table above and returns the explicit ambiguity error.
  - \`runCheck\` calls the helper, feeds the result into \`buildCheckPlan\`.
  - Long doc updated to show the three forms.
  - \`--path\` flag help text notes the positional alternative.

No downstream changes: \`buildCheckPlan\`, \`runCheckPlan\`, and every helper that takes a \`path\` parameter stay untouched. The positional just flows through the same argument.

## Tests

\`cmd/aguara/commands/check_test.go\`:
- \`TestCheck_PositionalPath_Dot\` — \`aguara check .\` resolves to cwd (chdir into a node_modules fixture, verify npm pipeline fires).
- \`TestCheck_PositionalPath_RelativeWithEcosystemFlag\` — positional + \`--ecosystem npm\` coexist; positional supplies path, flag narrows dispatch.
- \`TestCheck_PositionalPath_PlusPathFlagIsAmbiguity\` — both forms together error with \`"ambiguous path"\`, no silent fallback.
- \`TestCheck_PositionalPath_TwoArgsRejected\` — \`check a b\` errors via \`cobra.MaximumNArgs(1)\`.
- \`TestCheck_ResolveCheckPathArg_TableSemantics\` — helper-level table that pins the 2x2 truth table in one place.

## Codex review trail

1 round, CLEAN. The change is consistent with the existing check plan flow and the precedence table is covered end-to-end.

## Test plan

- [x] \`go test -race -count=1 ./...\`: clean
- [x] \`go vet ./...\` and \`make lint\`: 0 issues
- [x] Manual smoke: \`aguara check /tmp/fixture\`, \`aguara check . --ecosystem npm\`, \`aguara check x --path y\` (errors), \`aguara check a b\` (errors via cobra)
- [x] 1 codex review round, CLEAN PASS
- [ ] CI green