### PR TITLE
release: prep v0.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,25 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.17.1] - 2026-05-18
+
+QA backlog patch release. Four release-blocker bugs surfaced by
+end-to-end testing of v0.17.0 in Docker are fixed. No new
+analyzers, no schema changes to existing tools, no new commands.
+Verified end-to-end side-by-side against `ghcr.io/garagon/aguara:0.17.0`.
+
+### Fixed
+
+- **MCPCFG_003 leaked captured matched_text into JSON and SARIF output** (#108). The rule was missed in the original `sensitive:` flag rollout. Now carries `sensitive: true`; `RedactSensitiveFindings` scrubs `matched_text` before any output formatter sees it. Regression tests pin the YAML→runtime→output chain.
+- **`aguara check` JSON output was missing npm and PyPI entries in `ecosystems[]`** (#114, closes #109). The incident path that handles npm and PyPI initialised `Ecosystems` to an empty non-nil slice and never appended an entry of its own. Dashboards iterating `ecosystems[]` for coverage saw "npm/PyPI not covered" even when packages were checked and findings fired. Both paths now append one `EcosystemResult` per call with `ecosystem`, `path`, `source`, `packages_read`, `findings_count`. Unreadable target directories now return an explicit error instead of silently emitting a misleading "scanned 0 packages" entry.
+- **`aguara check [path]` ignored positional arguments** (#116, closes #111). `aguara check ./myrepo` silently scanned the current directory because the runtime only read `--path`. The positional form is now accepted via `cobra.MaximumNArgs(1)`; `--path` and the positional together produce an explicit `ambiguous path` error rather than silent precedence.
+- **`aguara audit` reported `verdict.status: "pass"` when criticals existed** (#117, closes #110). The verdict status is now tri-state `pass | findings | fail`: `pass` only when zero findings, `findings` when findings exist but no gate (`--ci` / `--fail-on`) was crossed (exit 0), `fail` when the gate was crossed (exit non-zero, unchanged from v0.17.0).
+
+### Backward compatibility notes
+
+- `verdict.status` in `aguara audit` output may now be `"findings"` in cases where v0.17.0 returned `"pass"`. Consumers that switch on `{"pass", "fail"}` should add a `"findings"` arm or treat it as a non-fail signal. The `"fail"` arm continues to fire on exactly the same input set; `ThresholdExceeded` is unchanged.
+- `ecosystems[]` in `aguara check` JSON may now contain entries where v0.17.0 returned `[]` for npm-only or PyPI-only paths. Consumers iterating the array unconditionally already handle this; consumers checking `len == 0` as "not scanned" should look at the per-entry data instead.
+
 ## [0.17.0] - 2026-05-17
 
 `aguara check .` now walks the dependency surface of a modern repo

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.17.0
+INSTALL_SH_TEST_VERSION ?= v0.17.1
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
 Installs the latest binary to `~/.local/bin`. Customize with environment variables:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.17.0 sh
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.17.1 sh
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | INSTALL_DIR=/usr/local/bin sh
 ```
 
@@ -73,7 +73,7 @@ To update an existing install, rerun the installer. It downloads the selected re
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
 
 # Update/pin to a specific release
-curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.17.0 sh
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.17.1 sh
 ```
 
 ### Alternative methods
@@ -94,7 +94,7 @@ docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara scan /scan
 docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara scan /scan --severity high --format json
 
 # Use a specific version
-docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara:0.17.0 scan /scan
+docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara:0.17.1 scan /scan
 ```
 
 **From source** (requires Go 1.25+):
@@ -278,11 +278,11 @@ aguara scan --auto
 #### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.17.0
+- uses: garagon/aguara@v0.17.1
   with:
     path: .
     fail-on: high
-    version: v0.17.0
+    version: v0.17.1
 ```
 
 Both pins (the action ref AND the `version:` input) are required. The
@@ -295,12 +295,12 @@ Scans your repository, uploads findings to GitHub Code Scanning, and
 optionally fails the build:
 
 ```yaml
-- uses: garagon/aguara@v0.17.0
+- uses: garagon/aguara@v0.17.1
   with:
     path: ./mcp-server/
     severity: medium
     fail-on: high
-    version: v0.17.0
+    version: v0.17.1
 ```
 
 All inputs are optional. See [`action.yml`](action.yml) for the full list.
@@ -664,7 +664,7 @@ Your agent gets 4 tools: `scan_content`, `check_mcp_config`, `list_rules`, and `
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale, so we are not using it as a product signal for this release. The scanner, CLI, Docker image, and signed release artifacts remain the supported surfaces for v0.17.0.
+Aguara Watch is being reworked. The previous public observatory is stale, so we are not using it as a product signal for this release. The scanner, CLI, Docker image, and signed release artifacts remain the supported surfaces for v0.17.1.
 
 ## Go Library
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.17.0"
+        DEFAULT_REF="v0.17.1"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.17.0 tag rather than `@v1`
+// The action ref is pinned to the v0.17.1 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.17.0
+        uses: garagon/aguara@v0.17.1
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.17.0
+          version: v0.17.1
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
QA backlog patch release. Bumps every version pin from \`v0.17.0\` to \`v0.17.1\` and moves the CHANGELOG \`Unreleased\` contents into the \`[0.17.1]\` entry. No code or behaviour changes; the four fixes themselves landed in #108, #114, #116, and #117 already on main.

## Pins bumped

Every location \`check-version-pins.sh\` inspects:

- \`cmd/aguara/commands/init.go\` — \`workflowTemplateV2\` \`uses:\` and \`version:\` inputs + the explanatory comment line that names the tag.
- \`action.yml\` — \`DEFAULT_REF\` for the install.sh fallback.
- \`Makefile\` — \`INSTALL_SH_TEST_VERSION\` (the cap-drop docker test target's default version).
- \`README.md\` — install.sh \`VERSION=\` snippet, the Docker tag in the ghcr.io quickstart, the GitHub Action \`uses:\` + \`version:\` pair in two places, the Watch section line that references the current release.

## CHANGELOG

\`Unreleased\` contents moved to \`[0.17.1] - 2026-05-18\`. Entry organised as **Fixed** + **Backward compatibility notes**.

The four PRs listed by number with one-line summaries each, so readers reading the changelog directly can grep the PR for full context without the entry ballooning.

The backward-compat block calls out the two consumer-visible contract surfaces that may behave differently from v0.17.0:

- \`verdict.status\` tri-state (\`pass | findings | fail\`): consumers switching on \`{pass, fail}\` should add a \`findings\` arm or treat it as non-fail. \`fail\` arm fires on exactly the same input set; \`ThresholdExceeded\` unchanged.
- \`ecosystems[]\` may now contain entries where v0.17.0 returned \`[]\` for npm-only or PyPI-only paths. Consumers iterating the array unconditionally already handle this; \`len == 0\` checks need to look at per-entry data instead.

## Test plan

- [x] \`VERSION=v0.17.1 .github/scripts/check-version-pins.sh\`: clean
- [x] \`go test -race -count=1 ./...\`: clean
- [x] \`go vet ./...\` + \`make lint\`: 0 issues
- [x] \`aguara init --ci\` on a temp dir generates a workflow whose \`uses:\` and \`version:\` lines both literally show v0.17.1
- [x] 1 codex review round, CLEAN PASS (pin consistency + cmd/aguara/commands tests passing)
- [ ] CI green

## Out of scope (NOT in this commit)

- README.md WIP rewrite found in working tree was preserved via \`git stash\` ("WIP: README rewrite (pre-existing, preserved for separate work)"). Release-prep does not mix with content rewrites; that work continues on its own branch when ready.
- Tag \`v0.17.1\` is **not** in this PR. After merge, the canonical ritual runs separately: tag at the merge commit, wait for GoReleaser + Docker workflows, \`VERSION=v0.17.1 .github/scripts/verify-release.sh\` from a clean machine, rewrite release body per \`feedback_release_notes_vs_changelog\`. That step is gated on explicit maintainer OK.