### PR TITLE
chore(deps): bump cosign-installer to v4.1.2, pin cosign-release to v2.6.3

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Cosign
-        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # cosign-installer v4 defaults to cosign v3, whose new bundle
+          # format and GoReleaser interop are not yet validated against
+          # our signing flow. Pin the last v2.x (v2.6.3) so the installer
+          # action update carries no signing-behavior change; a cosign v3
+          # migration is a separate, deliberate PR.
+          cosign-release: "v2.6.3"
 
       - uses: docker/metadata-action@v5
         id: meta

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,14 @@ jobs:
       # specific release for reproducibility; consumers can update via
       # Dependabot.
       - name: Install Cosign
-        uses: sigstore/cosign-installer@dc72c7d5c4d10cd6bcb8cf6e3fd625a9e5e537da # v3.7.0
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # cosign-installer v4 defaults to cosign v3, whose new bundle
+          # format and GoReleaser interop are not yet validated against
+          # our signing flow. Pin the last v2.x (v2.6.3) so the installer
+          # action update carries no signing-behavior change; a cosign v3
+          # migration is a separate, deliberate PR.
+          cosign-release: "v2.6.3"
 
       # syft generates SPDX SBOMs that GoReleaser attaches to each archive.
       - name: Install Syft


### PR DESCRIPTION
## What

Bumps `sigstore/cosign-installer` to v4.1.2 in both `docker.yml` (image signing) and `release.yml` (checksum signing), and pins `cosign-release: "v2.6.3"` on both steps.

## Why pin the binary

cosign-installer v4 defaults to installing **cosign v3**, which turns on the new bundle format by default and has known GoReleaser interop friction. Our signing flow already uses the `--bundle` format (`sign-blob --bundle` plus `verify-blob --bundle`), so we are partly prepared, but the v3 bundle-format default and GoReleaser interop are not yet validated against an actual signed release. Pinning `cosign-release: "v2.6.3"` (the last v2.x) takes the installer-action update with **zero change in signing behavior**.

## Relation to Dependabot

Supersedes #145 (the standalone cosign-installer bump, which would default to cosign v3); recommend closing #145 in favor of this. The other five bumps (#142, #143, #144, #146, #147) are independent.

## Scope

Workflow YAML only. No code, no release. A cosign v3 migration (new bundle format, GoReleaser config, `verify-release.sh` validation, and a dry run) is a separate, deliberate change.
