### PR TITLE
release: prep v0.18.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,54 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-05-19
+
+Patch release adding manual threat-intel coverage for the May 2026
+npm supply-chain incident affecting AntV visualization libraries
+and a small set of related packages. The embedded OSV snapshot did
+not carry these tuples at the time of release, so `aguara check`
+returned clean on installed trees and `pnpm-lock.yaml` lockfiles
+that pinned the malicious versions. v0.18.1 closes that gap.
+
+### Added
+
+- Manual `KnownCompromised` entries for the @antv wave: `@antv/g2`,
+  `@antv/g6`, `@antv/x6`, `@antv/l7`, `@antv/f2`, `@antv/data-set`,
+  `@antv/g-image-exporter`, `@antv/infographic`, plus
+  `echarts-for-react`, `timeago.js`, `size-sensor`, `canvas-nest.js`.
+  Twelve packages, 22 confirmed compromised versions. Every entry
+  is verified against `registry.npmjs.org`: the `deprecated` field
+  on the version carries an explicit security, `"risk"`, `"published
+  in error"`, or malicious-version notice from the package
+  maintainer. Versions without that registry signal are not
+  included even when third-party trackers list the package.
+- IOC metadata on the @antv advisory carrier entry for the direct
+  HTTPS exfiltration channel (`t.m-kosche.com`,
+  `/api/public/otel/v1/traces`).
+- Regression test
+  `TestKnownCompromisedSnapshotGeneratedAtCoversFreshestEntry` that
+  walks every dated entry in `KnownCompromised` and requires the
+  manual snapshot's `GeneratedAt` to be at or after the freshest
+  entry. Future intel additions that forget to bump the timestamp
+  fail the suite with a direct pointer at `intel_adapter.go`.
+
+### Changed
+
+- `knownCompromisedGeneratedAt` bumped to `2026-05-19` to cover the
+  new entries.
+
+### Compatibility
+
+Drop-in for v0.18.0. No schema changes, no flag renames, no rule
+ID changes. Consumers reading `verdict.status` and `ecosystems[]`
+continue to see the same field shapes; the @antv-affected projects
+now produce CRITICAL findings where v0.18.0 was silent.
+
+The TanStack / Mistral / UiPath wave reported in the same campaign
+is already covered by the embedded OSV snapshot (`MAL-2026-3432`
+and adjacent `MAL-2026-*` records) and is not duplicated by the
+manual intel.
+
 ## [0.18.0] - 2026-05-18
 
 `aguara check .` now reads `pnpm-lock.yaml` directly. A pnpm

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.18.0
+INSTALL_SH_TEST_VERSION ?= v0.18.1
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ brew install garagon/tap/aguara
 ### Docker
 
 ```bash
-docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.18.0 check /repo
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.18.1 check /repo
 ```
 
 The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 10001, base images are digest-pinned, and the image is signed at the digest with Cosign plus SPDX SBOM and SLSA provenance attestations. Tag a specific release for reproducibility.
@@ -69,14 +69,14 @@ The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.18.0 sh
+  | VERSION=v0.18.1 sh
 ```
 
 `install.sh` downloads `checksums.txt` from the release and verifies the archive's SHA256 against it, aborting if neither `sha256sum` nor `shasum` is available. This catches a tampered or corrupted archive at the registry layer, but it does not verify the Cosign signature on `checksums.txt` itself. For full keyless-signature verification on the curl-pipe path, follow up with the Cosign step in [Verifying signed releases](#verifying-signed-releases). Default install location is `~/.local/bin`. Override for CI or containers:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.18.0 INSTALL_DIR=/usr/local/bin sh
+  | VERSION=v0.18.1 INSTALL_DIR=/usr/local/bin sh
 ```
 
 ### From source
@@ -96,7 +96,7 @@ Every release is signed with [Cosign](https://github.com/sigstore/cosign) keyles
 **Verify the release archive**:
 
 ```bash
-VERSION=v0.18.0
+VERSION=v0.18.1
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
@@ -358,11 +358,11 @@ aguara discover --format json
 ### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.18.0
+- uses: garagon/aguara@v0.18.1
   with:
     path: .
     fail-on: high
-    version: v0.18.0
+    version: v0.18.1
 ```
 
 Both pins (the action ref AND the `version:` input) are required. The action ref alone pins only the composite action and its install script; `version:` pins the Aguara binary the action installs. Setting both makes the workflow reproducible and dependabot-friendly: when a new release lands, the bot updates both together.
@@ -370,12 +370,12 @@ Both pins (the action ref AND the `version:` input) are required. The action ref
 Scans your repository, uploads findings to GitHub Code Scanning, and optionally fails the build:
 
 ```yaml
-- uses: garagon/aguara@v0.18.0
+- uses: garagon/aguara@v0.18.1
   with:
     path: ./mcp-server/
     severity: medium
     fail-on: high
-    version: v0.18.0
+    version: v0.18.1
 ```
 
 All inputs are optional. See [`action.yml`](action.yml) for the full list.
@@ -395,7 +395,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 
 ```yaml
 - name: Scan for security issues
-  run: docker run --rm -v "${{ github.workspace }}:/scan:ro" ghcr.io/garagon/aguara:0.18.0 scan /scan --ci
+  run: docker run --rm -v "${{ github.workspace }}:/scan:ro" ghcr.io/garagon/aguara:0.18.1 scan /scan --ci
 ```
 
 ### Manual / GitLab CI
@@ -404,7 +404,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitHub Actions (without the action)
 - name: Scan skills for security issues
   run: |
-    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.0 sh
+    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.1 sh
     aguara scan .claude/skills/ --ci
 ```
 
@@ -412,7 +412,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.0 sh
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.1 sh
     - aguara scan .claude/skills/ --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:
@@ -621,7 +621,7 @@ See the [mcp-aguara README](https://github.com/garagon/mcp-aguara) for install, 
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.18.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
+Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.18.1. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
 
 ## Enterprise use
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.18.0"
+        DEFAULT_REF="v0.18.1"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.18.0 tag rather than `@v1`
+// The action ref is pinned to the v0.18.1 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.18.0
+        uses: garagon/aguara@v0.18.1
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.18.0
+          version: v0.18.1
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
## Summary

Patch release prep for **v0.18.1**. Bumps the version pins from v0.18.0 to v0.18.1 across all release-tracked sites and adds the CHANGELOG entry.

The patch ships the manual threat-intel additions for the May 2026 @antv supply-chain incident already landed on main (PR #134 + PR #135): 12 packages, 22 confirmed compromised versions, all verified against the npm registry's `deprecated` field. The `t.m-kosche.com` exfiltration endpoint is recorded as IOC metadata on the advisory carrier entry.

## CHANGELOG highlights

- Manual `KnownCompromised` entries for the @antv wave (npm): `@antv/g2`, `@antv/g6`, `@antv/x6`, `@antv/l7`, `@antv/f2`, `@antv/data-set`, `@antv/g-image-exporter`, `@antv/infographic`, `echarts-for-react`, `timeago.js`, `size-sensor`, `canvas-nest.js`.
- Direct HTTPS exfil endpoint IOCs (`t.m-kosche.com`, `/api/public/otel/v1/traces`) on the advisory carrier entry.
- Regression test `TestKnownCompromisedSnapshotGeneratedAtCoversFreshestEntry` that enforces `snap.GeneratedAt >= max(KnownCompromised[*].Date)`.
- TanStack / Mistral / UiPath wave from the same campaign was already covered by the embedded OSV snapshot (`MAL-2026-3432` and adjacent `MAL-2026-*` records) and is not duplicated.

## Pin scope (v0.18.0 → v0.18.1)

| File | What changed |
|---|---|
| `cmd/aguara/commands/init.go` | workflow template: comment, `uses:` line, `version:` input |
| `action.yml` | `DEFAULT_REF` |
| `Makefile` | `INSTALL_SH_TEST_VERSION` |
| `README.md` | install.sh `VERSION=` snippets, Docker tag references (`:0.18.1`), GitHub Action `uses:` + `version:` blocks, Aguara Watch surface line |

`VERSION=v0.18.1 .github/scripts/check-version-pins.sh` clean.

## Compatibility

Drop-in for v0.18.0. No schema changes, no flag renames, no rule ID changes. Consumers reading `verdict.status` and `ecosystems[]` continue to see the same field shapes; the @antv-affected projects now produce CRITICAL findings where v0.18.0 was silent.

## Test plan

- [x] `go test -race -count=1 ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues
- [x] `VERSION=v0.18.1 .github/scripts/check-version-pins.sh` clean
- [x] `aguara init --ci` on a temp dir scaffolds a workflow with `garagon/aguara@v0.18.1` and `version: v0.18.1`
- [ ] CI green on this PR