### PR TITLE
fix(pattern): prefilter respects weak alternations and optional quantifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pattern prefilter no longer silently filters rules whose literal
+  evidence is hidden inside weak alternation branches or optional
+  characters.** The keyword extractor used by the Aho-Corasick
+  prefilter now treats an alternation as filterable only when every
+  branch produces at least one literal of `minKeywordLen` or more.
+  This applies to alternation groups (`(api|secret)`), top-level
+  alternations in a regex pattern (`api|secret` with no enclosing
+  parens, the form a custom rule might write directly), and nested
+  alternations. Alternations with even one weak branch contribute no
+  keywords; outer literals carry the filter when present. Optional
+  quantifiers (`?`, `*`, `{0,n}`) on a literal character now trim
+  that character from the indexed keyword, so a regex like
+  `https?://` indexes "http", not "https". Optional groups
+  (`(...)?` and friends) likewise contribute no keywords. Under
+  `match_mode: any`, a rule with any unfilterable pattern now falls
+  back to "always run" instead of being filtered on the remaining
+  patterns' literals. Concrete impact on built-in rules: `MCPCFG_003`
+  ("Hardcoded secrets in MCP env block"), `SSRF_002`, `SSRF_006`,
+  and `SSRF_009` were silently filtered out by `aguara scan` even
+  though their YAML rule self-tests passed. They now reach the regex
+  stage on every applicable file. A new
+  `TestRuleSelfTestsRunThroughMatcher` in `internal/engine/pattern/`
+  runs every built-in rule's `true_positive` through the real
+  `Matcher` (prefilter included) so future drift in keyword
+  extraction (or in custom rule authoring with top-level
+  alternations) surfaces in CI.
+
 ## [0.18.2] - 2026-05-19
 
 Patch release fixing duplicate findings when `aguara check --fresh`

--- a/internal/engine/pattern/matcher_test.go
+++ b/internal/engine/pattern/matcher_test.go
@@ -13,6 +13,81 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestRuleSelfTestsRunThroughMatcher is a regression test for the pattern
+// prefilter's keyword extraction. The rules-package self-test
+// (internal/rules.TestRuleSelfTest) only invokes the matcher's predicate
+// (matchesRule) directly, which bypasses the keyword prefilter. That gap
+// previously let MCPCFG_003 pass its own true_positive test even though
+// `aguara scan` silently filtered every match out at the prefilter stage
+// because every literal in pattern 2's alternation branches that the rule
+// relied on was either below minKeywordLen or hidden inside the
+// `API[_-]?KEY` branch with no extractable literal.
+//
+// This test loads every built-in rule, builds a real Matcher (prefilter
+// included), and runs each rule's true_positive examples through
+// Analyze(). Failing here means a future rule introduced a regex whose
+// literal evidence is below minKeywordLen along some alternation path AND
+// the prefilter is incorrectly skipping it.
+func TestRuleSelfTestsRunThroughMatcher(t *testing.T) {
+	rawRules, err := rules.LoadFromFS(builtin.FS())
+	require.NoError(t, err)
+
+	compiled, errs := rules.CompileAll(rawRules)
+	require.Empty(t, errs)
+
+	matcher := pattern.NewMatcher(compiled)
+	idx := make(map[string]*rules.CompiledRule, len(compiled))
+	for _, r := range compiled {
+		idx[r.ID] = r
+	}
+
+	for _, raw := range rawRules {
+		raw := raw
+		rule, ok := idx[raw.ID]
+		if !ok {
+			continue
+		}
+		t.Run(raw.ID, func(t *testing.T) {
+			for _, tp := range raw.Examples.TruePositive {
+				relPath := selfTestFilename(rule)
+				target := &scanner.Target{
+					RelPath: relPath,
+					Content: []byte(tp),
+				}
+				findings, err := matcher.Analyze(context.Background(), target)
+				require.NoError(t, err)
+				saw := false
+				for _, f := range findings {
+					if f.RuleID == raw.ID {
+						saw = true
+						break
+					}
+				}
+				require.Truef(t, saw,
+					"rule %s: true_positive %q reached the rule's matchesRule predicate but the Matcher (with prefilter) did not produce a finding. This usually means extractKeywords is over-filtering — some alternation branch produced no >=minKeywordLen literal.",
+					raw.ID, tp)
+			}
+		})
+	}
+}
+
+// selfTestFilename returns a relative path whose extension matches the
+// rule's first target, so rulesForFile returns the rule when the matcher
+// dispatches by file extension. If the rule has no targets (matches every
+// file) any extension works.
+func selfTestFilename(rule *rules.CompiledRule) string {
+	if len(rule.Targets) == 0 {
+		return "selftest.txt"
+	}
+	t := rule.Targets[0]
+	// "*.json" -> "selftest.json", "*.md" -> "selftest.md".
+	if len(t) > 2 && t[:2] == "*." {
+		return "selftest" + t[1:]
+	}
+	// Literal filename (Makefile, package.json, ...).
+	return t
+}
+
 func compileTestRule(t *testing.T, raw rules.RawRule) *rules.CompiledRule {
 	t.Helper()
 	cr, err := rules.Compile(raw)

--- a/internal/engine/pattern/prefilter.go
+++ b/internal/engine/pattern/prefilter.go
@@ -34,12 +34,27 @@ type prefilter struct {
 }
 
 // buildPrefilter creates a keyword-based pre-filter from compiled rules.
+//
+// A pattern that produces zero extractable literals (either because all its
+// literals are below minKeywordLen, or because some alternation branch has no
+// literal evidence) is treated as "always passes the prefilter". The
+// downstream effect depends on the rule's match_mode:
+//   - MatchAny: matching via any pattern is enough, so if any pattern has no
+//     usable literal evidence the rule must be marked noKeyword (always run).
+//     Otherwise the indexed union of all patterns' literals filters the rule
+//     correctly.
+//   - MatchAll: every pattern must match, so a pattern with no literal
+//     evidence does not constrain anything but the remaining patterns'
+//     literals still apply (content lacking those literals cannot satisfy
+//     match_mode: all). Only when *every* pattern is unfilterable does the
+//     rule fall back to noKeyword.
 func buildPrefilter(compiled []*rules.CompiledRule) *prefilter {
 	// Collect keywords per rule, deduplicating across rules.
 	kwToRules := make(map[string]map[string]bool) // keyword -> set of rule IDs
 	noKeyword := make(map[string]bool)
 
 	for _, rule := range compiled {
+		forceNoKeyword := false
 		ruleHasKeyword := false
 		for _, pat := range rule.Patterns {
 			var kws []string
@@ -51,6 +66,18 @@ func buildPrefilter(compiled []*rules.CompiledRule) *prefilter {
 			case rules.PatternRegex:
 				kws = extractKeywords(pat.Value)
 			}
+			if len(kws) == 0 {
+				// Pattern provides no usable literal evidence. Under MatchAny
+				// the rule could match via this pattern without any of the
+				// other patterns' keywords appearing, so we must give up on
+				// filtering it. Under MatchAll the other patterns' keywords
+				// remain reliable filters.
+				if rule.MatchMode == rules.MatchAny {
+					forceNoKeyword = true
+					break
+				}
+				continue
+			}
 			for _, kw := range kws {
 				if kwToRules[kw] == nil {
 					kwToRules[kw] = make(map[string]bool)
@@ -59,7 +86,7 @@ func buildPrefilter(compiled []*rules.CompiledRule) *prefilter {
 				ruleHasKeyword = true
 			}
 		}
-		if !ruleHasKeyword {
+		if forceNoKeyword || !ruleHasKeyword {
 			noKeyword[rule.ID] = true
 		}
 	}
@@ -120,8 +147,47 @@ func (p *prefilter) candidateRules(lowerContent string) map[string]bool {
 // that must appear in any matching text. Only runs of alphanumeric/underscore
 // characters of minKeywordLen+ length are returned. Content inside character
 // classes ([...]) and quantifiers ({...}) is skipped.
+//
+// Alternations are paren-aware: an alternation group whose branches do not
+// all produce a keyword (e.g. `(API[_-]?KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)`
+// where the `API[_-]?KEY` branch yields no >=4-char literal after stripping
+// the character class) contributes no keywords, because content matching the
+// regex via the weak branch would carry none of the longer branches'
+// literals. Optional groups (`(...)?`, `(...)*`, `(...){0,n}`) also
+// contribute no keywords because the group may match zero times.
+// Literals outside such alternations are still extracted and indexed
+// normally, so a pattern like `subprocess\.(run|call|Popen)` still filters
+// on "subprocess" even though the `run` branch is weak.
 func extractKeywords(pattern string) []string {
 	p := stripFlags(pattern)
+	return extractKeywordsFrom(p)
+}
+
+// extractKeywordsFrom walks a pre-stripped regex, accumulating literals as
+// keywords and recursing on parenthesized groups. Recursion is required so
+// that nested alternations like `((A|B)|cdef)` get their weak inner
+// alternations rejected before the outer alternation decides whether to
+// contribute literals.
+//
+// Top-level alternations (e.g. `api|secret`, no enclosing parens) are
+// handled before the linear walk: the regex matches via either branch, so
+// every branch must produce at least one >=minKeywordLen literal for the
+// pattern to be filterable. Without this guard the walker would treat `|`
+// as a plain boundary and silently index only the strong branches'
+// literals - the exact gap that motivated the alternation-aware fix in
+// the parenthesized case.
+func extractKeywordsFrom(p string) []string {
+	if branches := splitTopLevelAlternation(p); len(branches) > 1 {
+		var altKws []string
+		for _, branch := range branches {
+			bKws := extractKeywordsFrom(branch)
+			if len(bKws) == 0 {
+				return nil
+			}
+			altKws = append(altKws, bKws...)
+		}
+		return altKws
+	}
 
 	var keywords []string
 	var buf strings.Builder
@@ -155,6 +221,10 @@ func extractKeywords(pattern string) []string {
 			continue
 		}
 		if ch == '{' && !inQuantifier {
+			// `{0,n}` or `{0}` on the preceding character makes that
+			// character optional. Trim it from the buffer so the
+			// indexed literal only reflects what is actually required.
+			trimOptionalTail(&buf, p, i)
 			inQuantifier = true
 			flushKeyword(&buf, &keywords)
 			continue
@@ -167,15 +237,242 @@ func extractKeywords(pattern string) []string {
 			continue
 		}
 
+		if ch == '(' {
+			end := findMatchingParen(p, i)
+			if end == -1 {
+				// Malformed input; treat as a boundary and keep walking so we
+				// don't crash on a stray unbalanced paren.
+				flushKeyword(&buf, &keywords)
+				continue
+			}
+			inner := stripGroupFlags(p[i+1 : end])
+			flushKeyword(&buf, &keywords)
+
+			optional := isOptionalQuantifier(p, end+1)
+
+			branches := splitTopLevelAlternation(inner)
+			if len(branches) == 1 {
+				// Plain grouping, no alternation. The group's literals are
+				// required as long as the group itself is required, so only
+				// contribute when not under an optional quantifier.
+				if !optional {
+					keywords = append(keywords, extractKeywordsFrom(inner)...)
+				}
+			} else {
+				// Alternation. Every branch must produce at least one keyword
+				// for the alternation to contribute literals: a branch with
+				// no extractable literal could match content carrying none of
+				// the other branches' literals, which would falsely filter
+				// the rule out. Optional alternations contribute nothing
+				// regardless of branch strength.
+				if !optional {
+					var altKws []string
+					allBranchesStrong := true
+					for _, branch := range branches {
+						bKws := extractKeywordsFrom(branch)
+						if len(bKws) == 0 {
+							allBranchesStrong = false
+							break
+						}
+						altKws = append(altKws, bKws...)
+					}
+					if allBranchesStrong {
+						keywords = append(keywords, altKws...)
+					}
+				}
+			}
+			i = end
+			continue
+		}
+
+		if ch == ')' {
+			// Stray close paren (only reachable if findMatchingParen failed
+			// to find a match upstream and we kept walking). Treat as a
+			// boundary so any literal in progress is flushed.
+			flushKeyword(&buf, &keywords)
+			continue
+		}
+
 		if isKeywordChar(ch) {
 			buf.WriteByte(ch)
 		} else {
+			// `?` or `*` on the preceding character makes that
+			// character optional, so the indexed keyword must only
+			// span the required prefix. Without this trim, a regex
+			// like `https?` would be indexed on the literal "https"
+			// even though "http" alone is enough to match.
+			trimOptionalTail(&buf, p, i)
 			flushKeyword(&buf, &keywords)
 		}
 	}
 	flushKeyword(&buf, &keywords)
 
 	return keywords
+}
+
+// trimOptionalTail removes the last byte from buf when the character at
+// position pos in p is an optional quantifier (`?`, `*`, or `{0,...}`).
+// The optional quantifier applies to the immediately preceding regex atom;
+// when that atom is a literal character, the literal is not required to
+// appear in matching content and must be excluded from the prefilter
+// keyword.
+func trimOptionalTail(buf *strings.Builder, p string, pos int) {
+	if !isOptionalQuantifier(p, pos) || buf.Len() == 0 {
+		return
+	}
+	s := buf.String()
+	buf.Reset()
+	buf.WriteString(s[:len(s)-1])
+}
+
+// findMatchingParen returns the index of the ')' that closes the '(' at
+// start, or -1 if no match is found. Honors character classes and escaped
+// metacharacters so a '(' inside `[(]` or after `\` does not perturb the
+// depth count.
+func findMatchingParen(p string, start int) int {
+	depth := 1
+	inCharClass := false
+	escaped := false
+	for i := start + 1; i < len(p); i++ {
+		ch := p[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if ch == '[' && !inCharClass {
+			inCharClass = true
+			continue
+		}
+		if ch == ']' && inCharClass {
+			inCharClass = false
+			continue
+		}
+		if inCharClass {
+			continue
+		}
+		switch ch {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// splitTopLevelAlternation splits inner group content on '|' characters at
+// depth 0 (not inside nested parens or character classes). Returns the input
+// as a single element when there is no top-level alternation.
+func splitTopLevelAlternation(s string) []string {
+	var branches []string
+	depth := 0
+	inCharClass := false
+	escaped := false
+	start := 0
+	for i := 0; i < len(s); i++ {
+		ch := s[i]
+		if escaped {
+			escaped = false
+			continue
+		}
+		if ch == '\\' {
+			escaped = true
+			continue
+		}
+		if ch == '[' && !inCharClass {
+			inCharClass = true
+			continue
+		}
+		if ch == ']' && inCharClass {
+			inCharClass = false
+			continue
+		}
+		if inCharClass {
+			continue
+		}
+		switch ch {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case '|':
+			if depth == 0 {
+				branches = append(branches, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	branches = append(branches, s[start:])
+	return branches
+}
+
+// stripGroupFlags removes leading group prefixes inside a (...) group:
+//   - non-capturing `?:`
+//   - lookahead `?=` and `?!`
+//   - lookbehind `?<=` and `?<!` (Go's regexp doesn't support these but the
+//     stripper accepts them defensively)
+//   - inline flags `?i:`, `?im:`, etc.
+//   - named capture `?P<name>`
+//
+// Returns the input unchanged when no recognized prefix is found.
+func stripGroupFlags(s string) string {
+	if len(s) < 2 || s[0] != '?' {
+		return s
+	}
+	switch s[1] {
+	case ':', '=', '!':
+		return s[2:]
+	case '<':
+		if len(s) >= 3 && (s[2] == '=' || s[2] == '!') {
+			return s[3:]
+		}
+	case 'P':
+		if len(s) >= 3 && s[2] == '<' {
+			if gt := strings.Index(s, ">"); gt > 0 {
+				return s[gt+1:]
+			}
+		}
+	}
+	// Inline flag group like `?i:foo` or `?im:foo`.
+	if colon := strings.Index(s, ":"); colon > 0 {
+		for j := 1; j < colon; j++ {
+			ch := s[j]
+			if ch != 'i' && ch != 's' && ch != 'm' && ch != 'U' && ch != '-' {
+				return s
+			}
+		}
+		return s[colon+1:]
+	}
+	return s
+}
+
+// isOptionalQuantifier reports whether the character at position pos in p is
+// a quantifier that allows zero matches (`?`, `*`, `{0,...}`). Used to mark
+// a group's literals as non-required.
+func isOptionalQuantifier(p string, pos int) bool {
+	if pos >= len(p) {
+		return false
+	}
+	switch p[pos] {
+	case '?', '*':
+		return true
+	case '{':
+		// Look for `{0,...}` or `{0}` - a quantifier starting with 0.
+		end := strings.Index(p[pos:], "}")
+		if end == -1 {
+			return false
+		}
+		quant := p[pos+1 : pos+end]
+		return strings.HasPrefix(quant, "0,") || quant == "0"
+	}
+	return false
 }
 
 // isKeywordChar returns true for characters that form useful keyword literals.

--- a/internal/engine/pattern/prefilter_test.go
+++ b/internal/engine/pattern/prefilter_test.go
@@ -15,9 +15,15 @@ func TestExtractKeywords(t *testing.T) {
 		want    []string
 	}{
 		{
-			name:    "simple literal with flag",
+			// Outer "subprocess" is required regardless of which branch of
+			// (run|call|Popen) matches, so it indexes. The alternation has a
+			// weak `run` branch (3 chars after the minKeywordLen filter), so
+			// the alternation as a whole contributes no literals: indexing
+			// "call" and "popen" would falsely filter out content matching
+			// via the `run` branch.
+			name:    "outer literal kept when alternation has weak branch",
 			pattern: `(?i)subprocess\.(run|call|Popen)`,
-			want:    []string{"subprocess", "call", "popen"},
+			want:    []string{"subprocess"},
 		},
 		{
 			name:    "escaped metachar",
@@ -25,9 +31,14 @@ func TestExtractKeywords(t *testing.T) {
 			want:    []string{"eval"},
 		},
 		{
-			name:    "alternation with short branches",
+			// Both alternations are weighed independently. (curl|wget) has
+			// two strong branches, so its literals index. (bash|sh) has a
+			// weak `sh` branch so the second alternation contributes nothing
+			// (indexing "bash" alone would falsely filter out content like
+			// `wget x | sh`).
+			name:    "alternation with weak second branch drops its literals",
 			pattern: `(?i)(curl|wget)\s+[^|]+\|\s*(bash|sh)\b`,
-			want:    []string{"curl", "wget", "bash"},
+			want:    []string{"curl", "wget"},
 		},
 		{
 			name:    "credential prefix",
@@ -40,9 +51,13 @@ func TestExtractKeywords(t *testing.T) {
 			want:    []string{"ghp_"},
 		},
 		{
-			name:    "private key header",
+			// `(RSA|DSA|EC|OPENSSH|PGP)?` is optional, so the regex can match
+			// content without any of those literals. Even if every branch
+			// were strong the group's literals would be untrustworthy as a
+			// filter. Only the outer required literals contribute.
+			name:    "optional alternation contributes no literals",
 			pattern: `-----BEGIN\s+(RSA|DSA|EC|OPENSSH|PGP)?\s*PRIVATE KEY`,
-			want:    []string{"begin", "openssh", "private"},
+			want:    []string{"begin", "private"},
 		},
 		{
 			name:    "no literals (all char classes and quantifiers)",
@@ -55,9 +70,13 @@ func TestExtractKeywords(t *testing.T) {
 			want:    nil,
 		},
 		{
-			name:    "mixed length alternation",
+			// The `pwd` branch (3 chars) is weak. With no outer >=4-char
+			// literal to fall back on, the whole pattern is unfilterable:
+			// indexing on "password"/"passwd" would silently drop matches
+			// like `pwd = secret`.
+			name:    "alternation with weak branch and no outer literal is unfilterable",
 			pattern: `(?i)(password|passwd|pwd)\s*[=:]`,
-			want:    []string{"password", "passwd"},
+			want:    nil,
 		},
 		{
 			name:    "non-capturing group handled",
@@ -83,6 +102,103 @@ func TestExtractKeywords(t *testing.T) {
 			name:    "quantifier content skipped",
 			pattern: `[a-z]{3,10}food`,
 			want:    []string{"food"},
+		},
+		{
+			// Regression for MCPCFG_003 ("Hardcoded secrets in MCP env
+			// block"). The `API[_-]?KEY` branch yields no >=4-char literal
+			// after the char-class strip (the only runs are `api` and
+			// `key`, both 3 chars), so the alternation as a whole cannot
+			// be trusted as a filter signal. Outer literals in the rest of
+			// the pattern are all 1-char or char classes, so the entire
+			// pattern is unfilterable: the rule must be marked noKeyword
+			// or content with `API_KEY` would be silently skipped.
+			name:    "MCPCFG_003 secret pattern is unfilterable",
+			pattern: `(?i)["'][A-Z_]*(API[_-]?KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[A-Z_]*["']\s*:\s*["'][a-zA-Z0-9_\-]{20,}["']`,
+			want:    nil,
+		},
+		{
+			// Nested alternation: inner `(A|B)` is unfilterable (both
+			// branches weak). The outer alternation then has one branch
+			// (`(A|B)`) with no literal, so the outer is also unfilterable.
+			// With no outer literal to fall back on the pattern as a whole
+			// is unfilterable.
+			name:    "nested weak alternation propagates",
+			pattern: `((A|B)|cdefgh)`,
+			want:    nil,
+		},
+		{
+			// Same nested-weak alternation, but now a strong outer literal
+			// keeps the pattern filterable on that literal alone.
+			name:    "outer literal preserved even when nested alternations collapse",
+			pattern: `\bprefix\b((A|B)|cdefgh)`,
+			want:    []string{"prefix"},
+		},
+		{
+			// When the outer regex has a strong literal, an unfilterable
+			// alternation does NOT poison the whole pattern. The outer
+			// literal remains a valid filter.
+			name:    "outer literal survives unfilterable alternation",
+			pattern: `exfiltrate\s+(a|b|c)`,
+			want:    []string{"exfiltrate"},
+		},
+		{
+			// `?` on the trailing `s` makes the `s` optional, so the
+			// required literal is "http", not "https". Indexing on
+			// "https" would falsely filter content that matches the
+			// regex via the http branch (the SSRF_002 / SSRF_006 /
+			// SSRF_009 rules tripped on this in production).
+			name:    "trailing ? makes preceding char optional",
+			pattern: `(?i)https?://`,
+			want:    []string{"http"},
+		},
+		{
+			// Top-level alternation with a weak branch. Without the
+			// pre-walk split, the walker would treat `|` as a plain
+			// boundary, drop `api` (3 chars), and index "secret" alone.
+			// Content matching via `api` would be falsely filtered.
+			name:    "top-level alternation with weak branch is unfilterable",
+			pattern: `(?i)api|secret`,
+			want:    nil,
+		},
+		{
+			// Top-level alternation, every branch strong. Both literals
+			// must be indexed: content matching via either branch must
+			// route to the rule.
+			name:    "top-level alternation with all strong branches",
+			pattern: `(?i)apikey|secret`,
+			want:    []string{"apikey", "secret"},
+		},
+		{
+			// Top-level alternation where both branches happen to repeat
+			// the same strong literal `prefix`. The branches stay
+			// filterable because each independently yields at least one
+			// keyword; `prefix` shows up in both extracted slices because
+			// the extractor walks each branch independently rather than
+			// hoisting shared text out of an AST.
+			name:    "top-level alternation with a repeated strong branch literal",
+			pattern: `(?i)prefix.*api|prefix.*secret`,
+			want:    []string{"prefix", "prefix", "secret"},
+		},
+		{
+			// `*` is even more permissive than `?` (zero or more) and
+			// must also trim the preceding character from the indexed
+			// literal.
+			name:    "trailing * makes preceding char optional",
+			pattern: `abcds*\b`,
+			want:    []string{"abcd"},
+		},
+		{
+			// `{0,3}` is an optional quantifier (zero is allowed).
+			name:    "trailing {0,n} makes preceding char optional",
+			pattern: `abcds{0,3}\b`,
+			want:    []string{"abcd"},
+		},
+		{
+			// `{1,3}` requires at least one occurrence, so the preceding
+			// character IS required.
+			name:    "trailing {1,n} keeps preceding char",
+			pattern: `abcds{1,3}\b`,
+			want:    []string{"abcds"},
 		},
 	}
 
@@ -136,6 +252,101 @@ func TestPrefilterOverlappingKeywords(t *testing.T) {
 	got = pf.candidateRules("run bash command")
 	require.True(t, got["SHORT"], "rule keyed on 'bash' must be a candidate when content has 'bash'")
 	require.False(t, got["LONG"], "rule keyed on 'bashrc' must NOT be a candidate when content has only 'bash'")
+}
+
+// TestPrefilterMatchModeAwareness pins how buildPrefilter resolves rules
+// that contain at least one pattern with no extractable literal evidence.
+// The match-mode semantics differ: under MatchAny a single unfilterable
+// pattern means the rule must always run (any pattern matching is enough
+// for a finding), while under MatchAll the other patterns' literals remain
+// reliable because *every* pattern must match.
+func TestPrefilterMatchModeAwareness(t *testing.T) {
+	strongPat := rules.CompiledPattern{
+		Type:  rules.PatternRegex,
+		Value: "(?i)exfiltrate",
+		Regex: regexp.MustCompile(`(?i)exfiltrate`),
+	}
+	// (a|b) has no >=4-char literal in any branch -> unfilterable.
+	weakPat := rules.CompiledPattern{
+		Type:  rules.PatternRegex,
+		Value: "(?i)(a|b)",
+		Regex: regexp.MustCompile(`(?i)(a|b)`),
+	}
+
+	anyRule := &rules.CompiledRule{
+		ID:        "ANY_MIXED",
+		MatchMode: rules.MatchAny,
+		Patterns:  []rules.CompiledPattern{strongPat, weakPat},
+	}
+	allRule := &rules.CompiledRule{
+		ID:        "ALL_MIXED",
+		MatchMode: rules.MatchAll,
+		Patterns:  []rules.CompiledPattern{strongPat, weakPat},
+	}
+	allWeakRule := &rules.CompiledRule{
+		ID:        "ALL_WEAK",
+		MatchMode: rules.MatchAll,
+		Patterns:  []rules.CompiledPattern{weakPat, weakPat},
+	}
+
+	pf := buildPrefilter([]*rules.CompiledRule{anyRule, allRule, allWeakRule})
+
+	// MatchAny + unfilterable pattern -> rule always runs.
+	require.True(t, pf.noKeywordRules["ANY_MIXED"],
+		"MatchAny rule with an unfilterable pattern must be noKeyword")
+
+	// MatchAll + at least one filterable pattern -> rule is filtered on the
+	// strong pattern's literal. Content lacking "exfiltrate" cannot match
+	// pattern 1, so the rule cannot match either.
+	require.False(t, pf.noKeywordRules["ALL_MIXED"],
+		"MatchAll rule with a strong pattern must be filterable on it")
+	got := pf.candidateRules("exfiltrate this data")
+	require.True(t, got["ALL_MIXED"], "content with 'exfiltrate' must route ALL_MIXED")
+	got = pf.candidateRules("totally unrelated text")
+	require.False(t, got["ALL_MIXED"], "content without 'exfiltrate' must not route ALL_MIXED")
+
+	// MatchAll + every pattern unfilterable -> rule must always run.
+	require.True(t, pf.noKeywordRules["ALL_WEAK"],
+		"MatchAll rule whose every pattern is unfilterable must be noKeyword")
+}
+
+// TestPrefilterMCPCFG003Equivalent is a regression test for the specific
+// shape that triggered the prefilter gap: a MatchAll rule whose first
+// pattern has no >=4-char literal (env: { fragment) and whose second
+// pattern has an alternation with one weak branch (API[_-]?KEY among the
+// alternatives). Before the alternation-aware fix the rule was indexed on
+// {secret, token, password, credential} and silently filtered out content
+// like `{"env": {"API_KEY": "..."}}` because none of those four literals
+// appeared. After the fix both patterns return zero literals and the rule
+// must fall back to noKeyword so the scanner reaches the regex stage.
+func TestPrefilterMCPCFG003Equivalent(t *testing.T) {
+	envPat := rules.CompiledPattern{
+		Type:  rules.PatternRegex,
+		Value: `(?i)["']env["']\s*:\s*\{`,
+		Regex: regexp.MustCompile(`(?i)["']env["']\s*:\s*\{`),
+	}
+	secretPat := rules.CompiledPattern{
+		Type:  rules.PatternRegex,
+		Value: `(?i)["'][A-Z_]*(API[_-]?KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[A-Z_]*["']\s*:\s*["'][a-zA-Z0-9_\-]{20,}["']`,
+		Regex: regexp.MustCompile(`(?i)["'][A-Z_]*(API[_-]?KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)[A-Z_]*["']\s*:\s*["'][a-zA-Z0-9_\-]{20,}["']`),
+	}
+	rule := &rules.CompiledRule{
+		ID:        "MCPCFG_003",
+		MatchMode: rules.MatchAll,
+		Patterns:  []rules.CompiledPattern{envPat, secretPat},
+	}
+
+	pf := buildPrefilter([]*rules.CompiledRule{rule})
+
+	require.True(t, pf.noKeywordRules["MCPCFG_003"],
+		"MCPCFG_003-shaped rule must be noKeyword: both patterns are unfilterable")
+
+	// Content with API_KEY but none of {secret, token, password, credential}
+	// must still route to the rule. Before the fix this returned an empty
+	// candidate set.
+	got := pf.candidateRules(`{"env":{"github_api_key":"ghp_real1234567890abcdef"}}`)
+	require.True(t, got["MCPCFG_003"],
+		"content containing the MCPCFG_003 secret pattern must reach the rule")
 }
 
 func TestStripFlags(t *testing.T) {


### PR DESCRIPTION
## Summary

The Aho-Corasick keyword prefilter that gates regex evaluation was silently filtering out rules whose literal evidence lived in a weak alternation branch (group-level OR top-level) or behind an optional quantifier. The rule self-test (`internal/rules.TestRuleSelfTest`) ran patterns through `matchesRule` directly and bypassed the prefilter, so the gap never reached CI even though four built-in rules were affected in production:

- `MCPCFG_003` ("Hardcoded secrets in MCP env block") on configs naming the env var `API_KEY` rather than `*_TOKEN` / `*_SECRET` / `*_PASSWORD` / `*_CREDENTIAL`. The alternation `(API[_-]?KEY|SECRET|TOKEN|PASSWORD|CREDENTIAL)` has no extractable `>=4`-char literal in the `API[_-]?KEY` branch, so content matching via that branch carries none of the longer branches' literals and the prefilter dropped it.
- `SSRF_002`, `SSRF_006`, `SSRF_009` on content with `http://` rather than `https://`. The `?` on the trailing `s` in `https?` means `http` is the required prefix, but the extractor indexed the full literal `https`.

The same shape can appear in user-authored custom rules. A regex like `api|secret` (top-level alternation, no enclosing parens) would walk linearly under the old extractor: `api` drops below `minKeywordLen`, `|` is treated as a plain boundary, and `secret` indexes alone. Content matching via the `api` branch is silently dropped. This PR closes that hole too so custom rules aren't bitten by it.

## Fix

Four coordinated changes in `internal/engine/pattern/prefilter.go`:

1. **Top-level alternation handling.** `extractKeywordsFrom` now calls `splitTopLevelAlternation` on the pattern before the linear walk. If the pattern has multiple top-level branches, every branch must independently produce at least one `>=minKeywordLen` keyword; otherwise the entire pattern is unfilterable. Single-branch input falls through to the existing walker unchanged.
2. **Paren-aware extraction.** When the walker enters a `(...)` group it finds the matching `)`, strips group flags (`?:`, `?=`, `?!`, `?<=`, `?<!`, `?i:`, `?P<name>`), and splits the inner content on top-level `|`. The same all-branches-strong rule applies. Optional groups (`(...)?`, `(...)*`, `(...){0,n}`) contribute no literals.
3. **Optional quantifiers on literal characters trim the keyword.** `?`, `*`, and `{0,n}` after a literal byte make that byte optional, so it is removed from the indexed keyword. `https?://` now indexes `http`.
4. **`buildPrefilter` respects `match_mode`.** Under `MatchAny` a single unfilterable pattern means the rule must always run, because matching via that pattern requires no keyword evidence. Under `MatchAll` the remaining patterns' literals stay valid filters (every pattern must match, so any one filterable pattern's keyword gates the rule).

## Hardening

`internal/engine/pattern/matcher_test.go` gains `TestRuleSelfTestsRunThroughMatcher`, which loads every built-in rule, builds a real `Matcher` (prefilter included), and runs each rule's `true_positive` examples through `Analyze`. Failure means the prefilter filtered a true positive that `matchesRule` would have caught - exactly the gap that hid the four affected rules.

## Sites touched

- `internal/engine/pattern/prefilter.go` (the fix)
- `internal/engine/pattern/prefilter_test.go` (unit coverage)
- `internal/engine/pattern/matcher_test.go` (rule-level hardening test)
- `CHANGELOG.md` ([Unreleased] entry)

## Test plan

- [x] `make build` produces the binary against the new prefilter
- [x] `make test` passes (`go test -race -count=1 ./...`)
- [x] `make vet` clean
- [x] `make lint` clean (0 issues)
- [x] `TestExtractKeywords` covers: outer literals kept when alternation has a weak branch, weak-second-branch dropping its literals, optional alternation contributing no literals, nested weak alternation propagating, MCPCFG_003-equivalent pattern shape, trailing `?` / `*` / `{0,n}` / `{1,n}` quantifier handling, **top-level alternation with weak branch (unfilterable)**, **top-level alternation with all strong branches**, and **top-level alternation with a repeated strong branch literal**
- [x] `TestPrefilterMatchModeAwareness` and `TestPrefilterMCPCFG003Equivalent` pin the `buildPrefilter` behavior
- [x] `TestRuleSelfTestsRunThroughMatcher` passes for all 193 built-in rules; failure on `SSRF_002` / `SSRF_006` / `SSRF_009` / `MCPCFG_003` was confirmed before the fix and now passes
- [x] Existing `TestExtractKeywords` cases updated where they encoded the over-permissive old behavior; the underlying rules' regex matching is unchanged, only the prefilter index is tighter