### PR TITLE
chore(intel): deprecate the legacy raw-OSV refresh API

### DIFF
--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -1084,26 +1084,25 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 }
 
 // resolveCheckIntel builds the IntelOverride the check pipeline
-// should consume. ecosystems scopes a --fresh refresh to only the
-// OSV buckets the plan actually touches (a `--ecosystem maven`
-// user does NOT want a --fresh to pull npm + PyPI just because
-// those happened to be the legacy intel.Update default). An empty
-// ecosystems list leaves intel.Update's default behaviour intact
-// (all supported ecosystems in v0.17).
+// should consume. ecosystems is the set of OSV buckets the plan
+// touches; it scopes WHICH ecosystems the check looks at. A non-empty
+// list also means there is something to check, so --fresh is worth a
+// network fetch (the fetched signed bundle always covers all supported
+// ecosystems regardless).
 //
 // The logic is:
 //
-//  1. If --fresh was passed, run intel.Update for `ecosystems`;
-//     on success save to local Store and override with
-//     [embedded..., refreshed]. IntelSummary.Mode = "online",
-//     Snapshot = "remote-fresh".
-//  2. If --fresh failed AND --allow-stale was passed, fall back
-//     to a local-only or embedded-only override and continue.
-//  3. If --fresh was NOT passed AND a local snapshot exists,
-//     layer it over the embedded snapshots. Mode stays "offline";
-//     Snapshot = "local".
+//  1. If --fresh was passed, fetch + verify Aguara's signed advisory
+//     bundle (fetchVerifiedSnapshot); on success save it to the local
+//     Store via SaveVerified and override with [embedded..., refreshed].
+//     IntelSummary.Mode = "online", Snapshot = "remote-fresh".
+//  2. If --fresh failed AND --allow-stale was passed, fall back ONLY to
+//     a previously verified local snapshot; error if none is cached.
+//  3. If --fresh was NOT passed AND a previously verified local snapshot
+//     exists, layer it over the embedded snapshots. Mode stays
+//     "offline"; Snapshot = "local-verified".
 //  4. Otherwise, return nil so the check uses the cached embedded
-//     matcher (the legacy default path).
+//     matcher (the default offline path).
 //
 // This is the only place the CLI touches the network for `check`.
 // Returning nil keeps the default-check contract intact: no flags,
@@ -1124,13 +1123,10 @@ func resolveCheckIntel(ctx context.Context, ecosystems []string) (*incident.Inte
 
 	if flagCheckFresh && len(ecosystems) == 0 {
 		// --fresh on an empty plan (e.g. `aguara check --fresh
-		// --path <empty-dir>` autodetect that found nothing)
-		// has nothing to refresh. We skip the network entirely
-		// rather than fall through to intel.Update's empty-
-		// default behaviour, which would refresh every supported
-		// ecosystem just to satisfy a check that will produce
-		// zero findings. The local / embedded snapshot is the
-		// safe answer.
+		// --path <empty-dir>` autodetect that found nothing) has
+		// nothing to check, so there is no point fetching the bundle
+		// over the network. The local / embedded snapshot is the safe
+		// answer.
 		return localOrEmbeddedOverride(store), nil
 	}
 

--- a/internal/intel/update.go
+++ b/internal/intel/update.go
@@ -111,13 +111,13 @@ type EcosystemResult struct {
 //
 // The HTTP path is opt-in: Update fetches raw OSV dumps directly.
 //
-// LEGACY: no aguara CLI path calls Update anymore. `aguara update`,
-// `check --fresh`, and `audit --fresh` all fetch Aguara's signed
-// advisory bundle and verify it (cmd/aguara/commands/freshintel.go).
+// Deprecated: Update fetches raw OSV over TLS and performs NO signature
+// verification. No aguara CLI path uses it anymore: `aguara update`,
+// `check --fresh`, and `audit --fresh` fetch Aguara's signed advisory
+// bundle and verify it before use (cmd/aguara/commands/freshintel.go).
 // Update is retained only as library API for external consumers and may
-// be deprecated in a future release; it performs NO signature
-// verification (it trusts raw OSV over TLS), so it must not be wired
-// back into a trusted runtime path.
+// be removed in a future major version; it must not be wired back into a
+// trusted runtime path.
 func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 	if opts.Importer == nil {
 		return nil, fmt.Errorf("intel update: Importer is required (CLI must wire osvimport.ImportFromZip)")

--- a/internal/intel/update_test.go
+++ b/internal/intel/update_test.go
@@ -1,3 +1,5 @@
+//lint:file-ignore SA1019 This file intentionally exercises intel.Update, the deprecated raw-OSV refresh library API, to keep its behaviour covered while it remains exported.
+
 package intel_test
 
 import (


### PR DESCRIPTION
## Summary

Marks the internal `intel.Update` raw-OSV refresh API as deprecated, now that fresh intel uses signed, verified bundles.

`aguara update`, `aguara check --fresh`, and `aguara audit --fresh` all fetch Aguara's signed advisory bundle and verify it before use, so the old direct-OSV refresh path is no longer used by any CLI command. The function is documented as deprecated but kept as library API (no removal) and its behavior is unchanged.

## Changes

- `intel.Update`: `Deprecated:` godoc note (no signature verification; do not wire into a trusted path).
- Its tests keep it covered, with a file-scoped staticcheck ignore for the intentional deprecated-API usage.
- Refreshed a few `check.go` comments that still described `--fresh` as running `intel.Update`.

No API is removed and no runtime behavior changes.

## Test plan

- [ ] `go test ./...` and `golangci-lint run ./...` pass (the deprecation does not trip lint on the API's own tests)