### PR TITLE
feat(intel): check/audit --fresh consume the verified signed bundle (PR 3)

### DIFF
--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -34,9 +34,9 @@ prompt injection, credential leaks, etc.) together, and report a
 single combined verdict.
 
 Default audits stay offline -- they use the same embedded threat intel
-the standalone 'aguara check' uses. Pass --fresh to refresh OSV intel
-before the audit. Pass --ci to fail-on critical with no color (the
-default for unattended CI runs).`,
+the standalone 'aguara check' uses. Pass --fresh to refresh from Aguara's
+signed advisory bundle (verified before use) before the audit. Pass --ci
+to fail-on critical with no color (the default for unattended CI runs).`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runAudit,
 }
@@ -47,7 +47,7 @@ func init() {
 	auditCmd.Flags().StringVar(&flagAuditFailOn, "fail-on", "", "Exit code 1 when findings reach this severity (critical, warning, info)")
 	auditCmd.Flags().BoolVar(&flagAuditFresh, "fresh", false, "Refresh threat intel from Aguara's signed advisory bundle before the audit (network opt-in)")
 	auditCmd.Flags().BoolVar(&flagAuditInsecure, "insecure-intel", false, "Skip advisory-bundle signature verification (also requires AGUARA_INSECURE_INTEL=1; mirrors / air-gapped / tests only; manifest + blob digests are still checked)")
-	auditCmd.Flags().BoolVar(&flagAuditAllowStale, "allow-stale", false, "Continue with cached/embedded intel if --fresh refresh fails")
+	auditCmd.Flags().BoolVar(&flagAuditAllowStale, "allow-stale", false, "If --fresh fails, fall back to previously verified local intel (errors if none is cached)")
 	auditCmd.Flags().StringVar(&flagAuditBaseline, "baseline", "", "Gate scan findings only on those NOT in this baseline file (package findings always gate; fails closed if missing/malformed)")
 	auditCmd.Flags().StringVar(&flagAuditWriteBaseline, "write-baseline", "", "Write the scan findings as a baseline to this file (skips sensitive findings); package findings still gate")
 	// Runtime errors (ErrThresholdExceeded after the verdict

--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -22,6 +22,7 @@ var (
 	flagAuditAllowStale    bool
 	flagAuditBaseline      string
 	flagAuditWriteBaseline string
+	flagAuditInsecure      bool
 )
 
 var auditCmd = &cobra.Command{
@@ -44,7 +45,8 @@ func init() {
 	auditCmd.Flags().StringVar(&flagAuditPath, "path", "", "Path to audit (also accepted as a positional argument; defaults to '.')")
 	auditCmd.Flags().BoolVar(&flagAuditCI, "ci", false, "CI mode: --fail-on critical, no color")
 	auditCmd.Flags().StringVar(&flagAuditFailOn, "fail-on", "", "Exit code 1 when findings reach this severity (critical, warning, info)")
-	auditCmd.Flags().BoolVar(&flagAuditFresh, "fresh", false, "Refresh threat intel before the audit (network opt-in)")
+	auditCmd.Flags().BoolVar(&flagAuditFresh, "fresh", false, "Refresh threat intel from Aguara's signed advisory bundle before the audit (network opt-in)")
+	auditCmd.Flags().BoolVar(&flagAuditInsecure, "insecure-intel", false, "Skip advisory-bundle signature verification (also requires AGUARA_INSECURE_INTEL=1; mirrors / air-gapped / tests only; manifest + blob digests are still checked)")
 	auditCmd.Flags().BoolVar(&flagAuditAllowStale, "allow-stale", false, "Continue with cached/embedded intel if --fresh refresh fails")
 	auditCmd.Flags().StringVar(&flagAuditBaseline, "baseline", "", "Gate scan findings only on those NOT in this baseline file (package findings always gate; fails closed if missing/malformed)")
 	auditCmd.Flags().StringVar(&flagAuditWriteBaseline, "write-baseline", "", "Write the scan findings as a baseline to this file (skips sensitive findings); package findings still gate")
@@ -103,9 +105,11 @@ func runAudit(cmd *cobra.Command, args []string) error {
 	// check-side globals so resolveCheckIntel reads the right
 	// intent. Restoring them on exit keeps the two surfaces from
 	// leaking state across commands in long-lived test runs.
-	prevFresh, prevAllowStale := flagCheckFresh, flagCheckAllowStale
-	flagCheckFresh, flagCheckAllowStale = flagAuditFresh, flagAuditAllowStale
-	defer func() { flagCheckFresh, flagCheckAllowStale = prevFresh, prevAllowStale }()
+	prevFresh, prevAllowStale, prevInsecure := flagCheckFresh, flagCheckAllowStale, flagCheckInsecure
+	flagCheckFresh, flagCheckAllowStale, flagCheckInsecure = flagAuditFresh, flagAuditAllowStale, flagAuditInsecure
+	defer func() {
+		flagCheckFresh, flagCheckAllowStale, flagCheckInsecure = prevFresh, prevAllowStale, prevInsecure
+	}()
 
 	// 1. Build the same check plan `aguara check` would build
 	// for `target`. audit reuses buildCheckPlan + runCheckPlan

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -5,15 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 
 	"github.com/garagon/aguara/internal/incident"
 	"github.com/garagon/aguara/internal/intel"
-	"github.com/garagon/aguara/internal/intel/osvimport"
 	"github.com/garagon/aguara/internal/packagecheck"
 	"github.com/spf13/cobra"
 )
@@ -25,6 +22,7 @@ var (
 	flagCheckCI          bool
 	flagCheckFresh       bool
 	flagCheckAllowStale  bool
+	flagCheckInsecure    bool
 )
 
 const (
@@ -114,8 +112,9 @@ func init() {
 	checkCmd.Flags().StringSliceVar(&flagCheckEcosystems, "ecosystem", nil, "Package ecosystem (auto-detect by default; repeatable or comma-separated): python, npm, go, cargo, composer, ruby, maven, nuget")
 	checkCmd.Flags().StringVar(&flagCheckFailOn, "fail-on", "", "Exit with code 1 if findings reach this severity: critical, warning, info")
 	checkCmd.Flags().BoolVar(&flagCheckCI, "ci", false, "CI mode: equivalent to --fail-on critical --no-color")
-	checkCmd.Flags().BoolVar(&flagCheckFresh, "fresh", false, "Refresh threat intel before checking (network opt-in)")
-	checkCmd.Flags().BoolVar(&flagCheckAllowStale, "allow-stale", false, "Continue with cached/embedded intel if --fresh refresh fails")
+	checkCmd.Flags().BoolVar(&flagCheckFresh, "fresh", false, "Refresh threat intel from Aguara's signed advisory bundle before checking (network opt-in)")
+	checkCmd.Flags().BoolVar(&flagCheckAllowStale, "allow-stale", false, "If --fresh fails, fall back to previously verified local intel (errors if none is cached)")
+	checkCmd.Flags().BoolVar(&flagCheckInsecure, "insecure-intel", false, "Skip advisory-bundle signature verification (also requires AGUARA_INSECURE_INTEL=1; mirrors / air-gapped / tests only; manifest + blob digests are still checked)")
 	// Runtime errors (ErrThresholdExceeded after --ci, --fresh
 	// network failures) should not trigger Cobra's flag-usage
 	// block: a CI log that prints "Error: findings exceed severity
@@ -1138,25 +1137,36 @@ func resolveCheckIntel(ctx context.Context, ecosystems []string) (*incident.Inte
 		ctx, cancel := context.WithTimeout(ctx, intel.DefaultHTTPTimeout)
 		defer cancel()
 
-		res, err := intel.Update(ctx, intel.UpdateOptions{
-			Importer:   osvUpdateAdapter,
-			Stderr:     os.Stderr,
-			Ecosystems: ecosystems,
-		})
+		insecure, ierr := resolveInsecureIntel(flagCheckInsecure)
+		if ierr != nil {
+			return nil, ierr
+		}
+
+		// Shared trust-root path: fetch + verify the signed advisory
+		// bundle (same as `aguara update`). A verification failure is
+		// fatal; we never trust an unverified fetch.
+		snap, err := fetchVerifiedSnapshot(ctx, intelBundleBaseURL, insecure)
 		if err != nil {
 			if !flagCheckAllowStale {
-				return nil, fmt.Errorf("--fresh refresh failed: %w (pass --allow-stale to fall back to cached intel)", err)
+				return nil, fmt.Errorf("--fresh refresh failed: %w (pass --allow-stale to fall back to previously verified local intel)", err)
 			}
-			fmt.Fprintf(os.Stderr, "warning: --fresh refresh failed (%v); falling back to cached intel\n", err)
-			return localOrEmbeddedOverride(store), nil
+			// --allow-stale: fall back ONLY to a previously verified
+			// local cache. If none exists, error rather than silently
+			// dropping to embedded -- the user asked for fresh intel.
+			ov := localOrEmbeddedOverride(store)
+			if ov == nil {
+				return nil, fmt.Errorf("--fresh refresh failed (%w) and no previously verified local intel is cached", err)
+			}
+			fmt.Fprintf(os.Stderr, "warning: --fresh refresh failed (%v); falling back to previously verified local intel\n", err)
+			return ov, nil
 		}
 		if store != nil {
-			if saveErr := store.Save(res.Snapshot); saveErr != nil {
+			if saveErr := store.Save(snap); saveErr != nil {
 				fmt.Fprintf(os.Stderr, "warning: --fresh: save snapshot failed: %v\n", saveErr)
 			}
 		}
 		snaps := append([]intel.Snapshot{}, incident.EmbeddedSnapshots()...)
-		snaps = append(snaps, res.Snapshot)
+		snaps = append(snaps, snap)
 		return &incident.IntelOverride{
 			Snapshots:     snaps,
 			Mode:          "online",
@@ -1191,17 +1201,6 @@ func localOrEmbeddedOverride(store *intel.Store) *incident.IntelOverride {
 		Mode:          "offline",
 		SnapshotLabel: "local",
 	}
-}
-
-// osvUpdateAdapter is the production wiring of intel.UpdateOptions.Importer
-// to osvimport.ImportFromZip. Mirrors the adapter in update.go so the
-// two CLI surfaces (`aguara update` and `aguara check --fresh`) share
-// one importer hook.
-func osvUpdateAdapter(r io.ReaderAt, size int64, ecosystems []string, generatedAt time.Time) (intel.Snapshot, error) {
-	return osvimport.ImportFromZip(r, size, osvimport.Options{
-		Ecosystems:  ecosystems,
-		GeneratedAt: generatedAt,
-	})
 }
 
 // checkSeverityRank orders Finding.Severity strings against the

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -101,8 +101,9 @@ Supported values (case-insensitive):
   maven  (alias: java)
   nuget  (aliases: dotnet, csharp)
 
-The known-bad list ships embedded with the binary; --fresh refreshes
-only the ecosystems actually being checked.`,
+The known-bad list ships embedded with the binary; --fresh refreshes it
+from Aguara's signed advisory bundle (verified before use), which covers
+all supported ecosystems.`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runCheck,
 }
@@ -1108,11 +1109,11 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 // Returning nil keeps the default-check contract intact: no flags,
 // no network.
 //
-// LEGACY (pending follow-up): a --fresh refresh here still calls
-// intel.Update, which fetches raw OSV over TLS WITHOUT a signature
-// check. `aguara update` already migrated to verified signed bundles
-// (PR 2); check / audit --fresh are not yet migrated, so --fresh here
-// trusts OSV transport only until that follow-up lands.
+// A --fresh refresh fetches Aguara's signed advisory bundle and verifies
+// it (signature + identity + manifest/blob digests) before trusting it,
+// via the shared fetchVerifiedSnapshot path. ecosystems still scopes
+// WHICH ecosystems the check looks at, but the fetched bundle always
+// covers all of them.
 func resolveCheckIntel(ctx context.Context, ecosystems []string) (*incident.IntelOverride, error) {
 	store, storeErr := intel.DefaultStore()
 	if storeErr != nil {
@@ -1161,7 +1162,9 @@ func resolveCheckIntel(ctx context.Context, ecosystems []string) (*incident.Inte
 			return ov, nil
 		}
 		if store != nil {
-			if saveErr := store.Save(snap); saveErr != nil {
+			// SaveVerified writes a provenance marker so a later
+			// --allow-stale can prove the cache was verified.
+			if saveErr := store.SaveVerified(snap); saveErr != nil {
 				fmt.Fprintf(os.Stderr, "warning: --fresh: save snapshot failed: %v\n", saveErr)
 			}
 		}
@@ -1177,20 +1180,23 @@ func resolveCheckIntel(ctx context.Context, ecosystems []string) (*incident.Inte
 	return localOrEmbeddedOverride(store), nil
 }
 
-// localOrEmbeddedOverride returns an override layered over the
-// embedded snapshots when a local snapshot exists, or nil when no
-// local snapshot is found. Returning nil for the no-local case
-// keeps the cached default matcher in play -- no per-check
-// allocation, no behavioural change for the default `aguara check`
-// invocation.
+// localOrEmbeddedOverride returns an override layered over the embedded
+// snapshots when a PREVIOUSLY VERIFIED local snapshot exists, or nil
+// otherwise. "Verified" means written by a successful signed-bundle
+// refresh (SaveVerified wrote a matching provenance marker); a legacy or
+// hand-written snapshot.json with no marker is ignored. Returning nil
+// keeps the cached embedded matcher in play for the default `aguara
+// check`; the --allow-stale path treats nil as a hard error instead.
 func localOrEmbeddedOverride(store *intel.Store) *incident.IntelOverride {
 	if store == nil {
 		return nil
 	}
-	snap, err := store.Load()
+	snap, err := store.LoadVerified()
 	if err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
-			fmt.Fprintf(os.Stderr, "warning: local intel snapshot unreadable: %v\n", err)
+			// A present-but-unverified or mismatched marker is worth
+			// surfacing; a plain "no verified cache" stays quiet.
+			fmt.Fprintf(os.Stderr, "warning: no usable verified local intel: %v\n", err)
 		}
 		return nil
 	}
@@ -1199,7 +1205,7 @@ func localOrEmbeddedOverride(store *intel.Store) *incident.IntelOverride {
 	return &incident.IntelOverride{
 		Snapshots:     snaps,
 		Mode:          "offline",
-		SnapshotLabel: "local",
+		SnapshotLabel: "local-verified",
 	}
 }
 

--- a/cmd/aguara/commands/fresh_test.go
+++ b/cmd/aguara/commands/fresh_test.go
@@ -110,22 +110,38 @@ func TestCheckFreshTamperedBundleErrorsAndDoesNotWrite(t *testing.T) {
 	require.True(t, os.IsNotExist(statErr), "failed verification must not write the cache")
 }
 
-func TestCheckFreshAllowStaleUsesExistingCache(t *testing.T) {
+func TestCheckFreshAllowStaleUsesVerifiedCache(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	// Seed a previously verified local cache.
-	intelDir := filepath.Join(home, ".aguara", "intel")
-	require.NoError(t, os.MkdirAll(intelDir, 0o700))
 	snapPath := storeSnapshotPath(home)
-	existing := []byte(`{"schema_version":1,"generated_at":"2026-01-01T00:00:00Z","sources":[],"records":[]}` + "\n")
-	require.NoError(t, os.WriteFile(snapPath, existing, 0o600))
 
-	// Fresh fails (tampered), but --allow-stale falls back to the cache.
+	// First, a successful --fresh writes a VERIFIED cache (snapshot +
+	// provenance marker).
+	require.NoError(t, runCheckFresh(t, t.TempDir(), serveSignedBundle(t, false)))
+	before, err := os.ReadFile(snapPath)
+	require.NoError(t, err)
+
+	// Now --fresh fails (tampered); --allow-stale falls back to the
+	// previously verified cache without overwriting it.
 	require.NoError(t, runCheckFresh(t, t.TempDir(), serveSignedBundle(t, true), "--allow-stale"))
-
 	after, err := os.ReadFile(snapPath)
 	require.NoError(t, err)
-	require.Equal(t, existing, after, "fallback must not overwrite the existing verified cache")
+	require.Equal(t, before, after, "fallback must not overwrite the verified cache")
+}
+
+func TestCheckFreshAllowStaleRejectsUnverifiedLegacyCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Seed a raw snapshot.json with NO provenance marker -- e.g. a cache
+	// left by the legacy direct-OSV path or a hand-written file. It must
+	// NOT be trusted as "previously verified".
+	intelDir := filepath.Join(home, ".aguara", "intel")
+	require.NoError(t, os.MkdirAll(intelDir, 0o700))
+	require.NoError(t, os.WriteFile(storeSnapshotPath(home),
+		[]byte(`{"schema_version":1,"generated_at":"2026-01-01T00:00:00Z","sources":[],"records":[]}`+"\n"), 0o600))
+
+	err := runCheckFresh(t, t.TempDir(), serveSignedBundle(t, true), "--allow-stale")
+	require.Error(t, err, "--allow-stale must reject an unverified (markerless) local snapshot")
 }
 
 func TestCheckFreshAllowStaleWithoutCacheErrors(t *testing.T) {

--- a/cmd/aguara/commands/fresh_test.go
+++ b/cmd/aguara/commands/fresh_test.go
@@ -1,0 +1,193 @@
+package commands
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// captureStderrBytes redirects os.Stderr (where the --insecure-intel
+// warning and --fresh fallback notices are written) for the duration of
+// fn and returns the captured bytes.
+func captureStderrBytes(t *testing.T, fn func()) []byte {
+	t.Helper()
+	orig := os.Stderr
+	tmp, err := os.CreateTemp(t.TempDir(), "stderr-*.txt")
+	require.NoError(t, err)
+	os.Stderr = tmp
+	defer func() {
+		os.Stderr = orig
+		_ = tmp.Close()
+	}()
+	fn()
+	_ = tmp.Sync()
+	data, err := os.ReadFile(tmp.Name())
+	require.NoError(t, err)
+	return data
+}
+
+// serveBundleBadSignature serves a valid manifest + blob but a corrupted
+// signing bundle, so signature verification must fail while the
+// manifest/blob content checks would still pass.
+func serveBundleBadSignature(t *testing.T) string {
+	t.Helper()
+	manifest, err := os.ReadFile(bundleFixturePath(t, "valid_manifest.json"))
+	require.NoError(t, err)
+	blob, err := os.ReadFile(bundleFixturePath(t, "valid_blob.json.gz"))
+	require.NoError(t, err)
+	badBundle, err := os.ReadFile(bundleFixturePath(t, "valid_bundle.sigstore.json"))
+	require.NoError(t, err)
+	badBundle = append([]byte{}, badBundle...)
+	badBundle[len(badBundle)/2] ^= 0xFF
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/generated_intel.meta.json", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(manifest) })
+	mux.HandleFunc("/generated_intel.meta.json.bundle", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(badBundle) })
+	mux.HandleFunc("/generated_intel.json.gz", func(w http.ResponseWriter, _ *http.Request) { _, _ = w.Write(blob) })
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL
+}
+
+// runCheckFresh runs `aguara check <dir> --ecosystem npm --fresh ...`
+// against baseURL with the store rooted at a temp HOME. --ecosystem npm
+// guarantees a non-empty plan so the --fresh fetch actually fires.
+// writeBenignNPM seeds a non-compromised node_modules tree so
+// `--ecosystem npm` has a target to check (no finding noise), letting the
+// test exercise the --fresh fetch path itself.
+func writeBenignNPM(t *testing.T, dir string) {
+	t.Helper()
+	nm := filepath.Join(dir, "node_modules", "leftpad")
+	require.NoError(t, os.MkdirAll(nm, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(nm, "package.json"),
+		[]byte(`{"name":"leftpad","version":"1.0.0"}`), 0o644))
+}
+
+func runCheckFresh(t *testing.T, dir, baseURL string, extra ...string) error {
+	t.Helper()
+	writeBenignNPM(t, dir)
+	resetFlags()
+	prev := intelBundleBaseURL
+	intelBundleBaseURL = baseURL
+	out := filepath.Join(t.TempDir(), "check.json")
+	args := append([]string{"check", dir, "--ecosystem", "npm", "--fresh", "--format", "json", "-o", out}, extra...)
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs(args)
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		intelBundleBaseURL = prev
+		resetFlags()
+	})
+	return rootCmd.Execute()
+}
+
+func storeSnapshotPath(home string) string {
+	return filepath.Join(home, ".aguara", "intel", "snapshot.json")
+}
+
+func TestCheckFreshHappyPathWritesStore(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	require.NoError(t, runCheckFresh(t, t.TempDir(), serveSignedBundle(t, false)))
+	_, err := os.Stat(storeSnapshotPath(home))
+	require.NoError(t, err, "--fresh must write the verified snapshot to the store")
+}
+
+func TestCheckFreshTamperedBundleErrorsAndDoesNotWrite(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	err := runCheckFresh(t, t.TempDir(), serveSignedBundle(t, true))
+	require.Error(t, err, "a tampered bundle must fail --fresh")
+	_, statErr := os.Stat(storeSnapshotPath(home))
+	require.True(t, os.IsNotExist(statErr), "failed verification must not write the cache")
+}
+
+func TestCheckFreshAllowStaleUsesExistingCache(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// Seed a previously verified local cache.
+	intelDir := filepath.Join(home, ".aguara", "intel")
+	require.NoError(t, os.MkdirAll(intelDir, 0o700))
+	snapPath := storeSnapshotPath(home)
+	existing := []byte(`{"schema_version":1,"generated_at":"2026-01-01T00:00:00Z","sources":[],"records":[]}` + "\n")
+	require.NoError(t, os.WriteFile(snapPath, existing, 0o600))
+
+	// Fresh fails (tampered), but --allow-stale falls back to the cache.
+	require.NoError(t, runCheckFresh(t, t.TempDir(), serveSignedBundle(t, true), "--allow-stale"))
+
+	after, err := os.ReadFile(snapPath)
+	require.NoError(t, err)
+	require.Equal(t, existing, after, "fallback must not overwrite the existing verified cache")
+}
+
+func TestCheckFreshAllowStaleWithoutCacheErrors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	err := runCheckFresh(t, t.TempDir(), serveSignedBundle(t, true), "--allow-stale")
+	require.Error(t, err, "--allow-stale with no cached verified intel must error, not fall back to embedded")
+}
+
+func TestCheckFreshInsecureWithoutEnvErrors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AGUARA_INSECURE_INTEL", "") // explicitly unset
+	err := runCheckFresh(t, t.TempDir(), serveSignedBundle(t, false), "--insecure-intel")
+	require.Error(t, err, "--insecure-intel without AGUARA_INSECURE_INTEL=1 must error")
+	require.Contains(t, err.Error(), "AGUARA_INSECURE_INTEL")
+}
+
+func TestCheckFreshInsecureWithEnvBypassesBadSignature(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	badSig := serveBundleBadSignature(t)
+
+	// Without --insecure-intel, the bad signature is fatal.
+	require.Error(t, runCheckFresh(t, t.TempDir(), badSig),
+		"a bad signature must fail --fresh without --insecure-intel")
+
+	// With --insecure-intel + env, signature is skipped (manifest/blob
+	// still valid) and a warning is emitted.
+	t.Setenv("AGUARA_INSECURE_INTEL", "1")
+	var err error
+	stderr := captureStderrBytes(t, func() {
+		err = runCheckFresh(t, t.TempDir(), badSig, "--insecure-intel")
+	})
+	require.NoError(t, err, "--insecure-intel + env must accept a valid manifest/blob despite a bad signature")
+	require.Contains(t, string(stderr), "WARNING", "--insecure-intel must emit a visible warning")
+	require.FileExists(t, storeSnapshotPath(home))
+}
+
+func TestAuditFreshTamperedBundleErrors(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	// audit derives ecosystems from discovery, so seed a real npm tree
+	// to produce a non-empty plan that triggers the --fresh fetch.
+	dir := t.TempDir()
+	writeCompromisedNPM(t, dir)
+
+	resetFlags()
+	prev := intelBundleBaseURL
+	intelBundleBaseURL = serveSignedBundle(t, true)
+	out := filepath.Join(t.TempDir(), "audit.json")
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"audit", dir, "--fresh", "--format", "json", "-o", out})
+	t.Cleanup(func() {
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		intelBundleBaseURL = prev
+		resetFlags()
+	})
+	require.Error(t, rootCmd.Execute(), "audit --fresh must fail on a tampered bundle (mirrors check)")
+	_, statErr := os.Stat(storeSnapshotPath(home))
+	require.True(t, os.IsNotExist(statErr), "failed audit --fresh must not write the cache")
+}

--- a/cmd/aguara/commands/freshintel.go
+++ b/cmd/aguara/commands/freshintel.go
@@ -1,0 +1,88 @@
+package commands
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/garagon/aguara/internal/intel/bundle"
+)
+
+// intelInsecureEnv must be set to "1" alongside the --insecure-intel flag
+// to disable signature verification of the advisory bundle. Requiring both
+// the flag and the env var makes it hard to trip accidentally from a CI
+// arg, and it is never sourced from config.
+const intelInsecureEnv = "AGUARA_INSECURE_INTEL"
+
+// resolveInsecureIntel validates the --insecure-intel opt-out. It returns
+// true only when BOTH the flag and intelInsecureEnv=1 are present, and
+// emits a stderr warning on every such run. A flag set without the env var
+// is a hard error rather than a silent downgrade.
+func resolveInsecureIntel(flag bool) (bool, error) {
+	if !flag {
+		return false, nil
+	}
+	if os.Getenv(intelInsecureEnv) != "1" {
+		return false, fmt.Errorf("--insecure-intel also requires %s=1 in the environment; it disables advisory-bundle signature verification and is only for mirrors, air-gapped hosts, and tests", intelInsecureEnv)
+	}
+	fmt.Fprintf(os.Stderr, "WARNING: --insecure-intel: advisory-bundle signature/identity verification is DISABLED (manifest and blob digests are still checked). Do not use in production.\n")
+	return true, nil
+}
+
+// fetchVerifiedSnapshot is the single trust-root path shared by
+// `aguara update`, `check --fresh`, and `audit --fresh`: fetch the signed
+// advisory bundle from baseURL and return the decoded snapshot. It never
+// returns a snapshot that failed verification.
+//
+// With insecure=false (default) it verifies the Sigstore signature and
+// pinned publisher identity, then validates the manifest against the blob.
+// With insecure=true it skips only the signature/identity step; the
+// manifest/blob content checks (schema, name, sizes, digests, decode)
+// still run.
+func fetchVerifiedSnapshot(ctx context.Context, baseURL string, insecure bool) (intel.Snapshot, error) {
+	get := func(name string) ([]byte, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/"+name, nil)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("User-Agent", "aguara-update/1.0 (+https://github.com/garagon/aguara)")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("fetch %s: %w", name, err)
+		}
+		defer func() { _ = resp.Body.Close() }()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("fetch %s: http %d %s", name, resp.StatusCode, resp.Status)
+		}
+		data, err := io.ReadAll(io.LimitReader(resp.Body, intel.MaxHTTPBodyBytes+1))
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", name, err)
+		}
+		if int64(len(data)) > intel.MaxHTTPBodyBytes {
+			return nil, fmt.Errorf("%s exceeds %d byte cap", name, intel.MaxHTTPBodyBytes)
+		}
+		return data, nil
+	}
+
+	manifest, err := get("generated_intel.meta.json")
+	if err != nil {
+		return intel.Snapshot{}, err
+	}
+	blob, err := get(bundle.ExpectedBlobName)
+	if err != nil {
+		return intel.Snapshot{}, err
+	}
+	if insecure {
+		// The signing bundle is not needed when signature verification
+		// is disabled.
+		return bundle.DecodeUnverified(manifest, blob)
+	}
+	bundleBytes, err := get("generated_intel.meta.json.bundle")
+	if err != nil {
+		return intel.Snapshot{}, err
+	}
+	return bundle.VerifyAndDecode(manifest, bundleBytes, blob)
+}

--- a/cmd/aguara/commands/scan_test.go
+++ b/cmd/aguara/commands/scan_test.go
@@ -42,9 +42,11 @@ func resetFlags() {
 	flagCheckCI = false
 	flagCheckFresh = false
 	flagCheckAllowStale = false
+	flagCheckInsecure = false
 	flagUpdateTimeout = intel.DefaultHTTPTimeout
 	flagUpdateEcosystems = nil
 	flagUpdateAllowEmpty = false
+	flagUpdateInsecure = false
 	flagAuditPath = ""
 	flagAuditCI = false
 	flagAuditFailOn = ""
@@ -52,6 +54,7 @@ func resetFlags() {
 	flagAuditAllowStale = false
 	flagAuditBaseline = ""
 	flagAuditWriteBaseline = ""
+	flagAuditInsecure = false
 }
 
 // scanToFile runs aguara scan and writes output to a temp file, returning the content.

--- a/cmd/aguara/commands/update.go
+++ b/cmd/aguara/commands/update.go
@@ -43,8 +43,8 @@ only then writes the snapshot to ~/.aguara/intel/snapshot.json.
 The bundle is produced from OSV.dev by the intel-publish workflow and
 signed there; the update command only trusts a verified, signed bundle
 and does not fetch OSV directly. A bundle that fails verification is not
-used. (check / audit --fresh still use the legacy direct-OSV path until a
-follow-up migrates them to verified bundles.)
+used. 'aguara check --fresh' and 'aguara audit --fresh' use the same
+verified bundle.
 
 This command is the only place 'aguara update' touches the network.
 Default 'aguara check' invocations stay offline.
@@ -107,7 +107,9 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("aguara update: verified bundle has 0 records; refusing to overwrite cached intel (pass --allow-empty to save anyway)")
 	}
 
-	if err := store.Save(snap); err != nil {
+	// SaveVerified writes a provenance marker so a later --allow-stale
+	// fallback can prove this cache came from a verified signed bundle.
+	if err := store.SaveVerified(snap); err != nil {
 		return fmt.Errorf("aguara update: save snapshot: %w", err)
 	}
 

--- a/cmd/aguara/commands/update.go
+++ b/cmd/aguara/commands/update.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"net/http"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -13,7 +12,6 @@ import (
 	"time"
 
 	"github.com/garagon/aguara/internal/intel"
-	"github.com/garagon/aguara/internal/intel/bundle"
 	"github.com/spf13/cobra"
 )
 
@@ -21,6 +19,7 @@ var (
 	flagUpdateTimeout    time.Duration
 	flagUpdateEcosystems []string
 	flagUpdateAllowEmpty bool
+	flagUpdateInsecure   bool
 )
 
 // defaultIntelBundleBaseURL is where the signed advisory-intel bundle is
@@ -61,6 +60,7 @@ func init() {
 	// supported ecosystem, so a partial fetch is not possible.
 	updateCmd.Flags().StringSliceVar(&flagUpdateEcosystems, "ecosystem", nil, "Ignored: the signed bundle covers all supported ecosystems (a partial fetch is not possible)")
 	updateCmd.Flags().BoolVar(&flagUpdateAllowEmpty, "allow-empty", false, "Save a 0-record snapshot anyway (defaults to error so a bad publish cannot wipe cached intel)")
+	updateCmd.Flags().BoolVar(&flagUpdateInsecure, "insecure-intel", false, "Skip advisory-bundle signature verification (also requires AGUARA_INSECURE_INTEL=1; mirrors / air-gapped / tests only; manifest + blob digests are still checked)")
 	// Runtime errors (HTTP failures, verification failures) should not
 	// trigger Cobra's flag-usage block. Same rationale as scan / check.
 	updateCmd.SilenceUsage = true
@@ -83,19 +83,20 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 		fmt.Fprintln(os.Stderr, "aguara update: --ecosystem is ignored for signed bundles; the published bundle covers all supported ecosystems")
 	}
 
-	ctx, cancel := context.WithTimeout(cmd.Context(), flagUpdateTimeout)
-	defer cancel()
-
-	manifest, bundleBytes, blob, err := fetchSignedBundle(ctx, http.DefaultClient, intelBundleBaseURL)
+	insecure, err := resolveInsecureIntel(flagUpdateInsecure)
 	if err != nil {
 		return fmt.Errorf("aguara update: %w", err)
 	}
 
-	// Verify EVERYTHING before anything is written: signature + pinned
-	// identity, manifest schema, blob name, gzip/json digests + sizes,
-	// and bundle_schema_version against the decoded snapshot. A failure
-	// here means the cache is left untouched (no partial writes).
-	snap, err := bundle.VerifyAndDecode(manifest, bundleBytes, blob)
+	ctx, cancel := context.WithTimeout(cmd.Context(), flagUpdateTimeout)
+	defer cancel()
+
+	// Fetch + verify EVERYTHING before anything is written: signature +
+	// pinned identity (unless --insecure-intel), manifest schema, blob
+	// name, gzip/json digests + sizes, and bundle_schema_version against
+	// the decoded snapshot. A failure leaves the cache untouched (no
+	// partial writes).
+	snap, err := fetchVerifiedSnapshot(ctx, intelBundleBaseURL, insecure)
 	if err != nil {
 		return fmt.Errorf("aguara update: %w", err)
 	}
@@ -111,47 +112,6 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	return writeUpdateOutput(snap, store.Dir)
-}
-
-// fetchSignedBundle downloads the manifest, its Sigstore bundle, and the
-// gzipped snapshot blob from baseURL. Each download is capped at
-// intel.MaxHTTPBodyBytes so a hostile or runaway response cannot exhaust
-// memory. It performs no verification; the caller verifies before trust.
-func fetchSignedBundle(ctx context.Context, client *http.Client, baseURL string) (manifest, bundleBytes, blob []byte, err error) {
-	get := func(name string) ([]byte, error) {
-		req, rerr := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/"+name, nil)
-		if rerr != nil {
-			return nil, rerr
-		}
-		req.Header.Set("User-Agent", "aguara-update/1.0 (+https://github.com/garagon/aguara)")
-		resp, rerr := client.Do(req)
-		if rerr != nil {
-			return nil, fmt.Errorf("fetch %s: %w", name, rerr)
-		}
-		defer func() { _ = resp.Body.Close() }()
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("fetch %s: http %d %s", name, resp.StatusCode, resp.Status)
-		}
-		data, rerr := io.ReadAll(io.LimitReader(resp.Body, intel.MaxHTTPBodyBytes+1))
-		if rerr != nil {
-			return nil, fmt.Errorf("read %s: %w", name, rerr)
-		}
-		if int64(len(data)) > intel.MaxHTTPBodyBytes {
-			return nil, fmt.Errorf("%s exceeds %d byte cap", name, intel.MaxHTTPBodyBytes)
-		}
-		return data, nil
-	}
-
-	if manifest, err = get("generated_intel.meta.json"); err != nil {
-		return nil, nil, nil, err
-	}
-	if bundleBytes, err = get("generated_intel.meta.json.bundle"); err != nil {
-		return nil, nil, nil, err
-	}
-	if blob, err = get(bundle.ExpectedBlobName); err != nil {
-		return nil, nil, nil, err
-	}
-	return manifest, bundleBytes, blob, nil
 }
 
 // updateOutput is the JSON-stable shape `aguara update --format json`

--- a/internal/intel/bundle/decode.go
+++ b/internal/intel/bundle/decode.go
@@ -35,6 +35,23 @@ func VerifyAndDecode(manifestBytes, bundleBytes, blobBytes []byte) (intel.Snapsh
 	return checkManifestAgainstBlob(meta, blobBytes)
 }
 
+// DecodeUnverified parses and content-validates the manifest against the
+// blob WITHOUT verifying the Sigstore signature or publisher identity. It
+// still enforces manifest_schema (present + supported), the blob name,
+// the gzip/json digests + sizes, and the snapshot decode -- it only skips
+// the cryptographic trust check.
+//
+// This backs --insecure-intel, which is gated behind both a flag and an
+// env var at the CLI and is intended only for mirrors, air-gapped
+// re-hosting, and tests. It must never be reachable from config.
+func DecodeUnverified(manifestBytes, blobBytes []byte) (intel.Snapshot, error) {
+	meta, err := parseManifest(manifestBytes)
+	if err != nil {
+		return intel.Snapshot{}, err
+	}
+	return checkManifestAgainstBlob(meta, blobBytes)
+}
+
 // checkManifestAgainstBlob runs the content checks (steps 3-6 above)
 // that bind a verified manifest to the downloaded blob. Split from the
 // signature path so the content invariants can be unit-tested

--- a/internal/intel/bundle/decode_test.go
+++ b/internal/intel/bundle/decode_test.go
@@ -1,6 +1,7 @@
 package bundle
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -44,6 +45,29 @@ func TestCheckManifestAgainstBlobValid(t *testing.T) {
 	}
 	if len(snap.Records) != 1 || snap.Records[0].ID != "MAL-2026-1" {
 		t.Fatalf("unexpected decoded snapshot: %+v", snap.Records)
+	}
+}
+
+func TestDecodeUnverifiedStillChecksContent(t *testing.T) {
+	// DecodeUnverified skips the signature but must still enforce the
+	// manifest/blob content checks.
+	meta, gz := validTriple(t)
+	mb, err := json.Marshal(meta)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	snap, err := DecodeUnverified(mb, gz)
+	if err != nil {
+		t.Fatalf("valid manifest/blob must decode unverified, got: %v", err)
+	}
+	if len(snap.Records) == 0 {
+		t.Fatal("expected decoded records")
+	}
+	// A tampered blob is still rejected even without signature checking.
+	bad := append([]byte{}, gz...)
+	bad[len(bad)/2] ^= 0xFF
+	if _, err := DecodeUnverified(mb, bad); err == nil {
+		t.Fatal("DecodeUnverified must still reject a blob that does not match the manifest digest")
 	}
 }
 

--- a/internal/intel/store.go
+++ b/internal/intel/store.go
@@ -1,6 +1,8 @@
 package intel
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,6 +29,18 @@ type Store struct {
 // status.json (recording last update attempt + error) will land
 // in the runtime-update PR; the current Store keeps state in-memory.
 const snapshotFileName = "snapshot.json"
+
+// verifiedMarkerFileName is the provenance marker written next to the
+// snapshot by SaveVerified. Its presence + matching digest is what marks
+// a local snapshot as "previously verified by a signed bundle".
+const verifiedMarkerFileName = "verified.json"
+
+// verifiedMarker binds a local snapshot to a successful signature
+// verification by recording the SHA-256 of the exact snapshot bytes.
+type verifiedMarker struct {
+	SnapshotSHA256 string    `json:"snapshot_sha256"`
+	VerifiedAt     time.Time `json:"verified_at"`
+}
 
 // MaxSnapshotBytes caps the size of any snapshot Store will Load
 // from disk. Snapshots are user-trusted data after `aguara update`
@@ -64,6 +78,9 @@ func DefaultStore() (*Store, error) {
 
 // snapshotPath returns the path to the on-disk snapshot file.
 func (s *Store) snapshotPath() string { return filepath.Join(s.Dir, snapshotFileName) }
+
+// verifiedMarkerPath returns the path to the provenance marker.
+func (s *Store) verifiedMarkerPath() string { return filepath.Join(s.Dir, verifiedMarkerFileName) }
 
 // ensureDir creates s.Dir with permissions readable+writable only
 // by the current user, never by group or world. The snapshot is
@@ -126,48 +143,91 @@ func (s *Store) Load() (*Snapshot, error) {
 // a struct that cannot serialise (e.g. an exotic time) errors out
 // before the on-disk file is touched.
 func (s *Store) Save(snap Snapshot) error {
+	data, err := s.marshalForSave(snap)
+	if err != nil {
+		return err
+	}
+	if err := s.ensureDir(); err != nil {
+		return fmt.Errorf("intel store: mkdir: %w", err)
+	}
+	return s.atomicWrite(s.snapshotPath(), data)
+}
+
+// SaveVerified persists snap AND a provenance marker (verified.json)
+// recording that this snapshot came from a signature-verified advisory
+// bundle. The marker binds to the snapshot by SHA-256 of the exact bytes
+// written, so a later hand-edit or swap of snapshot.json invalidates it.
+// LoadVerified (and therefore --allow-stale) trusts a local snapshot only
+// when this marker is present and matches; a legacy or hand-written
+// snapshot.json with no marker is treated as unverified.
+//
+// The snapshot is written first, then the marker, so a torn write leaves
+// at worst a snapshot with a missing/mismatched marker -- which reads as
+// "unverified", the safe outcome.
+func (s *Store) SaveVerified(snap Snapshot) error {
+	data, err := s.marshalForSave(snap)
+	if err != nil {
+		return err
+	}
+	if err := s.ensureDir(); err != nil {
+		return fmt.Errorf("intel store: mkdir: %w", err)
+	}
+	if err := s.atomicWrite(s.snapshotPath(), data); err != nil {
+		return err
+	}
+	sum := sha256.Sum256(data)
+	marker := verifiedMarker{
+		SnapshotSHA256: hex.EncodeToString(sum[:]),
+		VerifiedAt:     time.Now().UTC(),
+	}
+	markerData, err := json.MarshalIndent(marker, "", "  ")
+	if err != nil {
+		return fmt.Errorf("intel store: marshal verified marker: %w", err)
+	}
+	return s.atomicWrite(s.verifiedMarkerPath(), markerData)
+}
+
+// marshalForSave validates the schema and serialises snap, applying the
+// size cap. Shared by Save and SaveVerified so both write identical bytes.
+func (s *Store) marshalForSave(snap Snapshot) ([]byte, error) {
 	if snap.SchemaVersion == 0 {
 		snap.SchemaVersion = CurrentSchemaVersion
 	}
 	if snap.SchemaVersion > CurrentSchemaVersion {
-		return fmt.Errorf("intel store: refusing to save schema v%d (this binary writes v%d)",
+		return nil, fmt.Errorf("intel store: refusing to save schema v%d (this binary writes v%d)",
 			snap.SchemaVersion, CurrentSchemaVersion)
 	}
 	data, err := json.MarshalIndent(snap, "", "  ")
 	if err != nil {
-		return fmt.Errorf("intel store: marshal: %w", err)
+		return nil, fmt.Errorf("intel store: marshal: %w", err)
 	}
 	if int64(len(data)) > MaxSnapshotBytes {
-		return fmt.Errorf("intel store: snapshot serialises to %d bytes, exceeds %d cap",
+		return nil, fmt.Errorf("intel store: snapshot serialises to %d bytes, exceeds %d cap",
 			len(data), MaxSnapshotBytes)
 	}
+	return data, nil
+}
 
-	if err := s.ensureDir(); err != nil {
-		return fmt.Errorf("intel store: mkdir: %w", err)
-	}
-
-	dst := s.snapshotPath()
-	tmp, err := os.CreateTemp(s.Dir, ".snapshot-*.json")
+// atomicWrite writes data to dst via a temp file in the same directory,
+// fsynced and chmod 0600, then renamed over dst. A concurrent reader sees
+// only the old or the new file, never a half-written one.
+func (s *Store) atomicWrite(dst string, data []byte) error {
+	tmp, err := os.CreateTemp(s.Dir, ".intel-*.tmp")
 	if err != nil {
 		return fmt.Errorf("intel store: tempfile: %w", err)
 	}
 	tmpName := tmp.Name()
-	cleanup := func() {
+	if _, err := tmp.Write(data); err != nil {
 		_ = tmp.Close()
 		_ = os.Remove(tmpName)
-	}
-
-	if _, err := tmp.Write(data); err != nil {
-		cleanup()
 		return fmt.Errorf("intel store: write %s: %w", tmpName, err)
 	}
 	if err := tmp.Sync(); err != nil {
-		cleanup()
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
 		return fmt.Errorf("intel store: fsync %s: %w", tmpName, err)
 	}
 	if err := tmp.Close(); err != nil {
-		// Close may report errors deferred from earlier writes;
-		// surface them rather than silently dropping the snapshot.
 		_ = os.Remove(tmpName)
 		return fmt.Errorf("intel store: close %s: %w", tmpName, err)
 	}
@@ -180,6 +240,50 @@ func (s *Store) Save(snap Snapshot) error {
 		return fmt.Errorf("intel store: rename %s -> %s: %w", tmpName, dst, err)
 	}
 	return nil
+}
+
+// LoadVerified loads the snapshot ONLY if the provenance marker is present
+// and matches it byte-for-byte. It returns os.ErrNotExist when there is no
+// snapshot or no marker (so callers can treat "no verified intel" the same
+// as "no intel"), and a distinct error when a marker exists but does not
+// match the snapshot (tamper / partial write).
+func (s *Store) LoadVerified() (*Snapshot, error) {
+	data, err := os.ReadFile(s.snapshotPath())
+	if err != nil {
+		return nil, err // includes os.ErrNotExist
+	}
+	if int64(len(data)) > MaxSnapshotBytes {
+		return nil, fmt.Errorf("intel store: snapshot exceeds %d bytes (cap)", MaxSnapshotBytes)
+	}
+	markerData, err := os.ReadFile(s.verifiedMarkerPath())
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			// Snapshot present but no provenance marker: treat as
+			// not-verified (legacy / hand-written cache).
+			return nil, os.ErrNotExist
+		}
+		return nil, fmt.Errorf("intel store: read verified marker: %w", err)
+	}
+	var marker verifiedMarker
+	if err := json.Unmarshal(markerData, &marker); err != nil {
+		return nil, fmt.Errorf("intel store: decode verified marker: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	if marker.SnapshotSHA256 != hex.EncodeToString(sum[:]) {
+		return nil, fmt.Errorf("intel store: snapshot does not match its verified marker (cache was modified after verification)")
+	}
+	var snap Snapshot
+	if err := json.Unmarshal(data, &snap); err != nil {
+		return nil, fmt.Errorf("intel store: decode %s: %w", s.snapshotPath(), err)
+	}
+	if snap.SchemaVersion == 0 {
+		snap.SchemaVersion = CurrentSchemaVersion
+	}
+	if snap.SchemaVersion > CurrentSchemaVersion {
+		return nil, fmt.Errorf("intel store: snapshot schema v%d is newer than this binary (v%d); upgrade aguara",
+			snap.SchemaVersion, CurrentSchemaVersion)
+	}
+	return &snap, nil
 }
 
 // Status returns the current Store status. It never fails: missing

--- a/internal/intel/store_test.go
+++ b/internal/intel/store_test.go
@@ -185,3 +185,46 @@ func TestStoreSaveOverwritesAtomically(t *testing.T) {
 	require.Len(t, got.Records, 1)
 	require.Equal(t, "second", got.Records[0].ID)
 }
+
+func TestStoreSaveVerifiedRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	s := &intel.Store{Dir: dir}
+	snap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		GeneratedAt:   time.Date(2026, time.May, 28, 0, 0, 0, 0, time.UTC),
+		Records:       []intel.Record{{ID: "MAL-1", Ecosystem: "npm", Name: "x", Kind: intel.KindMalicious, Summary: "s", Versions: []string{"1.0.0"}}},
+	}
+	require.NoError(t, s.SaveVerified(snap))
+
+	// The provenance marker must exist alongside the snapshot.
+	require.FileExists(t, filepath.Join(dir, "verified.json"))
+
+	got, err := s.LoadVerified()
+	require.NoError(t, err)
+	require.Len(t, got.Records, 1)
+	require.Equal(t, "MAL-1", got.Records[0].ID)
+}
+
+func TestStoreLoadVerifiedRejectsMissingMarker(t *testing.T) {
+	dir := t.TempDir()
+	s := &intel.Store{Dir: dir}
+	// Plain Save writes the snapshot but NO provenance marker (legacy
+	// path). LoadVerified must treat it as not-verified.
+	require.NoError(t, s.Save(intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion}))
+	_, err := s.LoadVerified()
+	require.ErrorIs(t, err, os.ErrNotExist, "a markerless snapshot must read as not-verified")
+}
+
+func TestStoreLoadVerifiedRejectsTamperedSnapshot(t *testing.T) {
+	dir := t.TempDir()
+	s := &intel.Store{Dir: dir}
+	require.NoError(t, s.SaveVerified(intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		Records:       []intel.Record{{ID: "MAL-1", Ecosystem: "npm", Name: "x", Kind: intel.KindMalicious, Summary: "s", Versions: []string{"1.0.0"}}},
+	}))
+	// Hand-edit snapshot.json after verification: the marker no longer matches.
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "snapshot.json"),
+		[]byte(`{"schema_version":1,"sources":[],"records":[]}`+"\n"), 0o600))
+	_, err := s.LoadVerified()
+	require.Error(t, err, "a snapshot edited after verification must fail LoadVerified")
+}

--- a/internal/intel/update.go
+++ b/internal/intel/update.go
@@ -111,12 +111,13 @@ type EcosystemResult struct {
 //
 // The HTTP path is opt-in: Update fetches raw OSV dumps directly.
 //
-// LEGACY: as of PR 2, `aguara update` no longer calls this -- it fetches
-// a signed bundle and verifies it (see cmd/aguara/commands/update.go).
-// Update is retained as library API and is still the path behind
-// `check / audit --fresh` until a follow-up migrates those to verified
-// signed bundles too. Until then, --fresh trusts OSV over TLS without a
-// signature check.
+// LEGACY: no aguara CLI path calls Update anymore. `aguara update`,
+// `check --fresh`, and `audit --fresh` all fetch Aguara's signed
+// advisory bundle and verify it (cmd/aguara/commands/freshintel.go).
+// Update is retained only as library API for external consumers and may
+// be deprecated in a future release; it performs NO signature
+// verification (it trusts raw OSV over TLS), so it must not be wired
+// back into a trusted runtime path.
 func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 	if opts.Importer == nil {
 		return nil, fmt.Errorf("intel update: Importer is required (CLI must wire osvimport.ImportFromZip)")


### PR DESCRIPTION
**PR 3 (final) of the signed advisory bundles block** (v0.21.0). `check --fresh` and `audit --fresh` now refresh from Aguara's **signed** advisory bundle through the same fetch → verify → decode path as `aguara update`. `--fresh` no longer means raw OSV.

## What

- **Shared trust-root path** (`freshintel.go`): `fetchVerifiedSnapshot` is the one fetch+verify+decode used by `update`, `check --fresh`, and `audit --fresh`.
- **`--insecure-intel`**: requires the flag **and** `AGUARA_INSECURE_INTEL=1` (never config), warns every run, skips **only** signature/identity; manifest/blob checks (schema, name, sizes, digests, decode) still run.
- **`--allow-stale` provenance (review P1 fix)**: a successful verified refresh now writes a provenance marker (`~/.aguara/intel/verified.json`) binding the snapshot by SHA-256. `--allow-stale` falls back **only** to a snapshot that still matches its marker; a legacy direct-OSV cache, a hand-written file, or an edited snapshot has no valid marker and is **rejected** (errors, never silent embedded). The default offline path likewise ignores unverified local snapshots and uses the build-signed embedded snapshot.
- `aguara update` + `check`/`audit --fresh` write via `Store.SaveVerified`; `Store.LoadVerified` enforces the marker.
- `intel.Update` retained as library API (unverified, library-only; must not be re-wired into runtime); no CLI path uses it.

## Tests

happy path → store written; tampered → error + no write; **`--allow-stale` uses a real verified cache (byte-identical)**; **`--allow-stale` rejects an unverified/legacy markerless cache**; `--allow-stale` without cache → error; `--insecure-intel` without env → error; `--insecure-intel` + env bypasses a bad signature (manifest/blob still validated) + warns; `audit --fresh` tampered → error; `DecodeUnverified` content-check unit; store `SaveVerified`/`LoadVerified` round-trip + missing-marker + tampered-snapshot rejections.

## Wording (review P2 fix)
Corrected stale text now that `--fresh` is the signed bundle: audit Long + `--allow-stale` help, update Long, check Long (bundle covers all ecosystems), and the `resolveCheckIntel` / `intel.Update` docs.

## Size
9.38 → **20.13 MiB stripped**, under the ~22 MiB budget.

## Scope
`intel.Update` not deleted; no release prep, no data-flow, no large docs.

## Verification
`go build ./...` ✅ · `go vet ./...` ✅ · `golangci-lint run ./...` ✅ 0 issues · `go test -race -count=1 ./...` ✅ all pass.