### PR TITLE
fix(release): preserve SBOM JSON during verification

### DIFF
--- a/.github/scripts/verify-release.sh
+++ b/.github/scripts/verify-release.sh
@@ -107,7 +107,10 @@ info "docker version: ${DOCKER_VERSION}"
 # image regresses to a single platform.
 PLATFORM="linux/${ARCH}"
 SBOM_JSON=$(docker buildx imagetools inspect "${IMAGE}:${VERSION_STRIPPED}" --format '{{json .SBOM}}')
-echo "$SBOM_JSON" | jq -e --arg p "$PLATFORM" \
+# Use printf, not echo: a valid SPDX SBOM can contain backslash escapes
+# (e.g. in CPE / PURL strings), and echo may interpret those escapes and
+# corrupt the JSON before jq parses it, causing a false "malformed" error.
+printf '%s' "$SBOM_JSON" | jq -e --arg p "$PLATFORM" \
     'if has($p) then .[$p].SPDX.SPDXID == "SPDXRef-DOCUMENT"
      else .SPDX.SPDXID == "SPDXRef-DOCUMENT" end' >/dev/null \
     || err "Docker image SBOM (SPDX) missing or malformed for ${PLATFORM}"


### PR DESCRIPTION
## Summary

Fixes a false negative in `verify-release.sh` when validating Docker SBOM attestations.

Some valid SPDX SBOMs can contain escaped characters. The script was passing the SBOM JSON through `echo` before `jq`, which can alter those escapes and make valid JSON fail parsing. This switches the check to preserve the JSON bytes before parsing.

No release artifacts, build steps, signatures, or Docker images are changed.

## Why

v0.21.0 published correctly: archives, checksums, binary version, Docker signature, SBOM, and SLSA provenance are present. The verification script was the brittle part.

## Test plan

- [ ] `VERSION=v0.21.0 .github/scripts/verify-release.sh` passes 6/6