### PR TITLE
release: prep v0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,42 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-05-25
+
+Range-aware malicious-package matching plus static behavioral detection
+for confirmed TrapDoor-style payloads. This extends Aguara from exact
+incident advisories into version-range matching for supported semver
+ecosystems and deterministic detection of two payload shapes from the
+TrapDoor campaign. It is range + behavioral coverage for the confirmed
+TrapDoor surfaces, not full coverage of the campaign.
+
+### Added
+
+- **Range-aware matching for supported semver ecosystems (npm).** The
+  intel matcher now evaluates OSV-style version ranges, not just exact
+  versions, for ecosystems whose grammar a semver engine can resolve
+  (npm in this release). `aguara check` now flags the 16 npm TrapDoor
+  packages npm security-held in their entirety (OSV records them as
+  `introduced:0`, every version malicious) at any installed version,
+  offline, across installed npm trees and pnpm lockfiles. These ride
+  hand-curated range-only advisories under `SOCKET-2026-05-24-trapdoor`;
+  the rule deliberately does not embed OSV's full npm range corpus.
+- **`PY_IMPORTTIME_REMOTE_JS_001`** (supply-chain, CRITICAL): detects a
+  Python package that, at install or import time (`setup.py` /
+  `__init__.py`), downloads remote JavaScript and runs it through Node
+  (`node -e` / `--eval`). Requires the fetch of a `.js` payload and the
+  Node eval together; mentions of Node or JavaScript in docs do not
+  trip it.
+- **`RS_BUILD_WALLET_EXFIL_001`** (supply-chain, CRITICAL): detects a
+  Cargo build script (`build.rs`) that reads crypto wallet/keystore
+  material (Sui / Move / Solana / Aptos) and sends it over the network.
+  Requires an actual keystore read plus a network exfil sink; a build
+  that only compiles native code or only reads a path does not fire.
+
+Both behavioral rules are static pattern detections and do not execute
+package code. Analyzer-level data-flow hardening for each is tracked as
+follow-up work.
+
 ## [0.18.4] - 2026-05-25
 
 Patch release adding local threat-intel advisories for the TrapDoor

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.18.4
+INSTALL_SH_TEST_VERSION ?= v0.19.0
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ brew install garagon/tap/aguara
 ### Docker
 
 ```bash
-docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.18.4 check /repo
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.19.0 check /repo
 ```
 
 The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 10001, base images are digest-pinned, and the image is signed at the digest with Cosign plus SPDX SBOM and SLSA provenance attestations. Tag a specific release for reproducibility.
@@ -69,14 +69,14 @@ The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.18.4 sh
+  | VERSION=v0.19.0 sh
 ```
 
 `install.sh` downloads `checksums.txt` from the release and verifies the archive's SHA256 against it, aborting if neither `sha256sum` nor `shasum` is available. This catches a tampered or corrupted archive at the registry layer, but it does not verify the Cosign signature on `checksums.txt` itself. For full keyless-signature verification on the curl-pipe path, follow up with the Cosign step in [Verifying signed releases](#verifying-signed-releases). Default install location is `~/.local/bin`. Override for CI or containers:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.18.4 INSTALL_DIR=/usr/local/bin sh
+  | VERSION=v0.19.0 INSTALL_DIR=/usr/local/bin sh
 ```
 
 ### From source
@@ -96,7 +96,7 @@ Every release is signed with [Cosign](https://github.com/sigstore/cosign) keyles
 **Verify the release archive**:
 
 ```bash
-VERSION=v0.18.4
+VERSION=v0.19.0
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
@@ -358,11 +358,11 @@ aguara discover --format json
 ### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.18.4
+- uses: garagon/aguara@v0.19.0
   with:
     path: .
     fail-on: high
-    version: v0.18.4
+    version: v0.19.0
 ```
 
 Both pins (the action ref AND the `version:` input) are required. The action ref alone pins only the composite action and its install script; `version:` pins the Aguara binary the action installs. Setting both makes the workflow reproducible and dependabot-friendly: when a new release lands, the bot updates both together.
@@ -370,12 +370,12 @@ Both pins (the action ref AND the `version:` input) are required. The action ref
 Scans your repository, uploads findings to GitHub Code Scanning, and optionally fails the build:
 
 ```yaml
-- uses: garagon/aguara@v0.18.4
+- uses: garagon/aguara@v0.19.0
   with:
     path: ./mcp-server/
     severity: medium
     fail-on: high
-    version: v0.18.4
+    version: v0.19.0
 ```
 
 All inputs are optional. See [`action.yml`](action.yml) for the full list.
@@ -395,7 +395,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 
 ```yaml
 - name: Scan for security issues
-  run: docker run --rm -v "${{ github.workspace }}:/scan:ro" ghcr.io/garagon/aguara:0.18.4 scan /scan --ci
+  run: docker run --rm -v "${{ github.workspace }}:/scan:ro" ghcr.io/garagon/aguara:0.19.0 scan /scan --ci
 ```
 
 ### Manual / GitLab CI
@@ -404,7 +404,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitHub Actions (without the action)
 - name: Scan skills for security issues
   run: |
-    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.4 sh
+    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.19.0 sh
     aguara scan .claude/skills/ --ci
 ```
 
@@ -412,7 +412,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.18.4 sh
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.19.0 sh
     - aguara scan .claude/skills/ --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:
@@ -621,7 +621,7 @@ See the [mcp-aguara README](https://github.com/garagon/mcp-aguara) for install, 
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.18.4. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
+Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.19.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
 
 ## Enterprise use
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.18.4"
+        DEFAULT_REF="v0.19.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.18.4 tag rather than `@v1`
+// The action ref is pinned to the v0.19.0 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.18.4
+        uses: garagon/aguara@v0.19.0
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.18.4
+          version: v0.19.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
## What

Release prep for v0.19.0, the range + behavioral TrapDoor lane. Bumps the release-pinned version references from v0.18.4 to v0.19.0 and dates the CHANGELOG section. No detection changes in this PR.

## What this release ships (already merged on main)

- **Range-aware malicious-package matching for supported semver ecosystems (npm)**: a semver range engine (#152), matcher range support (#153), and range-only TrapDoor advisories (#154). `aguara check` now flags the 16 npm TrapDoor packages npm security-held in their entirety (OSV records them as `introduced:0`, every version malicious) at any installed version, offline, across installed npm trees and pnpm lockfiles.
- **`PY_IMPORTTIME_REMOTE_JS_001`** (#155): detects a PyPI package that, at install or import time, downloads remote JavaScript and runs it through Node (`node -e` / `--eval`).
- **`RS_BUILD_WALLET_EXFIL_001`** (#157): detects a Cargo `build.rs` that reads crypto wallet/keystore material (Sui / Move / Solana / Aptos) and sends it over the network.

This is range + behavioral coverage for the confirmed TrapDoor surfaces, not full coverage of the campaign. Analyzer-level data-flow hardening for the two behavioral rules is tracked in #156 and #158.

## Version pins (verified by `check-version-pins.sh`)

- `cmd/aguara/commands/init.go`: scaffolded GHA workflow action ref + binary version
- `action.yml`: `DEFAULT_REF`
- `Makefile`: `INSTALL_SH_TEST_VERSION`
- `README.md`: install snippets, docker pull tags, GHA examples

## CHANGELOG

Adds `[0.19.0] - 2026-05-25` covering the range-aware npm matching, `PY_IMPORTTIME_REMOTE_JS_001`, and `RS_BUILD_WALLET_EXFIL_001`.

## Gates

- `VERSION=v0.19.0 .github/scripts/check-version-pins.sh`: all pins agree
- `go build ./...` / `go vet ./...` / `golangci-lint run ./...`: clean (0 issues)
- `go test -race -count=1 ./...`: pass
- `make verify-docker`: all Docker validation targets passed

Tag v0.19.0 from main after merge.
