### PR TITLE
release: prep v0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,65 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-05-18
+
+`aguara check .` now reads `pnpm-lock.yaml` directly. A pnpm
+project freshly cloned from git — no `pnpm install` yet, no
+`node_modules` — is now checked against the embedded npm
+threat-intel snapshot the same way an installed npm tree is.
+Compromised packages declared in the lockfile surface as CRITICAL
+findings before any install runs.
+
+This closes the largest gap in v0.17.x's "supply-chain check"
+story: the public framing claimed Aguara walked the dependency
+surface of a modern repo, but pnpm — the package manager a large
+slice of modern Node projects use — had no pre-install coverage.
+`aguara check .` returned `ecosystems: []` for the npm pipeline on
+any pnpm repo until the user ran `pnpm install` first.
+
+### Added
+
+- **`pnpm-lock.yaml` parser in the packagecheck path** (#119).
+  Refs are routed through the existing npm ecosystem so they
+  match against the same OSV npm advisories the installed-tree
+  pipeline uses. No new ecosystem, no new OSV bucket. Coverage:
+  - modern v6+ keys (`name@version`, `@scope/pkg@version`)
+  - legacy v5 slash-form keys (`/name/version`, `/@scope/pkg/version`)
+  - v9+ paren-encoded peer-dep suffixes including scoped peers
+    (`@commitlint/cli@19.6.1(@types/node@22.10.2)`)
+  - pre-v9 underscore-encoded peer-dep suffixes
+  - dedup of peer-resolved duplicate entries so a package
+    consumed with multiple peer resolutions counts once
+  - deterministic output ordering (sorted keys)
+  - rejection of non-registry sources: `workspace:`, `file:`,
+    `link:`, `github:`, `git:`, `http:`, `https:`
+- **`aguara check .` (no flags) now autodetects pnpm-lock.yaml
+  alongside the other six packagecheck ecosystems and the
+  installed-tree npm path.** A repo with both `pnpm-lock.yaml`
+  and `node_modules` produces two `ecosystems[]` entries with
+  `source: "pnpm-lock.yaml"` and `source: "node_modules"`
+  respectively so consumers see both surfaces independently.
+- **`aguara check --ecosystem npm`** now covers both surfaces.
+  Gated on `node_modules` existing so a pnpm-only repo (no
+  install yet) no longer errors with "no node_modules
+  directory"; the packagecheck lockfile pipeline runs in that
+  case.
+
+### Changed
+
+- `aguara check` terminal output for single-ecosystem npm plans
+  now reads "Scanning npm dependencies" instead of "npm
+  node_modules tree". The neutral wording covers both the
+  installed-tree and pnpm-lock-only surfaces without
+  misrepresenting either.
+
+### Compatibility
+
+Drop-in for v0.17.x. No schema changes, no flag renames, no rule
+ID changes. Consumers reading `verdict.status` and `ecosystems[]`
+continue to see the same field shapes; pnpm projects will start
+producing additional entries where the array was empty before.
+
 ## [0.17.1] - 2026-05-18
 
 QA backlog patch release. Four release-blocker bugs surfaced by

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.17.1
+INSTALL_SH_TEST_VERSION ?= v0.18.0
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
 Installs the latest binary to `~/.local/bin`. Customize with environment variables:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.17.1 sh
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.0 sh
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | INSTALL_DIR=/usr/local/bin sh
 ```
 
@@ -73,7 +73,7 @@ To update an existing install, rerun the installer. It downloads the selected re
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | sh
 
 # Update/pin to a specific release
-curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.17.1 sh
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.0 sh
 ```
 
 ### Alternative methods
@@ -94,7 +94,7 @@ docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara scan /scan
 docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara scan /scan --severity high --format json
 
 # Use a specific version
-docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara:0.17.1 scan /scan
+docker run --rm -v "$(pwd)":/scan ghcr.io/garagon/aguara:0.18.0 scan /scan
 ```
 
 **From source** (requires Go 1.25+):
@@ -278,29 +278,29 @@ aguara scan --auto
 #### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.17.1
+- uses: garagon/aguara@v0.18.0
   with:
     path: .
     fail-on: high
-    version: v0.17.1
+    version: v0.18.0
 ```
 
 Both pins (the action ref AND the `version:` input) are required. The
 action ref alone pins only the composite action and its install
 script; `version:` pins the Aguara binary the action installs. Setting
 both makes the workflow reproducible and dependabot-friendly: when
-v0.17.1 lands, the bot updates both together.
+v0.18.0 lands, the bot updates both together.
 
 Scans your repository, uploads findings to GitHub Code Scanning, and
 optionally fails the build:
 
 ```yaml
-- uses: garagon/aguara@v0.17.1
+- uses: garagon/aguara@v0.18.0
   with:
     path: ./mcp-server/
     severity: medium
     fail-on: high
-    version: v0.17.1
+    version: v0.18.0
 ```
 
 All inputs are optional. See [`action.yml`](action.yml) for the full list.
@@ -674,7 +674,7 @@ Your agent gets 4 tools: `scan_content`, `check_mcp_config`, `list_rules`, and `
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale, so we are not using it as a product signal for this release. The scanner, CLI, Docker image, and signed release artifacts remain the supported surfaces for v0.17.1.
+Aguara Watch is being reworked. The previous public observatory is stale, so we are not using it as a product signal for this release. The scanner, CLI, Docker image, and signed release artifacts remain the supported surfaces for v0.18.0.
 
 ## Go Library
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.17.1"
+        DEFAULT_REF="v0.18.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -388,6 +388,16 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 	if len(ecoFlags) > 0 {
 		plan.explicitEcosystem = true
 		var packagecheckIDs []string
+		// explicitNPMRequested records whether the user passed
+		// `--ecosystem npm`. We preserve the historical "explicit
+		// npm + no signal anywhere = error" contract (smoke-tested
+		// in benchmarks/smoke-npm-incident.sh case 4) by checking
+		// after Discover that SOMETHING npm-shaped (node_modules
+		// or pnpm-lock.yaml) was actually found. Without this
+		// post-discover check, the new packagecheck npm fallback
+		// would silently turn the user-error case into a
+		// clean-looking empty result.
+		explicitNPMRequested := false
 		for _, raw := range ecoFlags {
 			token, err := canonicaliseCheckEcosystem(raw)
 			if err != nil {
@@ -399,6 +409,7 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 				plan.pythonPath = path
 				plan.requestedEcosystems = append(plan.requestedEcosystems, intel.EcosystemPyPI)
 			case ecoNPM:
+				explicitNPMRequested = true
 				// Explicit `--ecosystem npm` now covers two surfaces:
 				//   1. installed-tree (node_modules + .pnpm store)
 				//      via incident.CheckNPM. Gated on node_modules
@@ -482,6 +493,35 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 				return checkPlan{}, fmt.Errorf("check: discover %s: %w", root, err)
 			}
 			plan.packagecheckTargets = targets
+		}
+		// Preserve the historical "explicit npm with no signal
+		// anywhere = error" UX contract (smoke-tested in
+		// benchmarks/smoke-npm-incident.sh case 4). A user who
+		// passes `--ecosystem npm --path <empty-dir>` is signalling
+		// "I want an npm check here" and getting back a clean-looking
+		// empty result would silently hide the path mistake. We
+		// allow the empty result ONLY when at least one npm signal
+		// was discovered: runNPM (installed tree) or a packagecheck
+		// npm target (pnpm-lock.yaml today; package-lock.json /
+		// yarn.lock when those land).
+		if explicitNPMRequested && !plan.runNPM {
+			haveNPMTarget := false
+			for _, t := range plan.packagecheckTargets {
+				if t.Ecosystem == intel.EcosystemNPM {
+					haveNPMTarget = true
+					break
+				}
+			}
+			if !haveNPMTarget {
+				root := path
+				if root == "" {
+					root = "."
+				}
+				return checkPlan{}, fmt.Errorf(
+					"npm check: %s has no node_modules tree and no pnpm-lock.yaml; pass the path to a project with one or remove --ecosystem npm",
+					root,
+				)
+			}
 		}
 		return plan, nil
 	}

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -398,6 +398,14 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 		// would silently turn the user-error case into a
 		// clean-looking empty result.
 		explicitNPMRequested := false
+		// otherEcosystemRequested tracks whether the user combined
+		// `--ecosystem npm` with at least one non-npm ecosystem
+		// (e.g. `--ecosystem npm --ecosystem go`). In that case the
+		// legacy "no npm signal here = error" contract must yield to
+		// the discovered non-npm targets; otherwise a multi-ecosystem
+		// CI config would refuse to run on any repo or subproject
+		// without an npm surface, which is a functional regression.
+		otherEcosystemRequested := false
 		for _, raw := range ecoFlags {
 			token, err := canonicaliseCheckEcosystem(raw)
 			if err != nil {
@@ -408,6 +416,7 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 				plan.runPython = true
 				plan.pythonPath = path
 				plan.requestedEcosystems = append(plan.requestedEcosystems, intel.EcosystemPyPI)
+				otherEcosystemRequested = true
 			case ecoNPM:
 				explicitNPMRequested = true
 				// Explicit `--ecosystem npm` now covers two surfaces:
@@ -481,6 +490,7 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 				}
 				packagecheckIDs = append(packagecheckIDs, osvID)
 				plan.requestedEcosystems = append(plan.requestedEcosystems, osvID)
+				otherEcosystemRequested = true
 			}
 		}
 		if len(packagecheckIDs) > 0 {
@@ -504,7 +514,13 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 		// was discovered: runNPM (installed tree) or a packagecheck
 		// npm target (pnpm-lock.yaml today; package-lock.json /
 		// yarn.lock when those land).
-		if explicitNPMRequested && !plan.runNPM {
+		//
+		// Scope the error to npm-only invocations. When npm is
+		// combined with any other ecosystem the user is asking for
+		// a multi-ecosystem audit and a missing npm surface should
+		// not abort the run; the discovered non-npm targets still
+		// have something to scan.
+		if explicitNPMRequested && !otherEcosystemRequested && !plan.runNPM {
 			haveNPMTarget := false
 			for _, t := range plan.packagecheckTargets {
 				if t.Ecosystem == intel.EcosystemNPM {

--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -986,6 +986,55 @@ func TestCheck_ExplicitNPMEcosystemOnPnpmRepoFires(t *testing.T) {
 	require.GreaterOrEqual(t, result.Ecosystems[0].FindingsCount, 1, "node-ipc 9.2.3 should fire")
 }
 
+func TestCheck_ExplicitNPMSoleEcosystemMissingSurfaceErrors(t *testing.T) {
+	// `aguara check --ecosystem npm --path <empty-dir>` must keep
+	// the legacy error contract (smoke-tested in
+	// benchmarks/smoke-npm-incident.sh case 4): explicit npm with no
+	// node_modules and no pnpm-lock.yaml is a user mistake, not a
+	// clean result.
+	empty := t.TempDir()
+
+	resetFlags()
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{
+		"check",
+		"--ecosystem", "npm",
+		"--path", empty,
+		"--format", "json",
+		"--no-update-check",
+	})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		resetFlags()
+	})
+
+	err := rootCmd.Execute()
+	require.Error(t, err, "explicit --ecosystem npm with no npm surface must error")
+	require.Contains(t, err.Error(), "npm check")
+	require.Contains(t, err.Error(), "no node_modules tree")
+}
+
+func TestCheck_ExplicitNPMWithOtherEcosystemSkipsLegacyError(t *testing.T) {
+	// `aguara check --ecosystem npm --ecosystem go --path <go-only>`
+	// must NOT abort on the missing npm surface. The user is asking
+	// for a multi-ecosystem audit; the discovered Go target should
+	// still run. Regression guard against the v0.18.0 release-prep
+	// commit where the explicit-npm error fired even when paired
+	// with another ecosystem (codex P2).
+	result := checkToFile(t,
+		"--ecosystem", "npm",
+		"--ecosystem", "go",
+		"--path", "../../../internal/packagecheck/testdata/go-clean",
+	)
+
+	require.NotNil(t, result, "multi-ecosystem check must return a result, not error out")
+	require.Len(t, result.Ecosystems, 1, "exactly one ecosystems[] entry expected (Go); npm has no surface here")
+	require.Equal(t, "Go", result.Ecosystems[0].Ecosystem)
+}
+
 // --- Issue #109: npm and PyPI emit ecosystems[] entries on the incident path ---
 
 func TestCheckExplicitNPM_AppendsEcosystemsEntry(t *testing.T) {

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.17.1 tag rather than `@v1`
+// The action ref is pinned to the v0.18.0 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.17.1
+        uses: garagon/aguara@v0.18.0
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.17.1
+          version: v0.18.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
## Summary

Prep PR for **v0.18.0**. Bumps the version pins, refreshes user-facing docs, and locks the v0.18.0 smoke-contract regression that the pnpm-lock work surfaced in #119.

### Why v0.18.0 vs v0.17.2

`pnpm-lock.yaml` support is not a wording change. It closes the largest gap in the v0.17.x supply-chain story: `aguara check .` on a pnpm repo with no `pnpm install` yet returned `ecosystems: []` for the npm pipeline. After v0.18.0 the lockfile is checked against the embedded npm snapshot at clone time, so a compromised pnpm declaration becomes a CRITICAL finding before any install runs. That is a new public capability; minor bump.

### CHANGELOG highlights

- pnpm-lock.yaml parser in the packagecheck path (#119). Modern v6+ keys, legacy v5 slash-form, v9+ paren-encoded peers including scoped peers, pre-v9 underscore peers, dedup, deterministic order, non-registry source rejection.
- `aguara check .` autodetects pnpm-lock.yaml alongside the other six packagecheck ecosystems and the installed-tree npm path.
- `aguara check --ecosystem npm` covers both surfaces. Gated on node_modules existing so a pnpm-only repo no longer errors with "no node_modules directory".
- Terminal label for single-ecosystem npm plans is now "Scanning npm dependencies" (neutral wording covers both installed-tree and pnpm-lock-only).

### Pin scope

Bumps `v0.17.1` → `v0.18.0` in 11 places:

- `cmd/aguara/commands/init.go` (workflowTemplateV2: `uses:`, `version:`, comment)
- `action.yml` (`DEFAULT_REF`)
- `Makefile` (`INSTALL_SH_TEST_VERSION`)
- `README.md` (install URL, Docker tag, action `uses:` + `version:`, dependabot prose, Watch section, version block)

`VERSION=v0.18.0 .github/scripts/check-version-pins.sh`: clean.

### Smoke-contract preservation

Adds a post-Discover validation in `buildCheckPlan` so explicit `--ecosystem npm` against a directory with no node_modules tree and no pnpm-lock.yaml continues to error (the case 4 contract in `benchmarks/smoke-npm-incident.sh`). Scoped to npm-only invocations: `--ecosystem npm --ecosystem go --path <go-only>` now correctly runs the Go target instead of aborting. Two regression tests pin both arms.

### Verification

- `go test -race -count=1 ./...`: green
- `go vet ./...`: clean
- `golangci-lint run ./...`: 0 issues
- `make verify-docker`: 6/6 smoke targets pass (npm incident, supply-chain, v0.16 commands)
- `aguara init --ci` on a temp dir scaffolds a workflow with `garagon/aguara@v0.18.0` and `version: v0.18.0`

## Test plan

- [x] `go test -race -count=1 ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run ./...`
- [x] `make verify-docker`
- [x] `VERSION=v0.18.0 .github/scripts/check-version-pins.sh`
- [ ] CI green on this PR