### PR TITLE
fix(incident): add manual intel for the May 2026 @antv npm compromise

### DIFF
--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -973,6 +973,36 @@ func TestCheck_PnpmLockCleanFixtureProducesZeroFindings(t *testing.T) {
 	require.Empty(t, result.Findings, "top-level findings must be empty on clean fixture")
 }
 
+func TestCheck_PnpmLockMiniShaiHuludAntvFiresFinding(t *testing.T) {
+	// Mini Shai-Hulud / @antv wave: `aguara check <pnpm-repo>` on a
+	// fresh clone must detect the compromised @antv/g2 5.6.8 and
+	// echarts-for-react 3.2.7 entries via the pnpm-lock.yaml path
+	// without needing pnpm install to have run. End-to-end coverage:
+	// autodetect picks pnpm-lock.yaml as npm ecosystem; parser
+	// extracts both refs; matcher hits the manual incident entries
+	// (these versions are NOT in the embedded OSV snapshot today,
+	// which is why the manual intel exists).
+	result := checkToFile(t, "../../../internal/packagecheck/testdata/pnpm-mini-shai-hulud-antv")
+
+	require.Len(t, result.Ecosystems, 1)
+	require.Equal(t, "npm", result.Ecosystems[0].Ecosystem)
+	require.Equal(t, "pnpm-lock.yaml", result.Ecosystems[0].Source)
+	require.GreaterOrEqual(t, result.Ecosystems[0].FindingsCount, 2,
+		"@antv/g2 5.6.8 and echarts-for-react 3.2.7 must both fire")
+
+	titles := make([]string, 0, len(result.Findings))
+	for _, f := range result.Findings {
+		require.Equal(t, incident.SevCritical, f.Severity,
+			"all Mini Shai-Hulud findings must be CRITICAL, got %q on %q", f.Severity, f.Title)
+		titles = append(titles, f.Title)
+	}
+	joined := strings.Join(titles, " | ")
+	require.Contains(t, joined, "@antv/g2 5.6.8")
+	require.Contains(t, joined, "echarts-for-react 3.2.7")
+	require.Contains(t, joined, "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		"finding title must carry the advisory ID so dashboards can correlate")
+}
+
 func TestCheck_ExplicitNPMEcosystemOnPnpmRepoFires(t *testing.T) {
 	// `aguara check --ecosystem npm --path <pnpm-only-repo>` must
 	// scan pnpm-lock.yaml even though there's no node_modules. The

--- a/internal/incident/compromised.go
+++ b/internal/incident/compromised.go
@@ -124,6 +124,113 @@ var KnownCompromised = []CompromisedPackage{
 		Date:      "2022-03-07",
 		Summary:   "Historical malicious node-ipc releases (originally surfaced as the \"peacenotwar\" / RIAEvangelist incident) tied to destructive or unauthorized file-writing behavior on installs from specific geographies. Listed separately from the 2026 compromise because the payload and motivation differ.",
 	},
+
+	// --- Mini Shai-Hulud 2026 supply-chain wave (@antv) ---
+	//
+	// May 2026 campaign documented by Socket targeting AntV and a
+	// small set of related visualization packages. The malicious
+	// versions ship install-time / import-time credential-stealing
+	// payloads. Every entry below is verified against the npm
+	// registry: the registry's `deprecated` field on the version
+	// carries an explicit security, "risk", "published in error",
+	// or malicious-version notice. Versions without that registry
+	// signal are intentionally omitted even when third-party
+	// trackers list the package.
+	//
+	// The TanStack / Mistral / UiPath wave from the same campaign
+	// is already covered by the embedded OSV snapshot
+	// (MAL-2026-3432 and adjacent MAL-2026-* records) and is not
+	// duplicated here.
+	//
+	// Sources:
+	//   - https://socket.dev/blog/antv-packages-compromised
+	//   - npm registry metadata (registry.npmjs.org)
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "@antv/g2",
+		Versions:  []string{"5.5.8", "5.6.8"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise; affected @antv/g2 versions were flagged by the maintainers via npm's deprecated field (reason: \"risk\"). Aligned with the @antv wave Socket reported in May 2026.",
+		IOCs: []IOC{
+			{Type: "runtime", Value: "bun"},
+			{Type: "path", Value: "setup.mjs"},
+			{Type: "endpoint", Value: "filev2.getsession.org"},
+		},
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "@antv/g6",
+		Versions:  []string{"5.2.1", "5.3.1"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise; npm deprecated message flags these versions as published with a compromised key.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "@antv/x6",
+		Versions:  []string{"3.2.7", "3.3.7"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise; versions flagged via npm's deprecated field (reason: \"published in error\") and removed from latest dist-tag.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "@antv/l7",
+		Versions:  []string{"2.26.10", "2.27.10"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise; npm deprecated message labels these versions as malicious.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "@antv/f2",
+		Versions:  []string{"5.16.0"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise; npm deprecated message flags this version (reason: \"risk\").",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "@antv/data-set",
+		Versions:  []string{"0.12.8", "0.13.8"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise; npm deprecated message flags these versions as published in error.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "echarts-for-react",
+		Versions:  []string{"3.0.7", "3.1.7", "3.2.7"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise affecting echarts-for-react alongside the @antv wave; npm deprecated message flags these versions as published in error.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "timeago.js",
+		Versions:  []string{"4.1.2"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise; npm deprecated message flags this version as published in error.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "size-sensor",
+		Versions:  []string{"1.0.4", "1.1.4", "1.2.4"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise; npm deprecated message flags these versions as published in error.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "canvas-nest.js",
+		Versions:  []string{"2.2.4"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise; npm deprecated message flags this version as published in error.",
+	},
+
 }
 
 // IsCompromised checks if a package name+version is in the PyPI

--- a/internal/incident/intel_adapter.go
+++ b/internal/incident/intel_adapter.go
@@ -185,7 +185,9 @@ func KnownCompromisedSnapshot() intel.Snapshot {
 // knownCompromisedGeneratedAt is the stamp used for the manual
 // snapshot. Updated by hand when the manual list grows so consumers
 // can detect a stale embedded snapshot. Reproducible across builds.
-var knownCompromisedGeneratedAt = time.Date(2026, time.May, 15, 0, 0, 0, 0, time.UTC)
+// Must be >= the freshest Date string in KnownCompromised; a
+// regression test in intel_adapter_test.go enforces that ordering.
+var knownCompromisedGeneratedAt = time.Date(2026, time.May, 19, 0, 0, 0, 0, time.UTC)
 
 // normalizeEcosystemForIntel maps the legacy ecosystem strings used
 // by CompromisedPackage entries to the canonical intel ecosystem

--- a/internal/incident/intel_adapter_test.go
+++ b/internal/incident/intel_adapter_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/garagon/aguara/internal/incident"
 	"github.com/garagon/aguara/internal/intel"
@@ -64,6 +65,34 @@ func TestKnownCompromisedSnapshotShape(t *testing.T) {
 	for _, src := range snap.Sources {
 		require.Equal(t, intel.SourceManual, src.Kind)
 	}
+}
+
+func TestKnownCompromisedSnapshotGeneratedAtCoversFreshestEntry(t *testing.T) {
+	// The snapshot's GeneratedAt must be at or after the freshest
+	// Date string in KnownCompromised. If a new intel entry is added
+	// with a later Date but knownCompromisedGeneratedAt is not
+	// bumped, `aguara check --format json` would report an intel
+	// freshness timestamp older than the very incident it just
+	// detected, which breaks dashboards that gate on intel age.
+	snap := incident.KnownCompromisedSnapshot()
+
+	var freshest time.Time
+	var freshestEntry string
+	for _, cp := range incident.KnownCompromised {
+		if cp.Date == "" {
+			continue
+		}
+		d, err := time.Parse("2006-01-02", cp.Date)
+		require.NoErrorf(t, err, "entry %s %s has unparseable Date %q", cp.Ecosystem, cp.Name, cp.Date)
+		if d.After(freshest) {
+			freshest = d
+			freshestEntry = cp.Name + " (" + cp.Advisory + ", " + cp.Date + ")"
+		}
+	}
+	require.False(t, freshest.IsZero(), "expected at least one dated entry in KnownCompromised")
+	require.Falsef(t, snap.GeneratedAt.Before(freshest),
+		"snapshot GeneratedAt %s is older than the freshest manual entry %s; bump knownCompromisedGeneratedAt in intel_adapter.go",
+		snap.GeneratedAt.Format("2006-01-02"), freshestEntry)
 }
 
 func TestKnownCompromisedSnapshotReproducible(t *testing.T) {

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -124,6 +124,69 @@ func TestCheckNPM_NestedNodeModules(t *testing.T) {
 	}
 }
 
+func TestCheckNPM_MiniShaiHulud_AntvWave(t *testing.T) {
+	// Mini Shai-Hulud / @antv wave: compromised versions must flag
+	// CRITICAL on an installed tree. Picks one scoped (@antv/g2)
+	// and one unscoped (echarts-for-react) package to exercise both
+	// scoped-path and unscoped-path lookup branches.
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "@antv/g2", "5.6.8")
+	writeNPMPackage(t, nm, "echarts-for-react", "3.2.7")
+	writeNPMPackage(t, nm, "react", "18.3.1") // unrelated; must NOT flag
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if got := len(result.Findings); got != 2 {
+		t.Fatalf("expected 2 findings (compromised @antv/g2 5.6.8 + echarts-for-react 3.2.7), got %d: %+v", got, result.Findings)
+	}
+	for _, f := range result.Findings {
+		if f.Severity != incident.SevCritical {
+			t.Errorf("expected CRITICAL severity, got %q on %q", f.Severity, f.Title)
+		}
+	}
+	// Title should name the specific package+version+advisory so a
+	// dashboard reader can correlate without digging into Detail.
+	wantTitles := []string{
+		"@antv/g2 5.6.8 is a known compromised npm package (SOCKET-2026-05-19-mini-shai-hulud-antv)",
+		"echarts-for-react 3.2.7 is a known compromised npm package (SOCKET-2026-05-19-mini-shai-hulud-antv)",
+	}
+	for _, want := range wantTitles {
+		var found bool
+		for _, f := range result.Findings {
+			if f.Title == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected finding title %q not present; got %+v", want, result.Findings)
+		}
+	}
+}
+
+func TestCheckNPM_MiniShaiHulud_NeighborVersionDoesNotFalsePositive(t *testing.T) {
+	// Versions adjacent to a compromised pin must NOT flag. Guards
+	// against accidental range expansion when adding manual intel.
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "@antv/g2", "5.4.8")           // current latest, clean
+	writeNPMPackage(t, nm, "@antv/g6", "5.1.1")           // current latest, clean
+	writeNPMPackage(t, nm, "size-sensor", "1.0.3")        // current latest, clean
+	writeNPMPackage(t, nm, "@antv/data-set", "0.11.8")    // current latest, clean
+	writeNPMPackage(t, nm, "echarts-for-react", "3.0.6")  // current latest, clean
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if len(result.Findings) != 0 {
+		t.Errorf("clean / neighbor versions must not flag, got: %+v", result.Findings)
+	}
+}
+
 func TestCheckNPM_CleanTree(t *testing.T) {
 	dir := t.TempDir()
 	nm := filepath.Join(dir, "node_modules")

--- a/internal/packagecheck/testdata/pnpm-mini-shai-hulud-antv/pnpm-lock.yaml
+++ b/internal/packagecheck/testdata/pnpm-mini-shai-hulud-antv/pnpm-lock.yaml
@@ -1,0 +1,33 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      '@antv/g2':
+        specifier: 5.6.8
+        version: 5.6.8
+      echarts-for-react:
+        specifier: 3.2.7
+        version: 3.2.7
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
+packages:
+  '@antv/g2@5.6.8':
+    resolution: {integrity: sha512-FAKE_FIXTURE_DO_NOT_VERIFY==}
+
+  echarts-for-react@3.2.7:
+    resolution: {integrity: sha512-FAKE_FIXTURE_DO_NOT_VERIFY==}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-FAKE_FIXTURE_DO_NOT_VERIFY==}
+
+snapshots:
+  '@antv/g2@5.6.8': {}
+  echarts-for-react@3.2.7: {}
+  lodash@4.17.21: {}


### PR DESCRIPTION
## Summary

Adds known-compromised package/version entries for the May 2026 npm supply-chain incident affecting the AntV visualization libraries and a small set of related packages.

The embedded OSV snapshot did not carry these tuples at the time of writing, so `aguara check` returned clean on installed trees and `pnpm-lock.yaml` lockfiles that pinned the malicious versions.

## Coverage added (npm ecosystem)

| Package | Versions | npm registry `deprecated` field |
|---|---|---|
| `@antv/g2` | 5.5.8, 5.6.8 | `"risk"` |
| `@antv/g6` | 5.2.1, 5.3.1 | `"SECURITY: This version was published with a compromised key. Do not use this version."` |
| `@antv/x6` | 3.2.7, 3.3.7 | `"This version was published in error..."` |
| `@antv/l7` | 2.26.10, 2.27.10 | `"恶意版本"` (malicious version) |
| `@antv/f2` | 5.16.0 | `"risk"` |
| `@antv/data-set` | 0.12.8, 0.13.8 | `"This version was published in error..."` |
| `echarts-for-react` | 3.0.7, 3.1.7, 3.2.7 | `"This version was published in error..."` |
| `timeago.js` | 4.1.2 | `"This version was published in error..."` |
| `size-sensor` | 1.0.4, 1.1.4, 1.2.4 | `"This version was published in error..."` |
| `canvas-nest.js` | 2.2.4 | `"This version was published in error..."` |

## Verification policy

Every entry is verified against `registry.npmjs.org`. The `deprecated` field on the version must carry an explicit security, `"risk"`, `"published in error"`, or malicious-version notice from the package maintainer. Versions without that registry-side signal were omitted even when third-party trackers list the package.

The TanStack / Mistral / UiPath wave reported in the same campaign is already covered by the embedded OSV snapshot (`MAL-2026-3432` and adjacent `MAL-2026-*` records) and is not duplicated here.

## Snapshot freshness

`knownCompromisedGeneratedAt` is bumped to `2026-05-19` so the manual snapshot's `GeneratedAt` covers the new entries. A regression test (`TestKnownCompromisedSnapshotGeneratedAtCoversFreshestEntry`) walks `KnownCompromised`, parses every `Date` string, and requires `snap.GeneratedAt >= max(Date)`. Future intel additions that forget the bump fail the suite with a direct pointer at `intel_adapter.go`.

## Tests

- `TestCheckNPM_MiniShaiHulud_AntvWave`: installed-tree (`node_modules`) path emits CRITICAL with the advisory ID in the finding title; covers one scoped and one unscoped package.
- `TestCheckNPM_MiniShaiHulud_NeighborVersionDoesNotFalsePositive`: pins adjacent clean versions; asserts no findings. Regression guard against accidental range expansion in future intel updates.
- `TestCheck_PnpmLockMiniShaiHuludAntvFiresFinding`: new `testdata/pnpm-mini-shai-hulud-antv/pnpm-lock.yaml` fixture wired through the full CLI; asserts CRITICAL on a pre-install `pnpm-lock.yaml` (no `node_modules` present).
- `TestKnownCompromisedSnapshotGeneratedAtCoversFreshestEntry`: new freshness guard described above.
- Existing `TestKnownCompromisedSnapshotParity` continues to pass and exercises every new entry through the intel matcher path.

## End-to-end side-by-side

```bash
docker run --rm --network none -v /tmp/fixture:/repo:ro \
  ghcr.io/garagon/aguara:0.18.0 check /repo --format json
# findings_count: 0

docker run --rm --network none -v /tmp/fixture:/repo:ro \
  <this-branch-image> check /repo --format json
# findings_count: 2
# - CRITICAL @antv/g2 5.6.8 is a known compromised npm package (SOCKET-2026-05-19-mini-shai-hulud-antv)
# - CRITICAL echarts-for-react 3.2.7 is a known compromised npm package (SOCKET-2026-05-19-mini-shai-hulud-antv)
```

## Scope

- Data-only addition to `KnownCompromised`.
- One-line timestamp bump on `knownCompromisedGeneratedAt`.
- No schema change.
- No new analyzer, no new rule, no behavioral detection.
- No CHANGELOG entry (will land with the v0.18.1 release prep).

## Test plan

- [x] `go test -race -count=1 ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues
- [x] `VERSION=v0.18.0 .github/scripts/check-version-pins.sh` clean
- [x] Side-by-side Docker E2E against `ghcr.io/garagon/aguara:0.18.0` shows the gap closes
- [ ] CI green on this PR