### PR TITLE
chore: add Dependabot config for Go modules, Actions, and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      go-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: docker
+    directories:
+      - /
+      - /benchmarks
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 3


### PR DESCRIPTION
## Summary

Adds `.github/dependabot.yml` so Dependabot opens PRs for non-security dependency updates. Security updates are already enabled at the repo level; this adds the version-update side.

## Coverage

| Ecosystem | Directory | Schedule | Open PR limit | Grouping |
|---|---|---|---|---|
| `gomod` | `/` | weekly | 5 | minor + patch grouped |
| `github-actions` | `/` | weekly | 5 | minor + patch grouped |
| `docker` | `/`, `/benchmarks` | weekly | 3 | none (major + minor + patch as individual PRs) |

Major-version bumps in `gomod` and `github-actions` open as individual PRs so breaking changes get explicit review.

## Scope

- No code changes
- No workflow changes
- After merge, Dependabot will start opening update PRs on the schedule above

## Test plan

- [x] `dependabot.yml` schema validates against version 2
- [ ] CI green on this PR (no code paths touched)