### PR TITLE
ci(intel-publish): sign manifest with --new-bundle-format

### DIFF
--- a/.github/workflows/intel-publish.yml
+++ b/.github/workflows/intel-publish.yml
@@ -96,7 +96,12 @@ jobs:
       - name: Sign manifest (Cosign keyless)
         run: |
           set -euo pipefail
-          cosign sign-blob --yes \
+          # --new-bundle-format writes the self-contained Sigstore
+          # protobuf bundle (cert + signature + Rekor inclusion proof),
+          # which the in-process verifier (sigstore-go, v0.21.0 PR 1)
+          # consumes. The legacy {base64Signature,cert,rekorBundle}
+          # format is not parseable by sigstore-go.
+          cosign sign-blob --yes --new-bundle-format \
             --bundle dist/generated_intel.meta.json.bundle \
             dist/generated_intel.meta.json
           test -f dist/generated_intel.meta.json.bundle


### PR DESCRIPTION
PR 0 follow-up. The `intel-publish` workflow currently signs the manifest with cosign's **legacy** bundle format (`{base64Signature, cert, rekorBundle}`), which `sigstore-go` does not parse. Switch the sign step to `cosign sign-blob --new-bundle-format` so it emits the self-contained Sigstore protobuf bundle (cert + signature + Rekor inclusion proof) that the in-process verifier (v0.21.0 PR 1) will consume.

- One-line change to the sign step; `cosign verify-blob` auto-detects the new format, so the in-workflow verify gate is unchanged.
- Asset name (`generated_intel.meta.json.bundle`) and the rest of the pipeline are unchanged.
- **No runtime changes.**

Validated post-merge via manual dispatch on main: confirm the run succeeds, the in-workflow verify gate passes, and `cosign verify-blob` validates the freshly published `intel-latest` manifest in the new format against the pinned identity.