### PR TITLE
feat(intel): add semver range evaluation engine

### DIFF
--- a/internal/intel/versions/range.go
+++ b/internal/intel/versions/range.go
@@ -1,0 +1,91 @@
+package versions
+
+// Range is one OSV affected range, reduced to its version bounds. It
+// mirrors the bound fields of intel.VersionRange but is defined here so
+// this package carries no dependency on internal/intel (which imports
+// this package). The OSV range Type is deliberately absent: the caller
+// must only construct a Range from a semver-compatible OSV range.
+//
+// OSV semantics:
+//   - Introduced: inclusive lower bound. "" means OSV gave no
+//     introduced event (no lower bound). "0" is OSV's sentinel for
+//     "from the beginning of the version line" and is also treated as
+//     no lower bound (so it matches every version, including
+//     prereleases).
+//   - Fixed: exclusive upper bound.
+//   - LastAffected: inclusive upper bound.
+//
+// A range carries at most one upper bound. A Fixed and a LastAffected
+// on the same range, or a range with no bound at all, is malformed and
+// matches nothing.
+type Range struct {
+	Introduced   string
+	Fixed        string
+	LastAffected string
+}
+
+// Affected reports whether version falls inside any of the ranges
+// (ranges are ORed, matching OSV semantics where a record's affected
+// entry may list several ranges). It returns false when version cannot
+// be parsed as semver, so a caller can pass an arbitrary installed
+// version string safely.
+func Affected(version string, ranges []Range) bool {
+	v, ok := Parse(version)
+	if !ok {
+		return false
+	}
+	for _, r := range ranges {
+		if r.contains(v) {
+			return true
+		}
+	}
+	return false
+}
+
+// contains reports whether v is inside this single range.
+func (r Range) contains(v Version) bool {
+	// A range with no bounds at all carries no information; treat it as
+	// malformed rather than "matches everything" so a garbage record
+	// cannot flag every version.
+	if r.Introduced == "" && r.Fixed == "" && r.LastAffected == "" {
+		return false
+	}
+	// A range cannot have both an exclusive and an inclusive upper
+	// bound; that event sequence is malformed.
+	if r.Fixed != "" && r.LastAffected != "" {
+		return false
+	}
+
+	// Lower bound. "" and the "0" sentinel both mean no lower bound.
+	if r.Introduced != "" && r.Introduced != "0" {
+		intro, ok := Parse(r.Introduced)
+		if !ok {
+			return false
+		}
+		if v.Compare(intro) < 0 {
+			return false
+		}
+	}
+
+	// Upper bound: Fixed is exclusive, LastAffected is inclusive.
+	switch {
+	case r.Fixed != "":
+		fixed, ok := Parse(r.Fixed)
+		if !ok {
+			return false
+		}
+		if v.Compare(fixed) >= 0 {
+			return false
+		}
+	case r.LastAffected != "":
+		last, ok := Parse(r.LastAffected)
+		if !ok {
+			return false
+		}
+		if v.Compare(last) > 0 {
+			return false
+		}
+	}
+
+	return true
+}

--- a/internal/intel/versions/range_test.go
+++ b/internal/intel/versions/range_test.go
@@ -1,0 +1,67 @@
+package versions
+
+import "testing"
+
+func TestAffected(t *testing.T) {
+	cases := []struct {
+		name    string
+		version string
+		ranges  []Range
+		want    bool
+	}{
+		// introduced:0, fixed:1.0.13 -> [0, 1.0.13)
+		{"intro0 fixed: in range", "1.0.12", []Range{{Introduced: "0", Fixed: "1.0.13"}}, true},
+		{"intro0 fixed: at fixed (exclusive)", "1.0.13", []Range{{Introduced: "0", Fixed: "1.0.13"}}, false},
+		{"intro0 fixed: above fixed", "2.0.0", []Range{{Introduced: "0", Fixed: "1.0.13"}}, false},
+
+		// introduced:1.0.0, fixed:1.0.13 -> [1.0.0, 1.0.13)
+		{"bounded: below introduced", "0.9.9", []Range{{Introduced: "1.0.0", Fixed: "1.0.13"}}, false},
+		{"bounded: at introduced (inclusive)", "1.0.0", []Range{{Introduced: "1.0.0", Fixed: "1.0.13"}}, true},
+		{"bounded: in range", "1.0.12", []Range{{Introduced: "1.0.0", Fixed: "1.0.13"}}, true},
+		{"bounded: at fixed (exclusive)", "1.0.13", []Range{{Introduced: "1.0.0", Fixed: "1.0.13"}}, false},
+
+		// last_affected:1.0.12 (inclusive upper)
+		{"last_affected: at bound (inclusive)", "1.0.12", []Range{{Introduced: "0", LastAffected: "1.0.12"}}, true},
+		{"last_affected: above bound", "1.0.13", []Range{{Introduced: "0", LastAffected: "1.0.12"}}, false},
+
+		// the TrapDoor shape: introduced:0, no upper bound -> matches everything
+		{"whole-package: low version", "0.0.1", []Range{{Introduced: "0"}}, true},
+		{"whole-package: high version", "99.99.99", []Range{{Introduced: "0"}}, true},
+		{"whole-package: prerelease", "1.0.0-alpha", []Range{{Introduced: "0"}}, true},
+
+		// empty introduced means no lower bound
+		{"no lower bound: below fixed", "0.0.1", []Range{{Fixed: "1.0.0"}}, true},
+		{"no lower bound: at fixed", "1.0.0", []Range{{Fixed: "1.0.0"}}, false},
+
+		// prerelease vs bounds
+		{"prerelease below release introduced", "1.0.0-rc.1", []Range{{Introduced: "1.0.0", Fixed: "2.0.0"}}, false},
+		{"release at introduced", "1.0.0", []Range{{Introduced: "1.0.0", Fixed: "2.0.0"}}, true},
+
+		// multiple ranges OR
+		{"multi-range: matches second", "3.5.0", []Range{
+			{Introduced: "1.0.0", Fixed: "1.1.0"},
+			{Introduced: "3.0.0", Fixed: "4.0.0"},
+		}, true},
+		{"multi-range: matches none", "2.0.0", []Range{
+			{Introduced: "1.0.0", Fixed: "1.1.0"},
+			{Introduced: "3.0.0", Fixed: "4.0.0"},
+		}, false},
+
+		// malformed -> no match
+		{"unparseable version", "not-a-version", []Range{{Introduced: "0"}}, false},
+		// Overflowing component must not wrap into a value that mis-matches a bound.
+		{"overflow version vs lower bound", "99999999999999999999.0.0", []Range{{Introduced: "1.0.0"}}, false},
+		{"unparseable introduced bound", "1.0.0", []Range{{Introduced: "abc", Fixed: "2.0.0"}}, false},
+		{"unparseable fixed bound", "1.0.0", []Range{{Introduced: "0", Fixed: "xyz"}}, false},
+		{"empty range (no bounds)", "1.0.0", []Range{{}}, false},
+		{"both fixed and last_affected", "1.0.0", []Range{{Introduced: "0", Fixed: "2.0.0", LastAffected: "1.5.0"}}, false},
+		{"no ranges", "1.0.0", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Affected(tc.version, tc.ranges); got != tc.want {
+				t.Errorf("Affected(%q, %+v) = %v, want %v", tc.version, tc.ranges, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/intel/versions/semver.go
+++ b/internal/intel/versions/semver.go
@@ -1,0 +1,179 @@
+// Package versions is a small, dependency-free semver evaluator for
+// OSV-style affected ranges. It answers one question: given a version
+// string and a set of ranges, is the version affected?
+//
+// Scope and boundaries:
+//
+//   - Semver only. Parse implements Semantic Versioning 2.0.0
+//     precedence (major.minor.patch, prerelease ordering, build
+//     metadata ignored for precedence). PEP 440, Maven, and Go
+//     pseudo-version grammars are out of scope; callers that hold a
+//     non-semver ecosystem must not route through this package.
+//   - Ecosystem-agnostic. This package does not know which ecosystems
+//     are semver. The matcher owns the ecosystem -> grammar decision
+//     and only calls Affected for semver ecosystems (npm, crates.io).
+//     Keeping ecosystem knowledge out of here is also what lets this
+//     package stay free of any dependency on internal/intel, which
+//     imports it (the cycle would otherwise be intel -> versions ->
+//     intel).
+//   - Type-agnostic ranges. Range carries only the OSV event bounds,
+//     not the OSV range Type. The matcher/importer is responsible for
+//     passing only semver-compatible ranges; a record's PEP440 or
+//     unknown-type range must be filtered out before it reaches here.
+//   - Conservative. An unparseable version, an unparseable bound, or a
+//     malformed range yields no match. A wrong match is worse than no
+//     match: this engine gates malicious-package findings.
+package versions
+
+import "strings"
+
+// Version is a parsed semver value. Build metadata is intentionally
+// not retained: it does not participate in precedence.
+type Version struct {
+	major      int
+	minor      int
+	patch      int
+	prerelease []string // dot-separated identifiers; empty for a release
+}
+
+// Parse parses a semver string. A single leading 'v' is accepted and
+// stripped (so "v1.2.3" and "1.2.3" parse identically) because OSV and
+// some ecosystems prefix versions with it. Build metadata (everything
+// after '+') is discarded. Returns ok=false for anything that is not a
+// numeric major.minor.patch core with optional prerelease.
+func Parse(s string) (Version, bool) {
+	s = strings.TrimSpace(s)
+	s = strings.TrimPrefix(s, "v")
+	if s == "" {
+		return Version{}, false
+	}
+	// Drop build metadata: ignored for precedence.
+	if i := strings.IndexByte(s, '+'); i >= 0 {
+		s = s[:i]
+	}
+	// Split off the prerelease segment. A '-' marks a prerelease, which
+	// must then be non-empty with non-empty dot-separated identifiers;
+	// "1.2.3-" is malformed.
+	var pre string
+	hasPre := false
+	if i := strings.IndexByte(s, '-'); i >= 0 {
+		pre = s[i+1:]
+		s = s[:i]
+		hasPre = true
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return Version{}, false
+	}
+	maj, ok1 := atoiStrict(parts[0])
+	min, ok2 := atoiStrict(parts[1])
+	pat, ok3 := atoiStrict(parts[2])
+	if !ok1 || !ok2 || !ok3 {
+		return Version{}, false
+	}
+	v := Version{major: maj, minor: min, patch: pat}
+	if hasPre {
+		ids := strings.Split(pre, ".")
+		for _, id := range ids {
+			if id == "" {
+				return Version{}, false // empty prerelease identifier (incl. trailing '-')
+			}
+		}
+		v.prerelease = ids
+	}
+	return v, true
+}
+
+// Compare returns -1, 0, or +1 as v is less than, equal to, or greater
+// than o, following Semver 2.0.0 precedence rules.
+func (v Version) Compare(o Version) int {
+	if c := cmpInt(v.major, o.major); c != 0 {
+		return c
+	}
+	if c := cmpInt(v.minor, o.minor); c != 0 {
+		return c
+	}
+	if c := cmpInt(v.patch, o.patch); c != 0 {
+		return c
+	}
+	return comparePrerelease(v.prerelease, o.prerelease)
+}
+
+// comparePrerelease implements Semver 2.0.0 section 11: a version with
+// a prerelease has lower precedence than the same version without one;
+// identifiers are compared left to right, numeric identifiers
+// numerically, alphanumeric lexically, numeric below alphanumeric, and
+// a longer set of identifiers wins when all preceding are equal.
+func comparePrerelease(a, b []string) int {
+	switch {
+	case len(a) == 0 && len(b) == 0:
+		return 0
+	case len(a) == 0: // a is a release, b is a prerelease -> a is greater
+		return 1
+	case len(b) == 0:
+		return -1
+	}
+	for i := 0; i < len(a) && i < len(b); i++ {
+		if c := comparePrereleaseIdent(a[i], b[i]); c != 0 {
+			return c
+		}
+	}
+	return cmpInt(len(a), len(b))
+}
+
+func comparePrereleaseIdent(a, b string) int {
+	an, aNum := atoiStrict(a)
+	bn, bNum := atoiStrict(b)
+	switch {
+	case aNum && bNum:
+		return cmpInt(an, bn)
+	case aNum && !bNum:
+		return -1 // numeric identifiers have lower precedence than alphanumeric
+	case !aNum && bNum:
+		return 1
+	default:
+		return strings.Compare(a, b)
+	}
+}
+
+const maxInt = int(^uint(0) >> 1)
+
+// atoiStrict parses a non-negative base-10 integer. It rejects empty
+// input, signs, and any non-digit byte, so "+1", "-1", "1a", and ""
+// all fail. This is stricter than strconv.Atoi on purpose: a core or
+// numeric-prerelease identifier is digits only.
+//
+// It also rejects values that would overflow int. The accumulator
+// would otherwise wrap (e.g. a major component above maxInt becoming
+// negative), and since this gates malicious-package matching, a
+// silently-wrapped version is treated as unparseable -> no match,
+// rather than risking a wrong comparison.
+func atoiStrict(s string) (int, bool) {
+	if s == "" {
+		return 0, false
+	}
+	n := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			return 0, false
+		}
+		d := int(c - '0')
+		if n > (maxInt-d)/10 { // n*10 + d would overflow int
+			return 0, false
+		}
+		n = n*10 + d
+	}
+	return n, true
+}
+
+func cmpInt(a, b int) int {
+	switch {
+	case a < b:
+		return -1
+	case a > b:
+		return 1
+	default:
+		return 0
+	}
+}

--- a/internal/intel/versions/semver_test.go
+++ b/internal/intel/versions/semver_test.go
@@ -1,0 +1,92 @@
+package versions
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	cases := []struct {
+		in    string
+		ok    bool
+		major int
+		minor int
+		patch int
+		pre   int // number of prerelease identifiers
+	}{
+		{"1.2.3", true, 1, 2, 3, 0},
+		{"v1.2.3", true, 1, 2, 3, 0}, // leading v accepted
+		{"0.1.0", true, 0, 1, 0, 0},
+		{"1.0.12", true, 1, 0, 12, 0},
+		{"1.2.3-alpha.1", true, 1, 2, 3, 2}, // prerelease identifiers
+		{"1.2.3+build.5", true, 1, 2, 3, 0}, // build metadata dropped
+		{"1.2.3-rc.1+build", true, 1, 2, 3, 2},
+		{"  1.2.3  ", true, 1, 2, 3, 0}, // trimmed
+		// rejects
+		{"", false, 0, 0, 0, 0},
+		{"1.2", false, 0, 0, 0, 0},        // too few parts
+		{"1.2.3.4", false, 0, 0, 0, 0},    // too many parts
+		{"1.2.x", false, 0, 0, 0, 0},      // non-numeric
+		{"-1.2.3", false, 0, 0, 0, 0},     // sign
+		{"1.2.3-", false, 0, 0, 0, 0},     // empty prerelease
+		{"1.2.3-a..b", false, 0, 0, 0, 0}, // empty prerelease identifier
+		{"latest", false, 0, 0, 0, 0},
+		// Overflowing numeric components must not silently wrap; reject
+		// them as unparseable so range comparisons stay correct.
+		{"9999999999999999999999999.0.0", false, 0, 0, 0, 0},
+		{"1.18446744073709551616.0", false, 0, 0, 0, 0}, // 2^64 in minor
+	}
+	for _, tc := range cases {
+		v, ok := Parse(tc.in)
+		if ok != tc.ok {
+			t.Errorf("Parse(%q) ok = %v, want %v", tc.in, ok, tc.ok)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		if v.major != tc.major || v.minor != tc.minor || v.patch != tc.patch {
+			t.Errorf("Parse(%q) = %d.%d.%d, want %d.%d.%d", tc.in, v.major, v.minor, v.patch, tc.major, tc.minor, tc.patch)
+		}
+		if len(v.prerelease) != tc.pre {
+			t.Errorf("Parse(%q) prerelease count = %d, want %d", tc.in, len(v.prerelease), tc.pre)
+		}
+	}
+}
+
+func TestCompare(t *testing.T) {
+	cases := []struct {
+		a    string
+		b    string
+		want int
+	}{
+		{"1.0.0", "1.0.0", 0},
+		{"1.0.0", "2.0.0", -1},
+		{"1.2.0", "1.1.9", 1},
+		{"1.0.12", "1.0.13", -1},
+		{"1.0.13", "1.0.12", 1},
+		// prerelease < release
+		{"1.0.0-alpha", "1.0.0", -1},
+		{"1.0.0", "1.0.0-alpha", 1},
+		// prerelease identifier ordering (semver §11 examples)
+		{"1.0.0-alpha", "1.0.0-alpha.1", -1},      // fewer fields < more
+		{"1.0.0-alpha.1", "1.0.0-alpha.beta", -1}, // numeric < alphanumeric
+		{"1.0.0-alpha.beta", "1.0.0-beta", -1},
+		{"1.0.0-beta.2", "1.0.0-beta.11", -1}, // numeric compared numerically, not lexically
+		{"1.0.0-rc.1", "1.0.0-rc.1", 0},
+		// build metadata is ignored for precedence
+		{"1.0.0+build1", "1.0.0+build2", 0},
+		{"1.0.0+build", "1.0.0", 0},
+	}
+	for _, tc := range cases {
+		va, oka := Parse(tc.a)
+		vb, okb := Parse(tc.b)
+		if !oka || !okb {
+			t.Fatalf("setup parse failed for %q/%q", tc.a, tc.b)
+		}
+		if got := va.Compare(vb); got != tc.want {
+			t.Errorf("Compare(%q, %q) = %d, want %d", tc.a, tc.b, got, tc.want)
+		}
+		// Antisymmetry: Compare(b,a) must be the negation.
+		if got := vb.Compare(va); got != -tc.want {
+			t.Errorf("Compare(%q, %q) = %d, want %d (antisymmetry)", tc.b, tc.a, got, -tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## What

Adds `internal/intel/versions`, a small dependency-free semver evaluator for normalized OSV-style affected ranges. Foundation for range-aware malicious-package matching (wired into the matcher in a follow-up PR).

## API

- `Parse(string) (Version, bool)` - Semver 2.0.0 precedence (major.minor.patch, prerelease ordering, build metadata ignored for precedence). Leading `v` accepted; unparseable or int-overflowing input yields no match.
- `Affected(version string, ranges []Range) bool` - evaluates normalized range bounds. Raw OSV event parsing stays out of this package. `Range` carries OSV bounds (`Introduced` inclusive, `Fixed` exclusive, `LastAffected` inclusive). `introduced:"0"` and empty introduced both mean no lower bound; a bound-less range, or one with both `Fixed` and `LastAffected`, is malformed and matches nothing. Multiple ranges OR.

## Design boundaries

- **Semver only** - no PEP 440 / Maven / Go pseudo-versions.
- **Ecosystem- and type-agnostic** - the matcher (a follow-up PR) owns which ecosystems are semver and passes only semver-type ranges. This also avoids an import cycle (`internal/intel` imports this package).
- **Conservative by default** - malformed versions, malformed ranges, unsupported range shapes, and integer-overflowing components match nothing.

## Scope

This PR intentionally has no runtime behavior change. It is safe to review as a pure library/test addition; matcher/importer wiring comes in follow-up PRs. The package is not imported anywhere, so there is zero effect on `scan` / `check` / `audit` output. Tests cover parse/precedence (prerelease ordering, build metadata, overflow rejection) and the full OSV range matrix (the `introduced:0` whole-package shape, exclusive `fixed`, inclusive `last_affected`, multi-range OR, malformed yields no match).
