### PR TITLE
feat(check): support pnpm-lock.yaml in npm package checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ Coverage by ecosystem:
 
 | Ecosystem | Evidence read | Coverage today |
 |---|---|---|
-| npm | `node_modules` (incl. pnpm `.pnpm` store) | Strong malicious-package coverage |
+| npm | `node_modules` (incl. pnpm `.pnpm` store), `pnpm-lock.yaml` | Strong malicious-package coverage; pnpm lockfile readable pre-install |
 | PyPI | `site-packages`, `.pth`, pip/uv/npx caches | Strong malicious-package + persistence coverage |
 | RubyGems | `Gemfile.lock` | Strong malicious-package coverage |
 | NuGet | `packages.lock.json`, `*.csproj`/`*.fsproj`/`*.vbproj` | Strong exact-version malicious-package coverage |
@@ -546,13 +546,23 @@ Aguara is not claiming to be a full SCA vulnerability scanner yet. v0.17
 adds offline malicious-package checks across ecosystems. General
 CVE/range matching is the next layer.
 
+For pnpm projects, Aguara reads `pnpm-lock.yaml` directly. You do not need to run `pnpm install` first:
+
+```bash
+# Works before install in pnpm repos
+git clone <pnpm-repo>
+cd <pnpm-repo>
+aguara check .
+```
+
 Auto-detection rules (in order):
-- If the path is or contains `node_modules`, run the npm check.
-- Walk the path recursively for lockfiles (`go.sum`, `Cargo.lock`,
-  `composer.lock`, `Gemfile.lock`, `pom.xml`, `gradle.lockfile`,
-  `gradle/dependency-locks/*.lockfile`, `packages.lock.json`,
-  `*.csproj`/`*.fsproj`/`*.vbproj`). Skip `.git/`, `vendor/`,
-  `node_modules/`, `.aguara/`, `target/`, `bin/`, `obj/`, `.gradle/`.
+- If the path is or contains `node_modules`, run the installed-tree npm check (covers both flat `node_modules/<pkg>` and pnpm's `.pnpm` store).
+- Walk the path recursively for lockfiles (`pnpm-lock.yaml`, `go.sum`,
+  `Cargo.lock`, `composer.lock`, `Gemfile.lock`, `pom.xml`,
+  `gradle.lockfile`, `gradle/dependency-locks/*.lockfile`,
+  `packages.lock.json`, `*.csproj`/`*.fsproj`/`*.vbproj`). Skip `.git/`,
+  `vendor/`, `node_modules/`, `.aguara/`, `target/`, `bin/`, `obj/`,
+  `.gradle/`.
 - If the explicit `--path` looks like a Python install
   (`site-packages` / `dist-packages` basename, or contains `*.dist-info`),
   run the Python check.

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -402,14 +402,27 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 				// Explicit `--ecosystem npm` now covers two surfaces:
 				//   1. installed-tree (node_modules + .pnpm store)
 				//      via incident.CheckNPM. Gated on node_modules
-				//      actually existing under path so a pnpm-only
-				//      repo (no install yet) does NOT error from
-				//      "no node_modules directory".
+				//      actually existing under the probe path so a
+				//      pnpm-only repo (no install yet) does NOT error
+				//      from "no node_modules directory".
 				//   2. lockfile (pnpm-lock.yaml) via packagecheck
 				//      discovery + ParsePNPMLock. Always added for
 				//      explicit npm so the user gets the pre-install
 				//      audit surface regardless of node_modules state.
-				if path == "" || filepath.Base(path) == "node_modules" || statDir(filepath.Join(path, "node_modules")) {
+				//
+				// Empty --path defaults to cwd for the existence
+				// probe (matching how other explicit packagecheck
+				// ecosystems treat the empty-path case via the
+				// `root := "."` default further down). Without this,
+				// `aguara check --ecosystem npm` from a pnpm-only
+				// cwd would set runNPM=true on an empty path, which
+				// incident.CheckNPM rejects up front and the
+				// packagecheck pnpm pipeline never gets to run.
+				probe := path
+				if probe == "" {
+					probe = "."
+				}
+				if filepath.Base(probe) == "node_modules" || statDir(filepath.Join(probe, "node_modules")) {
 					plan.runNPM = true
 					plan.npmPath = path
 				}

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -600,7 +600,12 @@ func singleEcoEnvLabel(token string) string {
 	case ecoPython:
 		return "Python environment"
 	case ecoNPM:
-		return "npm node_modules tree"
+		// Neutral label so both surfaces match: incident.CheckNPM
+		// scans node_modules + the pnpm .pnpm store; packagecheck
+		// scans pnpm-lock.yaml directly. A pnpm-only repo with no
+		// install would otherwise see "npm node_modules tree"
+		// when only the lockfile was read.
+		return "npm dependencies"
 	case ecoGo:
 		return "Go modules"
 	case ecoCargo:

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -771,11 +771,19 @@ func runPackagecheckPlan(plan checkPlan, override *incident.IntelOverride) (*inc
 	}
 	for _, hit := range runRes.Hits {
 		// Recover the CLI dispatch label from the OSV bucket so
-		// ecosystemFindingText picks the right wording. Falls back
-		// to a generic message if the ecosystem is unknown (which
-		// should never happen because packagecheckEcosystems and
-		// osvIDToEcoToken stay in sync via the same map literal).
+		// ecosystemFindingText picks the right wording.
+		// npm is intentionally absent from osvIDToEcoToken (it
+		// flows through the incident path), but pnpm-lock.yaml
+		// hits land HERE with hit.Ref.Ecosystem == EcosystemNPM,
+		// so map them back to ecoNPM explicitly. Without this,
+		// the wording would fall through to the generic
+		// "compromised package" copy instead of the npm-specific
+		// title + remediation, losing parity with the
+		// installed-tree findings.
 		ecoToken := osvIDToEcoToken[hit.Ref.Ecosystem]
+		if ecoToken == "" && hit.Ref.Ecosystem == intel.EcosystemNPM {
+			ecoToken = ecoNPM
+		}
 		title, remediation := ecosystemFindingText(ecoToken, hit)
 		result.Findings = append(result.Findings, incident.Finding{
 			Severity:    incident.SevCritical,
@@ -854,6 +862,18 @@ func ecosystemFindingText(ecoToken string, hit packagecheck.Hit) (title, remedia
 	case ecoNuGet:
 		return fmt.Sprintf("%s %s is a known compromised NuGet package (%s)", name, version, id),
 			fmt.Sprintf("Update %s to a fixed version in the project file or packages.lock.json and restore. Rotate secrets reachable from builds that used the compromised package.", name)
+	case ecoNPM:
+		// pnpm-lock.yaml packagecheck hits land here. Mirrors the
+		// wording incident.CheckNPM emits for installed-tree
+		// findings so the two surfaces produce consistent
+		// finding text. Remediation points at the package manager
+		// generically (npm install / pnpm install / yarn) since
+		// the hit could have come from any of the npm registry
+		// consumers, and explicitly calls out the lockfile
+		// pinning that would otherwise re-introduce the same
+		// version on the next install.
+		return fmt.Sprintf("%s %s is a known compromised npm package (%s)", name, version, id),
+			fmt.Sprintf("Remove %s@%s from the lockfile and reinstall against a fixed version. Audit recent runs of the surrounding pipeline and rotate any tokens this environment has held.", name, version)
 	default:
 		// Defensive: a packagecheck ecosystem without a wording
 		// entry still produces a usable finding rather than a

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -331,6 +331,17 @@ func (p checkPlan) singleEcoToken() string {
 		return ecoNPM
 	}
 	if len(p.packagecheckTargets) > 0 {
+		// npm packagecheck targets (pnpm-lock.yaml today;
+		// package-lock.json / yarn.lock in follow-ups) are not in
+		// osvIDToEcoToken because npm normally flows through the
+		// incident path. Without this explicit map-back, a
+		// pnpm-only plan (no node_modules, no other lockfiles)
+		// would surface "" from singleEcoToken and the terminal
+		// formatter would fall through to the multi-ecosystem
+		// label even though the plan is single-ecosystem.
+		if p.packagecheckTargets[0].Ecosystem == intel.EcosystemNPM {
+			return ecoNPM
+		}
 		return osvIDToEcoToken[p.packagecheckTargets[0].Ecosystem]
 	}
 	// Explicit empty-discovery case: a single --ecosystem

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -424,7 +424,14 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 				}
 				if filepath.Base(probe) == "node_modules" || statDir(filepath.Join(probe, "node_modules")) {
 					plan.runNPM = true
-					plan.npmPath = path
+					// Use the probe (already defaulted to ".")
+					// rather than the original (possibly empty)
+					// path. incident.CheckNPM rejects an empty
+					// path with an up-front error before any
+					// scan runs, so passing it the resolved
+					// probe matches the actual directory the
+					// existence check just confirmed.
+					plan.npmPath = probe
 				}
 				plan.requestedEcosystems = append(plan.requestedEcosystems, intel.EcosystemNPM)
 				packagecheckIDs = append(packagecheckIDs, intel.EcosystemNPM)

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -388,9 +388,22 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 				plan.pythonPath = path
 				plan.requestedEcosystems = append(plan.requestedEcosystems, intel.EcosystemPyPI)
 			case ecoNPM:
-				plan.runNPM = true
-				plan.npmPath = path
+				// Explicit `--ecosystem npm` now covers two surfaces:
+				//   1. installed-tree (node_modules + .pnpm store)
+				//      via incident.CheckNPM. Gated on node_modules
+				//      actually existing under path so a pnpm-only
+				//      repo (no install yet) does NOT error from
+				//      "no node_modules directory".
+				//   2. lockfile (pnpm-lock.yaml) via packagecheck
+				//      discovery + ParsePNPMLock. Always added for
+				//      explicit npm so the user gets the pre-install
+				//      audit surface regardless of node_modules state.
+				if path == "" || filepath.Base(path) == "node_modules" || statDir(filepath.Join(path, "node_modules")) {
+					plan.runNPM = true
+					plan.npmPath = path
+				}
 				plan.requestedEcosystems = append(plan.requestedEcosystems, intel.EcosystemNPM)
+				packagecheckIDs = append(packagecheckIDs, intel.EcosystemNPM)
 			default:
 				osvID, ok := packagecheckEcosystems[token]
 				if !ok {

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -422,19 +422,47 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 				if probe == "" {
 					probe = "."
 				}
-				if filepath.Base(probe) == "node_modules" || statDir(filepath.Join(probe, "node_modules")) {
+				// Resolve to absolute so the basename check sees
+				// the real directory name rather than ".". A user
+				// running `aguara check --ecosystem npm --path .`
+				// from INSIDE a node_modules tree would otherwise
+				// miss the installed-tree detection (filepath.Base
+				// of "." is "."), skip incident.CheckNPM entirely,
+				// and silently scan nothing.
+				resolved := probe
+				if abs, err := filepath.Abs(probe); err == nil {
+					resolved = abs
+				}
+				rootIsNodeModules := filepath.Base(resolved) == "node_modules"
+				if rootIsNodeModules || statDir(filepath.Join(resolved, "node_modules")) {
 					plan.runNPM = true
-					// Use the probe (already defaulted to ".")
-					// rather than the original (possibly empty)
-					// path. incident.CheckNPM rejects an empty
-					// path with an up-front error before any
-					// scan runs, so passing it the resolved
-					// probe matches the actual directory the
-					// existence check just confirmed.
-					plan.npmPath = probe
+					// When the root is node_modules itself, pass
+					// the RESOLVED absolute path so
+					// incident.CheckNPM's own basename check
+					// recognises it. Passing "." would otherwise
+					// hit `filepath.Base(".") == "."` and fail
+					// with "not a node_modules directory".
+					// For the parent-of-node_modules case the
+					// probe is the project root that contains
+					// node_modules and works as-is.
+					if rootIsNodeModules {
+						plan.npmPath = resolved
+					} else {
+						plan.npmPath = probe
+					}
 				}
 				plan.requestedEcosystems = append(plan.requestedEcosystems, intel.EcosystemNPM)
-				packagecheckIDs = append(packagecheckIDs, intel.EcosystemNPM)
+				// Skip the packagecheck npm discovery when the
+				// scan root IS node_modules. incident.CheckNPM
+				// already walks the installed tree; the
+				// packagecheck recursive walk would re-traverse
+				// the same tree only for pickPnpmTarget's
+				// hasNodeModulesAncestor check to reject every
+				// path. Substantial redundant work on large
+				// installs without producing any new findings.
+				if !rootIsNodeModules {
+					packagecheckIDs = append(packagecheckIDs, intel.EcosystemNPM)
+				}
 			default:
 				osvID, ok := packagecheckEcosystems[token]
 				if !ok {

--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -913,6 +913,22 @@ func TestCheck_ResolveCheckPathArg_TableSemantics(t *testing.T) {
 
 // --- pnpm-lock.yaml coverage: npm ecosystem, packagecheck path ---
 
+func TestCheckPlan_PnpmOnlyMapsToNPMToken(t *testing.T) {
+	// pnpm-only autodetect plan (no node_modules, no other lockfiles)
+	// has a single packagecheckTarget with Ecosystem=npm. The reverse
+	// map osvIDToEcoToken does not include npm because npm normally
+	// flows through the incident path, so singleEcoToken needs the
+	// explicit npm short-circuit to return ecoNPM. Without it the
+	// terminal formatter falls through to a wrong / generic label.
+	plan, err := buildCheckPlan(nil, "../../../internal/packagecheck/testdata/pnpm-compromised")
+	require.NoError(t, err)
+	require.False(t, plan.runNPM, "fixture has no node_modules; incident.CheckNPM must not be triggered")
+	require.Len(t, plan.packagecheckTargets, 1, "fixture has exactly one pnpm-lock.yaml target")
+	require.Equal(t, "npm", plan.packagecheckTargets[0].Ecosystem)
+	require.Equal(t, ecoNPM, plan.singleEcoToken(),
+		"pnpm-only plan must report ecoNPM so the terminal label matches the pipeline that actually ran")
+}
+
 func TestCheck_PnpmLockCompromisedFixtureFiresFinding(t *testing.T) {
 	// `aguara check <pnpm-repo>` on a fresh clone (no node_modules)
 	// must detect node-ipc 9.2.3 in pnpm-lock.yaml. End-to-end

--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -911,6 +911,65 @@ func TestCheck_ResolveCheckPathArg_TableSemantics(t *testing.T) {
 	}
 }
 
+// --- pnpm-lock.yaml coverage: npm ecosystem, packagecheck path ---
+
+func TestCheck_PnpmLockCompromisedFixtureFiresFinding(t *testing.T) {
+	// `aguara check <pnpm-repo>` on a fresh clone (no node_modules)
+	// must detect node-ipc 9.2.3 in pnpm-lock.yaml. End-to-end
+	// coverage of: discovery picks pnpm-lock.yaml as npm ecosystem,
+	// ParsePNPMLock extracts the ref, matcher hits the embedded
+	// node-ipc 9.2.3 record, finding is CRITICAL, ecosystems[]
+	// entry reports source=pnpm-lock.yaml.
+	result := checkToFile(t, "../../../internal/packagecheck/testdata/pnpm-compromised")
+
+	require.Len(t, result.Ecosystems, 1, "exactly one ecosystems[] entry expected for pnpm-only fixture (no node_modules)")
+	got := result.Ecosystems[0]
+	require.Equal(t, "npm", got.Ecosystem)
+	require.Equal(t, "pnpm-lock.yaml", got.Source)
+	require.Contains(t, got.Path, "pnpm-lock.yaml")
+	require.GreaterOrEqual(t, got.PackagesRead, 1, "lockfile has at least one declared package")
+	require.GreaterOrEqual(t, got.FindingsCount, 1, "node-ipc@9.2.3 in the embedded compromised list must produce at least one finding")
+
+	// Find the node-ipc finding in the flat findings slice.
+	var nodeIPCFinding *incident.Finding
+	for i := range result.Findings {
+		if strings.Contains(result.Findings[i].Title, "node-ipc") {
+			nodeIPCFinding = &result.Findings[i]
+			break
+		}
+	}
+	require.NotNil(t, nodeIPCFinding, "node-ipc finding missing; got: %+v", result.Findings)
+	require.Equal(t, incident.SevCritical, nodeIPCFinding.Severity, "node-ipc 9.2.3 must be CRITICAL")
+}
+
+func TestCheck_PnpmLockCleanFixtureProducesZeroFindings(t *testing.T) {
+	// Clean pnpm fixture (lodash + @types/node, neither
+	// compromised) must produce zero findings while still emitting
+	// the ecosystems[] entry so consumers see "pipeline ran, scanned
+	// N packages, zero findings" rather than silence.
+	result := checkToFile(t, "../../../internal/packagecheck/testdata/pnpm-clean")
+
+	require.Len(t, result.Ecosystems, 1, "exactly one ecosystems[] entry expected")
+	require.Equal(t, "npm", result.Ecosystems[0].Ecosystem)
+	require.Equal(t, "pnpm-lock.yaml", result.Ecosystems[0].Source)
+	require.GreaterOrEqual(t, result.Ecosystems[0].PackagesRead, 1)
+	require.Equal(t, 0, result.Ecosystems[0].FindingsCount, "clean fixture must have zero findings")
+	require.Empty(t, result.Findings, "top-level findings must be empty on clean fixture")
+}
+
+func TestCheck_ExplicitNPMEcosystemOnPnpmRepoFires(t *testing.T) {
+	// `aguara check --ecosystem npm --path <pnpm-only-repo>` must
+	// scan pnpm-lock.yaml even though there's no node_modules. The
+	// incident.CheckNPM pipeline is gated on node_modules existing;
+	// the packagecheck pnpm discovery covers the pre-install case.
+	result := checkToFile(t, "--ecosystem", "npm", "--path", "../../../internal/packagecheck/testdata/pnpm-compromised")
+
+	require.Len(t, result.Ecosystems, 1, "pnpm-only repo with --ecosystem npm: exactly one ecosystems[] entry (pnpm-lock.yaml; incident.CheckNPM correctly skipped because node_modules absent)")
+	require.Equal(t, "npm", result.Ecosystems[0].Ecosystem)
+	require.Equal(t, "pnpm-lock.yaml", result.Ecosystems[0].Source)
+	require.GreaterOrEqual(t, result.Ecosystems[0].FindingsCount, 1, "node-ipc 9.2.3 should fire")
+}
+
 // --- Issue #109: npm and PyPI emit ecosystems[] entries on the incident path ---
 
 func TestCheckExplicitNPM_AppendsEcosystemsEntry(t *testing.T) {

--- a/internal/packagecheck/discovery.go
+++ b/internal/packagecheck/discovery.go
@@ -290,7 +290,7 @@ func pickNuGetTargets(dir string) []Target {
 }
 
 // pickPnpmTarget returns a Target for a pnpm project rooted at dir,
-// or nil when no pnpm-lock.yaml is present.
+// or nil when no pnpm-lock.yaml is present at that directory.
 //
 // pnpm installs from the npm registry, so the Target's ecosystem is
 // intel.EcosystemNPM. The Source label distinguishes it from the
@@ -299,11 +299,19 @@ func pickNuGetTargets(dir string) []Target {
 // (package-lock.json, yarn.lock) which will land as their own
 // pickers in this slice.
 //
-// node_modules is in defaultSkipDirs, so a pnpm-lock.yaml that
-// somehow ended up under node_modules (vendored copy, broken
-// extraction) is not discovered. Only the project-root lockfile
-// is considered.
+// node_modules is in defaultSkipDirs, so a nested node_modules child
+// is skipped during recursion. But when the scan root ITSELF is
+// node_modules (a legitimate npm input — `aguara check ./node_modules`
+// is documented) the skip-rule never fires (it is gated on
+// `path != root`), and Discover would walk installed package
+// contents. Any dependency that ships a pnpm-lock.yaml as a fixture
+// or dev lockfile would then produce findings unrelated to the
+// user's project. Skip when any ancestor segment is `node_modules`
+// so the recursive walk only picks up the user's actual lockfile.
 func pickPnpmTarget(dir string) []Target {
+	if hasNodeModulesAncestor(dir) {
+		return nil
+	}
 	if statRegular(filepath.Join(dir, "pnpm-lock.yaml")) {
 		return []Target{{
 			Ecosystem: intel.EcosystemNPM,
@@ -312,6 +320,23 @@ func pickPnpmTarget(dir string) []Target {
 		}}
 	}
 	return nil
+}
+
+// hasNodeModulesAncestor walks the cleaned path and reports whether
+// any segment is exactly "node_modules". Returns true even when the
+// supplied path's basename is node_modules (the scan-root case the
+// defaultSkipDirs gate misses).
+func hasNodeModulesAncestor(dir string) bool {
+	for d := filepath.Clean(dir); ; {
+		if filepath.Base(d) == "node_modules" {
+			return true
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			return false
+		}
+		d = parent
+	}
 }
 
 func statRegular(path string) bool {

--- a/internal/packagecheck/discovery.go
+++ b/internal/packagecheck/discovery.go
@@ -58,6 +58,7 @@ var lockfilePickers = []lockfilePicker{
 	{intel.EcosystemRubyGems, pickRubyTarget},
 	{intel.EcosystemMaven, pickMavenTargets},
 	{intel.EcosystemNuGet, pickNuGetTargets},
+	{intel.EcosystemNPM, pickPnpmTarget},
 }
 
 // Discover walks root and returns one Target per lockfile / discovery
@@ -286,6 +287,31 @@ func pickNuGetTargets(dir string) []Target {
 		}
 	}
 	return out
+}
+
+// pickPnpmTarget returns a Target for a pnpm project rooted at dir,
+// or nil when no pnpm-lock.yaml is present.
+//
+// pnpm installs from the npm registry, so the Target's ecosystem is
+// intel.EcosystemNPM. The Source label distinguishes it from the
+// installed-tree npm pipeline (incident.CheckNPM with Source
+// "node_modules") and from any future npm lockfile parsers
+// (package-lock.json, yarn.lock) which will land as their own
+// pickers in this slice.
+//
+// node_modules is in defaultSkipDirs, so a pnpm-lock.yaml that
+// somehow ended up under node_modules (vendored copy, broken
+// extraction) is not discovered. Only the project-root lockfile
+// is considered.
+func pickPnpmTarget(dir string) []Target {
+	if statRegular(filepath.Join(dir, "pnpm-lock.yaml")) {
+		return []Target{{
+			Ecosystem: intel.EcosystemNPM,
+			Path:      filepath.Join(dir, "pnpm-lock.yaml"),
+			Source:    "pnpm-lock.yaml",
+		}}
+	}
+	return nil
 }
 
 func statRegular(path string) bool {

--- a/internal/packagecheck/discovery_test.go
+++ b/internal/packagecheck/discovery_test.go
@@ -94,6 +94,30 @@ func TestDiscover_NoGoFilesReturnsEmpty(t *testing.T) {
 	}
 }
 
+func TestDiscover_FindsPnpmLockAsNPM(t *testing.T) {
+	// pnpm-lock.yaml routes through the packagecheck path with
+	// Ecosystem=npm and Source="pnpm-lock.yaml". This is what
+	// makes `aguara check .` on a fresh clone of a pnpm repo
+	// (no node_modules yet) surface npm coverage.
+	root := filepath.Join("testdata", "pnpm-compromised")
+	targets, err := Discover(root, []string{intel.EcosystemNPM})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if got, want := len(targets), 1; got != want {
+		t.Fatalf("targets = %d, want %d (targets=%+v)", got, want, targets)
+	}
+	if targets[0].Ecosystem != intel.EcosystemNPM {
+		t.Errorf("ecosystem = %q, want %q", targets[0].Ecosystem, intel.EcosystemNPM)
+	}
+	if targets[0].Source != "pnpm-lock.yaml" {
+		t.Errorf("source = %q, want pnpm-lock.yaml", targets[0].Source)
+	}
+	if !strings.HasSuffix(targets[0].Path, "pnpm-lock.yaml") {
+		t.Errorf("path = %q, want suffix pnpm-lock.yaml", targets[0].Path)
+	}
+}
+
 func TestDiscover_DefaultsToAllSupportedWhenEcosystemsNil(t *testing.T) {
 	// PR #2: nil means "scan every ecosystem packagecheck knows
 	// about". Today that's Go only; future PRs flow additively

--- a/internal/packagecheck/discovery_test.go
+++ b/internal/packagecheck/discovery_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
 )
 
 func TestDiscover_MonorepoFindsBothGoTargets(t *testing.T) {
@@ -92,6 +93,27 @@ func TestDiscover_NoGoFilesReturnsEmpty(t *testing.T) {
 	if len(targets) != 0 {
 		t.Errorf("targets = %+v, want empty", targets)
 	}
+}
+
+func TestDiscover_SkipsPnpmLockUnderNodeModulesRoot(t *testing.T) {
+	// When the user passes a node_modules directory as the scan
+	// root (legitimate npm input), the recursive walk would
+	// normally pick up pnpm-lock.yaml shipped inside dependency
+	// packages as fixtures or dev lockfiles, producing findings
+	// unrelated to the user's project. The defaultSkipDirs gate
+	// only fires when `path != root`, so the pnpm picker has its
+	// own ancestor check to short-circuit.
+	root := t.TempDir()
+	nm := filepath.Join(root, "node_modules")
+	depDir := filepath.Join(nm, "some-dep")
+	require.NoError(t, os.MkdirAll(depDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(depDir, "pnpm-lock.yaml"), []byte("lockfileVersion: '9.0'\npackages:\n  node-ipc@9.2.3: {}\n"), 0o644))
+
+	// Scan root IS node_modules. The pnpm picker must NOT report
+	// the dep's lockfile as a project signal.
+	targets, err := Discover(nm, []string{intel.EcosystemNPM})
+	require.NoError(t, err)
+	require.Empty(t, targets, "pnpm-lock.yaml inside node_modules must not be discovered when root is node_modules; got %+v", targets)
 }
 
 func TestDiscover_FindsPnpmLockAsNPM(t *testing.T) {

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -3,6 +3,7 @@ package packagecheck
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/garagon/aguara/internal/intel"
@@ -61,7 +62,21 @@ func ParsePNPMLock(target Target) ([]PackageRef, error) {
 	// peer-variant and inflate both packages_read and
 	// findings_count for compromised packages.
 	seen := make(map[string]bool, len(lock.Packages))
-	for key := range lock.Packages {
+	// Sort keys before iterating so the emitted refs land in
+	// deterministic order. Go's map iteration is randomized; the
+	// runner preserves the input order into Hits and the CLI
+	// preserves Hits order into CheckResult.Findings, so without
+	// this sort a pnpm lock with two or more matched packages
+	// would produce different JSON / terminal finding order across
+	// runs. Aguara advertises deterministic scans; the other
+	// packagecheck parsers read line-by-line and are deterministic
+	// for free.
+	keys := make([]string, 0, len(lock.Packages))
+	for k := range lock.Packages {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, key := range keys {
 		name, version, ok := parsePnpmPackageKey(key)
 		if !ok {
 			continue
@@ -122,6 +137,20 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 		if strings.HasPrefix(key, prefix) {
 			return "", "", false
 		}
+	}
+
+	// Strip the parens-style peer-dep suffix from the key BEFORE
+	// classifying scoped vs unscoped. v9+ encodes resolved peer
+	// deps as "name@version(peer@version)" and the peer can itself
+	// be scoped ("@commitlint/cli@19.6.1(@types/node@22.10.2)").
+	// A scoped peer adds an extra "/" to the key, which would fool
+	// the scoped slash-count heuristic into treating the key as v5
+	// slash-form and splitting on the wrong "/". The peer suffix
+	// is always after the version, so removing it pre-classification
+	// is safe; the underscore-style suffix is removed downstream
+	// from the version string itself.
+	if i := strings.IndexByte(key, '('); i >= 0 {
+		key = key[:i]
 	}
 
 	// Two pnpm key formats coexist in the wild:

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -1,0 +1,162 @@
+package packagecheck
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/garagon/aguara/internal/intel"
+	"gopkg.in/yaml.v3"
+)
+
+// ParsePNPMLock reads a pnpm-lock.yaml file and returns the declared
+// npm packages. pnpm installs from the npm registry, so refs land in
+// intel.EcosystemNPM with Source="pnpm-lock.yaml" and match against
+// OSV's npm advisories the same way package-lock.json or
+// node_modules entries would.
+//
+// The primary user flow this unlocks is the pre-install audit:
+//
+//	git clone <pnpm repo>
+//	aguara check .
+//
+// before any `pnpm install` has materialised node_modules. Without
+// pnpm-lock.yaml parsing, that invocation returns ecosystems: []
+// for the npm pipeline because the only npm signal Aguara reads
+// today (node_modules/.pnpm store) is absent on a fresh clone.
+//
+// Pure offline: no pnpm execution, no network. The parser uses
+// gopkg.in/yaml.v3 to read the structured packages map rather than
+// regex-scanning the file so peer-dep / build-hook suffixes embedded
+// in the package keys are handled deterministically.
+//
+// Non-registry sources (workspace:, file:, link:, github:, git:,
+// http://, https://) are skipped — they are not addressable in the
+// npm registry and matching them against npm advisories would
+// false-positive on name collisions.
+func ParsePNPMLock(target Target) ([]PackageRef, error) {
+	data, err := os.ReadFile(target.Path)
+	if err != nil {
+		return nil, fmt.Errorf("open pnpm-lock.yaml: %w", err)
+	}
+	var lock struct {
+		Packages map[string]any `yaml:"packages"`
+	}
+	if err := yaml.Unmarshal(data, &lock); err != nil {
+		return nil, fmt.Errorf("parse pnpm-lock.yaml: %w", err)
+	}
+
+	// Pre-allocate enough capacity for the common case; YAML maps
+	// in Go have non-deterministic iteration order so callers that
+	// depend on ordering should sort afterwards. The Runner doesn't.
+	refs := make([]PackageRef, 0, len(lock.Packages))
+	for key := range lock.Packages {
+		name, version, ok := parsePnpmPackageKey(key)
+		if !ok {
+			continue
+		}
+		refs = append(refs, PackageRef{
+			Ecosystem: intel.EcosystemNPM,
+			Name:      name,
+			Version:   version,
+			Path:      target.Path,
+			Source:    "pnpm-lock.yaml",
+		})
+	}
+	return refs, nil
+}
+
+// parsePnpmPackageKey extracts (name, version) from a pnpm-lock
+// packages-map key. The key format pnpm uses is one of:
+//
+//	node-ipc@9.2.3                        (unscoped, modern)
+//	/node-ipc@9.2.3                       (unscoped, older lockfile shape)
+//	@scope/pkg@1.2.3                      (scoped, modern)
+//	/@scope/pkg@1.2.3                     (scoped, older lockfile shape)
+//	lodash@4.17.21_react@18.0.0           (peer-dep suffix, pre-v9)
+//	react@18.2.0(some-peer@1.0.0)         (peer-dep suffix, v9+)
+//
+// The version portion after the LAST "@" is stripped of anything
+// after a "_" or "(" so the matcher sees the actual installed
+// version, not the peer-dep-decorated form.
+//
+// Returns ok=false for:
+//
+//   - bare names without a version ("node-ipc", "node-ipc@")
+//   - non-registry sources (file:, link:, workspace:, github:, git:,
+//     http:, https:): these are not addressable in the npm registry
+//     and matching them against npm OSV records would false-positive
+//     on name collisions (e.g. a local "lodash" link would inherit
+//     every lodash advisory).
+//   - keys we cannot parse into a clean (name, version) pair
+//
+// Conservative by design: better to under-emit than to surface false
+// positives on shapes pnpm uses for non-registry packages.
+func parsePnpmPackageKey(key string) (string, string, bool) {
+	// Older lockfiles prefix entries with "/". Strip before the
+	// source-prefix checks so "/file:..." and "file:..." are
+	// treated identically.
+	key = strings.TrimPrefix(key, "/")
+
+	// Hard reject non-registry sources. Each prefix is a literal
+	// pnpm spec; no wildcards.
+	for _, prefix := range []string{
+		"file:", "link:", "workspace:", "github:", "git:", "http:", "https:",
+	} {
+		if strings.HasPrefix(key, prefix) {
+			return "", "", false
+		}
+	}
+
+	// Pick the package@version separator. LastIndex is wrong: the
+	// peer-dep encoding "lodash@4.17.21_react@18.0.0" has the
+	// LAST "@" inside the peer-dep suffix, not at the package /
+	// version boundary. Correct rule:
+	//   - scoped key "@scope/pkg@1.2.3..."  -> find "@" AFTER the
+	//     first "/"; that is the boundary between name and version.
+	//   - unscoped key "node-ipc@1.2.3..."  -> find the FIRST "@";
+	//     anything later belongs to a peer-dep suffix.
+	var at int
+	if strings.HasPrefix(key, "@") {
+		// Scoped: "@scope/pkg@1.2.3"
+		slash := strings.IndexByte(key, '/')
+		if slash < 0 {
+			// "@scope" with no "/pkg" after — invalid.
+			return "", "", false
+		}
+		rel := strings.IndexByte(key[slash:], '@')
+		if rel < 0 {
+			// "@scope/pkg" without a version-separating "@".
+			return "", "", false
+		}
+		at = slash + rel
+	} else {
+		// Unscoped: first "@" is the version separator.
+		at = strings.IndexByte(key, '@')
+		if at <= 0 {
+			// at == -1: no "@" at all.
+			// at == 0: key starts with "@" but didn't match scoped
+			// shape above (cleared at "@"-trim above is impossible
+			// since we only TrimPrefix "/"). Belt + suspenders.
+			return "", "", false
+		}
+	}
+	name := key[:at]
+	version := key[at+1:]
+	if name == "" || version == "" {
+		return "", "", false
+	}
+
+	// Strip peer-dep / build-hook suffix. Two encodings exist in
+	// the wild:
+	//   pre-v9: "react@18.2.0_react-dom@18.2.0"   (underscore separator)
+	//   v9+:    "react@18.2.0(peer-dep@1.0.0)"    (paren wrapper)
+	// SemVer build metadata uses "+", which is preserved.
+	if i := strings.IndexAny(version, "_("); i >= 0 {
+		version = version[:i]
+	}
+	if version == "" {
+		return "", "", false
+	}
+	return name, version, true
+}

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -50,11 +50,27 @@ func ParsePNPMLock(target Target) ([]PackageRef, error) {
 	// in Go have non-deterministic iteration order so callers that
 	// depend on ordering should sort afterwards. The Runner doesn't.
 	refs := make([]PackageRef, 0, len(lock.Packages))
+
+	// Dedup on cleaned (name, version). pnpm encodes resolved
+	// peer-dep relationships into the package key, so the same
+	// underlying (name, version) can appear under multiple keys
+	// when a package is consumed with different peer-dep
+	// resolutions ("react@18.2.0(peer-a@1.0.0)" and
+	// "react@18.2.0(peer-b@2.0.0)" both strip to react@18.2.0).
+	// Without dedup here the runner would emit one Hit per
+	// peer-variant and inflate both packages_read and
+	// findings_count for compromised packages.
+	seen := make(map[string]bool, len(lock.Packages))
 	for key := range lock.Packages {
 		name, version, ok := parsePnpmPackageKey(key)
 		if !ok {
 			continue
 		}
+		composite := name + "@" + version
+		if seen[composite] {
+			continue
+		}
+		seen[composite] = true
 		refs = append(refs, PackageRef{
 			Ecosystem: intel.EcosystemNPM,
 			Name:      name,

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -124,41 +124,62 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 		}
 	}
 
-	// Pick the package@version separator. LastIndex is wrong: the
-	// peer-dep encoding "lodash@4.17.21_react@18.0.0" has the
-	// LAST "@" inside the peer-dep suffix, not at the package /
-	// version boundary. Correct rule:
-	//   - scoped key "@scope/pkg@1.2.3..."  -> find "@" AFTER the
-	//     first "/"; that is the boundary between name and version.
-	//   - unscoped key "node-ipc@1.2.3..."  -> find the FIRST "@";
-	//     anything later belongs to a peer-dep suffix.
-	var at int
+	// Two pnpm key formats are valid in the wild:
+	//
+	//   modern (v6+):    name@version           "@scope/pkg@1.2.3"
+	//   legacy (v5):     name/version           "@scope/pkg/1.2.3"
+	//
+	// Try the modern shape first by locating the version-separating
+	// "@". Correct rule:
+	//   - scoped key  ("@scope/pkg@1.2.3"):  find the "@" AFTER the
+	//     first "/"; that is the package/version boundary.
+	//     LastIndex would land in a peer-dep suffix instead.
+	//   - unscoped key ("node-ipc@1.2.3"):   first "@" is the
+	//     separator; anything later is a peer-dep suffix.
+	//
+	// If no "@" sits in a valid position, fall back to the legacy
+	// slash-separator shape (last "/" is the version boundary).
+	// Without this fallback, lockfileVersion 5.x projects with
+	// keys like "/lodash/4.17.21" or "/@types/node/20.5.0" would
+	// silently produce zero packages_read even when the lockfile
+	// declares compromised versions.
+	var (
+		name    string
+		version string
+	)
 	if strings.HasPrefix(key, "@") {
-		// Scoped: "@scope/pkg@1.2.3"
 		slash := strings.IndexByte(key, '/')
-		if slash < 0 {
-			// "@scope" with no "/pkg" after — invalid.
-			return "", "", false
+		if slash > 0 {
+			if rel := strings.IndexByte(key[slash:], '@'); rel >= 0 {
+				at := slash + rel
+				name = key[:at]
+				version = key[at+1:]
+			}
 		}
-		rel := strings.IndexByte(key[slash:], '@')
-		if rel < 0 {
-			// "@scope/pkg" without a version-separating "@".
-			return "", "", false
-		}
-		at = slash + rel
 	} else {
-		// Unscoped: first "@" is the version separator.
-		at = strings.IndexByte(key, '@')
-		if at <= 0 {
-			// at == -1: no "@" at all.
-			// at == 0: key starts with "@" but didn't match scoped
-			// shape above (cleared at "@"-trim above is impossible
-			// since we only TrimPrefix "/"). Belt + suspenders.
-			return "", "", false
+		if at := strings.IndexByte(key, '@'); at > 0 {
+			name = key[:at]
+			version = key[at+1:]
 		}
 	}
-	name := key[:at]
-	version := key[at+1:]
+	if name == "" {
+		// Legacy v5 fallback: last "/" splits name from version.
+		// Validate slash structure to avoid mis-classifying malformed
+		// modern keys (like "@scope/pkg" with no version) as v5:
+		//   - scoped v5 keys are "@scope/pkg/version" (2 slashes)
+		//   - unscoped v5 keys are "name/version"     (1 slash)
+		// "@scope/pkg" has 1 slash and would otherwise resolve to
+		// (name="@scope", version="pkg"), which is wrong.
+		lastSlash := strings.LastIndexByte(key, '/')
+		if lastSlash <= 0 || lastSlash == len(key)-1 {
+			return "", "", false
+		}
+		if strings.HasPrefix(key, "@") && strings.Count(key, "/") < 2 {
+			return "", "", false
+		}
+		name = key[:lastSlash]
+		version = key[lastSlash+1:]
+	}
 	if name == "" || version == "" {
 		return "", "", false
 	}

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -124,50 +124,82 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 		}
 	}
 
-	// Two pnpm key formats are valid in the wild:
+	// Two pnpm key formats coexist in the wild:
 	//
-	//   modern (v6+):    name@version           "@scope/pkg@1.2.3"
-	//   legacy (v5):     name/version           "@scope/pkg/1.2.3"
+	//   modern (v6+):  name@version            "lodash@4.17.21"
+	//                  @scope/pkg@version      "@scope/pkg@1.2.3"
+	//   legacy (v5):   name/version            "lodash/4.17.21"
+	//                  @scope/pkg/version      "@scope/pkg/1.2.3"
 	//
-	// Try the modern shape first by locating the version-separating
-	// "@". Correct rule:
-	//   - scoped key  ("@scope/pkg@1.2.3"):  find the "@" AFTER the
-	//     first "/"; that is the package/version boundary.
-	//     LastIndex would land in a peer-dep suffix instead.
-	//   - unscoped key ("node-ipc@1.2.3"):   first "@" is the
-	//     separator; anything later is a peer-dep suffix.
+	// Both shapes can be decorated with a peer-dep suffix (pre-v9
+	// "..._peer@version" underscore, v9+ "...(peer@version)" parens).
+	// The peer suffix is always AFTER the version, so peer-aware
+	// stripping happens once after the (name, version) pair is picked.
 	//
-	// If no "@" sits in a valid position, fall back to the legacy
-	// slash-separator shape (last "/" is the version boundary).
-	// Without this fallback, lockfileVersion 5.x projects with
-	// keys like "/lodash/4.17.21" or "/@types/node/20.5.0" would
-	// silently produce zero packages_read even when the lockfile
-	// declares compromised versions.
+	// The tricky combination is legacy v5 slash-form with a peer
+	// underscore: "lodash/4.17.21_react@18.0.0". The "@" in that
+	// key belongs to the peer suffix, NOT the package/version
+	// boundary. Picking the first "@" as the separator would
+	// produce ("lodash/4.17.21_react", "18.0.0") and silently
+	// drop the real package match. Decide modern vs v5 BEFORE
+	// looking for the "@" separator.
+	//
+	// Decision rule:
+	//   - scoped key (starts with "@"):
+	//       modern if there is an "@" AFTER the first "/"
+	//       v5     otherwise (slash-fallback)
+	//   - unscoped key:
+	//       v5     if there is a "/" AND ("/" appears before the
+	//              first "@" OR there is no "@" at all)
+	//       modern otherwise
 	var (
 		name    string
 		version string
 	)
 	if strings.HasPrefix(key, "@") {
-		slash := strings.IndexByte(key, '/')
-		if slash > 0 {
+		// Slash count discriminates modern vs v5 for scoped keys:
+		//   1 slash  -> "@scope/pkg@version" or "@scope/pkg" (modern)
+		//   2+ slashes -> "@scope/pkg/version[_peer@...]" (v5)
+		// Without this check, a v5 key with a peer-dep suffix
+		// containing "@" (e.g. "@types/node/20.5.0_typescript@5.0.0")
+		// would route through the modern branch and pick the peer
+		// "@" as the version separator, producing
+		// (name="@types/node/20.5.0_typescript", version="5.0.0").
+		switch strings.Count(key, "/") {
+		case 1:
+			// Modern scoped form. The "@" AFTER the first slash
+			// is the package/version boundary; any later "@"
+			// belongs to a peer-dep suffix.
+			slash := strings.IndexByte(key, '/')
 			if rel := strings.IndexByte(key[slash:], '@'); rel >= 0 {
 				at := slash + rel
 				name = key[:at]
 				version = key[at+1:]
 			}
+			// No "@" after the slash -> "@scope/pkg" without
+			// a version. Leave name="" so the v5 fallback below
+			// rejects via the >= 2 slashes guard.
+		default:
+			// 0 slashes -> malformed scoped (just "@something").
+			// >= 2 slashes -> v5 form; leave name="" for v5
+			//                slash-fallback below.
 		}
 	} else {
-		if at := strings.IndexByte(key, '@'); at > 0 {
-			name = key[:at]
-			version = key[at+1:]
+		firstAt := strings.IndexByte(key, '@')
+		firstSlash := strings.IndexByte(key, '/')
+		isV5SlashForm := firstSlash >= 0 && (firstAt < 0 || firstSlash < firstAt)
+		if !isV5SlashForm && firstAt > 0 {
+			name = key[:firstAt]
+			version = key[firstAt+1:]
 		}
+		// v5 slash-form OR no "@" anywhere -> leave name="" for
+		// v5 slash-fallback below.
 	}
 	if name == "" {
-		// Legacy v5 fallback: last "/" splits name from version.
-		// Validate slash structure to avoid mis-classifying malformed
-		// modern keys (like "@scope/pkg" with no version) as v5:
-		//   - scoped v5 keys are "@scope/pkg/version" (2 slashes)
-		//   - unscoped v5 keys are "name/version"     (1 slash)
+		// Legacy v5 fallback. Validate slash structure to avoid
+		// mis-classifying malformed modern keys as v5:
+		//   - scoped v5 keys are "@scope/pkg/version" (>= 2 slashes)
+		//   - unscoped v5 keys are "name/version"     (>= 1 slash)
 		// "@scope/pkg" has 1 slash and would otherwise resolve to
 		// (name="@scope", version="pkg"), which is wrong.
 		lastSlash := strings.LastIndexByte(key, '/')

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -36,12 +36,18 @@ func TestParsePnpmPackageKey(t *testing.T) {
 		{"git: ref", "git:user/repo", "", "", false},
 		{"https: ref", "https://example.com/pkg", "", "", false},
 
+		// Legacy v5 slash-separator format
+		{"v5 unscoped", "/lodash/4.17.21", "lodash", "4.17.21", true},
+		{"v5 scoped", "/@types/node/20.5.0", "@types/node", "20.5.0", true},
+		{"v5 unscoped slash-only no leading", "lodash/4.17.21", "lodash", "4.17.21", true},
+
 		// Rejected: malformed
 		{"bare name no version", "node-ipc", "", "", false},
 		{"empty version after @", "node-ipc@", "", "", false},
 		{"only @", "@", "", "", false},
 		{"empty string", "", "", "", false},
 		{"bare scope without version", "@scope/pkg", "", "", false},
+		{"slash with empty version", "/lodash/", "", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -40,6 +40,10 @@ func TestParsePnpmPackageKey(t *testing.T) {
 		{"v5 unscoped", "/lodash/4.17.21", "lodash", "4.17.21", true},
 		{"v5 scoped", "/@types/node/20.5.0", "@types/node", "20.5.0", true},
 		{"v5 unscoped slash-only no leading", "lodash/4.17.21", "lodash", "4.17.21", true},
+		// Legacy v5 + peer-dep suffix: the "@" in the peer suffix
+		// must NOT be picked as the version separator.
+		{"v5 unscoped + peer underscore", "lodash/4.17.21_react@18.0.0", "lodash", "4.17.21", true},
+		{"v5 scoped + peer underscore", "/@types/node/20.5.0_typescript@5.0.0", "@types/node", "20.5.0", true},
 
 		// Rejected: malformed
 		{"bare name no version", "node-ipc", "", "", false},

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -45,6 +45,15 @@ func TestParsePnpmPackageKey(t *testing.T) {
 		{"v5 unscoped + peer underscore", "lodash/4.17.21_react@18.0.0", "lodash", "4.17.21", true},
 		{"v5 scoped + peer underscore", "/@types/node/20.5.0_typescript@5.0.0", "@types/node", "20.5.0", true},
 
+		// v9+ scoped key with a SCOPED peer suffix. The "/" inside
+		// "@types/node" inflates the key's slash count to 2 and
+		// would otherwise route through the v5 fallback (splitting
+		// on the wrong slash). Pre-stripping the paren suffix
+		// keeps the modern branch active.
+		{"v9 scoped + scoped peer paren", "@commitlint/cli@19.6.1(@types/node@22.10.2)", "@commitlint/cli", "19.6.1", true},
+		{"v9 scoped + unscoped peer paren", "@vitejs/plugin-react@4.0.0(vite@4.4.4)", "@vitejs/plugin-react", "4.0.0", true},
+		{"v9 unscoped + scoped peer paren", "react@18.2.0(@types/react@18.0.0)", "react", "18.2.0", true},
+
 		// Rejected: malformed
 		{"bare name no version", "node-ipc", "", "", false},
 		{"empty version after @", "node-ipc@", "", "", false},
@@ -251,6 +260,43 @@ packages:
 	require.Equal(t, "lodash", refs[0].Name)
 	require.Equal(t, "react", refs[1].Name)
 	require.Equal(t, "18.2.0", refs[1].Version)
+}
+
+func TestParsePNPMLock_DeterministicOrder(t *testing.T) {
+	// Aguara advertises deterministic scans. ParsePNPMLock sorts
+	// the package keys before emitting refs so the runner's Hits
+	// and downstream Findings land in stable order across runs.
+	// Without the sort, Go's randomized map iteration would
+	// produce different JSON / terminal output between invocations
+	// on the same lockfile.
+	dir := t.TempDir()
+	lock := filepath.Join(dir, "pnpm-lock.yaml")
+	require.NoError(t, os.WriteFile(lock, []byte(`lockfileVersion: '9.0'
+
+packages:
+  zeta@1.0.0:
+    resolution:
+      integrity: sha512-stub==
+  alpha@2.0.0:
+    resolution:
+      integrity: sha512-stub==
+  mike@3.0.0:
+    resolution:
+      integrity: sha512-stub==
+`), 0o644))
+
+	want := []string{"alpha", "mike", "zeta"}
+	for i := 0; i < 5; i++ {
+		refs, err := ParsePNPMLock(Target{
+			Ecosystem: intel.EcosystemNPM,
+			Path:      lock,
+			Source:    "pnpm-lock.yaml",
+		})
+		require.NoError(t, err)
+		require.Len(t, refs, 3)
+		got := []string{refs[0].Name, refs[1].Name, refs[2].Name}
+		require.Equal(t, want, got, "run %d produced different order; ParsePNPMLock must be deterministic", i+1)
+	}
 }
 
 func TestParsePNPMLock_MissingFile(t *testing.T) {

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -1,0 +1,211 @@
+package packagecheck
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParsePnpmPackageKey(t *testing.T) {
+	cases := []struct {
+		name     string
+		key      string
+		wantName string
+		wantVer  string
+		wantOK   bool
+	}{
+		// Accepted shapes
+		{"unscoped modern", "node-ipc@9.2.3", "node-ipc", "9.2.3", true},
+		{"unscoped slash-prefixed", "/node-ipc@9.2.3", "node-ipc", "9.2.3", true},
+		{"scoped modern", "@scope/pkg@1.2.3", "@scope/pkg", "1.2.3", true},
+		{"scoped slash-prefixed", "/@scope/pkg@1.2.3", "@scope/pkg", "1.2.3", true},
+		{"peer-dep underscore suffix", "lodash@4.17.21_react@18.0.0", "lodash", "4.17.21", true},
+		{"peer-dep paren suffix v9", "react@18.2.0(some-peer@1.0.0)", "react", "18.2.0", true},
+		{"prerelease version", "preact@10.0.0-alpha.1", "preact", "10.0.0-alpha.1", true},
+
+		// Rejected: non-registry sources
+		{"file: ref", "file:../local-pkg", "", "", false},
+		{"file: slash-prefixed", "/file:../local-pkg", "", "", false},
+		{"link: ref", "link:../local-pkg", "", "", false},
+		{"workspace: ref", "workspace:*", "", "", false},
+		{"github: ref", "github:user/repo", "", "", false},
+		{"git: ref", "git:user/repo", "", "", false},
+		{"https: ref", "https://example.com/pkg", "", "", false},
+
+		// Rejected: malformed
+		{"bare name no version", "node-ipc", "", "", false},
+		{"empty version after @", "node-ipc@", "", "", false},
+		{"only @", "@", "", "", false},
+		{"empty string", "", "", "", false},
+		{"bare scope without version", "@scope/pkg", "", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotName, gotVer, gotOK := parsePnpmPackageKey(tc.key)
+			require.Equal(t, tc.wantOK, gotOK, "ok mismatch")
+			if tc.wantOK {
+				require.Equal(t, tc.wantName, gotName, "name mismatch")
+				require.Equal(t, tc.wantVer, gotVer, "version mismatch")
+			}
+		})
+	}
+}
+
+func TestParsePNPMLock_ReadsUnscopedPackage(t *testing.T) {
+	dir := t.TempDir()
+	lock := filepath.Join(dir, "pnpm-lock.yaml")
+	require.NoError(t, os.WriteFile(lock, []byte(`lockfileVersion: '9.0'
+
+packages:
+  node-ipc@9.2.3:
+    resolution:
+      integrity: sha512-stub==
+`), 0o644))
+
+	refs, err := ParsePNPMLock(Target{
+		Ecosystem: intel.EcosystemNPM,
+		Path:      lock,
+		Source:    "pnpm-lock.yaml",
+	})
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	require.Equal(t, intel.EcosystemNPM, refs[0].Ecosystem)
+	require.Equal(t, "node-ipc", refs[0].Name)
+	require.Equal(t, "9.2.3", refs[0].Version)
+	require.Equal(t, "pnpm-lock.yaml", refs[0].Source)
+	require.Equal(t, lock, refs[0].Path)
+}
+
+func TestParsePNPMLock_ReadsScopedPackage(t *testing.T) {
+	dir := t.TempDir()
+	lock := filepath.Join(dir, "pnpm-lock.yaml")
+	require.NoError(t, os.WriteFile(lock, []byte(`lockfileVersion: '9.0'
+
+packages:
+  '@vitejs/plugin-react@4.0.0':
+    resolution:
+      integrity: sha512-stub==
+  '@types/node@20.5.0':
+    resolution:
+      integrity: sha512-stub==
+`), 0o644))
+
+	refs, err := ParsePNPMLock(Target{
+		Ecosystem: intel.EcosystemNPM,
+		Path:      lock,
+		Source:    "pnpm-lock.yaml",
+	})
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+	// Map iteration is non-deterministic; sort by name for stable assertions.
+	sort.Slice(refs, func(i, j int) bool { return refs[i].Name < refs[j].Name })
+	require.Equal(t, "@types/node", refs[0].Name)
+	require.Equal(t, "20.5.0", refs[0].Version)
+	require.Equal(t, "@vitejs/plugin-react", refs[1].Name)
+	require.Equal(t, "4.0.0", refs[1].Version)
+}
+
+func TestParsePNPMLock_IgnoresWorkspaceAndFileRefs(t *testing.T) {
+	// pnpm-lock.yaml routinely contains entries that are NOT npm
+	// registry packages: workspace siblings, file: relative paths,
+	// link: symlinks, github: URLs. Matching those against npm
+	// advisories would false-positive on name collisions (a local
+	// "lodash" symlink picking up every lodash CVE). The parser
+	// must skip them silently.
+	dir := t.TempDir()
+	lock := filepath.Join(dir, "pnpm-lock.yaml")
+	require.NoError(t, os.WriteFile(lock, []byte(`lockfileVersion: '9.0'
+
+packages:
+  node-ipc@9.2.3:
+    resolution:
+      integrity: sha512-stub==
+  'workspace:*':
+    resolution:
+      integrity: sha512-stub==
+  'file:../local-lodash':
+    resolution:
+      integrity: sha512-stub==
+  'link:../sibling':
+    resolution:
+      integrity: sha512-stub==
+  'github:user/repo':
+    resolution:
+      integrity: sha512-stub==
+`), 0o644))
+
+	refs, err := ParsePNPMLock(Target{
+		Ecosystem: intel.EcosystemNPM,
+		Path:      lock,
+		Source:    "pnpm-lock.yaml",
+	})
+	require.NoError(t, err)
+	require.Len(t, refs, 1, "only node-ipc@9.2.3 should be emitted; non-registry entries filtered")
+	require.Equal(t, "node-ipc", refs[0].Name)
+	require.Equal(t, "9.2.3", refs[0].Version)
+}
+
+func TestParsePNPMLock_PeerDepSuffix(t *testing.T) {
+	// pnpm encodes resolved peer-dep relationships into the package
+	// key. The actual installed version is the part before the
+	// underscore (pre-v9) or the opening paren (v9+). The parser
+	// strips both so matcher comparison uses the clean version.
+	dir := t.TempDir()
+	lock := filepath.Join(dir, "pnpm-lock.yaml")
+	require.NoError(t, os.WriteFile(lock, []byte(`lockfileVersion: '9.0'
+
+packages:
+  lodash@4.17.21_react@18.0.0:
+    resolution:
+      integrity: sha512-stub==
+  react@18.2.0(some-peer@1.0.0):
+    resolution:
+      integrity: sha512-stub==
+`), 0o644))
+
+	refs, err := ParsePNPMLock(Target{
+		Ecosystem: intel.EcosystemNPM,
+		Path:      lock,
+		Source:    "pnpm-lock.yaml",
+	})
+	require.NoError(t, err)
+	require.Len(t, refs, 2)
+	sort.Slice(refs, func(i, j int) bool { return refs[i].Name < refs[j].Name })
+	require.Equal(t, "lodash", refs[0].Name)
+	require.Equal(t, "4.17.21", refs[0].Version, "peer-dep underscore suffix must be stripped")
+	require.Equal(t, "react", refs[1].Name)
+	require.Equal(t, "18.2.0", refs[1].Version, "peer-dep paren suffix must be stripped")
+}
+
+func TestParsePNPMLock_EmptyPackages(t *testing.T) {
+	// A lockfile with a packages: key but no entries should produce
+	// zero refs without erroring. Same shape pnpm emits for a
+	// workspace root with all deps under sub-packages.
+	dir := t.TempDir()
+	lock := filepath.Join(dir, "pnpm-lock.yaml")
+	require.NoError(t, os.WriteFile(lock, []byte(`lockfileVersion: '9.0'
+
+packages: {}
+`), 0o644))
+
+	refs, err := ParsePNPMLock(Target{
+		Ecosystem: intel.EcosystemNPM,
+		Path:      lock,
+		Source:    "pnpm-lock.yaml",
+	})
+	require.NoError(t, err)
+	require.Empty(t, refs)
+}
+
+func TestParsePNPMLock_MissingFile(t *testing.T) {
+	_, err := ParsePNPMLock(Target{
+		Ecosystem: intel.EcosystemNPM,
+		Path:      "/nonexistent/pnpm-lock.yaml",
+		Source:    "pnpm-lock.yaml",
+	})
+	require.Error(t, err)
+}

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -201,6 +201,48 @@ packages: {}
 	require.Empty(t, refs)
 }
 
+func TestParsePNPMLock_DedupsPeerResolvedDuplicates(t *testing.T) {
+	// pnpm encodes resolved peer-dep relationships into the
+	// package key, so the same (name, version) can appear under
+	// several keys when a package is consumed with different peer
+	// resolutions. Without dedup the runner would emit one Hit
+	// per peer-variant and inflate both packages_read and
+	// findings_count for compromised packages. Lock the dedup at
+	// the parser boundary so the contract is consistent regardless
+	// of which dispatcher consumes the refs.
+	dir := t.TempDir()
+	lock := filepath.Join(dir, "pnpm-lock.yaml")
+	require.NoError(t, os.WriteFile(lock, []byte(`lockfileVersion: '9.0'
+
+packages:
+  react@18.2.0(peer-a@1.0.0):
+    resolution:
+      integrity: sha512-stub==
+  react@18.2.0(peer-b@2.0.0):
+    resolution:
+      integrity: sha512-stub==
+  react@18.2.0_react-dom@18.0.0:
+    resolution:
+      integrity: sha512-stub==
+  lodash@4.17.21:
+    resolution:
+      integrity: sha512-stub==
+`), 0o644))
+
+	refs, err := ParsePNPMLock(Target{
+		Ecosystem: intel.EcosystemNPM,
+		Path:      lock,
+		Source:    "pnpm-lock.yaml",
+	})
+	require.NoError(t, err)
+	require.Len(t, refs, 2, "three react@18.2.0 peer-variants must collapse to one ref + lodash")
+
+	sort.Slice(refs, func(i, j int) bool { return refs[i].Name < refs[j].Name })
+	require.Equal(t, "lodash", refs[0].Name)
+	require.Equal(t, "react", refs[1].Name)
+	require.Equal(t, "18.2.0", refs[1].Version)
+}
+
 func TestParsePNPMLock_MissingFile(t *testing.T) {
 	_, err := ParsePNPMLock(Target{
 		Ecosystem: intel.EcosystemNPM,

--- a/internal/packagecheck/runner.go
+++ b/internal/packagecheck/runner.go
@@ -110,6 +110,22 @@ func parseTarget(t Target) ([]PackageRef, error) {
 		return ParseMaven(t)
 	case intel.EcosystemNuGet:
 		return ParseNuGet(t)
+	case intel.EcosystemNPM:
+		// npm is unique in that the packagecheck path handles
+		// lockfile-style sources only (pnpm-lock.yaml today;
+		// package-lock.json / yarn.lock in follow-ups). The
+		// installed-tree npm signal (node_modules + .pnpm store)
+		// continues to flow through incident.CheckNPM, which
+		// produces its own ecosystems[] entry with
+		// Source="node_modules". Switching on Source here lets
+		// us add new npm lockfile formats without expanding the
+		// outer ecosystem switch.
+		switch t.Source {
+		case "pnpm-lock.yaml":
+			return ParsePNPMLock(t)
+		default:
+			return nil, fmt.Errorf("packagecheck: no npm parser for source %q", t.Source)
+		}
 	default:
 		return nil, fmt.Errorf("no parser for ecosystem %q", t.Ecosystem)
 	}

--- a/internal/packagecheck/runner_test.go
+++ b/internal/packagecheck/runner_test.go
@@ -276,6 +276,103 @@ func TestRunner_MavenSyntheticHit(t *testing.T) {
 	}
 }
 
+func TestRunner_PNPMLockHitsCompromisedNPMRecord(t *testing.T) {
+	// pnpm-lock.yaml support routes through the npm ecosystem path
+	// (pnpm installs from npm registry). The fixture declares
+	// node-ipc@9.2.3, which is in the May 2026 compromised list.
+	// Build a synthetic snapshot containing that exact record so
+	// the test does not depend on the embedded snapshot's contents.
+	snap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		GeneratedAt:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		Records: []intel.Record{{
+			ID:        "MAL-TEST-NPM-NODE-IPC-9.2.3",
+			Ecosystem: intel.EcosystemNPM,
+			Name:      "node-ipc",
+			Kind:      intel.KindMalicious,
+			Versions:  []string{"9.2.3"},
+		}},
+	}
+	runner := &Runner{Matcher: intel.NewMatcher(snap)}
+
+	targets, err := Discover(filepath.Join("testdata", "pnpm-compromised"), []string{intel.EcosystemNPM})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(targets) != 1 {
+		t.Fatalf("expected one pnpm-lock.yaml target, got %d: %+v", len(targets), targets)
+	}
+	if targets[0].Source != "pnpm-lock.yaml" {
+		t.Errorf("source = %q, want pnpm-lock.yaml", targets[0].Source)
+	}
+	if targets[0].Ecosystem != intel.EcosystemNPM {
+		t.Errorf("ecosystem = %q, want npm", targets[0].Ecosystem)
+	}
+
+	res, err := runner.Run(targets)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := len(res.Ecosystems), 1; got != want {
+		t.Fatalf("ecosystems = %d, want %d", got, want)
+	}
+	er := res.Ecosystems[0]
+	if er.Ecosystem != intel.EcosystemNPM {
+		t.Errorf("ecosystem = %q, want npm", er.Ecosystem)
+	}
+	if er.Source != "pnpm-lock.yaml" {
+		t.Errorf("source = %q, want pnpm-lock.yaml", er.Source)
+	}
+	if er.PackagesRead != 2 {
+		t.Errorf("packages_read = %d, want 2 (node-ipc + lodash)", er.PackagesRead)
+	}
+	if er.FindingsCount != 1 {
+		t.Errorf("findings_count = %d, want 1 (node-ipc 9.2.3)", er.FindingsCount)
+	}
+	if len(res.Hits) != 1 {
+		t.Fatalf("hits = %d, want 1", len(res.Hits))
+	}
+	if res.Hits[0].Ref.Name != "node-ipc" {
+		t.Errorf("hit ref name = %q, want node-ipc", res.Hits[0].Ref.Name)
+	}
+	if res.Hits[0].Ref.Version != "9.2.3" {
+		t.Errorf("hit ref version = %q, want 9.2.3", res.Hits[0].Ref.Version)
+	}
+}
+
+func TestRunner_PNPMCleanFixtureProducesZeroFindings(t *testing.T) {
+	// pnpm-clean fixture has lodash + @types/node, neither in any
+	// compromised list. The runner must still emit one
+	// EcosystemResult so consumers see "pipeline ran, scanned N
+	// packages, zero findings" rather than silence.
+	snap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		GeneratedAt:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+	}
+	runner := &Runner{Matcher: intel.NewMatcher(snap)}
+
+	targets, err := Discover(filepath.Join("testdata", "pnpm-clean"), []string{intel.EcosystemNPM})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	res, err := runner.Run(targets)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if got, want := len(res.Ecosystems), 1; got != want {
+		t.Fatalf("ecosystems = %d, want %d", got, want)
+	}
+	if res.Ecosystems[0].PackagesRead != 2 {
+		t.Errorf("packages_read = %d, want 2 (lodash + @types/node)", res.Ecosystems[0].PackagesRead)
+	}
+	if res.Ecosystems[0].FindingsCount != 0 {
+		t.Errorf("findings_count = %d, want 0 (clean fixture)", res.Ecosystems[0].FindingsCount)
+	}
+	if len(res.Hits) != 0 {
+		t.Errorf("hits = %d, want 0 (clean fixture)", len(res.Hits))
+	}
+}
+
 func TestRunner_NuGetSyntheticHit(t *testing.T) {
 	snap := intel.Snapshot{
 		SchemaVersion: intel.CurrentSchemaVersion,

--- a/internal/packagecheck/testdata/pnpm-clean/pnpm-lock.yaml
+++ b/internal/packagecheck/testdata/pnpm-clean/pnpm-lock.yaml
@@ -1,0 +1,25 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+
+importers:
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+      '@types/node':
+        specifier: ^20.5.0
+        version: 20.5.0
+
+packages:
+  lodash@4.17.21:
+    resolution: {integrity: sha512-FAKE_FIXTURE_DO_NOT_VERIFY==}
+
+  '@types/node@20.5.0':
+    resolution: {integrity: sha512-FAKE_FIXTURE_DO_NOT_VERIFY==}
+
+snapshots:
+  lodash@4.17.21: {}
+  '@types/node@20.5.0': {}

--- a/internal/packagecheck/testdata/pnpm-compromised/pnpm-lock.yaml
+++ b/internal/packagecheck/testdata/pnpm-compromised/pnpm-lock.yaml
@@ -1,0 +1,27 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      node-ipc:
+        specifier: 9.2.3
+        version: 9.2.3
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
+packages:
+  node-ipc@9.2.3:
+    resolution: {integrity: sha512-FAKE_FIXTURE_DO_NOT_VERIFY==}
+    engines: {node: '>=8.0.0'}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-FAKE_FIXTURE_DO_NOT_VERIFY==}
+
+snapshots:
+  node-ipc@9.2.3: {}
+  lodash@4.17.21: {}


### PR DESCRIPTION
## Summary

Adds native parsing of \`pnpm-lock.yaml\` so \`aguara check .\` on a freshly cloned pnpm repository surfaces npm coverage **before** any \`pnpm install\` has run. v0.17.0/v0.17.1 only read npm signal from the installed tree (node_modules + the pnpm .pnpm store), so the clone → audit flow silently returned \`ecosystems: []\` for the npm pipeline even when the lockfile already declared compromised packages.

## Architecture

pnpm is a package manager / lockfile format, not a separate registry: the packages it installs come from the npm registry. The new path routes refs through \`intel.EcosystemNPM\` with \`Source="pnpm-lock.yaml"\`, matching against the same OSV npm advisories the installed-tree pipeline uses. No \`EcosystemPNPM\`, no new OSV bucket.

Existing \`incident.CheckNPM\` behaviour on \`node_modules\` / \`.pnpm\` is unchanged. A pnpm repo with both lockfile and installed tree now produces **two** \`ecosystems[]\` entries (\`Source="pnpm-lock.yaml"\` and \`Source="node_modules"\`), so consumers see both surfaces independently.

## Patch surface

- **\`internal/packagecheck/discovery.go\`** — \`pickPnpmTarget\` added to \`lockfilePickers\` under \`intel.EcosystemNPM\`. Guards against scanning lockfiles inside dep packages when the scan root itself is \`node_modules\` (the \`defaultSkipDirs\` gate only fires on \`path != root\`).
- **\`internal/packagecheck/pnpm.go\`** — \`ParsePNPMLock\` reads YAML via \`gopkg.in/yaml.v3\`, iterates \`packages:\` map, normalises every key shape pnpm emits in the wild.
- **\`internal/packagecheck/runner.go\`** — \`parseTarget\` gains an \`EcosystemNPM\` case switching on \`target.Source\` so future npm lockfile parsers (\`package-lock.json\`, \`yarn.lock\`) drop in without expanding the outer ecosystem switch.
- **\`cmd/aguara/commands/check.go\`** — explicit \`--ecosystem npm\` wires the packagecheck npm discovery alongside \`incident.CheckNPM\`, gates the incident path on \`node_modules\` actually existing, resolves the probe to an absolute path so \`--path .\` from inside a \`node_modules\` tree works, skips the redundant packagecheck walk when the scan root IS \`node_modules\`, and routes npm hits back to \`ecoNPM\` for the npm-specific finding wording.

## Key parser shapes (from \`TestParsePnpmPackageKey\` table)

| Shape | Example | Result |
|---|---|---|
| modern unscoped | \`node-ipc@9.2.3\` | \`(node-ipc, 9.2.3)\` |
| modern scoped | \`@scope/pkg@1.2.3\` | \`(@scope/pkg, 1.2.3)\` |
| pre-v6 slash-prefixed | \`/node-ipc@9.2.3\` | \`(node-ipc, 9.2.3)\` |
| v5 unscoped | \`/lodash/4.17.21\` | \`(lodash, 4.17.21)\` |
| v5 scoped | \`/@types/node/20.5.0\` | \`(@types/node, 20.5.0)\` |
| v5 unscoped + peer underscore | \`lodash/4.17.21_react@18.0.0\` | \`(lodash, 4.17.21)\` |
| v5 scoped + peer underscore | \`/@types/node/20.5.0_typescript@5.0.0\` | \`(@types/node, 20.5.0)\` |
| v9 unscoped + scoped peer paren | \`react@18.2.0(@types/react@18.0.0)\` | \`(react, 18.2.0)\` |
| v9 scoped + scoped peer paren | \`@commitlint/cli@19.6.1(@types/node@22.10.2)\` | \`(@commitlint/cli, 19.6.1)\` |

Non-registry sources (\`workspace:\`, \`file:\`, \`link:\`, \`github:\`, \`git:\`, \`http:\`, \`https:\`) are rejected by prefix. Matching those against npm OSV advisories would false-positive on name collisions.

## Determinism + dedup

- pnpm encodes resolved peer-dep relationships into the package key, so the same \`(name, version)\` can appear under multiple keys when consumed with different peer resolutions. Pre-runner dedup on the cleaned composite ensures the runner emits one Hit per real package, not one per peer-variant.
- YAML map iteration is randomized; \`ParsePNPMLock\` sorts the keys before emitting refs so output is deterministic across runs (other packagecheck parsers are deterministic by virtue of line-by-line reads; this matches the contract).

## Tests

- \`internal/packagecheck/pnpm_test.go\` — \`TestParsePnpmPackageKey\` 28-case truth table (modern, v5, slash-prefixed, peer suffixes, scoped peer paren, malformed inputs). Plus parser-level tests for the YAML wrapper: unscoped/scoped read, workspace/file/github filtering, peer-dep suffix stripping, dedup of peer-resolved duplicates, deterministic order across 5 runs, empty packages map, missing file error.
- \`internal/packagecheck/discovery_test.go\` — \`TestDiscover_FindsPnpmLockAsNPM\` for the basic case; \`TestDiscover_SkipsPnpmLockUnderNodeModulesRoot\` for the scan-root = node_modules false-positive guard.
- \`internal/packagecheck/runner_test.go\` — \`TestRunner_PNPMLockHitsCompromisedNPMRecord\` end-to-end against a synthetic node-ipc 9.2.3 record + \`TestRunner_PNPMCleanFixtureProducesZeroFindings\`.
- \`cmd/aguara/commands/check_test.go\` — \`TestCheck_PnpmLockCompromisedFixtureFiresFinding\`, \`TestCheck_PnpmLockCleanFixtureProducesZeroFindings\`, \`TestCheck_ExplicitNPMEcosystemOnPnpmRepoFires\`, \`TestCheckPlan_PnpmOnlyMapsToNPMToken\`.

## Fixtures

- \`internal/packagecheck/testdata/pnpm-compromised/pnpm-lock.yaml\` — node-ipc@9.2.3 + lodash@4.17.21.
- \`internal/packagecheck/testdata/pnpm-clean/pnpm-lock.yaml\` — lodash@4.17.21 + @types/node@20.5.0. Both fixtures use synthetic placeholder integrity hashes.

## README

Coverage table row for npm extended with \`pnpm-lock.yaml\`. New paragraph + example block under "Supply-Chain Check" calling out the pre-install pnpm flow. Auto-detection rules list updated to include \`pnpm-lock.yaml\` in the recursive walk.

CHANGELOG entry deferred to the next release-prep PR per the established convention.

## Codex review trail

**6 rounds**, all producing real findings (no construct-an-evasion), all addressed:

1. Dedup peer-resolved duplicates + map npm packagecheck label
2. Skip pnpm locks inside node_modules + support v5 slash-form keys + default explicit npm empty path to cwd
3. Disambiguate v5 + peer-underscore parsing + propagate probe path to plan.npmPath
4. Strip peer suffixes before scoped/v5 classification + sort keys deterministically + neutral "npm dependencies" terminal label
5. Resolve explicit npm probe to absolute path + skip redundant packagecheck walk when root IS node_modules
6. Map npm packagecheck hits back to ecoNPM so finding wording matches incident.CheckNPM output

Each round caught a real shape pnpm users hit in practice. Opening the PR now so the GitHub codex bot can triage any further surface against real-world risk per the stop-rule for codex iteration.

## Test plan

- [x] \`go test -race -count=1 ./...\`: clean
- [x] \`go vet ./...\` + \`make lint\`: 0 issues
- [x] Manual smoke: \`aguara check .\` on pnpm-only fixture → CRITICAL node-ipc finding, ecosystems[npm/pnpm-lock.yaml]
- [x] Manual smoke: \`aguara check --ecosystem npm --path .\` from inside node_modules → incident.CheckNPM fires
- [x] Manual smoke: combined node_modules + pnpm-lock.yaml → two ecosystems[] entries, no redundant walk
- [x] Manual smoke: finding wording on packagecheck path matches "compromised npm package" (parity with incident path)
- [x] 6 codex review rounds, every round addressed
- [ ] CI green

## Out of scope (filed for follow-up if user feedback warrants)

- \`package-lock.json\` (npm CLI lockfile)
- \`yarn.lock\`
- \`bun.lock\` / \`bun.lockb\`
- range-aware OSV matching
- transitive dependency graph reachability
- workspace resolution beyond key parsing
- network calls / pnpm execution