### PR TITLE
chore(ci): pin third-party action refs to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         run: make build
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v7
+        uses: golangci/golangci-lint-action@9fae48acfc02a90574d7c304a1758ef9895495fa # v7
         with:
           version: "v2.9.0"
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.7.0
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       - uses: docker/metadata-action@v5
         id: meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,14 +30,14 @@ jobs:
       # specific release for reproducibility; consumers can update via
       # Dependabot.
       - name: Install Cosign
-        uses: sigstore/cosign-installer@v3.7.0
+        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
 
       # syft generates SPDX SBOMs that GoReleaser attaches to each archive.
       - name: Install Syft
-        uses: anchore/sbom-action/download-syft@v0.17.8
+        uses: anchore/sbom-action/download-syft@55dc4ee22412511ee8c3142cbea40418e6cec693 # v0.17.8
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@e435ccd777264be153ace6237001ef4d979d3a7a # v6
         with:
           version: "~> v2"
           args: release --clean


### PR DESCRIPTION
## Summary

Replaces tag-based refs with commit-SHA refs (with the tag retained as a trailing comment) for the four third-party actions used in CI and release workflows.

Tag refs are mutable: a compromised or retagged upstream release can swap the action's code without any change to this repo. Pinning to a commit SHA freezes the exact revision until an explicit bump.

## Pinned actions

| Workflow | Action | Tag | SHA |
|---|---|---|---|
| ci.yml | `golangci/golangci-lint-action` | v7 | `9fae48acfc02a90574d7c304a1758ef9895495fa` |
| docker.yml | `sigstore/cosign-installer` | v3.7.0 | `dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da` |
| release.yml | `sigstore/cosign-installer` | v3.7.0 | `dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da` |
| release.yml | `anchore/sbom-action` | v0.17.8 | `55dc4ee22412511ee8c3142cbea40418e6cec693` |
| release.yml | `goreleaser/goreleaser-action` | v6 | `e435ccd777264be153ace6237001ef4d979d3a7a` |

## Scope

- First-party refs (`actions/*`, `docker/*`, `github/*`) are left as tag refs in this change.
- Behavior of CI, Docker, and Release workflows is unchanged at the resolved revisions.

## Test plan

- [x] Each SHA resolved via `gh api repos/<owner>/<repo>/git/refs/tags/<tag>`
- [x] Grep audit confirms no third-party tag refs remain in `.github/workflows/`
- [ ] CI green on this PR