### PR TITLE
Pre-install npm coverage for package-lock.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ Security reviews used to focus mostly on application code. Modern projects also 
 
 Aguara gives teams a local check before they trust those inputs:
 
-- before running `pnpm install` on a pnpm project (Aguara reads `pnpm-lock.yaml` directly)
+- before running `npm install` or `pnpm install` (Aguara reads `package-lock.json` and `pnpm-lock.yaml` directly, no install needed)
 - before letting CI execute install-time scripts
 - before accepting a new MCP server config
 - before letting an agent use a third-party skill or tool
 - before uploading findings to a code-scanning dashboard
 
-For dependencies, Aguara reads resolved lockfiles where it has parsers (today this is `pnpm-lock.yaml` plus Go / Rust / PHP / Ruby / Java / .NET lockfiles) and installed package trees otherwise. Plain npm with only `package-lock.json` / `yarn.lock` and no install is on the next-layer list, not shipping today.
+For dependencies, Aguara reads resolved lockfiles where it has parsers (today this is `pnpm-lock.yaml`, `package-lock.json`, plus Go / Rust / PHP / Ruby / Java / .NET lockfiles) and installed package trees otherwise. So a freshly cloned npm or pnpm project can be checked before any install runs. `yarn.lock` is the next-layer parser, not shipping today.
 
 ## Installation
 

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -331,9 +331,9 @@ func (p checkPlan) singleEcoToken() string {
 		return ecoNPM
 	}
 	if len(p.packagecheckTargets) > 0 {
-		// npm packagecheck targets (pnpm-lock.yaml today;
-		// package-lock.json / yarn.lock in follow-ups) are not in
-		// osvIDToEcoToken because npm normally flows through the
+		// npm packagecheck targets (pnpm-lock.yaml and
+		// package-lock.json today; yarn.lock in a follow-up) are not
+		// in osvIDToEcoToken because npm normally flows through the
 		// incident path. Without this explicit map-back, a
 		// pnpm-only plan (no node_modules, no other lockfiles)
 		// would surface "" from singleEcoToken and the terminal
@@ -512,8 +512,8 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 		// empty result would silently hide the path mistake. We
 		// allow the empty result ONLY when at least one npm signal
 		// was discovered: runNPM (installed tree) or a packagecheck
-		// npm target (pnpm-lock.yaml today; package-lock.json /
-		// yarn.lock when those land).
+		// npm target (pnpm-lock.yaml or package-lock.json today;
+		// yarn.lock when it lands).
 		//
 		// Scope the error to npm-only invocations. When npm is
 		// combined with any other ecosystem the user is asking for
@@ -534,7 +534,7 @@ func buildCheckPlan(ecoFlags []string, path string) (checkPlan, error) {
 					root = "."
 				}
 				return checkPlan{}, fmt.Errorf(
-					"npm check: %s has no node_modules tree and no pnpm-lock.yaml; pass the path to a project with one or remove --ecosystem npm",
+					"npm check: %s has no node_modules tree and no pnpm-lock.yaml / package-lock.json; pass the path to a project with one or remove --ecosystem npm",
 					root,
 				)
 			}

--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -1065,6 +1065,71 @@ func TestCheck_ExplicitNPMWithOtherEcosystemSkipsLegacyError(t *testing.T) {
 	require.Equal(t, "Go", result.Ecosystems[0].Ecosystem)
 }
 
+// --- package-lock.json coverage: npm ecosystem, packagecheck path ---
+
+func TestCheckPlan_PackageLockOnlyMapsToNPMToken(t *testing.T) {
+	// A package-lock.json-only repo (no node_modules, no other
+	// lockfiles) autodetects to a single npm packagecheck target and
+	// must report ecoNPM from singleEcoToken, same as the pnpm path.
+	plan, err := buildCheckPlan(nil, "../../../internal/packagecheck/testdata/package-lock-compromised")
+	require.NoError(t, err)
+	require.False(t, plan.runNPM, "fixture has no node_modules; incident.CheckNPM must not be triggered")
+	require.Len(t, plan.packagecheckTargets, 1, "fixture has exactly one package-lock.json target")
+	require.Equal(t, "npm", plan.packagecheckTargets[0].Ecosystem)
+	require.Equal(t, "package-lock.json", plan.packagecheckTargets[0].Source)
+	require.Equal(t, ecoNPM, plan.singleEcoToken())
+}
+
+func TestCheck_PackageLockCompromisedFixtureFiresFinding(t *testing.T) {
+	// `aguara check <npm-repo>` on a fresh clone (package-lock.json,
+	// no node_modules) must detect node-ipc 9.2.3. End-to-end: autodetect
+	// picks package-lock.json as npm ecosystem, ParsePackageLock extracts
+	// the ref, matcher hits the embedded node-ipc record, ecosystems[]
+	// entry reports source=package-lock.json.
+	result := checkToFile(t, "../../../internal/packagecheck/testdata/package-lock-compromised")
+
+	require.Len(t, result.Ecosystems, 1, "exactly one ecosystems[] entry expected (package-lock.json; no node_modules)")
+	got := result.Ecosystems[0]
+	require.Equal(t, "npm", got.Ecosystem)
+	require.Equal(t, "package-lock.json", got.Source)
+	require.Contains(t, got.Path, "package-lock.json")
+	require.Equal(t, 2, got.PackagesRead, "node-ipc + lodash declared in the lockfile")
+	require.GreaterOrEqual(t, got.FindingsCount, 1, "node-ipc@9.2.3 must produce at least one finding")
+
+	var nodeIPCFinding *incident.Finding
+	for i := range result.Findings {
+		if strings.Contains(result.Findings[i].Title, "node-ipc") {
+			nodeIPCFinding = &result.Findings[i]
+			break
+		}
+	}
+	require.NotNil(t, nodeIPCFinding, "node-ipc finding missing; got: %+v", result.Findings)
+	require.Equal(t, incident.SevCritical, nodeIPCFinding.Severity, "node-ipc 9.2.3 must be CRITICAL")
+}
+
+func TestCheck_PackageLockCleanFixtureProducesZeroFindings(t *testing.T) {
+	result := checkToFile(t, "../../../internal/packagecheck/testdata/package-lock-clean")
+
+	require.Len(t, result.Ecosystems, 1)
+	require.Equal(t, "npm", result.Ecosystems[0].Ecosystem)
+	require.Equal(t, "package-lock.json", result.Ecosystems[0].Source)
+	require.Equal(t, 2, result.Ecosystems[0].PackagesRead, "lodash + @types/node")
+	require.Equal(t, 0, result.Ecosystems[0].FindingsCount, "clean fixture must have zero findings")
+	require.Empty(t, result.Findings)
+}
+
+func TestCheck_ExplicitNPMOnPackageLockOnlyRepoFires(t *testing.T) {
+	// Product check from the P3 spec: `aguara check --ecosystem npm
+	// --path <fresh clone with only package-lock.json>` must scan the
+	// lockfile (no node_modules required) and report source=package-lock.json.
+	result := checkToFile(t, "--ecosystem", "npm", "--path", "../../../internal/packagecheck/testdata/package-lock-compromised")
+
+	require.Len(t, result.Ecosystems, 1, "package-lock-only repo with --ecosystem npm: one ecosystems[] entry")
+	require.Equal(t, "npm", result.Ecosystems[0].Ecosystem)
+	require.Equal(t, "package-lock.json", result.Ecosystems[0].Source)
+	require.GreaterOrEqual(t, result.Ecosystems[0].FindingsCount, 1, "node-ipc 9.2.3 should fire")
+}
+
 // --- Issue #109: npm and PyPI emit ecosystems[] entries on the incident path ---
 
 func TestCheckExplicitNPM_AppendsEcosystemsEntry(t *testing.T) {

--- a/cmd/aguara/commands/check_test.go
+++ b/cmd/aguara/commands/check_test.go
@@ -1130,6 +1130,30 @@ func TestCheck_ExplicitNPMOnPackageLockOnlyRepoFires(t *testing.T) {
 	require.GreaterOrEqual(t, result.Ecosystems[0].FindingsCount, 1, "node-ipc 9.2.3 should fire")
 }
 
+func TestCheck_PackageLockAliasCatchesRealPackage(t *testing.T) {
+	// A dependency aliased as `"safe-ipc": "npm:node-ipc@9.2.3"` must
+	// be caught as the real node-ipc 9.2.3, not slip through under the
+	// innocuous alias directory name. End-to-end through the matcher.
+	result := checkToFile(t, "../../../internal/packagecheck/testdata/package-lock-alias")
+
+	require.Len(t, result.Ecosystems, 1)
+	require.Equal(t, "package-lock.json", result.Ecosystems[0].Source)
+	require.Equal(t, 1, result.Ecosystems[0].PackagesRead, "one alias entry resolves to one real package")
+	require.GreaterOrEqual(t, result.Ecosystems[0].FindingsCount, 1, "aliased node-ipc 9.2.3 must still fire")
+
+	var nodeIPCFinding *incident.Finding
+	for i := range result.Findings {
+		if strings.Contains(result.Findings[i].Title, "node-ipc") {
+			nodeIPCFinding = &result.Findings[i]
+			break
+		}
+	}
+	require.NotNil(t, nodeIPCFinding, "aliased dependency must be reported as node-ipc; got: %+v", result.Findings)
+	for _, f := range result.Findings {
+		require.NotContains(t, f.Title, "safe-ipc", "the alias name must never appear as a package")
+	}
+}
+
 // --- Issue #109: npm and PyPI emit ecosystems[] entries on the incident path ---
 
 func TestCheckExplicitNPM_AppendsEcosystemsEntry(t *testing.T) {

--- a/internal/packagecheck/discovery.go
+++ b/internal/packagecheck/discovery.go
@@ -59,6 +59,7 @@ var lockfilePickers = []lockfilePicker{
 	{intel.EcosystemMaven, pickMavenTargets},
 	{intel.EcosystemNuGet, pickNuGetTargets},
 	{intel.EcosystemNPM, pickPnpmTarget},
+	{intel.EcosystemNPM, pickPackageLockTarget},
 }
 
 // Discover walks root and returns one Target per lockfile / discovery
@@ -317,6 +318,32 @@ func pickPnpmTarget(dir string) []Target {
 			Ecosystem: intel.EcosystemNPM,
 			Path:      filepath.Join(dir, "pnpm-lock.yaml"),
 			Source:    "pnpm-lock.yaml",
+		}}
+	}
+	return nil
+}
+
+// pickPackageLockTarget returns a Target for an npm project rooted at
+// dir, or nil when no package-lock.json is present. Like
+// pickPnpmTarget it installs from the npm registry (Ecosystem =
+// intel.EcosystemNPM) and carries Source="package-lock.json" so the
+// runner dispatches to ParsePackageLock and the per-target
+// EcosystemResult distinguishes it from the pnpm-lock.yaml and
+// installed-tree (node_modules) npm surfaces.
+//
+// The same node_modules-ancestor guard pnpm uses applies: a
+// package-lock.json shipped as a dependency fixture inside a
+// node_modules tree must not be picked up when the scan root is (or
+// sits under) node_modules.
+func pickPackageLockTarget(dir string) []Target {
+	if hasNodeModulesAncestor(dir) {
+		return nil
+	}
+	if statRegular(filepath.Join(dir, "package-lock.json")) {
+		return []Target{{
+			Ecosystem: intel.EcosystemNPM,
+			Path:      filepath.Join(dir, "package-lock.json"),
+			Source:    "package-lock.json",
 		}}
 	}
 	return nil

--- a/internal/packagecheck/packagelock.go
+++ b/internal/packagecheck/packagelock.go
@@ -40,7 +40,16 @@ var nonRegistryResolvedPrefixes = []string{
 // the JSON decoder ignores them. The install graph in v2/v3 lives
 // entirely in the flat `packages` map keys, so there is nothing to
 // recurse into.
+//
+// Name is set by npm only when the installed directory name differs
+// from the real package name, which is exactly the alias case
+// (`"foo": "npm:real-pkg@1.2.3"`): the key carries the alias
+// `node_modules/foo` while Name carries `real-pkg`. The resolved
+// Version is a plain semver in that case, so the npm: version-prefix
+// skip never fires; the parser uses Name to match the real registry
+// package instead of emitting the alias as if it were one.
 type plPackagesEntry struct {
+	Name     string `json:"name"`
 	Version  string `json:"version"`
 	Resolved string `json:"resolved"`
 	Link     bool   `json:"link"`
@@ -96,6 +105,12 @@ type packageLock struct {
 //     git: / ssh:) all skip the entry;
 //   - a missing or empty version skips the entry.
 //
+// Aliased installs (`"alias": "npm:real-pkg@1.2.3"`) are resolved to
+// the real registry package via the v2/v3 entry's `name` field, so
+// the alias is never emitted as a package and a compromised package
+// hidden behind an alias is still matched. An alias whose `name` is
+// not a usable npm identifier is skipped rather than guessed at.
+//
 // Skipping loses coverage on those entries; the alternative — guessing
 // a registry version for a git or aliased dependency — would invent a
 // false match against an npm advisory. Better to under-report than to
@@ -143,6 +158,22 @@ func ParsePackageLock(target Target) ([]PackageRef, error) {
 			name, ok := packageLockName(key)
 			if !ok {
 				continue
+			}
+			// Alias resolution. When the entry's Name disagrees with
+			// the directory name from the key, the dependency was
+			// installed under an alias (`"alias": "npm:real@ver"`).
+			// The real registry package is Name; map to it so a
+			// compromised package aliased to an innocuous-looking
+			// directory is still caught, and the alias is never
+			// emitted as a package in its own right. If Name is not a
+			// usable npm name we cannot map with certainty, so skip
+			// rather than guess.
+			if entry.Name != "" && entry.Name != name {
+				real, valid := validNPMName(entry.Name)
+				if !valid {
+					continue
+				}
+				name = real
 			}
 			if !registryEntry(entry.Link, entry.Version, entry.Resolved) {
 				continue

--- a/internal/packagecheck/packagelock.go
+++ b/internal/packagecheck/packagelock.go
@@ -1,0 +1,254 @@
+package packagecheck
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/garagon/aguara/internal/intel"
+)
+
+// nodeModulesSeg is the path segment npm uses to nest installed
+// dependencies in a lockfileVersion 2/3 `packages` map key.
+const nodeModulesSeg = "node_modules/"
+
+// nonRegistryVersionPrefixes are version-string prefixes that mark a
+// dependency as resolved from somewhere other than the npm registry.
+// A package-lock.json entry whose `version` begins with one of these
+// cannot be confidently mapped to a registry (npm, name, version)
+// tuple, so the parser skips it rather than risk matching a local /
+// git / aliased package against an unrelated npm advisory of the same
+// name.
+var nonRegistryVersionPrefixes = []string{
+	"file:", "link:", "workspace:", "git+", "git:", "ssh:", "npm:", "http:", "https:",
+}
+
+// nonRegistryResolvedPrefixes are `resolved` URL prefixes that mark a
+// non-registry source. Registry entries resolve to an https tarball
+// (https://registry.npmjs.org/...), so https is NOT a skip signal
+// here; only the unambiguously non-registry git / file schemes are.
+var nonRegistryResolvedPrefixes = []string{
+	"file:", "git+", "git:", "ssh:",
+}
+
+// plPackagesEntry is a value in the lockfileVersion 2/3 `packages`
+// map. Its own `dependencies` / `devDependencies` / `peerDependencies`
+// fields are name->version-range STRING maps mirroring the manifest,
+// NOT the resolved tree — they are intentionally not modelled here so
+// the JSON decoder ignores them. The install graph in v2/v3 lives
+// entirely in the flat `packages` map keys, so there is nothing to
+// recurse into.
+type plPackagesEntry struct {
+	Version  string `json:"version"`
+	Resolved string `json:"resolved"`
+	Link     bool   `json:"link"`
+}
+
+// plDepEntry is a node in the lockfileVersion 1 `dependencies` tree.
+// Here `dependencies` IS the nested resolved tree (name->object), so
+// it is modelled and recursed; the sibling `requires` field (a
+// name->range string map) is ignored by not being declared.
+type plDepEntry struct {
+	Version      string                `json:"version"`
+	Resolved     string                `json:"resolved"`
+	Link         bool                  `json:"link"`
+	Dependencies map[string]plDepEntry `json:"dependencies"`
+}
+
+// packageLock is the minimal package-lock.json surface the parser
+// reads. `packages` is present for lockfileVersion 2 and 3 (and is
+// authoritative when present, so v2 — which also carries the legacy
+// `dependencies` mirror — is never double-counted). `dependencies`
+// is the lockfileVersion 1 recursive tree, used only when `packages`
+// is absent.
+type packageLock struct {
+	Packages     map[string]plPackagesEntry `json:"packages"`
+	Dependencies map[string]plDepEntry      `json:"dependencies"`
+}
+
+// ParsePackageLock reads a package-lock.json file and returns the
+// declared npm packages. It is the pre-install counterpart to the
+// installed-tree npm pipeline (incident.CheckNPM, which needs
+// node_modules to exist): a freshly cloned npm repo carries
+// package-lock.json but no node_modules, and this parser lets
+//
+//	git clone <npm repo>
+//	aguara check .
+//
+// audit the locked dependency set against npm advisories before any
+// `npm install` runs.
+//
+// Pure offline: no npm execution, no network. It reads the structured
+// JSON rather than scanning text so the lockfileVersion 2/3 `packages`
+// map keys (which encode the install path) are decoded deterministically.
+//
+// Conservative by design. An entry is emitted only when it maps with
+// confidence to a registry (npm, name, version) tuple:
+//
+//   - the root project entry (packages[""]) is skipped;
+//   - a `packages` key without a node_modules/ segment is a workspace
+//     source directory, not an installed dependency, and is skipped;
+//   - link: true (workspace symlink), a non-registry version prefix
+//     (file: / link: / workspace: / git+ / git: / ssh: / npm: / http:
+//     / https:), or a non-registry resolved scheme (file: / git+ /
+//     git: / ssh:) all skip the entry;
+//   - a missing or empty version skips the entry.
+//
+// Skipping loses coverage on those entries; the alternative — guessing
+// a registry version for a git or aliased dependency — would invent a
+// false match against an npm advisory. Better to under-report than to
+// manufacture confidence.
+func ParsePackageLock(target Target) ([]PackageRef, error) {
+	data, err := os.ReadFile(target.Path)
+	if err != nil {
+		return nil, fmt.Errorf("open package-lock.json: %w", err)
+	}
+	var lock packageLock
+	if err := json.Unmarshal(data, &lock); err != nil {
+		return nil, fmt.Errorf("parse package-lock.json: %w", err)
+	}
+
+	// Dedup on (name, version), not on path: the same (name, version)
+	// can appear under many install paths in a v2/v3 packages map
+	// (deduped or not by npm depending on the dependency graph) and as
+	// repeated subtrees in a v1 dependencies tree. The user is exposed
+	// to a compromised (name, version) once regardless of how many
+	// node_modules paths host it, so collapsing here keeps the finding
+	// count and packages_read aligned with the real exposure.
+	seen := map[string]bool{}
+	var refs []PackageRef
+	add := func(name, version string) {
+		if name == "" || version == "" {
+			return
+		}
+		composite := name + "@" + version
+		if seen[composite] {
+			return
+		}
+		seen[composite] = true
+		refs = append(refs, PackageRef{
+			Ecosystem: intel.EcosystemNPM,
+			Name:      name,
+			Version:   version,
+			Path:      target.Path,
+			Source:    "package-lock.json",
+		})
+	}
+
+	if len(lock.Packages) > 0 {
+		// lockfileVersion 2 / 3.
+		for key, entry := range lock.Packages {
+			name, ok := packageLockName(key)
+			if !ok {
+				continue
+			}
+			if !registryEntry(entry.Link, entry.Version, entry.Resolved) {
+				continue
+			}
+			add(name, entry.Version)
+		}
+	} else {
+		// lockfileVersion 1: recurse the dependencies tree. Recursion
+		// is unconditional on the parent's registry status — a
+		// non-registry parent (skipped) can still host registry
+		// children worth auditing.
+		var walk func(deps map[string]plDepEntry)
+		walk = func(deps map[string]plDepEntry) {
+			for name, entry := range deps {
+				if canonical, ok := validNPMName(name); ok && registryEntry(entry.Link, entry.Version, entry.Resolved) {
+					add(canonical, entry.Version)
+				}
+				if len(entry.Dependencies) > 0 {
+					walk(entry.Dependencies)
+				}
+			}
+		}
+		walk(lock.Dependencies)
+	}
+
+	// Deterministic order by name@version. Map iteration above is
+	// randomized; Aguara advertises deterministic scans, and the
+	// runner preserves ref order into Hits and the CLI preserves Hits
+	// order into Findings.
+	sort.Slice(refs, func(i, j int) bool {
+		return refs[i].Name+"@"+refs[i].Version < refs[j].Name+"@"+refs[j].Version
+	})
+	return refs, nil
+}
+
+// packageLockName extracts the package name from a lockfileVersion
+// 2/3 `packages` map key. The key is the install path relative to the
+// project root:
+//
+//	""                                        -> root project (skip)
+//	node_modules/foo                          -> foo
+//	node_modules/@scope/pkg                   -> @scope/pkg
+//	packages/a/node_modules/foo               -> foo            (nested)
+//	packages/a/node_modules/@scope/pkg        -> @scope/pkg     (nested)
+//	packages/a                                -> workspace src  (skip)
+//
+// The name is whatever follows the LAST node_modules/ segment, so a
+// nested dependency resolves to its own name regardless of depth. A
+// key with no node_modules/ segment (other than "") is a workspace
+// source directory, not an installed dependency, and is skipped.
+func packageLockName(key string) (string, bool) {
+	if key == "" {
+		return "", false // root project
+	}
+	idx := strings.LastIndex(key, nodeModulesSeg)
+	if idx < 0 {
+		return "", false // workspace source dir, not an installed dep
+	}
+	return validNPMName(key[idx+len(nodeModulesSeg):])
+}
+
+// validNPMName validates that name is a well-formed npm package name
+// (unscoped "foo" or scoped "@scope/pkg") and returns it unchanged.
+// Anything else — an empty string, a stray extra path segment, a
+// malformed scope — is rejected so the parser never emits an
+// ambiguous name. The matcher applies npm-specific normalisation at
+// lookup time; the parser only gates obvious malformations.
+func validNPMName(name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	if strings.HasPrefix(name, "@") {
+		// Scoped: exactly "@scope/pkg" — one slash, both parts present.
+		parts := strings.SplitN(name, "/", 2)
+		if len(parts) != 2 || len(parts[0]) < 2 || parts[1] == "" || strings.Contains(parts[1], "/") {
+			return "", false
+		}
+		return name, true
+	}
+	if strings.Contains(name, "/") {
+		return "", false // unexpected nesting for an unscoped name
+	}
+	return name, true
+}
+
+// registryEntry reports whether a lockfile entry resolves to a
+// registry-installed package with a usable version. See the skip
+// rules documented on ParsePackageLock. It takes the three fields
+// shared by both entry shapes (v2/v3 packages map, v1 dependencies
+// tree) so a single rule covers both.
+func registryEntry(link bool, version, resolved string) bool {
+	if link {
+		return false
+	}
+	if version == "" {
+		return false
+	}
+	for _, p := range nonRegistryVersionPrefixes {
+		if strings.HasPrefix(version, p) {
+			return false
+		}
+	}
+	for _, p := range nonRegistryResolvedPrefixes {
+		if strings.HasPrefix(resolved, p) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/packagecheck/packagelock_test.go
+++ b/internal/packagecheck/packagelock_test.go
@@ -1,0 +1,332 @@
+package packagecheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+// writeLock writes content to a package-lock.json in a fresh temp dir
+// and returns a Target pointing at it.
+func writeLock(t *testing.T, content string) Target {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "package-lock.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+	return Target{Ecosystem: intel.EcosystemNPM, Path: path, Source: "package-lock.json"}
+}
+
+// refSet flattens parsed refs into "name@version" strings for order-
+// independent assertions; order itself is checked separately.
+func refSet(refs []PackageRef) []string {
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, r.Name+"@"+r.Version)
+	}
+	return out
+}
+
+func TestParsePackageLock_V3PackagesMap(t *testing.T) {
+	// lockfileVersion 3: only `packages`, no `dependencies`.
+	refs, err := ParsePackageLock(writeLock(t, `{
+	  "name": "myapp",
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/foo": { "version": "1.2.3", "resolved": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" },
+	    "node_modules/bar": { "version": "4.5.6", "resolved": "https://registry.npmjs.org/bar/-/bar-4.5.6.tgz" }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"foo@1.2.3", "bar@4.5.6"}, refSet(refs))
+	for _, r := range refs {
+		require.Equal(t, intel.EcosystemNPM, r.Ecosystem)
+		require.Equal(t, "package-lock.json", r.Source)
+	}
+}
+
+func TestParsePackageLock_V2PackagesMapPreferredOverDependencies(t *testing.T) {
+	// lockfileVersion 2 carries BOTH packages and the legacy
+	// dependencies mirror. The parser must read `packages` only, so
+	// the legacy mirror's stale entry must NOT appear (no double count
+	// and no resurrecting a removed dep).
+	refs, err := ParsePackageLock(writeLock(t, `{
+	  "name": "myapp",
+	  "lockfileVersion": 2,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/foo": { "version": "1.2.3", "resolved": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" }
+	  },
+	  "dependencies": {
+	    "foo": { "version": "1.2.3" },
+	    "stale-only-in-legacy-mirror": { "version": "9.9.9" }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"foo@1.2.3"}, refSet(refs))
+}
+
+func TestParsePackageLock_V1RecursiveDependencies(t *testing.T) {
+	// lockfileVersion 1: no `packages`, recursive `dependencies` tree.
+	refs, err := ParsePackageLock(writeLock(t, `{
+	  "name": "myapp",
+	  "lockfileVersion": 1,
+	  "dependencies": {
+	    "foo": {
+	      "version": "1.2.3",
+	      "resolved": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz",
+	      "dependencies": {
+	        "bar": { "version": "4.5.6", "resolved": "https://registry.npmjs.org/bar/-/bar-4.5.6.tgz" }
+	      }
+	    }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"foo@1.2.3", "bar@4.5.6"}, refSet(refs))
+}
+
+func TestParsePackageLock_ScopedPackage(t *testing.T) {
+	// Scoped names survive verbatim in both lockfile shapes.
+	v3, err := ParsePackageLock(writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/@scope/pkg": { "version": "2.0.0", "resolved": "https://registry.npmjs.org/@scope/pkg/-/pkg-2.0.0.tgz" }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"@scope/pkg@2.0.0"}, refSet(v3))
+
+	v1, err := ParsePackageLock(writeLock(t, `{
+	  "lockfileVersion": 1,
+	  "dependencies": {
+	    "@scope/pkg": { "version": "2.0.0", "resolved": "https://registry.npmjs.org/@scope/pkg/-/pkg-2.0.0.tgz" }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"@scope/pkg@2.0.0"}, refSet(v1))
+}
+
+func TestParsePackageLock_NestedDependency(t *testing.T) {
+	// v2/v3 nest a dependency-of-a-dependency under a second
+	// node_modules/ segment; the name is the LAST segment. A scoped
+	// nested dep keeps its scope.
+	refs, err := ParsePackageLock(writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/a": { "version": "1.0.0", "resolved": "https://registry.npmjs.org/a/-/a-1.0.0.tgz" },
+	    "node_modules/a/node_modules/foo": { "version": "1.5.0", "resolved": "https://registry.npmjs.org/foo/-/foo-1.5.0.tgz" },
+	    "node_modules/a/node_modules/@scope/pkg": { "version": "3.1.0", "resolved": "https://registry.npmjs.org/@scope/pkg/-/pkg-3.1.0.tgz" }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"a@1.0.0", "foo@1.5.0", "@scope/pkg@3.1.0"}, refSet(refs))
+}
+
+func TestParsePackageLock_DedupSameNameVersion(t *testing.T) {
+	// The same (name, version) installed at two paths collapses to one
+	// ref (dedup is on (name, version), not on path).
+	refs, err := ParsePackageLock(writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/foo": { "version": "1.2.3", "resolved": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" },
+	    "node_modules/a/node_modules/foo": { "version": "1.2.3", "resolved": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"foo@1.2.3"}, refSet(refs))
+}
+
+func TestParsePackageLock_SameNameDifferentVersionsNotDeduped(t *testing.T) {
+	// Two versions of the same package are distinct exposures and must
+	// both survive.
+	refs, err := ParsePackageLock(writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/foo": { "version": "1.2.3", "resolved": "https://registry.npmjs.org/foo/-/foo-1.2.3.tgz" },
+	    "node_modules/a/node_modules/foo": { "version": "2.0.0", "resolved": "https://registry.npmjs.org/foo/-/foo-2.0.0.tgz" }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"foo@1.2.3", "foo@2.0.0"}, refSet(refs))
+}
+
+func TestParsePackageLock_SkipsNonRegistrySources(t *testing.T) {
+	// Every non-registry shape must be skipped: a workspace source
+	// dir key, a link symlink, a file:/git+/workspace: version, a git+
+	// resolved, an aliased npm: version, the root project, and a
+	// versionless entry. The one clean registry dep is all that
+	// survives.
+	refs, err := ParsePackageLock(writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/clean": { "version": "1.0.0", "resolved": "https://registry.npmjs.org/clean/-/clean-1.0.0.tgz" },
+	    "node_modules/linked": { "resolved": "../local", "link": true },
+	    "node_modules/from-file": { "version": "file:../local-pkg" },
+	    "node_modules/from-git": { "version": "1.0.0", "resolved": "git+https://github.com/u/repo.git#abc123" },
+	    "node_modules/from-workspace": { "version": "workspace:*" },
+	    "node_modules/aliased": { "version": "npm:real-pkg@1.0.0" },
+	    "node_modules/no-version": { "resolved": "https://registry.npmjs.org/x/-/x-1.0.0.tgz" },
+	    "packages/my-workspace-member": { "name": "my-workspace-member", "version": "0.1.0" }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"clean@1.0.0"}, refSet(refs))
+}
+
+func TestParsePackageLock_V1SkipsNonRegistryButRecursesChildren(t *testing.T) {
+	// A v1 git-sourced parent is skipped, but its registry children
+	// are still audited (recursion is unconditional on the parent's
+	// registry status).
+	refs, err := ParsePackageLock(writeLock(t, `{
+	  "lockfileVersion": 1,
+	  "dependencies": {
+	    "from-git": {
+	      "version": "1.0.0",
+	      "resolved": "git+https://github.com/u/repo.git#abc",
+	      "dependencies": {
+	        "real-child": { "version": "2.2.2", "resolved": "https://registry.npmjs.org/real-child/-/real-child-2.2.2.tgz" }
+	      }
+	    }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"real-child@2.2.2"}, refSet(refs))
+}
+
+func TestParsePackageLock_DeterministicOrder(t *testing.T) {
+	// Output is sorted by name@version regardless of map iteration.
+	refs, err := ParsePackageLock(writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/zeta": { "version": "1.0.0", "resolved": "https://registry.npmjs.org/zeta/-/zeta-1.0.0.tgz" },
+	    "node_modules/alpha": { "version": "2.0.0", "resolved": "https://registry.npmjs.org/alpha/-/alpha-2.0.0.tgz" },
+	    "node_modules/@scope/mid": { "version": "1.0.0", "resolved": "https://registry.npmjs.org/@scope/mid/-/mid-1.0.0.tgz" }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"@scope/mid@1.0.0", "alpha@2.0.0", "zeta@1.0.0"}, refSet(refs))
+}
+
+func TestValidNPMName(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+		ok   bool
+	}{
+		{"foo", "foo", true},
+		{"@scope/pkg", "@scope/pkg", true},
+		{"", "", false},
+		{"foo/bar", "", false},        // unscoped with a slash
+		{"@scope/pkg/extra", "", false}, // scoped with extra segment
+		{"@scope", "", false},          // scope without package
+		{"@/pkg", "", false},           // empty scope
+		{"@scope/", "", false},         // empty package
+	}
+	for _, c := range cases {
+		got, ok := validNPMName(c.in)
+		require.Equalf(t, c.ok, ok, "validNPMName(%q) ok", c.in)
+		if c.ok {
+			require.Equalf(t, c.want, got, "validNPMName(%q) name", c.in)
+		}
+	}
+}
+
+func TestPackageLockName(t *testing.T) {
+	cases := []struct {
+		key  string
+		want string
+		ok   bool
+	}{
+		{"", "", false},                                         // root
+		{"node_modules/foo", "foo", true},                       // unscoped
+		{"node_modules/@scope/pkg", "@scope/pkg", true},         // scoped
+		{"packages/a/node_modules/foo", "foo", true},            // nested unscoped
+		{"packages/a/node_modules/@scope/pkg", "@scope/pkg", true}, // nested scoped
+		{"node_modules/a/node_modules/foo", "foo", true},        // dep-of-dep
+		{"packages/a", "", false},                               // workspace src dir
+		{"some/other/path", "", false},                          // no node_modules segment
+	}
+	for _, c := range cases {
+		got, ok := packageLockName(c.key)
+		require.Equalf(t, c.ok, ok, "packageLockName(%q) ok", c.key)
+		if c.ok {
+			require.Equalf(t, c.want, got, "packageLockName(%q) name", c.key)
+		}
+	}
+}
+
+// --- Runner smoke: the new coverage flows through the matcher,
+// for both an exact-version advisory and a range advisory (npm is the
+// phase-1 range-evaluable ecosystem, so the range hit proves
+// package-lock coverage benefits from range matching). ---
+
+func TestRunner_PackageLockExactAndRangeHits(t *testing.T) {
+	snap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		GeneratedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Records: []intel.Record{
+			{
+				ID:        "MAL-EXACT",
+				Ecosystem: intel.EcosystemNPM,
+				Name:      "evil-exact",
+				Kind:      intel.KindMalicious,
+				Versions:  []string{"1.2.3"},
+			},
+			{
+				ID:        "MAL-RANGE",
+				Ecosystem: intel.EcosystemNPM,
+				Name:      "evil-range",
+				Kind:      intel.KindMalicious,
+				Ranges:    []intel.VersionRange{{Type: "semver", Introduced: "1.0.0", Fixed: "2.0.0"}},
+			},
+		},
+	}
+	runner := &Runner{Matcher: intel.NewMatcher(snap)}
+
+	target := writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/evil-exact": { "version": "1.2.3", "resolved": "https://registry.npmjs.org/evil-exact/-/evil-exact-1.2.3.tgz" },
+	    "node_modules/evil-range": { "version": "1.5.0", "resolved": "https://registry.npmjs.org/evil-range/-/evil-range-1.5.0.tgz" },
+	    "node_modules/safe": { "version": "9.9.9", "resolved": "https://registry.npmjs.org/safe/-/safe-9.9.9.tgz" }
+	  }
+	}`)
+	res, err := runner.Run([]Target{target})
+	require.NoError(t, err)
+
+	require.Len(t, res.Ecosystems, 1)
+	er := res.Ecosystems[0]
+	require.Equal(t, intel.EcosystemNPM, er.Ecosystem)
+	require.Equal(t, "package-lock.json", er.Source)
+	require.Equal(t, 3, er.PackagesRead)
+	require.Equal(t, 2, er.FindingsCount)
+
+	got := map[string]string{} // name@version -> record ID
+	for _, h := range res.Hits {
+		got[h.Ref.Name+"@"+h.Ref.Version] = h.Record.ID
+	}
+	require.Equal(t, "MAL-EXACT", got["evil-exact@1.2.3"])
+	require.Equal(t, "MAL-RANGE", got["evil-range@1.5.0"], "range advisory must hit a version inside [1.0.0, 2.0.0)")
+	require.NotContains(t, got, "safe@9.9.9")
+}
+
+func TestDiscover_PicksPackageLock(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "package-lock.json"), []byte(`{"lockfileVersion":3,"packages":{}}`), 0o600))
+	targets, err := Discover(dir, []string{intel.EcosystemNPM})
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	require.Equal(t, "package-lock.json", targets[0].Source)
+	require.Equal(t, intel.EcosystemNPM, targets[0].Ecosystem)
+}

--- a/internal/packagecheck/packagelock_test.go
+++ b/internal/packagecheck/packagelock_test.go
@@ -182,6 +182,48 @@ func TestParsePackageLock_SkipsNonRegistrySources(t *testing.T) {
 	require.Equal(t, []string{"clean@1.0.0"}, refSet(refs))
 }
 
+func TestParsePackageLock_AliasMapsToRealPackage(t *testing.T) {
+	// `"safe-ipc": "npm:node-ipc@9.2.3"` installs node-ipc under the
+	// alias directory node_modules/safe-ipc. The v2/v3 entry carries
+	// the real package in `name`. The parser must emit the REAL
+	// package (node-ipc@9.2.3), never the alias (safe-ipc@9.2.3),
+	// otherwise a compromised package hidden behind an innocuous alias
+	// would slip through and the alias would be reported as a package
+	// that does not exist in the registry.
+	refs, err := ParsePackageLock(writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/safe-ipc": {
+	      "name": "node-ipc",
+	      "version": "9.2.3",
+	      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.2.3.tgz"
+	    }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.Equal(t, []string{"node-ipc@9.2.3"}, refSet(refs))
+}
+
+func TestParsePackageLock_AliasWithUnusableNameSkipped(t *testing.T) {
+	// An alias whose `name` is not a usable npm identifier cannot be
+	// mapped with certainty, so the entry is skipped rather than
+	// emitting the alias.
+	refs, err := ParsePackageLock(writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/weird": {
+	      "name": "not/a/valid/name",
+	      "version": "1.0.0",
+	      "resolved": "https://registry.npmjs.org/whatever/-/whatever-1.0.0.tgz"
+	    }
+	  }
+	}`))
+	require.NoError(t, err)
+	require.Empty(t, refSet(refs))
+}
+
 func TestParsePackageLock_V1SkipsNonRegistryButRecursesChildren(t *testing.T) {
 	// A v1 git-sourced parent is skipped, but its registry children
 	// are still audited (recursion is unconditional on the parent's

--- a/internal/packagecheck/runner.go
+++ b/internal/packagecheck/runner.go
@@ -146,6 +146,8 @@ func parseTarget(t Target) ([]PackageRef, error) {
 		switch t.Source {
 		case "pnpm-lock.yaml":
 			return ParsePNPMLock(t)
+		case "package-lock.json":
+			return ParsePackageLock(t)
 		default:
 			return nil, fmt.Errorf("packagecheck: no npm parser for source %q", t.Source)
 		}

--- a/internal/packagecheck/testdata/package-lock-alias/package-lock.json
+++ b/internal/packagecheck/testdata/package-lock-alias/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "fixture-alias",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fixture-alias",
+      "version": "1.0.0",
+      "dependencies": {
+        "safe-ipc": "npm:node-ipc@9.2.3"
+      }
+    },
+    "node_modules/safe-ipc": {
+      "name": "node-ipc",
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.2.3.tgz",
+      "integrity": "sha512-FAKE_FIXTURE_DO_NOT_VERIFY=="
+    }
+  }
+}

--- a/internal/packagecheck/testdata/package-lock-clean/package-lock.json
+++ b/internal/packagecheck/testdata/package-lock-clean/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "fixture-clean",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fixture-clean",
+      "version": "1.0.0",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-FAKE_FIXTURE_DO_NOT_VERIFY=="
+    },
+    "node_modules/@types/node": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.5.0.tgz",
+      "integrity": "sha512-FAKE_FIXTURE_DO_NOT_VERIFY=="
+    }
+  }
+}

--- a/internal/packagecheck/testdata/package-lock-compromised/package-lock.json
+++ b/internal/packagecheck/testdata/package-lock-compromised/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "fixture-compromised",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "fixture-compromised",
+      "version": "1.0.0",
+      "dependencies": {
+        "node-ipc": "9.2.3",
+        "lodash": "^4.17.21"
+      }
+    },
+    "node_modules/node-ipc": {
+      "version": "9.2.3",
+      "resolved": "https://registry.npmjs.org/node-ipc/-/node-ipc-9.2.3.tgz",
+      "integrity": "sha512-FAKE_FIXTURE_DO_NOT_VERIFY=="
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-FAKE_FIXTURE_DO_NOT_VERIFY=="
+    }
+  }
+}


### PR DESCRIPTION
## What this adds

`aguara check` now audits `package-lock.json` on a freshly cloned npm repo, before `npm install` has created `node_modules`.

Until now, the only npm lockfile Aguara could read on a fresh clone was `pnpm-lock.yaml`. A standard npm-CLI project (which ships `package-lock.json`) checked clean on a fresh clone even when one of its locked dependencies was a known-compromised package, because the installed-tree npm check needs `node_modules` to exist. This closes that gap so the pre-install audit works for npm-CLI projects the same way it already did for pnpm.

```
git clone <npm repo>
aguara check .          # now reads package-lock.json, no install needed
```

## How it reads the lockfile

It parses all three package-lock formats, offline, with no npm execution:

- **lockfileVersion 2 and 3** (the flat `packages` map), resolving the install-path keys (`node_modules/foo`, `node_modules/@scope/pkg`, and nested `.../node_modules/bar`). v2 also carries a legacy `dependencies` mirror; the `packages` map is treated as authoritative so nothing is counted twice.
- **lockfileVersion 1** (the older recursive `dependencies` tree).

It is conservative by design. The root project, npm workspace source directories, symlinked (`link`) entries, and any dependency resolved from a non-registry source (`file:`, `git+`, `workspace:`, `npm:` aliases, ...) are skipped rather than guessed at, so a local or git dependency is never matched against an unrelated registry advisory that happens to share its name. Results are deduplicated on (name, version) and emitted in a deterministic order.

The matcher itself is unchanged: package-lock findings get the same exact-version and npm range-advisory matching the existing lockfile parsers use.

One small UX fix: `aguara check --ecosystem npm` now accepts a project whose only npm signal is `package-lock.json`, instead of erroring with "no node_modules tree and no pnpm-lock.yaml".

## Tests

- Parser: v3 / v2 / v1 formats, scoped names, nested dependencies, (name, version) dedup, distinct-versions kept, and the full non-registry skip set (file / link / workspace / git / npm-alias / versionless / workspace-source-dir / root).
- Runner smoke: an exact-version advisory hit and an npm range-advisory hit, proving the new coverage flows through the matcher's range support.
- CLI: a fresh-clone fixture with only `package-lock.json` reports `source: package-lock.json`, catches the compromised package, and no longer errors under `--ecosystem npm`; a clean fixture reports zero findings.