### PR TITLE
release: prep v0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-05-28
+
+Scan baseline / diff mode plus a smaller, more maintainable embedded
+advisory snapshot. No detection-engine changes and no change to advisory
+coverage or runtime matching behavior.
+
+### Added
+
+- **Scan baseline / diff mode.** `aguara scan --baseline <file>` gates
+  only on findings that are not already recorded in a baseline, so CI can
+  adopt Aguara on an existing repository without failing on pre-existing
+  findings. `--write-baseline <file>` records the current findings as
+  accepted. `aguara audit --baseline` / `--write-baseline` apply to the
+  scan half only; known-malicious package (check) findings always gate.
+  Fingerprints are line-independent (they survive line churn) and
+  per-occurrence (distinct findings in one file stay distinct).
+  Secret-bearing findings are never baselineable and are always reported.
+  Baseline metadata is surfaced in the terminal footer, the JSON
+  `baseline` summary, and SARIF `partialFingerprints`. `.aguara.yml`
+  accepts a `baseline:` key.
+
+### Changed
+
+- **Embedded advisory snapshot is now compressed.** The build-time OSV
+  snapshot ships as gzipped JSON via `go:embed` instead of a generated Go
+  literal, alongside a committed `generated_intel.meta.json` sidecar
+  (record count, ecosystems, content hashes) that keeps a regeneration
+  reviewable. Snapshot contents and runtime matching are unchanged; the
+  binary is roughly 11 MB smaller. `aguara update` and
+  `tools/update-intel` now emit the gzipped bundle plus the sidecar.
+- **Documentation describes the toxic-flow analyzer as capability
+  correlation / source-sink co-occurrence** rather than taint tracking,
+  to match what the analyzer actually does.
+
+The intel schema version and the on-disk update-cache format are
+unchanged.
+
 ## [0.19.0] - 2026-05-25
 
 Range-aware malicious-package matching plus static behavioral detection

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.19.0
+INSTALL_SH_TEST_VERSION ?= v0.20.0
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.19.0 sh
+  | VERSION=v0.20.0 sh
 ```
 
 `install.sh` downloads `checksums.txt` from the release and verifies the archive's SHA256 against it, aborting if neither `sha256sum` nor `shasum` is available. This catches a tampered or corrupted archive at the registry layer, but it does not verify the Cosign signature on `checksums.txt` itself. For full keyless-signature verification on the curl-pipe path, follow up with the Cosign step in [Verifying signed releases](#verifying-signed-releases). Default install location is `~/.local/bin`. Override for CI or containers:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.19.0 INSTALL_DIR=/usr/local/bin sh
+  | VERSION=v0.20.0 INSTALL_DIR=/usr/local/bin sh
 ```
 
 ### From source
@@ -96,7 +96,7 @@ Every release is signed with [Cosign](https://github.com/sigstore/cosign) keyles
 **Verify the release archive**:
 
 ```bash
-VERSION=v0.19.0
+VERSION=v0.20.0
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
@@ -358,11 +358,11 @@ aguara discover --format json
 ### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.19.0
+- uses: garagon/aguara@v0.20.0
   with:
     path: .
     fail-on: high
-    version: v0.19.0
+    version: v0.20.0
 ```
 
 Both pins (the action ref AND the `version:` input) are required. The action ref alone pins only the composite action and its install script; `version:` pins the Aguara binary the action installs. Setting both makes the workflow reproducible and dependabot-friendly: when a new release lands, the bot updates both together.
@@ -370,12 +370,12 @@ Both pins (the action ref AND the `version:` input) are required. The action ref
 Scans your repository, uploads findings to GitHub Code Scanning, and optionally fails the build:
 
 ```yaml
-- uses: garagon/aguara@v0.19.0
+- uses: garagon/aguara@v0.20.0
   with:
     path: ./mcp-server/
     severity: medium
     fail-on: high
-    version: v0.19.0
+    version: v0.20.0
 ```
 
 All inputs are optional. See [`action.yml`](action.yml) for the full list.
@@ -404,7 +404,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitHub Actions (without the action)
 - name: Scan skills for security issues
   run: |
-    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.19.0 sh
+    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.20.0 sh
     aguara scan .claude/skills/ --ci
 ```
 
@@ -412,7 +412,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.19.0 sh
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.20.0 sh
     - aguara scan .claude/skills/ --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:
@@ -621,7 +621,7 @@ See the [mcp-aguara README](https://github.com/garagon/mcp-aguara) for install, 
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.19.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
+Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.20.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
 
 ## Enterprise use
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.19.0"
+        DEFAULT_REF="v0.20.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.19.0 tag rather than `@v1`
+// The action ref is pinned to the v0.20.0 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.19.0
+        uses: garagon/aguara@v0.20.0
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.19.0
+          version: v0.20.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
Release prep for **v0.20.0**. Aggregates work merged since v0.19.0:

- **#162** compressed embedded advisory snapshot (`go:embed` gzipped JSON + signed-by-content sidecar; binary ~11 MB smaller; no advisory/matching change)
- **#163** scan baseline / diff mode (`scan`/`audit --baseline` / `--write-baseline`; check/package findings always gate; policy 2B sensitive-never-baselineable; baseline metadata in terminal/JSON/SARIF)
- **#161** detection-claim doc alignment (toxic-flow described as capability correlation / source-sink co-occurrence)

## Changes in this PR

- `CHANGELOG.md`: `## [0.20.0] - 2026-05-28` section (Added: baseline mode; Changed: compressed snapshot, doc alignment).
- Version pins bumped v0.19.0 → v0.20.0: `init.go` scaffolded workflow (action ref + binary `version:`), `action.yml` `DEFAULT_REF`, `Makefile` `INSTALL_SH_TEST_VERSION`, `README.md` install/usage snippets.

No code or detection-engine changes in this PR.

## Verification

- `VERSION=v0.20.0 .github/scripts/check-version-pins.sh` → all pins agree ✅
- `make build` ✅ · `go vet ./...` ✅ · `golangci-lint run ./...` ✅ 0 issues · `go test -race -count=1 ./...` ✅ all pass
- `make verify-docker` on `main` (the merged content) ✅ all targets

After merge: tag `v0.20.0` → GoReleaser (signed archives + Homebrew) + Docker (multi-arch, signed at digest). Then rewrite the GitHub release body and run `verify-release.sh`.