### PR TITLE
fix(incident): add range-only TrapDoor npm advisories

### DIFF
--- a/internal/incident/compromised.go
+++ b/internal/incident/compromised.go
@@ -3,6 +3,8 @@
 // supported language ecosystems (Python and npm).
 package incident
 
+import "github.com/garagon/aguara/internal/intel"
+
 // Ecosystem identifiers for CompromisedPackage entries and IsCompromised
 // lookups. The default empty value is treated as PyPI for backward
 // compatibility with releases that predate the ecosystem field.
@@ -18,13 +20,22 @@ const (
 // indicators of compromise (file paths, hashes, network endpoints) that
 // extend a detector beyond the package+version tuple.
 type CompromisedPackage struct {
-	Ecosystem string   `json:"ecosystem,omitempty"`
-	Name      string   `json:"name"`
-	Versions  []string `json:"versions"`
-	Advisory  string   `json:"advisory"`
-	Date      string   `json:"date"`
-	Summary   string   `json:"summary"`
-	IOCs      []IOC    `json:"iocs,omitempty"`
+	Ecosystem string `json:"ecosystem,omitempty"`
+	Name      string `json:"name"`
+	// Versions lists the exact affected versions. Either Versions or
+	// Ranges (or both) must be set for an entry to match anything.
+	Versions []string `json:"versions,omitempty"`
+	// Ranges lists affected version ranges for packages where no exact
+	// version list applies -- e.g. a whole-package compromise where
+	// every published version is malicious (introduced:"0"). Ranges
+	// match only for ecosystems whose grammar the runtime matcher can
+	// evaluate (npm in phase 1; see intel.EcosystemSupportsRanges). A
+	// range-only entry for an unsupported ecosystem will not match.
+	Ranges   []intel.VersionRange `json:"ranges,omitempty"`
+	Advisory string               `json:"advisory"`
+	Date     string               `json:"date"`
+	Summary  string               `json:"summary"`
+	IOCs     []IOC                `json:"iocs,omitempty"`
 }
 
 // IOC is a single indicator of compromise associated with a known-bad
@@ -40,6 +51,17 @@ type IOC struct {
 // campaign entry below. One ID keeps the campaign readable in output
 // and gives the matcher's same-ID version-merge a single anchor.
 const trapdoorAdvisory = "SOCKET-2026-05-24-trapdoor"
+
+// trapdoorWholePackageRange is the affected-range shared by the npm
+// TrapDoor packages npm security-held entirely: OSV records them as
+// introduced:"0" with no fixed version, meaning every published
+// version is malicious. The range-capable matcher (npm semver) flags
+// the package at any installed version. Shared so the 16 entries that
+// use it stay consistent. We deliberately do NOT embed the equivalent
+// OSV range corpus, which carries ~197k npm whole-package records and
+// would bloat the binary roughly 7x; the campaign's confirmed packages
+// ride the small hand-curated list instead.
+var trapdoorWholePackageRange = []intel.VersionRange{{Type: "SEMVER", Introduced: "0"}}
 
 // trapdoorNPMIOCs / trapdoorPyPIIOCs are the campaign indicators from
 // the Socket report, attached as metadata to each TrapDoor entry. They
@@ -284,14 +306,17 @@ var KnownCompromised = []CompromisedPackage{
 	// downloading attacker-hosted JavaScript from ddjidd564.github.io
 	// and running it through `node -e`. Campaign marker: P-2024-001.
 	//
-	// ONLY tuples with an exact OSV-confirmed malicious version are
-	// listed here. The verification harness found:
+	// The verification harness split the campaign into:
 	//   - 12 packages with exact OSV versions (5 npm @ 1.0.12,
-	//     7 PyPI @ 0.1.0/0.1.1) -- the entries below.
+	//     7 PyPI @ 0.1.0/0.1.1) -- the exact-version entries below.
 	//   - 16 npm packages OSV carries as range-only (introduced:0)
-	//     after npm security-held them; no exact version exists to
-	//     pin, so they are intentionally NOT added here (range matcher
-	//     work, tracked separately).
+	//     because npm security-held the whole package; every version
+	//     is malicious. These were excluded at v0.18.4 because the
+	//     matcher could not evaluate ranges. The matcher now can (npm
+	//     semver), so they are listed below as range-only entries
+	//     (Ranges: trapdoorWholePackageRange) rather than embedding
+	//     OSV's ~197k-record npm range corpus, which would bloat the
+	//     binary roughly 7x for no extra campaign coverage.
 	//   - 6 crates.io names with no OSV record and a 404 on the
 	//     registry; crates.io is out of manual intel until exact
 	//     versions are confirmed or a behavioral Rust rule lands.
@@ -404,6 +429,156 @@ var KnownCompromised = []CompromisedPackage{
 		Date:      "2026-05-24",
 		Summary:   "TrapDoor campaign PyPI package; import-time remote-JS execution via node -e from ddjidd564.github.io. Confirmed malicious at 0.1.0 (OSV MAL-2026-4262).",
 		IOCs:      trapdoorPyPIIOCs,
+	},
+
+	// TrapDoor npm packages npm security-held in their entirety: OSV
+	// records each as introduced:0 (every version malicious). Carried
+	// as range-only entries so the npm range-capable matcher flags any
+	// installed version. Confirmed by the verification harness (each
+	// cites its OSV MAL- id).
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "async-pipeline-builder",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4275 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "chain-key-validator",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4202 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "crypto-credential-scanner",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4203 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "defi-env-auditor",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4204 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "defi-threat-scanner",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4205 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "deployment-key-auditor",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4206 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "eth-wallet-sentinel",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4207 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "mnemonic-safety-check",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4208 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "model-switch-router",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4279 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "node-setup-helpers",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4280 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "project-init-tools",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4281 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "solidity-deploy-guard",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4218 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "wallet-backup-verifier",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4250 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "wallet-security-checker",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4219 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "web3-secrets-detector",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4220 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
+	},
+	{
+		Ecosystem: EcosystemNPM,
+		Name:      "workspace-config-loader",
+		Ranges:    trapdoorWholePackageRange,
+		Advisory:  trapdoorAdvisory,
+		Date:      "2026-05-24",
+		Summary:   "TrapDoor campaign npm package; whole package malicious (npm security-held, every version). Confirmed via OSV MAL-2026-4284 (introduced:0).",
+		IOCs:      trapdoorNPMIOCs,
 	},
 }
 

--- a/internal/incident/intel_adapter.go
+++ b/internal/incident/intel_adapter.go
@@ -167,6 +167,7 @@ func KnownCompromisedSnapshot() intel.Snapshot {
 			Severity: "critical",
 			Summary:  cp.Summary,
 			Versions: append([]string(nil), cp.Versions...),
+			Ranges:   append([]intel.VersionRange(nil), cp.Ranges...),
 			IOCs:     convertIOCs(cp.IOCs),
 		})
 	}

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -690,22 +690,32 @@ func TestCheckNPM_TrapDoor(t *testing.T) {
 	}
 }
 
-func TestCheckNPM_TrapDoor_RangeOnlyPackagesNotListed(t *testing.T) {
-	// async-pipeline-builder is part of the TrapDoor campaign, but OSV
-	// carries it range-only (introduced:0) after npm security-held it,
-	// so no exact version exists to pin and it was deliberately NOT
-	// added to manual intel. It must not flag, even at the campaign's
-	// version shape. This locks the "12 ready_exact only" scope.
-	dir := t.TempDir()
-	nm := filepath.Join(dir, "node_modules")
-	writeNPMPackage(t, nm, "async-pipeline-builder", "1.0.12")
+func TestCheckNPM_TrapDoor_WholePackageRangeFlagsAnyVersion(t *testing.T) {
+	// async-pipeline-builder is a TrapDoor package npm security-held in
+	// its entirety (OSV introduced:0). It is now carried as a range-only
+	// manual entry, so the range-capable matcher flags it at ANY
+	// installed version, not just one pinned version. (At v0.18.4 it was
+	// excluded because the matcher could not evaluate ranges.)
+	for _, version := range []string{"1.0.12", "2.5.0", "0.0.1"} {
+		dir := t.TempDir()
+		nm := filepath.Join(dir, "node_modules")
+		writeNPMPackage(t, nm, "async-pipeline-builder", version)
+		writeNPMPackage(t, nm, "left-pad", "1.3.0") // unrelated; must NOT flag
 
-	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
-	if err != nil {
-		t.Fatalf("CheckNPM returned error: %v", err)
-	}
-	if len(result.Findings) != 0 {
-		t.Fatalf("range-only campaign package must not be in manual intel, got: %+v", result.Findings)
+		result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+		if err != nil {
+			t.Fatalf("CheckNPM returned error: %v", err)
+		}
+		if len(result.Findings) != 1 {
+			t.Fatalf("version %s: expected 1 finding, got %d: %+v", version, len(result.Findings), result.Findings)
+		}
+		f := result.Findings[0]
+		if f.Severity != incident.SevCritical {
+			t.Errorf("version %s: severity = %q, want CRITICAL", version, f.Severity)
+		}
+		if !strings.Contains(f.Title, "async-pipeline-builder") || !strings.Contains(f.Title, "SOCKET-2026-05-24-trapdoor") {
+			t.Errorf("version %s: title = %q, want package + advisory", version, f.Title)
+		}
 	}
 }
 

--- a/internal/incident/trapdoor_pnpm_test.go
+++ b/internal/incident/trapdoor_pnpm_test.go
@@ -66,13 +66,13 @@ func TestTrapDoor_PnpmLockfileDetectedViaEmbeddedIntel(t *testing.T) {
 	}
 }
 
-// TestTrapDoor_PnpmRangeOnlyPackageNotListed confirms the scope cut
-// holds through the pnpm path too: a campaign package OSV carries
-// range-only (not added to manual intel) must not hit, even though
-// it appears in the lockfile.
-func TestTrapDoor_PnpmRangeOnlyPackageNotListed(t *testing.T) {
+// TestTrapDoor_PnpmWholePackageRangeFlagged confirms the range-only
+// TrapDoor entry is caught through the pnpm path too: a whole-package
+// (introduced:0) campaign package in a lockfile flags at any version
+// via the real embedded snapshot + the range-capable matcher.
+func TestTrapDoor_PnpmWholePackageRangeFlagged(t *testing.T) {
 	dir := t.TempDir()
-	lock := trapdoorPnpmLock("async-pipeline-builder", "1.0.12")
+	lock := trapdoorPnpmLock("async-pipeline-builder", "2.5.0") // any version matches introduced:0
 	if err := os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte(lock), 0o644); err != nil {
 		t.Fatalf("write pnpm-lock.yaml: %v", err)
 	}
@@ -86,7 +86,10 @@ func TestTrapDoor_PnpmRangeOnlyPackageNotListed(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Run: %v", err)
 	}
-	if len(res.Hits) != 0 {
-		t.Fatalf("range-only campaign package must not be in manual intel, got hits: %+v", res.Hits)
+	if len(res.Hits) != 1 {
+		t.Fatalf("expected 1 pnpm hit for the whole-package range, got %d: %+v", len(res.Hits), res.Hits)
+	}
+	if res.Hits[0].Record.ID != "SOCKET-2026-05-24-trapdoor" {
+		t.Errorf("hit advisory = %q, want SOCKET-2026-05-24-trapdoor", res.Hits[0].Record.ID)
 	}
 }


### PR DESCRIPTION
## What

Adds range-based local advisories for the 16 TrapDoor npm packages that OSV currently represents as whole-package affected ranges (`introduced:0`) rather than exact affected versions. They are carried under `SOCKET-2026-05-24-trapdoor`, and the range-capable matcher (from #152 / #153) flags them offline at any installed version. Together with v0.18.4's exact-version entries, Aguara now catches the confirmed npm TrapDoor set offline.

## How

- `CompromisedPackage` gains a `Ranges []intel.VersionRange` field; `KnownCompromisedSnapshot` plumbs it into `intel.Record.Ranges`.
- The 16 entries share `trapdoorWholePackageRange` (`SEMVER` `introduced:0`). They were excluded at v0.18.4 only because the matcher could not evaluate ranges then; it can now (npm semver).

## Why these are manual range advisories, not an OSV-snapshot change

While preparing this change, a scale check showed that retaining every range-only npm malicious-package record from OSV would add roughly 197k records and about 63 MB of generated source. That is a separate product decision, not a prerequisite for this incident-response lane. For this release, the targeted manual range advisories provide the confirmed TrapDoor coverage without changing the embedded-intel size profile.

## Gate: side-by-side Docker smoke (offline)

`ghcr.io/garagon/aguara:0.18.4` reports 0 findings for `async-pipeline-builder`; this branch flags it CRITICAL under `SOCKET-2026-05-24-trapdoor`. The fixture pins an arbitrary version (2.5.0), proving the whole-package range matches any installed version. Exactly one finding, so there is no manual/OSV duplication.

## Scope

Detection covers installed npm trees and pnpm lockfiles. crates.io stays out (no OSV records; behavioral rule later). No OSV importer or generated-intel change; no version bump. Runtime remains offline by default and does not execute package code.
