### PR TITLE
release: prep v0.18.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.18.2] - 2026-05-19
+
+Patch release fixing duplicate findings when `aguara check --fresh`
+pulls a refreshed OSV snapshot that has caught up to a hand-curated
+manual advisory. Without the fix, a single real-world exposure
+showed up as two findings: one for the manual advisory ID and one
+for the OSV one. `aguara check` (offline default) was unaffected
+because the embedded snapshots did not overlap.
+
+### Fixed
+
+- `aguara check` and `aguara audit` now emit one Finding per
+  `(ecosystem, name, version, path)` tuple even when multiple
+  intel records cover the same exposure. The check output layer
+  collapses duplicates to a single Finding; the matcher itself
+  keeps returning every record so correlation consumers see the
+  full set. `EmbeddedSnapshots()` returns the manual snapshot
+  first, so the curated advisory ID wins the title when both
+  manual and OSV cover the same tuple. User-facing advisory tokens
+  stay stable across `aguara check` and `aguara check --fresh`.
+
+### Compatibility
+
+Drop-in for v0.18.1. No JSON schema changes, no flag renames, no
+rule ID changes. JSON consumers that drove `findings_count` off
+the `--fresh` path will see a lower count for projects exposed to
+the AntV wave once OSV ingested the same tuples; the underlying
+exposure is identical, the count now reflects one row per real
+exposure.
+
 ## [0.18.1] - 2026-05-19
 
 Patch release adding manual threat-intel coverage for the May 2026

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.18.1
+INSTALL_SH_TEST_VERSION ?= v0.18.2
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ brew install garagon/tap/aguara
 ### Docker
 
 ```bash
-docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.18.1 check /repo
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.18.2 check /repo
 ```
 
 The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 10001, base images are digest-pinned, and the image is signed at the digest with Cosign plus SPDX SBOM and SLSA provenance attestations. Tag a specific release for reproducibility.
@@ -69,14 +69,14 @@ The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.18.1 sh
+  | VERSION=v0.18.2 sh
 ```
 
 `install.sh` downloads `checksums.txt` from the release and verifies the archive's SHA256 against it, aborting if neither `sha256sum` nor `shasum` is available. This catches a tampered or corrupted archive at the registry layer, but it does not verify the Cosign signature on `checksums.txt` itself. For full keyless-signature verification on the curl-pipe path, follow up with the Cosign step in [Verifying signed releases](#verifying-signed-releases). Default install location is `~/.local/bin`. Override for CI or containers:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.18.1 INSTALL_DIR=/usr/local/bin sh
+  | VERSION=v0.18.2 INSTALL_DIR=/usr/local/bin sh
 ```
 
 ### From source
@@ -96,7 +96,7 @@ Every release is signed with [Cosign](https://github.com/sigstore/cosign) keyles
 **Verify the release archive**:
 
 ```bash
-VERSION=v0.18.1
+VERSION=v0.18.2
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
@@ -358,11 +358,11 @@ aguara discover --format json
 ### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.18.1
+- uses: garagon/aguara@v0.18.2
   with:
     path: .
     fail-on: high
-    version: v0.18.1
+    version: v0.18.2
 ```
 
 Both pins (the action ref AND the `version:` input) are required. The action ref alone pins only the composite action and its install script; `version:` pins the Aguara binary the action installs. Setting both makes the workflow reproducible and dependabot-friendly: when a new release lands, the bot updates both together.
@@ -370,12 +370,12 @@ Both pins (the action ref AND the `version:` input) are required. The action ref
 Scans your repository, uploads findings to GitHub Code Scanning, and optionally fails the build:
 
 ```yaml
-- uses: garagon/aguara@v0.18.1
+- uses: garagon/aguara@v0.18.2
   with:
     path: ./mcp-server/
     severity: medium
     fail-on: high
-    version: v0.18.1
+    version: v0.18.2
 ```
 
 All inputs are optional. See [`action.yml`](action.yml) for the full list.
@@ -395,7 +395,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 
 ```yaml
 - name: Scan for security issues
-  run: docker run --rm -v "${{ github.workspace }}:/scan:ro" ghcr.io/garagon/aguara:0.18.1 scan /scan --ci
+  run: docker run --rm -v "${{ github.workspace }}:/scan:ro" ghcr.io/garagon/aguara:0.18.2 scan /scan --ci
 ```
 
 ### Manual / GitLab CI
@@ -404,7 +404,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitHub Actions (without the action)
 - name: Scan skills for security issues
   run: |
-    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.1 sh
+    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.2 sh
     aguara scan .claude/skills/ --ci
 ```
 
@@ -412,7 +412,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.1 sh
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.2 sh
     - aguara scan .claude/skills/ --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:
@@ -621,7 +621,7 @@ See the [mcp-aguara README](https://github.com/garagon/mcp-aguara) for install, 
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.18.1. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
+Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.18.2. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
 
 ## Enterprise use
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.18.1"
+        DEFAULT_REF="v0.18.2"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.18.1 tag rather than `@v1`
+// The action ref is pinned to the v0.18.2 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.18.1
+        uses: garagon/aguara@v0.18.2
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.18.1
+          version: v0.18.2
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
## Summary

Patch release prep for **v0.18.2**. Bumps the version pins from v0.18.1 to v0.18.2 across all release-tracked sites and adds the CHANGELOG entry.

The patch ships the check-output-layer dedup landed earlier on main (PR #137): when manual intel and a refreshed OSV snapshot both carry the same package/version, the matcher keeps returning every record for correlation, but check/audit now emit one Finding per real-world exposure. `aguara check` (offline default) was unaffected because the embedded snapshots did not overlap; the fix matters for the `--fresh` path once OSV catches up to a hand-curated tuple.

## CHANGELOG highlight

```
0.18.2 - 2026-05-19
Fixed: `aguara check` and `aguara audit` now emit one Finding per
(ecosystem, name, version, path) tuple even when multiple intel
records cover the same exposure. EmbeddedSnapshots() puts the
manual snapshot first, so the curated advisory ID wins the title.
```

## Pin scope (v0.18.1 → v0.18.2)

| File | What changed |
|---|---|
| `cmd/aguara/commands/init.go` | workflow template: comment, `uses:` line, `version:` input |
| `action.yml` | `DEFAULT_REF` |
| `Makefile` | `INSTALL_SH_TEST_VERSION` |
| `README.md` | install.sh `VERSION=` snippets, Docker tag references (`:0.18.2`), GitHub Action `uses:` + `version:` blocks, Aguara Watch surface line |

`VERSION=v0.18.2 .github/scripts/check-version-pins.sh` clean.

## Compatibility

Drop-in for v0.18.1. No JSON schema changes, no flag renames, no rule ID changes. JSON consumers that drove `findings_count` off the `--fresh` path will see a lower count for projects exposed to the affected tuples once OSV ingested them; the underlying exposure is identical, the count now reflects one row per real exposure.

## Test plan

- [x] `go test -race -count=1 ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` 0 issues
- [x] `VERSION=v0.18.2 .github/scripts/check-version-pins.sh` clean
- [x] `aguara init --ci` on a temp dir scaffolds a workflow with `garagon/aguara@v0.18.2` and `version: v0.18.2`
- [ ] CI green on this PR