### PR TITLE
fix(incident): expand May 2026 @antv intel + add t.m-kosche.com IOC

### DIFF
--- a/internal/incident/compromised.go
+++ b/internal/incident/compromised.go
@@ -156,6 +156,8 @@ var KnownCompromised = []CompromisedPackage{
 			{Type: "runtime", Value: "bun"},
 			{Type: "path", Value: "setup.mjs"},
 			{Type: "endpoint", Value: "filev2.getsession.org"},
+			{Type: "endpoint", Value: "t.m-kosche.com"},
+			{Type: "path", Value: "/api/public/otel/v1/traces"},
 		},
 	},
 	{
@@ -230,7 +232,22 @@ var KnownCompromised = []CompromisedPackage{
 		Date:      "2026-05-19",
 		Summary:   "Mini Shai-Hulud-linked npm compromise; npm deprecated message flags this version as published in error.",
 	},
-
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "@antv/g-image-exporter",
+		Versions:  []string{"1.2.42"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise; npm deprecated message flags this version as published in error. The version is also anomalous relative to the package's latest stable lineage (1.0.x), consistent with the @antv wave pattern of attacker-bumped majors/minors above the legitimate latest.",
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "@antv/infographic",
+		Versions:  []string{"0.3.19", "0.4.19"},
+		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
+		Date:      "2026-05-19",
+		Summary:   "Mini Shai-Hulud-linked npm compromise; npm deprecated message flags these versions as published with a compromised key.",
+	},
 }
 
 // IsCompromised checks if a package name+version is in the PyPI

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -167,16 +167,50 @@ func TestCheckNPM_MiniShaiHulud_AntvWave(t *testing.T) {
 	}
 }
 
+func TestCheckNPM_MiniShaiHulud_AntvWaveExpansion(t *testing.T) {
+	// Second-round @antv expansion: covers the additional packages
+	// added after the first hotfix landed. Same registry-attestation
+	// rule: only versions with explicit "published in error" or
+	// "compromised key" deprecation messages are included.
+	//
+	// node_modules holds one resolved version per package; the second
+	// version of @antv/infographic (0.3.19) is exercised through the
+	// snapshot parity test (TestKnownCompromisedSnapshotParity walks
+	// every Versions entry in every record).
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "@antv/g-image-exporter", "1.2.42")
+	writeNPMPackage(t, nm, "@antv/infographic", "0.4.19")
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if got := len(result.Findings); got != 2 {
+		t.Fatalf("expected 2 findings (g-image-exporter 1.2.42 + infographic 0.4.19), got %d: %+v", got, result.Findings)
+	}
+	for _, f := range result.Findings {
+		if f.Severity != incident.SevCritical {
+			t.Errorf("expected CRITICAL severity, got %q on %q", f.Severity, f.Title)
+		}
+		if !strings.Contains(f.Title, "SOCKET-2026-05-19-mini-shai-hulud-antv") {
+			t.Errorf("expected @antv advisory ID in title, got %q", f.Title)
+		}
+	}
+}
+
 func TestCheckNPM_MiniShaiHulud_NeighborVersionDoesNotFalsePositive(t *testing.T) {
 	// Versions adjacent to a compromised pin must NOT flag. Guards
 	// against accidental range expansion when adding manual intel.
 	dir := t.TempDir()
 	nm := filepath.Join(dir, "node_modules")
-	writeNPMPackage(t, nm, "@antv/g2", "5.4.8")           // current latest, clean
-	writeNPMPackage(t, nm, "@antv/g6", "5.1.1")           // current latest, clean
-	writeNPMPackage(t, nm, "size-sensor", "1.0.3")        // current latest, clean
-	writeNPMPackage(t, nm, "@antv/data-set", "0.11.8")    // current latest, clean
-	writeNPMPackage(t, nm, "echarts-for-react", "3.0.6")  // current latest, clean
+	writeNPMPackage(t, nm, "@antv/g2", "5.4.8")                   // current latest, clean
+	writeNPMPackage(t, nm, "@antv/g6", "5.1.1")                   // current latest, clean
+	writeNPMPackage(t, nm, "size-sensor", "1.0.3")                // current latest, clean
+	writeNPMPackage(t, nm, "@antv/data-set", "0.11.8")            // current latest, clean
+	writeNPMPackage(t, nm, "echarts-for-react", "3.0.6")          // current latest, clean
+	writeNPMPackage(t, nm, "@antv/g-image-exporter", "1.0.42")    // current latest, clean
+	writeNPMPackage(t, nm, "@antv/infographic", "0.2.19")         // current latest, clean
 
 	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
 	if err != nil {


### PR DESCRIPTION
## Summary

Second-round expansion of the @antv supply-chain intel after verifying additional candidates against the npm registry. Adds two packages and surfaces the recently disclosed direct-HTTPS exfiltration endpoint as IOC metadata on the existing carrier entry.

## Coverage added (npm ecosystem)

| Package | Versions | npm registry `deprecated` field |
|---|---|---|
| `@antv/g-image-exporter` | 1.2.42 | `"This version was published in error, please use the latest version instead."` Version is also anomalous above the current latest 1.0.42, matching the @antv wave pattern of attacker-bumped majors above the legitimate dist-tag latest. |
| `@antv/infographic` | 0.3.19, 0.4.19 | `"SECURITY: This version was published with a compromised key. Do not use this version."` |

## New IOC metadata on the @antv carrier entry

`@antv/g2` (the carrier entry for the `SOCKET-2026-05-19-mini-shai-hulud-antv` advisory) gains two new IOCs reflecting the direct-HTTPS exfiltration channel reported alongside the campaign:

- endpoint `t.m-kosche.com`
- path `/api/public/otel/v1/traces`

## Verification policy (same as the first hotfix)

Every entry is verified against `registry.npmjs.org`. The `deprecated` field on the version must carry an explicit security, `"risk"`, `"published in error"`, or malicious-version notice. Candidates listed by third-party trackers but without a registry signal stay out.

Intentionally skipped this round even though they were on the candidate list:

- `@antv/gi-assets-advance`, `@antv/x6-vector`, `@antv/vendor`, `@antv/x6-geometry` — show the suspicious version-bump pattern but lack a deprecated message today.

## Tests

- `TestCheckNPM_MiniShaiHulud_AntvWaveExpansion`: installs the new packages in `node_modules` and asserts CRITICAL findings with the advisory ID in the finding title.
- `TestCheckNPM_MiniShaiHulud_NeighborVersionDoesNotFalsePositive`: extended with the new packages' current-latest clean versions to keep the FP guard honest.
- Existing `TestKnownCompromisedSnapshotParity` and `TestKnownCompromisedSnapshotGeneratedAtCoversFreshestEntry` stay green. The snapshot timestamp is unchanged because the freshest entry date is unchanged.

## Scope

- Data-only addition to `KnownCompromised` (+1 entry for `@antv/g-image-exporter`, +1 entry for `@antv/infographic`).
- Two IOC entries appended to the existing `@antv/g2` carrier.
- No schema change.
- No new analyzer, no new rule, no behavioral detection.

## Test plan

- [x] `go test -race -count=1 ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues
- [ ] CI green on this PR