### PR TITLE
feat(intel): match supported OSV semver ranges at lookup time

### DIFF
--- a/internal/intel/matcher.go
+++ b/internal/intel/matcher.go
@@ -1,6 +1,10 @@
 package intel
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/garagon/aguara/internal/intel/versions"
+)
 
 // MatchInput describes a single installed package to look up in
 // one or more snapshots. Path is optional metadata that the caller
@@ -106,6 +110,7 @@ func NewMatcher(snapshots ...Snapshot) *Matcher {
 			}
 			if existing, ok := byID[idKey]; ok {
 				existing.Versions = unionVersions(existing.Versions, rec.Versions)
+				existing.Ranges = unionRanges(existing.Ranges, rec.Ranges)
 				continue
 			}
 			// First occurrence: take a defensive copy so a later
@@ -115,6 +120,7 @@ func NewMatcher(snapshots ...Snapshot) *Matcher {
 			// rebuild.
 			recCopy := rec
 			recCopy.Versions = append([]string(nil), rec.Versions...)
+			recCopy.Ranges = append([]VersionRange(nil), rec.Ranges...)
 			byID[idKey] = &recCopy
 			m.byKey[key] = append(m.byKey[key], &recCopy)
 		}
@@ -176,12 +182,106 @@ func (m *Matcher) MatchPackage(in MatchInput) []Match {
 	if len(candidates) == 0 {
 		return nil
 	}
+	allowRanges := ecosystemSupportsRanges(normalizeEcosystem(in.Ecosystem))
 	var out []Match
 	for _, rec := range candidates {
-		if rec == nil || !versionMatches(*rec, in.Version) {
+		if rec == nil {
+			continue
+		}
+		// Exact version match takes priority and is checked first, so
+		// behavior for records that carry Versions is unchanged. Only
+		// when the exact check misses do we consult ranges, and only
+		// for ecosystems whose grammar the semver engine can evaluate.
+		// A record matches at most once: the continue on exact match
+		// means a record carrying both Versions and Ranges does not
+		// produce two Match entries for one installed version.
+		switch {
+		case versionMatches(*rec, in.Version):
+		case allowRanges && rangeMatches(*rec, in.Version):
+		default:
 			continue
 		}
 		out = append(out, Match{Record: *rec, Path: in.Path})
+	}
+	return out
+}
+
+// ecosystemSupportsRanges reports whether MatchPackage will evaluate
+// Record.Ranges for this normalized ecosystem. Range matching is
+// enabled only for semver ecosystems the versions engine can evaluate.
+// Phase 1 is npm only: every TrapDoor range-only record is npm, and
+// npm version ordering is semver. crates.io is also semver and can be
+// added here once it carries malicious range records; until then it
+// stays out so range matching does not widen the matched surface with
+// no current benefit. PyPI / Maven / Go are intentionally excluded
+// because their grammars are not semver.
+func ecosystemSupportsRanges(eco string) bool {
+	return eco == EcosystemNPM
+}
+
+// rangeMatches reports whether version falls in any of the record's
+// semver-evaluable ranges. Ranges whose Type the semver engine cannot
+// order are skipped; a record with no evaluable range does not match.
+func rangeMatches(rec Record, version string) bool {
+	if len(rec.Ranges) == 0 {
+		return false
+	}
+	semverRanges := make([]versions.Range, 0, len(rec.Ranges))
+	for _, r := range rec.Ranges {
+		if !isSemverRangeType(r.Type) {
+			continue
+		}
+		semverRanges = append(semverRanges, versions.Range{
+			Introduced:   r.Introduced,
+			Fixed:        r.Fixed,
+			LastAffected: r.LastAffected,
+		})
+	}
+	if len(semverRanges) == 0 {
+		return false
+	}
+	return versions.Affected(version, semverRanges)
+}
+
+// isSemverRangeType reports whether an OSV range Type can be evaluated
+// by the semver engine. OSV uses "SEMVER" for semver ranges and
+// "ECOSYSTEM" for ecosystem-defined ordering; for the npm-only phase
+// both are semver-ordered. Any other type (e.g. "GIT", "PEP440") is
+// not evaluable here and contributes no match.
+func isSemverRangeType(t string) bool {
+	switch strings.ToUpper(strings.TrimSpace(t)) {
+	case "SEMVER", "ECOSYSTEM":
+		return true
+	default:
+		return false
+	}
+}
+
+// unionRanges returns a + b with duplicate ranges removed, preserving
+// order (a first, then any new entries from b). VersionRange is a
+// comparable struct so equality dedup is exact. Used when the same
+// advisory ID appears across snapshots (manual + OSV refresh) so the
+// merged record carries every affected range, not just the first
+// snapshot's.
+func unionRanges(a, b []VersionRange) []VersionRange {
+	if len(b) == 0 {
+		return a
+	}
+	seen := make(map[VersionRange]struct{}, len(a)+len(b))
+	out := make([]VersionRange, 0, len(a)+len(b))
+	for _, r := range a {
+		if _, ok := seen[r]; ok {
+			continue
+		}
+		seen[r] = struct{}{}
+		out = append(out, r)
+	}
+	for _, r := range b {
+		if _, ok := seen[r]; ok {
+			continue
+		}
+		seen[r] = struct{}{}
+		out = append(out, r)
 	}
 	return out
 }

--- a/internal/intel/matcher_test.go
+++ b/internal/intel/matcher_test.go
@@ -350,3 +350,130 @@ func TestMatcherPEP503TrailingSeparator(t *testing.T) {
 	require.Equal(t, "foo-bar", intel.PEP503Normalize("foo..bar"))
 	require.Equal(t, "foo-bar", intel.PEP503Normalize("foo__bar"))
 }
+
+// --- range matching (PR 2) ---
+
+func TestMatcherRangeOnlyNPMWholePackage(t *testing.T) {
+	// The TrapDoor shape: a malicious npm record with no exact
+	// versions, only an introduced:0 open range. Every installed
+	// version must match.
+	m := buildMatcher(t, intel.Record{
+		ID:        "MAL-2026-4275",
+		Ecosystem: intel.EcosystemNPM,
+		Name:      "async-pipeline-builder",
+		Kind:      intel.KindMalicious,
+		Ranges:    []intel.VersionRange{{Type: "SEMVER", Introduced: "0"}},
+	})
+	for _, v := range []string{"1.0.12", "0.0.1", "9.9.9"} {
+		hit := m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "async-pipeline-builder", Version: v})
+		require.Len(t, hit, 1, "version %s should match introduced:0 whole-package range", v)
+		require.Equal(t, "MAL-2026-4275", hit[0].Record.ID)
+	}
+}
+
+func TestMatcherRangeFixedBoundaryExclusive(t *testing.T) {
+	m := buildMatcher(t, intel.Record{
+		ID:        "MAL-RANGE",
+		Ecosystem: intel.EcosystemNPM,
+		Name:      "pkg",
+		Kind:      intel.KindMalicious,
+		Ranges:    []intel.VersionRange{{Type: "SEMVER", Introduced: "1.0.0", Fixed: "1.0.13"}},
+	})
+	require.Len(t, m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "pkg", Version: "1.0.12"}), 1)
+	require.Empty(t, m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "pkg", Version: "1.0.13"}), "fixed is exclusive")
+	require.Empty(t, m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "pkg", Version: "0.9.9"}), "below introduced")
+}
+
+func TestMatcherExactAndRangeSameRecordNoDuplicate(t *testing.T) {
+	// A record carrying both an exact Version and an overlapping
+	// Range must produce exactly one Match for a version that
+	// satisfies both: exact takes priority and the record is not
+	// double-counted.
+	m := buildMatcher(t, intel.Record{
+		ID:        "MAL-BOTH",
+		Ecosystem: intel.EcosystemNPM,
+		Name:      "pkg",
+		Kind:      intel.KindMalicious,
+		Versions:  []string{"1.0.12"},
+		Ranges:    []intel.VersionRange{{Type: "SEMVER", Introduced: "0"}},
+	})
+	require.Len(t, m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "pkg", Version: "1.0.12"}), 1,
+		"exact+range on one record must yield one match, not two")
+	require.Len(t, m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "pkg", Version: "2.0.0"}), 1,
+		"range-only hit on the same record still yields one match")
+}
+
+func TestMatcherRangeIgnoredForUnsupportedEcosystem(t *testing.T) {
+	// PyPI is not a semver range ecosystem in phase 1; a PyPI
+	// range-only record must not match (PEP 440 support is future).
+	m := buildMatcher(t, intel.Record{
+		ID:        "OSV-PYPI-RANGE",
+		Ecosystem: intel.EcosystemPyPI,
+		Name:      "somepkg",
+		Kind:      intel.KindMalicious,
+		Ranges:    []intel.VersionRange{{Type: "ECOSYSTEM", Introduced: "0"}},
+	})
+	require.Empty(t, m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemPyPI, Name: "somepkg", Version: "0.1.0"}),
+		"PyPI range-only must not match until PEP 440 support lands")
+}
+
+func TestMatcherRangeUnsupportedTypeNoMatch(t *testing.T) {
+	m := buildMatcher(t, intel.Record{
+		ID:        "MAL-GIT",
+		Ecosystem: intel.EcosystemNPM,
+		Name:      "pkg",
+		Kind:      intel.KindMalicious,
+		Ranges:    []intel.VersionRange{{Type: "GIT", Introduced: "0"}},
+	})
+	require.Empty(t, m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "pkg", Version: "1.0.0"}),
+		"a non-semver range type must not be evaluated")
+}
+
+func TestMatcherMergesRangesAcrossSnapshots(t *testing.T) {
+	// Same advisory ID in two snapshots, each carrying a different
+	// range. The merged record must match versions covered by either.
+	snap1 := intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion, Records: []intel.Record{{
+		ID: "MAL-MERGE", Ecosystem: intel.EcosystemNPM, Name: "pkg", Kind: intel.KindMalicious,
+		Ranges: []intel.VersionRange{{Type: "SEMVER", Introduced: "1.0.0", Fixed: "2.0.0"}},
+	}}}
+	snap2 := intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion, Records: []intel.Record{{
+		ID: "MAL-MERGE", Ecosystem: intel.EcosystemNPM, Name: "pkg", Kind: intel.KindMalicious,
+		Ranges: []intel.VersionRange{{Type: "SEMVER", Introduced: "3.0.0", Fixed: "4.0.0"}},
+	}}}
+	m := intel.NewMatcher(snap1, snap2)
+	require.Len(t, m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "pkg", Version: "1.5.0"}), 1, "first range")
+	require.Len(t, m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "pkg", Version: "3.5.0"}), 1, "second range (merged)")
+	require.Empty(t, m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "pkg", Version: "2.5.0"}), "gap between merged ranges")
+}
+
+func TestMatcherWithdrawnTombstoneRetractsRangeRecord(t *testing.T) {
+	live := intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion, Records: []intel.Record{{
+		ID: "MAL-RETRACT", Ecosystem: intel.EcosystemNPM, Name: "pkg", Kind: intel.KindMalicious,
+		Ranges: []intel.VersionRange{{Type: "SEMVER", Introduced: "0"}},
+	}}}
+	tomb := intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion, Records: []intel.Record{{
+		ID: "MAL-RETRACT", Ecosystem: intel.EcosystemNPM, Name: "pkg", Withdrawn: true,
+	}}}
+	m := intel.NewMatcher(live, tomb)
+	require.Empty(t, m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "pkg", Version: "1.0.0"}),
+		"a withdrawn tombstone must retract the live range record")
+}
+
+func TestMatcherDistinctIDsExactAndRangeBothMatch(t *testing.T) {
+	// Manual exact advisory + OSV range advisory for the same npm
+	// tuple, distinct IDs. Both surface at the matcher layer
+	// (provenance); the output layer collapses them to one finding.
+	// Manual snapshot loads first, so it keeps display priority.
+	manual := intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion, Records: []intel.Record{{
+		ID: "SOCKET-2026-05-24-trapdoor", Ecosystem: intel.EcosystemNPM, Name: "dev-env-bootstrapper",
+		Kind: intel.KindCompromised, Versions: []string{"1.0.12"},
+	}}}
+	osv := intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion, Records: []intel.Record{{
+		ID: "MAL-2026-4277", Ecosystem: intel.EcosystemNPM, Name: "dev-env-bootstrapper",
+		Kind: intel.KindMalicious, Ranges: []intel.VersionRange{{Type: "SEMVER", Introduced: "0"}},
+	}}}
+	m := intel.NewMatcher(manual, osv)
+	hit := m.MatchPackage(intel.MatchInput{Ecosystem: intel.EcosystemNPM, Name: "dev-env-bootstrapper", Version: "1.0.12"})
+	require.Len(t, hit, 2, "distinct IDs (manual exact + OSV range) both surface at the matcher layer")
+	require.Equal(t, "SOCKET-2026-05-24-trapdoor", hit[0].Record.ID, "manual advisory keeps first/display priority")
+}

--- a/internal/intel/types.go
+++ b/internal/intel/types.go
@@ -110,9 +110,12 @@ type Record struct {
 // OSV semantics: Introduced is inclusive, Fixed is exclusive,
 // LastAffected is inclusive of the last bad version.
 //
-// VersionRange is wire-format only in the first implementation:
-// Matcher does not consult ranges. Importers should set Versions
-// instead until range support lands with tests.
+// Matcher.MatchPackage consults ranges after exact Versions, but only
+// for ecosystems whose grammar the semver engine can evaluate (npm in
+// phase 1; see ecosystemSupportsRanges and isSemverRangeType in
+// matcher.go). Ranges for unsupported ecosystems or non-semver Types
+// are ignored, so importers must still set Versions for records that
+// must match in those ecosystems.
 type VersionRange struct {
 	Type         string `json:"type,omitempty"`
 	Introduced   string `json:"introduced,omitempty"`


### PR DESCRIPTION
## What

`Matcher.MatchPackage` now evaluates `Record.Ranges` after exact `Versions`, for ecosystems whose grammar the semver engine can evaluate. npm only in phase 1 (every TrapDoor range-only record is npm; npm ordering is semver). crates.io is also semver and is a one-line addition to `ecosystemSupportsRanges` once it carries range records.

## Rules

- Exact `Versions` is checked first and unchanged; a record matches at most once (a record carrying both `Versions` and an overlapping `Range` yields one match, not two).
- Only `SEMVER` / `ECOSYSTEM` range Types are evaluated; other types (`GIT`, `PEP440`, and so on) and unsupported ecosystems (PyPI, Maven, Go) contribute no match.
- Same-advisory-ID merge across snapshots now unions `Ranges` as well as `Versions`. Distinct advisory IDs still surface separately (provenance) and collapse at the output layer; the manual snapshot loads first, keeping display priority.
- Withdrawn tombstones retract range records like exact ones.

## Scope and sequencing

This PR adds matcher capability only. The OSV importer is intentionally untouched: it still drops range-only records, so the embedded snapshot carries no npm range records and real `check` / `scan` / `audit` output is unchanged.

**This PR is intentionally not an end-to-end feature yet; it only makes the matcher capable of evaluating supported ranges once the importer starts retaining them.**

PR 3 closes the loop: importer range retention, snapshot regeneration, and a side-by-side Docker smoke where v0.18.4 misses the 16 range-only npm packages and the branch catches them. The end-to-end coverage concern is therefore PR 3's acceptance gate, not a blocker for this PR.

Validated here by unit tests covering the full OSV range matrix: whole-package `introduced:0` match, exclusive `fixed` boundary, exact+range no-duplicate, range merge across snapshots, PyPI/GIT-type rejection, withdrawn-tombstone retraction, and distinct-ID provenance.
