### PR TITLE
feat(intel): intel-publish workflow + signed-manifest shape (PR 0)

### DIFF
--- a/.github/workflows/intel-publish.yml
+++ b/.github/workflows/intel-publish.yml
@@ -1,0 +1,133 @@
+name: Intel Publish
+
+# Publishes a signed advisory-intel bundle (the same artifact aguara
+# embeds at build time) to the rolling `intel-latest` release, so a
+# future `aguara update` / `--fresh` can fetch and verify it. This
+# workflow is the trust root for fresh intel: the manifest is signed
+# with Cosign keyless under this workflow's OIDC identity on main
+# (.github/workflows/intel-publish.yml@refs/heads/main).
+#
+# PR 0 scope: generator + publish + signing only. No runtime consumer
+# yet; aguara update / --fresh continue to fetch raw OSV until the
+# verifier lands (v0.21.0 PRs 1-3). End-to-end is validated post-merge
+# via a manual dispatch on main (a branch dispatch signs under a
+# different ref and will fail the in-workflow verify gate by design).
+
+on:
+  schedule:
+    # Weekly, Monday 06:00 UTC. Malicious-package intel does not move
+    # fast enough to warrant daily churn; manual dispatch covers urgency.
+    - cron: "0 6 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  # id-token: write is required for Cosign keyless signing via Sigstore +
+  # GitHub OIDC. The token never leaves the runner.
+  id-token: write
+
+# Never run two publishes at once; the rolling release assets are
+# overwritten in place.
+concurrency:
+  group: intel-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # fetch-depth 0 so `git describe` can derive a provenance
+          # string for the manifest's tool_version.
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Download OSV dumps
+        run: |
+          set -euo pipefail
+          mkdir -p osv
+          for eco in npm PyPI Go crates.io Packagist RubyGems Maven NuGet; do
+            echo "downloading ${eco}"
+            curl -fsSL --retry 3 --retry-delay 2 --max-time 300 \
+              -o "osv/${eco}.zip" \
+              "https://storage.googleapis.com/osv-vulnerabilities/${eco}/all.zip"
+          done
+
+      - name: Generate intel bundle + manifest
+        run: |
+          set -euo pipefail
+          mkdir -p dist
+          VER="$(git describe --tags --always --dirty)"
+          # --allow-empty: some ecosystems (Go, crates.io, Packagist,
+          # Maven) legitimately yield zero malicious-package records; the
+          # snapshot still ships their SourceMeta so the 8-ecosystem
+          # coverage invariant holds.
+          go run ./tools/update-intel \
+            --from-zip osv/npm.zip        --ecosystem npm \
+            --from-zip osv/PyPI.zip       --ecosystem PyPI \
+            --from-zip osv/Go.zip         --ecosystem Go \
+            --from-zip osv/crates.io.zip  --ecosystem crates.io \
+            --from-zip osv/Packagist.zip  --ecosystem Packagist \
+            --from-zip osv/RubyGems.zip   --ecosystem RubyGems \
+            --from-zip osv/Maven.zip      --ecosystem Maven \
+            --from-zip osv/NuGet.zip      --ecosystem NuGet \
+            --out dist/generated_intel.json.gz \
+            --tool-version "${VER}" \
+            --allow-empty
+          test -f dist/generated_intel.json.gz
+          test -f dist/generated_intel.meta.json
+          echo "--- manifest ---"
+          cat dist/generated_intel.meta.json
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin the last cosign v2.x to match release.yml / docker.yml;
+          # a v3 migration is a separate deliberate change.
+          cosign-release: "v2.6.3"
+
+      - name: Sign manifest (Cosign keyless)
+        run: |
+          set -euo pipefail
+          cosign sign-blob --yes \
+            --bundle dist/generated_intel.meta.json.bundle \
+            dist/generated_intel.meta.json
+          test -f dist/generated_intel.meta.json.bundle
+
+      - name: Verify manifest signature against expected identity
+        # In-workflow gate: the manifest must verify under the pinned
+        # identity (this workflow on main) before we publish. A run on
+        # any other ref fails here by design.
+        run: |
+          set -euo pipefail
+          cosign verify-blob \
+            --bundle dist/generated_intel.meta.json.bundle \
+            --certificate-identity "https://github.com/${GITHUB_REPOSITORY}/.github/workflows/intel-publish.yml@refs/heads/main" \
+            --certificate-oidc-issuer "https://token.actions.githubusercontent.com" \
+            dist/generated_intel.meta.json
+
+      - name: Publish to rolling intel-latest release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if ! gh release view intel-latest >/dev/null 2>&1; then
+            gh release create intel-latest \
+              --title "Advisory intel bundle (rolling)" \
+              --notes "Signed advisory-intel bundle, refreshed automatically by the intel-publish workflow. This is NOT a product release; see the tagged releases for aguara versions." \
+              --prerelease \
+              --latest=false \
+              --target "${GITHUB_SHA}"
+          fi
+          gh release upload intel-latest \
+            dist/generated_intel.json.gz \
+            dist/generated_intel.meta.json \
+            dist/generated_intel.meta.json.bundle \
+            --clobber

--- a/internal/incident/generated_intel.meta.json
+++ b/internal/incident/generated_intel.meta.json
@@ -1,6 +1,11 @@
 {
-  "schema_version": 1,
-  "generated_at": "2026-05-17T00:00:00Z",
+  "manifest_schema": 1,
+  "bundle_schema_version": 1,
+  "blob": "generated_intel.json.gz",
+  "gzip_sha256": "474c3716fdbec28732985a474d74ce4fd1317108173308beb3f66457b150a7cb",
+  "json_sha256": "a1aa27337de34848a595de3c5cc0dd95f386fa7683755579ba367bc9ca6d09ab",
+  "gzip_bytes": 1016882,
+  "json_bytes": 7605747,
   "record_count": 23926,
   "source_count": 8,
   "ecosystems": [
@@ -13,8 +18,5 @@
     "Maven",
     "NuGet"
   ],
-  "json_sha256": "a1aa27337de34848a595de3c5cc0dd95f386fa7683755579ba367bc9ca6d09ab",
-  "gzip_sha256": "474c3716fdbec28732985a474d74ce4fd1317108173308beb3f66457b150a7cb",
-  "json_bytes": 7605747,
-  "gzip_bytes": 1016882
+  "generated_at": "2026-05-17T00:00:00Z"
 }

--- a/internal/incident/generated_intel_test.go
+++ b/internal/incident/generated_intel_test.go
@@ -64,10 +64,18 @@ func TestEmbeddedIntelMetaMatchesBlob(t *testing.T) {
 	if meta.SourceCount != len(snap.Sources) {
 		t.Errorf("source_count mismatch: meta=%d snapshot=%d", meta.SourceCount, len(snap.Sources))
 	}
-	if meta.SchemaVersion != snap.SchemaVersion {
-		t.Errorf("schema_version mismatch: meta=%d snapshot=%d", meta.SchemaVersion, snap.SchemaVersion)
+	if meta.BundleSchemaVersion != snap.SchemaVersion {
+		t.Errorf("bundle_schema_version mismatch: meta=%d snapshot=%d", meta.BundleSchemaVersion, snap.SchemaVersion)
 	}
 	if !meta.GeneratedAt.Equal(snap.GeneratedAt) {
 		t.Errorf("generated_at mismatch: meta=%s snapshot=%s", meta.GeneratedAt, snap.GeneratedAt)
+	}
+	// Signed-manifest contract fields (PR 0): the committed embedded
+	// manifest must carry the manifest schema and name its blob.
+	if meta.ManifestSchema != intel.ManifestSchema {
+		t.Errorf("manifest_schema = %d, want %d", meta.ManifestSchema, intel.ManifestSchema)
+	}
+	if meta.Blob != "generated_intel.json.gz" {
+		t.Errorf("blob = %q, want generated_intel.json.gz", meta.Blob)
 	}
 }

--- a/internal/intel/snapshotgz_test.go
+++ b/internal/intel/snapshotgz_test.go
@@ -123,7 +123,19 @@ func TestBuildSnapshotMeta(t *testing.T) {
 	if err != nil {
 		t.Fatalf("encode: %v", err)
 	}
-	meta := BuildSnapshotMeta(snap, jsonBytes, gz)
+	meta := BuildSnapshotMeta(snap, jsonBytes, gz, "generated_intel.json.gz", "v9.9.9")
+	if meta.ManifestSchema != ManifestSchema {
+		t.Errorf("manifest_schema = %d, want %d", meta.ManifestSchema, ManifestSchema)
+	}
+	if meta.BundleSchemaVersion != snap.SchemaVersion {
+		t.Errorf("bundle_schema_version = %d, want %d", meta.BundleSchemaVersion, snap.SchemaVersion)
+	}
+	if meta.Blob != "generated_intel.json.gz" {
+		t.Errorf("blob = %q, want generated_intel.json.gz", meta.Blob)
+	}
+	if meta.ToolVersion != "v9.9.9" {
+		t.Errorf("tool_version = %q, want v9.9.9", meta.ToolVersion)
+	}
 	if meta.RecordCount != len(snap.Records) {
 		t.Errorf("record_count = %d, want %d", meta.RecordCount, len(snap.Records))
 	}

--- a/internal/intel/snapshotmeta.go
+++ b/internal/intel/snapshotmeta.go
@@ -6,45 +6,70 @@ import (
 	"time"
 )
 
-// SnapshotMeta is a small, human-reviewable sidecar describing an
-// embedded snapshot blob. It is committed next to the gzipped blob
-// (which git treats as binary) so a reviewer can see what changed in a
-// pull request -- record count, ecosystems, content hashes, sizes --
-// without decompressing anything.
+// ManifestSchema is the schema version of the SnapshotMeta document
+// itself (distinct from BundleSchemaVersion, which is the intel.Snapshot
+// schema the blob decodes to). Bumped only when the manifest shape
+// changes incompatibly. Verifiers reject manifests with a higher value.
+const ManifestSchema = 1
+
+// SnapshotMeta is the human-reviewable, signable manifest that travels
+// with an embedded or published intel blob. It is committed next to the
+// gzipped blob (which git treats as binary) so a reviewer can see what
+// changed in a pull request, and it is the document the intel-publish
+// workflow signs with Cosign keyless so `aguara update` can verify a
+// fresh bundle before trusting it.
 //
-// It is integrity metadata, not a signature: a test asserts these
-// hashes match the embedded blob, catching a blob regenerated without
-// refreshing its meta (or vice versa) so a future diff is never "just
-// a binary changed".
+// The hashes provably describe the blob: `gzip_sha256` binds the gzipped
+// blob bytes; `json_sha256` binds the decompressed JSON (defense in
+// depth). `blob` names the artifact the manifest describes so a verifier
+// does not have to assume a filename. Field order matches the published
+// contract.
 type SnapshotMeta struct {
-	SchemaVersion int       `json:"schema_version"`
-	GeneratedAt   time.Time `json:"generated_at"`
-	RecordCount   int       `json:"record_count"`
-	SourceCount   int       `json:"source_count"`
-	Ecosystems    []string  `json:"ecosystems"`
-	JSONSHA256    string    `json:"json_sha256"`
-	GzipSHA256    string    `json:"gzip_sha256"`
-	JSONBytes     int       `json:"json_bytes"`
-	GzipBytes     int       `json:"gzip_bytes"`
+	// ManifestSchema is this manifest document's own schema version.
+	ManifestSchema int `json:"manifest_schema"`
+	// BundleSchemaVersion is the intel.Snapshot schema the blob decodes
+	// to (intel.CurrentSchemaVersion at generation time).
+	BundleSchemaVersion int `json:"bundle_schema_version"`
+	// Blob is the filename of the gzipped-JSON blob this manifest
+	// describes (e.g. "generated_intel.json.gz").
+	Blob string `json:"blob"`
+	// GzipSHA256 is the sha256 of the gzipped blob bytes (binds the blob).
+	GzipSHA256 string `json:"gzip_sha256"`
+	// JSONSHA256 is the sha256 of the decompressed JSON (defense in depth).
+	JSONSHA256 string `json:"json_sha256"`
+	GzipBytes  int    `json:"gzip_bytes"`
+	JSONBytes  int    `json:"json_bytes"`
+	RecordCount int    `json:"record_count"`
+	SourceCount int    `json:"source_count"`
+	Ecosystems  []string  `json:"ecosystems"`
+	GeneratedAt time.Time `json:"generated_at"`
+	// ToolVersion is the aguara version that produced the bundle. Set by
+	// the publishing workflow; omitted from the committed embedded
+	// manifest to avoid a version string that drifts every release.
+	ToolVersion string `json:"tool_version,omitempty"`
 }
 
-// BuildSnapshotMeta derives the sidecar metadata for snap from its
-// canonical JSON bytes and gzipped bytes (as produced by
-// MarshalSnapshotJSON / EncodeSnapshotGZIP). The exact bytes are passed
-// in -- not recomputed -- so the hashes provably describe the blob that
-// actually ships.
-func BuildSnapshotMeta(snap Snapshot, jsonBytes, gzBytes []byte) SnapshotMeta {
+// BuildSnapshotMeta derives the manifest for snap from its canonical JSON
+// bytes and gzipped bytes (as produced by MarshalSnapshotJSON /
+// EncodeSnapshotGZIP). The exact bytes are passed in, not recomputed, so
+// the hashes provably describe the artifact that ships. blobName is the
+// filename the blob is written as; toolVersion is the producing aguara
+// version (pass "" to omit it, e.g. for the committed embedded manifest).
+func BuildSnapshotMeta(snap Snapshot, jsonBytes, gzBytes []byte, blobName, toolVersion string) SnapshotMeta {
 	jsonSum := sha256.Sum256(jsonBytes)
 	gzSum := sha256.Sum256(gzBytes)
 	return SnapshotMeta{
-		SchemaVersion: snap.SchemaVersion,
-		GeneratedAt:   snap.GeneratedAt,
-		RecordCount:   len(snap.Records),
-		SourceCount:   len(snap.Sources),
-		Ecosystems:    EcosystemsFromSources(snap.Sources),
-		JSONSHA256:    hex.EncodeToString(jsonSum[:]),
-		GzipSHA256:    hex.EncodeToString(gzSum[:]),
-		JSONBytes:     len(jsonBytes),
-		GzipBytes:     len(gzBytes),
+		ManifestSchema:      ManifestSchema,
+		BundleSchemaVersion: snap.SchemaVersion,
+		Blob:                blobName,
+		GzipSHA256:          hex.EncodeToString(gzSum[:]),
+		JSONSHA256:          hex.EncodeToString(jsonSum[:]),
+		GzipBytes:           len(gzBytes),
+		JSONBytes:           len(jsonBytes),
+		RecordCount:         len(snap.Records),
+		SourceCount:         len(snap.Sources),
+		Ecosystems:          EcosystemsFromSources(snap.Sources),
+		GeneratedAt:         snap.GeneratedAt,
+		ToolVersion:         toolVersion,
 	}
 }

--- a/tools/update-intel/main.go
+++ b/tools/update-intel/main.go
@@ -63,9 +63,10 @@ func main() {
 	var (
 		zips        multiFlag
 		ecosystems  multiFlag
-		outPath    string
-		genTime    string
-		allowEmpty bool
+		outPath     string
+		genTime     string
+		toolVersion string
+		allowEmpty  bool
 	)
 
 	fs := flag.NewFlagSet("update-intel", flag.ContinueOnError)
@@ -73,6 +74,7 @@ func main() {
 	fs.Var(&ecosystems, "ecosystem", "OSV ecosystem for the matching --from-zip (repeatable; e.g. npm, PyPI)")
 	fs.StringVar(&outPath, "out", "internal/incident/generated_intel.json.gz", "Path to the gzipped-JSON snapshot blob to write (a .meta.json sidecar is written alongside)")
 	fs.StringVar(&genTime, "generated-at", "", "Override the snapshot timestamp (RFC3339; defaults to now). Use this for reproducible builds.")
+	fs.StringVar(&toolVersion, "tool-version", "", "aguara version that produced the bundle, recorded in the manifest (e.g. v0.21.0). The intel-publish workflow sets this; leave empty for the committed embedded manifest.")
 	fs.BoolVar(&allowEmpty, "allow-empty", false, "Allow an ecosystem to produce zero records (default: error). Use only for initial bootstrap.")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
@@ -146,7 +148,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "update-intel: encode: %v\n", err)
 		os.Exit(1)
 	}
-	meta := intel.BuildSnapshotMeta(merged, jsonBytes, gz)
+	meta := intel.BuildSnapshotMeta(merged, jsonBytes, gz, filepath.Base(outPath), toolVersion)
 	metaJSON, err := json.MarshalIndent(meta, "", "  ")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "update-intel: marshal meta: %v\n", err)


### PR DESCRIPTION
**PR 0 of the signed advisory bundles block** (target v0.21.0). Infra + generator only: **no runtime, `update`, `--fresh`, or verifier changes**. This lays the trust-root foundation so PRs 1-3 can add in-process verification and wire it into `aguara update` / `check --fresh`.

## What

### `.github/workflows/intel-publish.yml`
- **Triggers:** `schedule` (weekly, Monday 06:00 UTC) + `workflow_dispatch`.
- **Permissions:** `id-token: write` (Cosign keyless OIDC), `contents: write`.
- **Pipeline:** download the 8 OSV `all.zip` dumps → `tools/update-intel` (consume → normalize → MAL-/keyword filter → generate) → `generated_intel.json.gz` + `generated_intel.meta.json` → **Cosign keyless `sign-blob`** the manifest → **verify in-workflow** against the expected identity → publish blob + manifest + `manifest.bundle` to a rolling **`intel-latest`** prerelease (`gh release upload --clobber`).
- **Signing identity (trust root):** `…/intel-publish.yml@refs/heads/main` + issuer `https://token.actions.githubusercontent.com`. The in-workflow verify gate pins exactly this, so a bundle is only trustworthy when produced by this workflow on `main`.
- Pinned actions match `release.yml`/`docker.yml` (`checkout@v4`, `setup-go@v6` go 1.25, `cosign-installer@…v4.1.2` + `cosign-release: v2.6.3`). Rolling release is `--prerelease --latest=false` so it never shadows a product release.

### Signed-manifest shape (the public contract, baked in now)
`internal/intel/SnapshotMeta` extended to the final shape so PR 1 inherits no migration:
```json
{
  "manifest_schema": 1,
  "bundle_schema_version": 1,
  "blob": "generated_intel.json.gz",
  "gzip_sha256": "...", "json_sha256": "...",
  "gzip_bytes": ..., "json_bytes": ...,
  "record_count": 23926, "source_count": 8,
  "ecosystems": ["npm","PyPI", ...],
  "generated_at": "...",
  "tool_version": "..."   // omitted from the committed embedded manifest
}
```
- `manifest_schema` (new const `intel.ManifestSchema`) is the manifest's own schema; `bundle_schema_version` (renamed from `schema_version`) is the `intel.Snapshot` schema the blob decodes to. `gzip_sha256` binds the blob; `json_sha256` is defense in depth.
- `tools/update-intel` gains `--tool-version`; passes blob basename + version into the manifest.
- `generated_intel.meta.json` regenerated to the new shape with **identical content hashes** (the blob is untouched). `tool_version` is omitted from the committed embedded manifest to avoid a per-release version string that drifts (the publish workflow sets it for fresh bundles).

## Why bake the shape now
This file becomes the public, signed contract. Shipping it without `manifest_schema` / `blob` would force PR 1 to start with a format migration or compatibility shim. Correct shape from day one.

## Out of scope (unchanged)
No `aguara update` / `check` / `--fresh` behavior, no verifier, no `sigstore-go` dependency yet, no advisory/matching changes. Those are PRs 1-3.

## Verification
- `go build ./...` ✅ · `go vet ./...` ✅ · `golangci-lint run ./...` ✅ 0 issues · `go test -race -count=1 ./...` ✅ all pass (meta-shape change exercised by `internal/intel` + the `incident` equivalence test, which now asserts `manifest_schema` + `blob` and the renamed `bundle_schema_version` against the committed manifest).
- Workflow YAML parses.

**End-to-end signing is validated post-merge** via a manual `workflow_dispatch` on `main` (a branch dispatch signs under a different OIDC ref and fails the in-workflow verify gate by design). I'll run that dispatch and confirm `cosign verify-blob` + the published `intel-latest` assets once this is on main.