### PR TITLE
release: prep v0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-05-28
+
+Trusted fresh threat intel. `aguara update` and `--fresh` checks now
+refresh from a signed advisory bundle that Aguara publishes and verifies
+before use, instead of fetching OSV directly. Detection rules, advisory
+coverage, and offline-by-default behavior are unchanged.
+
+### Added
+
+- **Signed advisory bundles for `--fresh` / `aguara update`.** Aguara
+  publishes a signed advisory bundle (the same snapshot it embeds) on a
+  schedule. `aguara update`, `aguara check --fresh`, and
+  `aguara audit --fresh` fetch that bundle and verify it in-process
+  before trusting it: Sigstore signature + the expected publisher
+  identity, then the manifest against the blob (schema, name, sizes,
+  SHA-256 digests) and a schema-compatible decode. A bundle that fails
+  any check is never used and never written to the cache (no partial
+  writes). Verification is offline (the Sigstore trusted root is
+  embedded).
+- **`--insecure-intel`** (on `update` / `check` / `audit`): skips only
+  the signature/identity check for mirrors, air-gapped hosts, and tests.
+  It requires both the flag and `AGUARA_INSECURE_INTEL=1`, is never read
+  from config, prints a warning on every run, and still enforces the
+  manifest/blob digest and schema checks.
+
+### Changed
+
+- **`--fresh` no longer fetches OSV directly.** It refreshes from
+  Aguara's signed advisory bundle, which covers all supported
+  ecosystems. OSV is consumed and signed in the publishing workflow, not
+  at runtime.
+- **`--allow-stale` falls back only to previously verified local
+  intel.** A successful verified refresh records a provenance marker; on
+  a failed refresh, `--allow-stale` reuses the local cache only when that
+  marker is present and matches the snapshot, and errors otherwise
+  rather than silently using unverified data.
+
+### Upgrade note
+
+A local snapshot cached by an older version has no verification marker,
+so it is ignored by default and by `--allow-stale`. This is intentional:
+unverified cached intel is not trusted. Run `aguara update` once after
+upgrading to seed the verified local cache. Default `aguara check` keeps
+working offline against the binary's embedded snapshot in the meantime.
+
 ## [0.20.0] - 2026-05-28
 
 Scan baseline / diff mode plus a smaller, more maintainable embedded

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.20.0
+INSTALL_SH_TEST_VERSION ?= v0.21.0
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.20.0 sh
+  | VERSION=v0.21.0 sh
 ```
 
 `install.sh` downloads `checksums.txt` from the release and verifies the archive's SHA256 against it, aborting if neither `sha256sum` nor `shasum` is available. This catches a tampered or corrupted archive at the registry layer, but it does not verify the Cosign signature on `checksums.txt` itself. For full keyless-signature verification on the curl-pipe path, follow up with the Cosign step in [Verifying signed releases](#verifying-signed-releases). Default install location is `~/.local/bin`. Override for CI or containers:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.20.0 INSTALL_DIR=/usr/local/bin sh
+  | VERSION=v0.21.0 INSTALL_DIR=/usr/local/bin sh
 ```
 
 ### From source
@@ -96,7 +96,7 @@ Every release is signed with [Cosign](https://github.com/sigstore/cosign) keyles
 **Verify the release archive**:
 
 ```bash
-VERSION=v0.20.0
+VERSION=v0.21.0
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
@@ -358,11 +358,11 @@ aguara discover --format json
 ### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.20.0
+- uses: garagon/aguara@v0.21.0
   with:
     path: .
     fail-on: high
-    version: v0.20.0
+    version: v0.21.0
 ```
 
 Both pins (the action ref AND the `version:` input) are required. The action ref alone pins only the composite action and its install script; `version:` pins the Aguara binary the action installs. Setting both makes the workflow reproducible and dependabot-friendly: when a new release lands, the bot updates both together.
@@ -370,12 +370,12 @@ Both pins (the action ref AND the `version:` input) are required. The action ref
 Scans your repository, uploads findings to GitHub Code Scanning, and optionally fails the build:
 
 ```yaml
-- uses: garagon/aguara@v0.20.0
+- uses: garagon/aguara@v0.21.0
   with:
     path: ./mcp-server/
     severity: medium
     fail-on: high
-    version: v0.20.0
+    version: v0.21.0
 ```
 
 All inputs are optional. See [`action.yml`](action.yml) for the full list.
@@ -404,7 +404,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitHub Actions (without the action)
 - name: Scan skills for security issues
   run: |
-    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.20.0 sh
+    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.21.0 sh
     aguara scan .claude/skills/ --ci
 ```
 
@@ -412,7 +412,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.20.0 sh
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.21.0 sh
     - aguara scan .claude/skills/ --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:
@@ -621,7 +621,7 @@ See the [mcp-aguara README](https://github.com/garagon/mcp-aguara) for install, 
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.20.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
+Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.21.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
 
 ## Enterprise use
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.20.0"
+        DEFAULT_REF="v0.21.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.20.0 tag rather than `@v1`
+// The action ref is pinned to the v0.21.0 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.20.0
+        uses: garagon/aguara@v0.21.0
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.20.0
+          version: v0.21.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
Release prep for **v0.21.0** — trusted fresh threat intel. Aggregates the signed advisory bundles block merged since v0.20.0:

- **#165** intel-publish workflow (publishes the signed bundle to `intel-latest`)
- **#166** sign with `--new-bundle-format` (Sigstore protobuf bundle)
- **#167** in-process verifier (`internal/intel/bundle`, sigstore-go)
- **#175** `aguara update` fetches + verifies the signed bundle
- **#176** `check --fresh` / `audit --fresh` on the same verified path + verified-provenance `--allow-stale` + `--insecure-intel`

## Changes in this PR

- `CHANGELOG.md`: `## [0.21.0] - 2026-05-28` (Added: signed bundles for `--fresh`, `--insecure-intel`; Changed: `--fresh` no longer raw OSV, `--allow-stale` verified-only) **including an upgrade note**: old markerless caches are ignored by design; run `aguara update` once after upgrading to seed the verified local cache.
- Version pins bumped v0.20.0 → v0.21.0 (`init.go` ×2, `action.yml`, `Makefile`, `README`). `check-version-pins.sh` passes.

No code or detection-engine changes in this PR.

## Verification
- `VERSION=v0.21.0 .github/scripts/check-version-pins.sh` → all pins agree ✅
- `make build` ✅ · `go vet ./...` ✅ · `golangci-lint run ./...` ✅ 0 issues · `go test -race -count=1 ./...` ✅ all pass

After merge: tag `v0.21.0` → GoReleaser + Docker, then rewrite the GitHub release body and run `verify-release.sh`.