### PR TITLE
fix(check): collapse duplicate manual and OSV findings per package version

### DIFF
--- a/internal/incident/checker.go
+++ b/internal/incident/checker.go
@@ -167,16 +167,26 @@ func Check(opts CheckOptions) (*CheckResult, error) {
 			Version:   pkg.Version,
 			Path:      pkg.Dir,
 		})
-		for _, hit := range hits {
-			result.Findings = append(result.Findings, Finding{
-				Severity:    SevCritical,
-				Title:       fmt.Sprintf("%s %s is a known compromised package (%s)", pkg.Name, pkg.Version, hit.Record.ID),
-				Detail:      hit.Record.Summary,
-				Path:        pkg.Dir,
-				Remediation: fmt.Sprintf("Run 'aguara clean' to remove %s and associated malware", pkg.Name),
-			})
-			pypiFindings++
+		if len(hits) == 0 {
+			continue
 		}
+		// One Finding per (ecosystem, name, version, path) tuple even
+		// when multiple intel records cover the same exposure. Same
+		// rationale as the npm path: the matcher keeps returning
+		// every record for correlation, but the user is exposed once
+		// per installed package and should see one row. Manual
+		// snapshot is first in EmbeddedSnapshots(), so hits[0] picks
+		// the curated advisory when both manual and OSV cover the
+		// tuple.
+		hit := hits[0]
+		result.Findings = append(result.Findings, Finding{
+			Severity:    SevCritical,
+			Title:       fmt.Sprintf("%s %s is a known compromised package (%s)", pkg.Name, pkg.Version, hit.Record.ID),
+			Detail:      hit.Record.Summary,
+			Path:        pkg.Dir,
+			Remediation: fmt.Sprintf("Run 'aguara clean' to remove %s and associated malware", pkg.Name),
+		})
+		pypiFindings++
 	}
 	// Surface PyPI as an Ecosystems[] entry on the result so JSON
 	// consumers see consistent multi-ecosystem coverage data. Before
@@ -499,10 +509,12 @@ func checkCaches(opts CheckOptions) []Finding {
 						Version:   pkg.Version,
 						Path:      path,
 					})
-					for _, hit := range hits {
-						if seen[path] {
-							break
-						}
+					// One Finding per cache path even when multiple
+					// intel records cover the same (name, version).
+					// hits[0] picks the manual advisory ID over the
+					// OSV one when both are present.
+					if len(hits) > 0 && !seen[path] {
+						hit := hits[0]
 						seen[path] = true
 						findings = append(findings, Finding{
 							Severity:    SevCritical,

--- a/internal/incident/npm.go
+++ b/internal/incident/npm.go
@@ -82,16 +82,31 @@ func CheckNPM(opts CheckOptions) (*CheckResult, error) {
 			Version:   pkg.Version,
 			Path:      pkg.Dir,
 		})
-		for _, hit := range hits {
-			result.Findings = append(result.Findings, Finding{
-				Severity:    SevCritical,
-				Title:       fmt.Sprintf("%s %s is a known compromised npm package (%s)", pkg.Name, pkg.Version, hit.Record.ID),
-				Detail:      hit.Record.Summary,
-				Path:        pkg.Dir,
-				Remediation: fmt.Sprintf("Remove %s@%s, audit recent runs of the surrounding pipeline, and rotate any tokens this environment has held.", pkg.Name, pkg.Version),
-			})
-			npmFindings++
+		if len(hits) == 0 {
+			continue
 		}
+		// One Finding per (ecosystem, name, version, path) tuple even
+		// when multiple intel records cover the same exposure (manual
+		// snapshot + OSV record for the same package/version after
+		// OSV catches up to a hand-curated advisory). The matcher
+		// keeps returning every record so correlators can still see
+		// the full set; this output layer collapses to the single
+		// real-world exposure the user must act on.
+		//
+		// EmbeddedSnapshots() returns the manual snapshot first and
+		// the OSV snapshot second, so hits[0] picks the manual
+		// advisory ID (e.g. SOCKET-*) over the OSV one (MAL-*) when
+		// both are present, keeping the finding's advisory token
+		// stable across `aguara check` and `aguara check --fresh`.
+		hit := hits[0]
+		result.Findings = append(result.Findings, Finding{
+			Severity:    SevCritical,
+			Title:       fmt.Sprintf("%s %s is a known compromised npm package (%s)", pkg.Name, pkg.Version, hit.Record.ID),
+			Detail:      hit.Record.Summary,
+			Path:        pkg.Dir,
+			Remediation: fmt.Sprintf("Remove %s@%s, audit recent runs of the surrounding pipeline, and rotate any tokens this environment has held.", pkg.Name, pkg.Version),
+		})
+		npmFindings++
 	}
 	// Surface npm as an Ecosystems[] entry on the result so JSON
 	// consumers see consistent multi-ecosystem coverage data. Before

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -7,8 +7,10 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/intel"
 )
 
 func writeNPMPackage(t *testing.T, root, importPath, version string) {
@@ -196,6 +198,78 @@ func TestCheckNPM_MiniShaiHulud_AntvWaveExpansion(t *testing.T) {
 		if !strings.Contains(f.Title, "SOCKET-2026-05-19-mini-shai-hulud-antv") {
 			t.Errorf("expected @antv advisory ID in title, got %q", f.Title)
 		}
+	}
+}
+
+func TestCheckNPM_CollapsesManualAndOSVDuplicate(t *testing.T) {
+	// When the matcher returns multiple advisories for the same
+	// (ecosystem, name, version, path) tuple - one from manual
+	// intel, one from a refreshed OSV snapshot - the check layer
+	// must emit exactly ONE finding, not one per advisory. The
+	// matcher itself keeps returning every record so correlation
+	// consumers see the full set; this is a check-output-layer
+	// dedup, not a matcher behaviour change.
+	//
+	// Manual must win the title because EmbeddedSnapshots() puts
+	// the manual snapshot first; advisory tokens stay stable
+	// across `aguara check` and `aguara check --fresh`.
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "@antv/g2", "5.6.8")
+
+	manualSnap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		GeneratedAt:   time.Date(2026, 5, 19, 0, 0, 0, 0, time.UTC),
+		Sources:       []intel.SourceMeta{{Kind: intel.SourceManual}},
+		Records: []intel.Record{{
+			ID:        "SOCKET-2026-05-19-mini-shai-hulud-antv",
+			Ecosystem: intel.EcosystemNPM,
+			Name:      "@antv/g2",
+			Kind:      intel.KindMalicious,
+			Summary:   "manual-side advisory",
+			Versions:  []string{"5.6.8"},
+		}},
+	}
+	osvSnap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		GeneratedAt:   time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC),
+		Sources:       []intel.SourceMeta{{Kind: intel.SourceOSV}},
+		Records: []intel.Record{{
+			ID:        "MAL-2026-3973",
+			Ecosystem: intel.EcosystemNPM,
+			Name:      "@antv/g2",
+			Kind:      intel.KindMalicious,
+			Summary:   "osv-side advisory",
+			Versions:  []string{"5.6.8"},
+		}},
+	}
+
+	result, err := incident.CheckNPM(incident.CheckOptions{
+		Path: nm,
+		Intel: &incident.IntelOverride{
+			Snapshots:     []intel.Snapshot{manualSnap, osvSnap},
+			Mode:          "online",
+			SnapshotLabel: "remote-fresh",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CheckNPM error: %v", err)
+	}
+	if got := len(result.Findings); got != 1 {
+		t.Fatalf("expected exactly 1 finding (manual+OSV collapse to one exposure), got %d: %+v", got, result.Findings)
+	}
+	got := result.Findings[0]
+	if !strings.Contains(got.Title, "SOCKET-2026-05-19-mini-shai-hulud-antv") {
+		t.Errorf("manual advisory must win the title; got %q", got.Title)
+	}
+	if strings.Contains(got.Title, "MAL-2026-3973") {
+		t.Errorf("OSV advisory must not appear in title when manual is present; got %q", got.Title)
+	}
+	if got.Severity != incident.SevCritical {
+		t.Errorf("expected CRITICAL, got %q", got.Severity)
+	}
+	if len(result.Ecosystems) != 1 || result.Ecosystems[0].FindingsCount != 1 {
+		t.Errorf("ecosystems[0].findings_count must be 1, got %+v", result.Ecosystems)
 	}
 }
 

--- a/internal/packagecheck/runner.go
+++ b/internal/packagecheck/runner.go
@@ -58,13 +58,34 @@ func (r *Runner) Run(targets []Target) (*RunResult, error) {
 		}
 		findings := 0
 		for _, ref := range refs {
-			// Some ecosystems (Composer especially) routinely
-			// ship version strings with a leading `v` while the
-			// OSV-side record carries the bare form. We query
-			// every alias the per-ecosystem helper returns and
-			// dedupe by advisory ID so a single (ref, advisory)
-			// match never emits two Findings.
-			seen := make(map[string]struct{})
+			// One Hit per (ecosystem, name, version, path) tuple,
+			// even when multiple advisories cover the same
+			// exposure. Two reasons:
+			//
+			//   1. Some ecosystems (Composer especially) ship
+			//      version strings with a leading `v` while OSV
+			//      records carry the bare form, so we have to
+			//      query every alias the per-ecosystem helper
+			//      returns. The first alias that hits wins; we
+			//      do not walk the rest.
+			//   2. Once manual intel and OSV both cover a tuple
+			//      (e.g. a hand-curated SOCKET-* advisory plus
+			//      the upstream MAL-* record after OSV catches
+			//      up), the matcher returns both records. The
+			//      user is exposed once, not twice; collapsing
+			//      to a single Hit keeps the user-facing count
+			//      stable across `aguara check` and `aguara
+			//      check --fresh`.
+			//
+			// The matcher itself keeps returning every record so
+			// correlation layers (intel.Matcher consumers,
+			// future analyzers) can still see the full set; we
+			// dedupe here at the output boundary.
+			//
+			// EmbeddedSnapshots() returns manual first and OSV
+			// second, so matches[0] picks the manual advisory
+			// ID when both are present.
+			var selected *intel.Match
 			for _, v := range versionAliases(ref.Ecosystem, ref.Version) {
 				matches := r.Matcher.MatchPackage(intel.MatchInput{
 					Ecosystem: ref.Ecosystem,
@@ -72,14 +93,16 @@ func (r *Runner) Run(targets []Target) (*RunResult, error) {
 					Version:   v,
 					Path:      ref.Path,
 				})
-				for _, m := range matches {
-					if _, dup := seen[m.Record.ID]; dup {
-						continue
-					}
-					seen[m.Record.ID] = struct{}{}
-					out.Hits = append(out.Hits, Hit{Ref: ref, Record: m.Record})
-					findings++
+				if len(matches) == 0 {
+					continue
 				}
+				m := matches[0]
+				selected = &m
+				break
+			}
+			if selected != nil {
+				out.Hits = append(out.Hits, Hit{Ref: ref, Record: selected.Record})
+				findings++
 			}
 		}
 		out.Ecosystems = append(out.Ecosystems, EcosystemResult{

--- a/internal/packagecheck/runner_test.go
+++ b/internal/packagecheck/runner_test.go
@@ -248,6 +248,67 @@ func TestRunner_ComposerAliasDoesNotDoubleCountFinding(t *testing.T) {
 	}
 }
 
+func TestRunnerCollapsesMultipleIntelRecordsPerPackageRef(t *testing.T) {
+	// When two snapshots cover the same (ecosystem, name, version)
+	// tuple - the typical manual + OSV overlap that lands once OSV
+	// catches up to a hand-curated advisory - the runner must emit
+	// ONE Hit, not one per advisory. The matcher keeps returning
+	// every record for correlation; this is a runner-output-layer
+	// collapse that keeps user-facing counts stable across
+	// `aguara check` and `aguara check --fresh`.
+	//
+	// The first snapshot's record wins (manual before OSV), so the
+	// surfaced advisory ID stays the curated one.
+	manualSnap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		Sources:       []intel.SourceMeta{{Kind: intel.SourceManual}},
+		Records: []intel.Record{{
+			ID:        "SOCKET-2026-05-19-mini-shai-hulud-antv",
+			Ecosystem: intel.EcosystemNPM,
+			Name:      "@antv/g2",
+			Kind:      intel.KindMalicious,
+			Versions:  []string{"5.6.8"},
+		}},
+	}
+	osvSnap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		Sources:       []intel.SourceMeta{{Kind: intel.SourceOSV}},
+		Records: []intel.Record{{
+			ID:        "MAL-2026-3973",
+			Ecosystem: intel.EcosystemNPM,
+			Name:      "@antv/g2",
+			Kind:      intel.KindMalicious,
+			Versions:  []string{"5.6.8"},
+		}},
+	}
+	runner := &Runner{Matcher: intel.NewMatcher(manualSnap, osvSnap)}
+	targets, err := Discover(filepath.Join("testdata", "pnpm-mini-shai-hulud-antv"), []string{intel.EcosystemNPM})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	res, err := runner.Run(targets)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Ecosystems) != 1 {
+		t.Fatalf("ecosystems = %d, want 1", len(res.Ecosystems))
+	}
+	// The fixture lockfile pins @antv/g2 5.6.8 + echarts-for-react 3.2.7
+	// + lodash 4.17.21. Only @antv/g2 has both snapshots covering it.
+	// echarts-for-react has no synthetic match here, so the total Hit
+	// count is exactly 1 even though MatchPackage returns two records
+	// per the matcher's correlation contract.
+	if got := len(res.Hits); got != 1 {
+		t.Fatalf("hits = %d, want 1 (manual+OSV duplicate must collapse to one); got=%+v", got, res.Hits)
+	}
+	if got := res.Ecosystems[0].FindingsCount; got != 1 {
+		t.Errorf("ecosystems[0].findings_count = %d, want 1", got)
+	}
+	if got := res.Hits[0].Record.ID; got != "SOCKET-2026-05-19-mini-shai-hulud-antv" {
+		t.Errorf("manual record must win; got record id %q", got)
+	}
+}
+
 func TestRunner_MavenSyntheticHit(t *testing.T) {
 	snap := intel.Snapshot{
 		SchemaVersion: intel.CurrentSchemaVersion,


### PR DESCRIPTION
## Summary

When a refreshed OSV snapshot catches up to a hand-curated manual advisory, the matcher correctly returns both records for the same `(ecosystem, name, version, path)` tuple. The check output layer was rendering each record as a separate Finding, so a single real-world exposure showed up twice in `aguara check --fresh` once OSV ingested a tuple already in the manual snapshot.

## Where the fix lives

At the output boundary, not in the matcher.

- The matcher keeps returning every record so correlation consumers (existing analyzers and any future tools that iterate `intel.Match`) can still see the full set.
- The check / runner output layers collapse to one Finding (or Hit) per `(ecosystem, name, version, path)` tuple.

`EmbeddedSnapshots()` returns the manual snapshot first and OSV second, so `hits[0]` picks the curated advisory ID (e.g. `SOCKET-*`) over the OSV one (e.g. `MAL-*`) when both are present. The user-facing advisory token stays stable across `aguara check` and `aguara check --fresh`.

## Sites touched

| File | Path | Behaviour after |
|---|---|---|
| `internal/incident/npm.go` | installed-tree npm | one Finding per package |
| `internal/incident/checker.go` | PyPI site-packages | one Finding per package |
| `internal/incident/checker.go` | PyPI dist-info cache scan | one Finding per cache path (already capped by `seen[path]`, now also short-circuits on first hit) |
| `internal/packagecheck/runner.go` | multi-ecosystem lockfile runner | one Hit per ref; version-alias loop now breaks on first match |

## Tests

- `TestCheckNPM_CollapsesManualAndOSVDuplicate`: synthetic manual + OSV snapshots covering the same package version. Asserts exactly one Finding and that the manual advisory ID wins the title.
- `TestRunnerCollapsesMultipleIntelRecordsPerPackageRef`: the same scenario routed through the packagecheck runner against the existing `pnpm-mini-shai-hulud-antv` fixture. Asserts one Hit and that the manual record wins.
- `TestMatcherDistinctIDsAtSameTupleStaySeparate` stays green: the matcher continues to return both records.
- `TestRunner_ComposerAliasDoesNotDoubleCountFinding` stays green: the version-alias dedup still works at the new layer.

## Scope and what does not change

- JSON schema unchanged
- `KnownCompromised` unchanged
- OSV importer unchanged
- `intel.Matcher` unchanged

## End-to-end

Before, with manual intel + OSV both covering an affected tuple:

```
aguara check /repo --ecosystem npm --fresh --format json
findings_count: 4
package A -> SOCKET-* and MAL-*  (2 findings)
package B -> SOCKET-* and MAL-*  (2 findings)
```

After:

```
findings_count: 2
package A -> SOCKET-*
package B -> SOCKET-*
```

## Test plan

- [x] `go test -race -count=1 ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues
- [x] `TestMatcherDistinctIDsAtSameTupleStaySeparate` still green (correct invariant preserved)
- [x] Docker E2E against `ghcr.io/garagon/aguara:0.18.1` confirms 4 -> 2 findings on the `--fresh` path
- [ ] CI green on this PR