### PR TITLE
fix(incident): add TrapDoor campaign advisories for confirmed tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Added
+
+- **Local advisories for the TrapDoor crypto-stealer campaign.** `aguara
+  check` now blocks the confirmed malicious package/version tuples from
+  the TrapDoor supply-chain campaign (Socket, 2026-05-24) under advisory
+  `SOCKET-2026-05-24-trapdoor`: 5 npm packages at `1.0.12`
+  (`build-scripts-utils`, `dev-env-bootstrapper`, `llm-context-compressor`,
+  `prompt-engineering-toolkit`, `token-usage-tracker`) and 7 PyPI packages
+  at `0.1.0`/`0.1.1` (`cryptowallet-safety`, `data-pipeline-check`,
+  `defi-risk-scanner`, `env-loader-cli`, `eth-security-auditor`,
+  `git-config-sync`, `solidity-build-guard`). Detection is offline and
+  covers pnpm lockfiles, installed npm trees, and installed Python
+  environments. Only tuples with an exact confirmed malicious version are
+  included; the campaign's range-only npm packages and its crates.io
+  packages (no exact version available yet) are intentionally not listed.
+
 ## [0.18.3] - 2026-05-21
 
 Patch release closing four built-in rule false negatives caused by the

--- a/internal/incident/checker_test.go
+++ b/internal/incident/checker_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -271,4 +272,38 @@ func TestCheckMultipleCompromised(t *testing.T) {
 	result, err := Check(CheckOptions{Path: dir})
 	require.NoError(t, err)
 	assert.GreaterOrEqual(t, len(result.Findings), 2, "should find both package and .pth")
+}
+
+func TestCheckDetectsTrapDoorPyPI(t *testing.T) {
+	// Two TrapDoor PyPI packages in a site-packages tree: a
+	// single-version entry (eth-security-auditor @ 0.1.0) and a
+	// multi-version entry exercised at its second version
+	// (data-pipeline-check @ 0.1.1). Both must flag CRITICAL with the
+	// campaign advisory. dist-info dirs use the wheel-style underscore
+	// name; the METADATA Name carries the canonical hyphenated form.
+	dir := t.TempDir()
+	for _, p := range []struct{ distName, metaName, version string }{
+		{"eth_security_auditor", "eth-security-auditor", "0.1.0"},
+		{"data_pipeline_check", "data-pipeline-check", "0.1.1"},
+	} {
+		distInfo := filepath.Join(dir, p.distName+"-"+p.version+".dist-info")
+		require.NoError(t, os.Mkdir(distInfo, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(distInfo, "METADATA"), []byte(
+			"Metadata-Version: 2.1\nName: "+p.metaName+"\nVersion: "+p.version+"\n",
+		), 0o644))
+	}
+
+	result, err := Check(CheckOptions{Path: dir})
+	require.NoError(t, err)
+
+	var trapdoor []Finding
+	for _, f := range result.Findings {
+		if strings.Contains(f.Title, "SOCKET-2026-05-24-trapdoor") {
+			trapdoor = append(trapdoor, f)
+		}
+	}
+	require.Len(t, trapdoor, 2, "both TrapDoor PyPI packages should flag; findings=%+v", result.Findings)
+	for _, f := range trapdoor {
+		assert.Equal(t, SevCritical, f.Severity)
+	}
 }

--- a/internal/incident/compromised.go
+++ b/internal/incident/compromised.go
@@ -36,6 +36,31 @@ type IOC struct {
 	Value string `json:"value"`
 }
 
+// trapdoorAdvisory is the single advisory ID shared by every TrapDoor
+// campaign entry below. One ID keeps the campaign readable in output
+// and gives the matcher's same-ID version-merge a single anchor.
+const trapdoorAdvisory = "SOCKET-2026-05-24-trapdoor"
+
+// trapdoorNPMIOCs / trapdoorPyPIIOCs are the campaign indicators from
+// the Socket report, attached as metadata to each TrapDoor entry. They
+// are shared (the whole campaign uses one payload), so they live in a
+// single slice each rather than being copy-pasted per entry. IOCs are
+// metadata only: matching is by (ecosystem, name, version), so these
+// never widen detection or risk a false positive.
+var (
+	trapdoorNPMIOCs = []IOC{
+		{Type: "runtime", Value: "P-2024-001"},
+		{Type: "path", Value: "trap-core.js"},
+		{Type: "path", Value: ".cursorrules"},
+		{Type: "path", Value: "CLAUDE.md"},
+	}
+	trapdoorPyPIIOCs = []IOC{
+		{Type: "runtime", Value: "P-2024-001"},
+		{Type: "endpoint", Value: "ddjidd564.github.io"},
+		{Type: "path", Value: "defi-security-best-practices"},
+	}
+)
+
 // KnownCompromised is the embedded list of known compromised packages.
 // Updated with each Aguara release.
 //
@@ -247,6 +272,138 @@ var KnownCompromised = []CompromisedPackage{
 		Advisory:  "SOCKET-2026-05-19-mini-shai-hulud-antv",
 		Date:      "2026-05-19",
 		Summary:   "Mini Shai-Hulud-linked npm compromise; npm deprecated message flags these versions as published with a compromised key.",
+	},
+
+	// --- TrapDoor crypto-stealer campaign 2026-05-24 (npm + PyPI) ---
+	//
+	// Cross-ecosystem campaign documented by Socket (2026-05-24). The
+	// npm packages run a postinstall hook that executes a shared
+	// trap-core.js payload (developer-secret harvesting, AWS/GitHub
+	// credential validation, persistence via .cursorrules / CLAUDE.md /
+	// git + shell hooks). The PyPI packages execute on import,
+	// downloading attacker-hosted JavaScript from ddjidd564.github.io
+	// and running it through `node -e`. Campaign marker: P-2024-001.
+	//
+	// ONLY tuples with an exact OSV-confirmed malicious version are
+	// listed here. The verification harness found:
+	//   - 12 packages with exact OSV versions (5 npm @ 1.0.12,
+	//     7 PyPI @ 0.1.0/0.1.1) -- the entries below.
+	//   - 16 npm packages OSV carries as range-only (introduced:0)
+	//     after npm security-held them; no exact version exists to
+	//     pin, so they are intentionally NOT added here (range matcher
+	//     work, tracked separately).
+	//   - 6 crates.io names with no OSV record and a 404 on the
+	//     registry; crates.io is out of manual intel until exact
+	//     versions are confirmed or a behavioral Rust rule lands.
+	//
+	// Source: https://socket.dev/blog/trapdoor-crypto-stealer-npm-pypi-crates
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "build-scripts-utils",
+		Versions:  []string{"1.0.12"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; postinstall trap-core.js credential-stealer with persistence. Confirmed malicious at 1.0.12 (OSV MAL-2026-4276).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "dev-env-bootstrapper",
+		Versions:  []string{"1.0.12"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; postinstall trap-core.js credential-stealer with persistence. Confirmed malicious at 1.0.12 (OSV MAL-2026-4277).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "llm-context-compressor",
+		Versions:  []string{"1.0.12"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; postinstall trap-core.js credential-stealer with persistence. Confirmed malicious at 1.0.12 (OSV MAL-2026-4278).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "prompt-engineering-toolkit",
+		Versions:  []string{"1.0.12"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; postinstall trap-core.js credential-stealer with persistence. Confirmed malicious at 1.0.12 (OSV MAL-2026-4282).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "token-usage-tracker",
+		Versions:  []string{"1.0.12"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; postinstall trap-core.js credential-stealer with persistence. Confirmed malicious at 1.0.12 (OSV MAL-2026-4283).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemPyPI,
+		Name:      "cryptowallet-safety",
+		Versions:  []string{"0.1.0"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign PyPI package; import-time remote-JS execution via node -e from ddjidd564.github.io. Confirmed malicious at 0.1.0 (OSV MAL-2026-4259).",
+		IOCs:      trapdoorPyPIIOCs,
+	},
+	{
+		Ecosystem: EcosystemPyPI,
+		Name:      "data-pipeline-check",
+		Versions:  []string{"0.1.0", "0.1.1"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign PyPI package; import-time remote-JS execution via node -e from ddjidd564.github.io. Confirmed malicious at 0.1.0 and 0.1.1 (OSV MAL-2026-4271).",
+		IOCs:      trapdoorPyPIIOCs,
+	},
+	{
+		Ecosystem: EcosystemPyPI,
+		Name:      "defi-risk-scanner",
+		Versions:  []string{"0.1.0"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign PyPI package; import-time remote-JS execution via node -e from ddjidd564.github.io. Confirmed malicious at 0.1.0 (OSV MAL-2026-4260).",
+		IOCs:      trapdoorPyPIIOCs,
+	},
+	{
+		Ecosystem: EcosystemPyPI,
+		Name:      "env-loader-cli",
+		Versions:  []string{"0.1.0", "0.1.1"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign PyPI package; import-time remote-JS execution via node -e from ddjidd564.github.io. Confirmed malicious at 0.1.0 and 0.1.1 (OSV MAL-2026-4272).",
+		IOCs:      trapdoorPyPIIOCs,
+	},
+	{
+		Ecosystem: EcosystemPyPI,
+		Name:      "eth-security-auditor",
+		Versions:  []string{"0.1.0"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign PyPI package; import-time remote-JS execution via node -e from ddjidd564.github.io. Confirmed malicious at 0.1.0 (OSV MAL-2026-4261).",
+		IOCs:      trapdoorPyPIIOCs,
+	},
+	{
+		Ecosystem: EcosystemPyPI,
+		Name:      "git-config-sync",
+		Versions:  []string{"0.1.0", "0.1.1"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign PyPI package; import-time remote-JS execution via node -e from ddjidd564.github.io. Confirmed malicious at 0.1.0 and 0.1.1 (OSV MAL-2026-4273).",
+		IOCs:      trapdoorPyPIIOCs,
+	},
+	{
+		Ecosystem: EcosystemPyPI,
+		Name:      "solidity-build-guard",
+		Versions:  []string{"0.1.0"},
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign PyPI package; import-time remote-JS execution via node -e from ddjidd564.github.io. Confirmed malicious at 0.1.0 (OSV MAL-2026-4262).",
+		IOCs:      trapdoorPyPIIOCs,
 	},
 }
 

--- a/internal/incident/intel_adapter.go
+++ b/internal/incident/intel_adapter.go
@@ -187,7 +187,7 @@ func KnownCompromisedSnapshot() intel.Snapshot {
 // can detect a stale embedded snapshot. Reproducible across builds.
 // Must be >= the freshest Date string in KnownCompromised; a
 // regression test in intel_adapter_test.go enforces that ordering.
-var knownCompromisedGeneratedAt = time.Date(2026, time.May, 19, 0, 0, 0, 0, time.UTC)
+var knownCompromisedGeneratedAt = time.Date(2026, time.May, 24, 0, 0, 0, 0, time.UTC)
 
 // normalizeEcosystemForIntel maps the legacy ecosystem strings used
 // by CompromisedPackage entries to the canonical intel ecosystem

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -665,3 +665,83 @@ func TestCheckNPM_IgnoresFixtureManifests(t *testing.T) {
 		t.Errorf("fixture manifests must not produce findings, got: %+v", result.Findings)
 	}
 }
+
+func TestCheckNPM_TrapDoor(t *testing.T) {
+	// TrapDoor campaign npm package at its confirmed malicious version
+	// in an installed tree must flag CRITICAL with the campaign advisory.
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "dev-env-bootstrapper", "1.0.12")
+	writeNPMPackage(t, nm, "left-pad", "1.3.0") // unrelated; must NOT flag
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 TrapDoor finding, got %d: %+v", len(result.Findings), result.Findings)
+	}
+	f := result.Findings[0]
+	if f.Severity != incident.SevCritical {
+		t.Errorf("severity = %q, want CRITICAL", f.Severity)
+	}
+	if !strings.Contains(f.Title, "dev-env-bootstrapper") || !strings.Contains(f.Title, "SOCKET-2026-05-24-trapdoor") {
+		t.Errorf("title = %q, want it to name the package and the campaign advisory", f.Title)
+	}
+}
+
+func TestCheckNPM_TrapDoor_RangeOnlyPackagesNotListed(t *testing.T) {
+	// async-pipeline-builder is part of the TrapDoor campaign, but OSV
+	// carries it range-only (introduced:0) after npm security-held it,
+	// so no exact version exists to pin and it was deliberately NOT
+	// added to manual intel. It must not flag, even at the campaign's
+	// version shape. This locks the "12 ready_exact only" scope.
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "async-pipeline-builder", "1.0.12")
+
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if len(result.Findings) != 0 {
+		t.Fatalf("range-only campaign package must not be in manual intel, got: %+v", result.Findings)
+	}
+}
+
+func TestCheckNPM_TrapDoor_DedupeManualAndOSV(t *testing.T) {
+	// Simulate `aguara check --fresh`: an OSV snapshot also carries the
+	// same tuple under its own ID (MAL-*). The matcher returns both
+	// records for correlation, but the user must see ONE finding, and
+	// it must keep the manual SOCKET advisory ID because the manual
+	// snapshot loads first (mirrors EmbeddedSnapshots() ordering).
+	dir := t.TempDir()
+	nm := filepath.Join(dir, "node_modules")
+	writeNPMPackage(t, nm, "dev-env-bootstrapper", "1.0.12")
+
+	osv := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		Records: []intel.Record{{
+			ID:        "MAL-2026-4277",
+			Ecosystem: intel.EcosystemNPM,
+			Name:      "dev-env-bootstrapper",
+			Kind:      intel.KindMalicious,
+			Versions:  []string{"1.0.12"},
+		}},
+	}
+	override := &incident.IntelOverride{
+		Snapshots:     []intel.Snapshot{incident.KnownCompromisedSnapshot(), osv},
+		Mode:          "online",
+		SnapshotLabel: "remote-fresh",
+	}
+	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm, Intel: override})
+	if err != nil {
+		t.Fatalf("CheckNPM returned error: %v", err)
+	}
+	if len(result.Findings) != 1 {
+		t.Fatalf("manual + OSV for the same tuple must collapse to 1 finding, got %d: %+v", len(result.Findings), result.Findings)
+	}
+	if !strings.Contains(result.Findings[0].Title, "SOCKET-2026-05-24-trapdoor") {
+		t.Errorf("finding should keep the manual advisory ID, got title %q", result.Findings[0].Title)
+	}
+}

--- a/internal/incident/trapdoor_pnpm_test.go
+++ b/internal/incident/trapdoor_pnpm_test.go
@@ -1,0 +1,92 @@
+package incident_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/garagon/aguara/internal/packagecheck"
+)
+
+// trapdoorPnpmLock returns a minimal pnpm-lock.yaml (v9 shape)
+// declaring a single name@version, mirroring the structure pnpm
+// writes. Kept inline rather than a committed fixture to match the
+// incident package's temp-dir test convention.
+func trapdoorPnpmLock(name, version string) string {
+	return "lockfileVersion: '9.0'\n\n" +
+		"importers:\n" +
+		"  .:\n" +
+		"    dependencies:\n" +
+		"      " + name + ":\n" +
+		"        specifier: " + version + "\n" +
+		"        version: " + version + "\n\n" +
+		"packages:\n" +
+		"  " + name + "@" + version + ":\n" +
+		"    resolution: {integrity: sha512-FAKE_FIXTURE_DO_NOT_VERIFY==}\n\n" +
+		"snapshots:\n" +
+		"  " + name + "@" + version + ": {}\n"
+}
+
+// TestTrapDoor_PnpmLockfileDetectedViaEmbeddedIntel exercises the
+// third exposure surface: a TrapDoor npm package declared in a
+// pnpm-lock.yaml. It builds the matcher from the REAL embedded
+// snapshots, so the manual SOCKET entry is matched end to end through
+// the actual pnpm parser and packagecheck runner.
+func TestTrapDoor_PnpmLockfileDetectedViaEmbeddedIntel(t *testing.T) {
+	dir := t.TempDir()
+	lock := trapdoorPnpmLock("dev-env-bootstrapper", "1.0.12")
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte(lock), 0o644); err != nil {
+		t.Fatalf("write pnpm-lock.yaml: %v", err)
+	}
+
+	matcher := intel.NewMatcher(incident.EmbeddedSnapshots()...)
+	targets, err := packagecheck.Discover(dir, []string{intel.EcosystemNPM})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	runner := &packagecheck.Runner{Matcher: matcher}
+	res, err := runner.Run(targets)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(res.Hits) != 1 {
+		t.Fatalf("expected 1 pnpm hit, got %d: %+v", len(res.Hits), res.Hits)
+	}
+	if res.Hits[0].Ref.Name != "dev-env-bootstrapper" {
+		t.Errorf("hit name = %q, want dev-env-bootstrapper", res.Hits[0].Ref.Name)
+	}
+	if res.Hits[0].Record.ID != "SOCKET-2026-05-24-trapdoor" {
+		t.Errorf("hit advisory = %q, want SOCKET-2026-05-24-trapdoor", res.Hits[0].Record.ID)
+	}
+	if len(res.Ecosystems) != 1 || res.Ecosystems[0].Source != "pnpm-lock.yaml" {
+		t.Errorf("ecosystem summary = %+v, want one pnpm-lock.yaml entry", res.Ecosystems)
+	}
+}
+
+// TestTrapDoor_PnpmRangeOnlyPackageNotListed confirms the scope cut
+// holds through the pnpm path too: a campaign package OSV carries
+// range-only (not added to manual intel) must not hit, even though
+// it appears in the lockfile.
+func TestTrapDoor_PnpmRangeOnlyPackageNotListed(t *testing.T) {
+	dir := t.TempDir()
+	lock := trapdoorPnpmLock("async-pipeline-builder", "1.0.12")
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte(lock), 0o644); err != nil {
+		t.Fatalf("write pnpm-lock.yaml: %v", err)
+	}
+
+	matcher := intel.NewMatcher(incident.EmbeddedSnapshots()...)
+	targets, err := packagecheck.Discover(dir, []string{intel.EcosystemNPM})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	res, err := (&packagecheck.Runner{Matcher: matcher}).Run(targets)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Hits) != 0 {
+		t.Fatalf("range-only campaign package must not be in manual intel, got hits: %+v", res.Hits)
+	}
+}


### PR DESCRIPTION
## What

Adds hand-curated `CompromisedPackage` advisories for the TrapDoor crypto-stealer supply-chain campaign (Socket, 2026-05-24) so `aguara check` blocks the confirmed malicious package/version tuples offline, without waiting for an embedded OSV snapshot refresh.

Scope is limited to the **12 packages with an exact, confirmed malicious version**. All share one advisory ID: `SOCKET-2026-05-24-trapdoor`.

## Verification (re-run at PR open, 2026-05-25)

Re-ran the OSV + registry verification across the full 34-package campaign surface. The result is stable, with no bucket changes:

| Disposition | Count | Action |
|---|---|---|
| exact version confirmed | 12 | added here |
| range-only (npm security-held, OSV `introduced:0`) | 16 | excluded, no exact version to pin |
| no OSV record + registry 404 (crates.io) | 6 | excluded |

Added tuples:

- npm @ `1.0.12`: `build-scripts-utils`, `dev-env-bootstrapper`, `llm-context-compressor`, `prompt-engineering-toolkit`, `token-usage-tracker`
- PyPI @ `0.1.0` / `0.1.1`: `cryptowallet-safety`, `data-pipeline-check`, `defi-risk-scanner`, `env-loader-cli`, `eth-security-auditor`, `git-config-sync`, `solidity-build-guard`

The 16 range-only npm packages and the 6 crates.io packages are intentionally left out: there is no exact malicious version to encode for them today.

## Detection surfaces

Offline detection is covered for:

- installed npm trees (`node_modules`, including the pnpm virtual store)
- pnpm lockfiles (`pnpm-lock.yaml`)
- installed Python environments (site-packages dist-info)

## Tests

- npm installed-tree: a TrapDoor package at its confirmed version flags CRITICAL with the campaign advisory.
- pnpm lockfile: the same package in a `pnpm-lock.yaml` is matched through the real embedded snapshot end to end.
- PyPI site-packages: two TrapDoor packages (single-version and multi-version) flag CRITICAL.
- Scope guards: a range-only campaign package (`async-pipeline-builder`) does NOT flag, via both the installed-tree and pnpm paths.
- Dedupe: a manual + OSV record for the same tuple collapses to one finding and keeps the manual advisory ID, so `aguara check --fresh` does not double-report.

## Scope

- `knownCompromisedGeneratedAt` bumped to 2026-05-24.
- No analyzer, matcher, or rule changes. No schema change.
- No version bump; CHANGELOG entry under Unreleased. The v0.18.4 release prep is separate.

## Verify

```
go test -race -count=1 ./internal/incident/... ./internal/intel/... ./internal/packagecheck/...
```
