### PR TITLE
release: prep v0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,51 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-05-29
+
+Check more npm projects before install, and reduce false positives on
+two high-risk install-script rules. `aguara check` now reads
+`package-lock.json` and `yarn.lock` (classic) pre-install, alongside the
+existing `pnpm-lock.yaml` support, and two co-presence rules become
+flow-sensitive bindings. Detection coverage, offline-by-default
+behavior, and rule IDs are unchanged.
+
+### Added
+
+- **Pre-install npm coverage for `package-lock.json`.** `aguara check`
+  reads `package-lock.json` on a freshly cloned npm project, before
+  `npm install` has created `node_modules`. It parses lockfile versions
+  1, 2, and 3, resolves npm aliases (`"alias": "npm:real@ver"`) to the
+  real registry package, and conservatively skips local / git /
+  workspace / aliased entries it cannot map with confidence to a
+  registry (name, version). Exact and npm range advisories both apply.
+- **Pre-install npm coverage for `yarn.lock` (classic v1).** The same
+  pre-install audit for Yarn classic projects, with the same
+  conservative skip rules. A Yarn Berry (v2+) lockfile is detected and
+  reported with a clear error instead of being parsed, so a Berry repo
+  is never silently treated as audited. Berry parsing is a future layer.
+
+So a freshly cloned npm, pnpm, or Yarn classic project can be checked
+before any install runs.
+
+### Changed
+
+- **Flow-sensitive binding for two high-risk rules.**
+  `PY_IMPORTTIME_REMOTE_JS_001` (Python install hooks that fetch and
+  `node -e` remote JavaScript) and `RS_BUILD_WALLET_EXFIL_001` (Cargo
+  `build.rs` scripts that read wallet/keystore material and send it)
+  moved from co-presence pattern rules to dedicated flow-sensitive
+  analyzers. They now fire only when the source value reaches the
+  execution or exfiltration sink within one or two hops, instead of when
+  the two halves merely co-occur in the same file. This cuts false
+  positives on both rules; the rule IDs and severity are unchanged.
+
+### Deprecated
+
+- `intel.Update` (the library helper that fetched OSV directly) is now
+  marked deprecated in favor of the signed-bundle refresh path added in
+  0.21.0. The API is retained for compatibility and no CLI path uses it.
+
 ## [0.21.0] - 2026-05-28
 
 Trusted fresh threat intel. `aguara update` and `--fresh` checks now

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ Check more npm projects before install, and reduce false positives on
 two high-risk install-script rules. `aguara check` now reads
 `package-lock.json` and `yarn.lock` (classic) pre-install, alongside the
 existing `pnpm-lock.yaml` support, and two co-presence rules become
-flow-sensitive bindings. Detection coverage, offline-by-default
-behavior, and rule IDs are unchanged.
+flow-sensitive bindings. Rule IDs, severities, and offline-by-default
+behavior are unchanged.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.15.0 (2026-05-13). 193 rules, 13 categories, 7 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, NLP, toxicflow, rugpull) plus the `aguara check --ecosystem {python,npm}` incident command, ~750 tests, 0 lint issues.
+Aguara v0.22.0 (2026-05-29). 193 YAML rules + 28 analyzer-emitted (221 cataloged), 13 categories, 9 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic, and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
 
 Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, multi-arch `linux/amd64+arm64`, runs as non-root UID 10001, base images digest-pinned, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
@@ -56,17 +56,19 @@ Aguara is a deterministic static security scanner for AI agent skills and MCP se
 
 Root package re-exports types from `internal/types` and exposes: `Scan()`, `ScanContent()`, `ListRules()`, `ExplainRule()`, `Discover()`. Used by external consumers like `aguara-mcp`. Functional options pattern (`WithMinSeverity()`, `WithWorkers()`, etc.).
 
-### Analysis Pipeline (6 default analyzers + rug-pull when --monitor is set, run sequentially per file)
+### Analysis Pipeline (8 default analyzers + rug-pull when --monitor is set, run sequentially per file)
 
 1. **Pattern Matcher** (`internal/engine/pattern/`) - Regex/contains matching against compiled rules. 8 decoders (base64, hex, URL encoding, Unicode escapes, HTML entities, hex escapes, base32, C-style octal escapes) for encoded evasion detection. Markdown code-block severity downgrade. Dynamic confidence based on pattern hit ratio.
 2. **CI Trust** (`internal/engine/ci/`) - YAML parser for `.github/workflows/*.yml`. Detects `pull_request_target` pwn-request chains, cache poisoning, OIDC token surface, and persisted-credentials checkouts. Emits `GHA_PWN_REQUEST_001` / `GHA_CACHE_001` / `GHA_OIDC_001` / `GHA_CHECKOUT_001`.
 3. **PkgMeta** (`internal/engine/pkgmeta/`) - JSON parser for `package.json`. Detects npm install-time lifecycle scripts paired with git-sourced dependencies, optional-git deps, and publish-surface chains. Emits `NPM_LIFECYCLE_GIT_001` / `NPM_OPTIONAL_GIT_001` / `NPM_PUBLISH_SURFACE_001`.
 4. **JSRisk** (`internal/engine/jsrisk/`) - Single-pass JavaScript scanner for `.js`/`.mjs`/`.cjs`. Detects obfuscator-shape payloads, install-time daemonization, CI secret harvesting, runner process-memory pivots, and Claude Code/VS Code persistence. Emits `JS_OBF_001` / `JS_DAEMON_001` / `JS_CI_SECRET_HARVEST_001` / `JS_PROC_MEM_OIDC_001` / `AGENT_PERSISTENCE_001`.
-5. **NLP Analyzer** (`internal/engine/nlp/`) - Goldmark AST walker for markdown; JSON/YAML string extractor for structured files. Keyword classification with proximity weighting. Detects prompt injection, authority claims, credential+exfil combos.
-6. **ToxicFlow** (`internal/engine/toxicflow/`) - Single-file source/sink co-occurrence + cross-file capability correlation (`crossfile.go`). Detects dangerous capability combinations within and across files in the same directory. Flat-dir filter (>50 files) prevents FPs on registries.
-7. **Rug-Pull** (`internal/engine/rugpull/`) - SHA256-based tool description change detection. CLI via `--monitor`, library via `WithStateDir()`.
+5. **PyRisk** (`internal/engine/pyrisk/`) - Flow-sensitive single-pass scanner for `setup.py`/`__init__.py`. Binds a remote-JS fetch to a `node -e`/`--eval` execution sink (≤2 hops, taint cleared on safe reassignment). Emits `PY_IMPORTTIME_REMOTE_JS_001` (moved from a co-presence YAML rule in v0.22.0).
+6. **RSBuild** (`internal/engine/rsbuild/`) - Flow-sensitive single-pass scanner for `build.rs`. Binds a wallet/keystore read to a network send sink (the tainted value must reach a send/body argument; ≤2 hops). Emits `RS_BUILD_WALLET_EXFIL_001` (moved from a co-presence YAML rule in v0.22.0).
+7. **NLP Analyzer** (`internal/engine/nlp/`) - Goldmark AST walker for markdown; JSON/YAML string extractor for structured files. Keyword classification with proximity weighting. Detects prompt injection, authority claims, credential+exfil combos.
+8. **ToxicFlow** (`internal/engine/toxicflow/`) - Single-file source/sink co-occurrence + cross-file capability correlation (`crossfile.go`). Detects dangerous capability combinations within and across files in the same directory. Flat-dir filter (>50 files) prevents FPs on registries.
+9. **Rug-Pull** (`internal/engine/rugpull/`) - SHA256-based tool description change detection. CLI via `--monitor`, library via `WithStateDir()`.
 
-All seven implement the `Analyzer` interface (`internal/scanner/analyzer.go`): `Name() string` + `Analyze(ctx, *Target) ([]Finding, error)`. The first six run on every scan; rug-pull only joins when the caller passes `--monitor` (CLI) or `WithStateDir` (library). `aguara check --ecosystem npm` (`internal/incident/npm.go`) is a separate command-line entry point, not part of the scan pipeline.
+All nine implement the `Analyzer` interface (`internal/scanner/analyzer.go`): `Name() string` + `Analyze(ctx, *Target) ([]Finding, error)`. The first eight run on every scan; rug-pull only joins when the caller passes `--monitor` (CLI) or `WithStateDir` (library). `aguara check` (`internal/incident/`, `internal/packagecheck/`) is a separate command-line entry point, not part of the scan pipeline.
 
 ### Key Package Relationships
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -148,12 +148,12 @@ When completing a product task (fixing a bug, adding a feature, releasing a vers
 ### Data consistency rule
 
 When any of these values change, update ALL references across the vault:
-- Rule count (currently 193)
+- Rule count (currently 193 YAML / 221 cataloged)
 - Test count (currently ~750)
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)
 - Watch skill count (currently 28,000+)
-- Version number (currently v0.15.0)
+- Version number (currently v0.22.0)
 
 Use `Grep` to find all occurrences before updating.
 

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.21.0
+INSTALL_SH_TEST_VERSION ?= v0.22.0
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ brew install garagon/tap/aguara
 ### Docker
 
 ```bash
-docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.19.0 check /repo
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.22.0 check /repo
 ```
 
 The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 10001, base images are digest-pinned, and the image is signed at the digest with Cosign plus SPDX SBOM and SLSA provenance attestations. Tag a specific release for reproducibility.
@@ -69,14 +69,14 @@ The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.21.0 sh
+  | VERSION=v0.22.0 sh
 ```
 
 `install.sh` downloads `checksums.txt` from the release and verifies the archive's SHA256 against it, aborting if neither `sha256sum` nor `shasum` is available. This catches a tampered or corrupted archive at the registry layer, but it does not verify the Cosign signature on `checksums.txt` itself. For full keyless-signature verification on the curl-pipe path, follow up with the Cosign step in [Verifying signed releases](#verifying-signed-releases). Default install location is `~/.local/bin`. Override for CI or containers:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.21.0 INSTALL_DIR=/usr/local/bin sh
+  | VERSION=v0.22.0 INSTALL_DIR=/usr/local/bin sh
 ```
 
 ### From source
@@ -96,7 +96,7 @@ Every release is signed with [Cosign](https://github.com/sigstore/cosign) keyles
 **Verify the release archive**:
 
 ```bash
-VERSION=v0.21.0
+VERSION=v0.22.0
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
@@ -358,11 +358,11 @@ aguara discover --format json
 ### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.21.0
+- uses: garagon/aguara@v0.22.0
   with:
     path: .
     fail-on: high
-    version: v0.21.0
+    version: v0.22.0
 ```
 
 Both pins (the action ref AND the `version:` input) are required. The action ref alone pins only the composite action and its install script; `version:` pins the Aguara binary the action installs. Setting both makes the workflow reproducible and dependabot-friendly: when a new release lands, the bot updates both together.
@@ -370,12 +370,12 @@ Both pins (the action ref AND the `version:` input) are required. The action ref
 Scans your repository, uploads findings to GitHub Code Scanning, and optionally fails the build:
 
 ```yaml
-- uses: garagon/aguara@v0.21.0
+- uses: garagon/aguara@v0.22.0
   with:
     path: ./mcp-server/
     severity: medium
     fail-on: high
-    version: v0.21.0
+    version: v0.22.0
 ```
 
 All inputs are optional. See [`action.yml`](action.yml) for the full list.
@@ -395,7 +395,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 
 ```yaml
 - name: Scan for security issues
-  run: docker run --rm -v "${{ github.workspace }}:/scan:ro" ghcr.io/garagon/aguara:0.19.0 scan /scan --ci
+  run: docker run --rm -v "${{ github.workspace }}:/scan:ro" ghcr.io/garagon/aguara:0.22.0 scan /scan --ci
 ```
 
 ### Manual / GitLab CI
@@ -404,7 +404,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitHub Actions (without the action)
 - name: Scan skills for security issues
   run: |
-    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.21.0 sh
+    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.22.0 sh
     aguara scan .claude/skills/ --ci
 ```
 
@@ -412,7 +412,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.21.0 sh
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.22.0 sh
     - aguara scan .claude/skills/ --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:
@@ -421,7 +421,7 @@ security-scan:
 
 ## How It Works
 
-Aguara runs 6 scan analyzers sequentially on every file by default; a 7th (Rug-Pull) joins when `--monitor` is enabled and a state store is configured. Each catches a different class of attack:
+Aguara runs 8 scan analyzers sequentially on every file by default; a 9th (Rug-Pull) joins when `--monitor` is enabled and a state store is configured. Each catches a different class of attack:
 
 | Analyzer | Engine | What it catches |
 |----------|--------|-----------------|
@@ -429,11 +429,13 @@ Aguara runs 6 scan analyzers sequentially on every file by default; a 7th (Rug-P
 | **CI Trust** | GitHub Actions YAML parser | `pull_request_target` chains, cache poisoning across fork boundaries, OIDC token surface paired with install/build/test, persisted-credentials checkouts on PR head refs. |
 | **PkgMeta** | `package.json` JSON parser | npm install-time lifecycle scripts plus git-sourced dependencies, optional-git deps with suspicious names, publish surfaces paired with trusted-publishing references. |
 | **JSRisk** | JavaScript single-pass scanner | Obfuscator-shape payloads, install-time daemonization via `child_process`, CI secret harvesting through real `process.env` reads plus network/registry sinks, runner-process memory pivots to extract OIDC tokens, Claude Code / VS Code workspace persistence, chain-aware DNS TXT exfil. |
+| **PyRisk** | Python install-hook scanner | Python install hooks (`setup.py` / `__init__.py`) that fetch remote JavaScript and run it through a `node -e` / `--eval` execution sink. Flow-sensitive: the executed value must trace back, in one or two hops, to the fetch. |
+| **RSBuild** | Cargo build-script scanner | Cargo build scripts (`build.rs`) that read wallet or keystore material and send it to a network sink. Flow-sensitive: the value reaching the request body must trace back, in one or two hops, to the keystore read. |
 | **NLP Analyzer** | Goldmark AST + JSON/YAML extraction | Prompt injection in markdown structure, plus tool poisoning in JSON/YAML description fields. Keyword classification with proximity weighting; clustered keywords score higher, sparse keywords in long text get penalized. |
 | **Toxic Flow** | Capability correlation | Dangerous capability combinations within a single file and across files in the same directory. Surfaces credential reads co-occurring with webhook sends, env-var reads alongside shell execution, destructive plus exec combos across MCP server tools. |
 | **Rug-Pull Detector** | SHA256 hash tracking | Tool descriptions that change between scans. CLI: `--monitor` flag. Library: `WithStateDir()` for persistent consumers. |
 
-Separate `aguara check` and `aguara audit` commands inspect installed package trees (Python `site-packages`, npm `node_modules` including the pnpm `.pnpm` store) and walk the repo recursively for Go, Rust, PHP, Ruby, Java, and .NET lockfiles, matching every declared package against the embedded threat-intel snapshot. See [Supply-Chain Check](#supply-chain-check) for the full surface.
+Separate `aguara check` and `aguara audit` commands inspect installed package trees (Python `site-packages`, npm `node_modules` including the pnpm `.pnpm` store), read npm lockfiles pre-install (`pnpm-lock.yaml`, `package-lock.json`, `yarn.lock` classic), and walk the repo recursively for Go, Rust, PHP, Ruby, Java, and .NET lockfiles, matching every declared package against the embedded threat-intel snapshot. See [Supply-Chain Check](#supply-chain-check) for the full surface.
 
 All content is NFKC-normalized before scanning to prevent Unicode evasion attacks. All layers report findings with severity, dynamic confidence score (0.50-0.95), matched text, file location with context lines, and remediation guidance. An aggregate risk score (0-100) summarizes overall threat level.
 
@@ -523,10 +525,10 @@ Supported directives:
 
 ## Rules
 
-Aguara currently exposes **219 cataloged detections** through `aguara list-rules`:
+Aguara currently exposes **221 cataloged detections** through `aguara list-rules`:
 
 - **193 embedded YAML pattern rules** across 13 categories
-- **26 analyzer-emitted detections** from ci-trust, pkgmeta, jsrisk, NLP, toxic-flow, and rug-pull
+- **28 analyzer-emitted detections** from ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxic-flow, and rug-pull
 
 The table groups coverage by emit-time category for readability:
 
@@ -621,7 +623,7 @@ See the [mcp-aguara README](https://github.com/garagon/mcp-aguara) for install, 
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.21.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
+Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.22.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
 
 ## Enterprise use
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.21.0"
+        DEFAULT_REF="v0.22.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.21.0 tag rather than `@v1`
+// The action ref is pinned to the v0.22.0 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.21.0
+        uses: garagon/aguara@v0.22.0
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.21.0
+          version: v0.22.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
Release prep for v0.22.0. Docs and version pins only, no logic changes (those shipped in #180, #181, #182, #183).

## What v0.22.0 gives users

- **Check more npm projects before install.** `aguara check` now reads `package-lock.json` and `yarn.lock` (classic) on a freshly cloned repo, before `npm install` / `yarn install` runs, alongside the existing `pnpm-lock.yaml` support. So an npm-CLI or Yarn project can be audited pre-install the same way pnpm projects already could.
- **Fewer false positives on two high-risk rules.** `PY_IMPORTTIME_REMOTE_JS_001` and `RS_BUILD_WALLET_EXFIL_001` are now flow-sensitive bindings: they fire only when the source value actually reaches the executed / exfiltrated sink, not when the two halves merely co-occur in a file.

## This PR

- **CHANGELOG**: `[0.22.0]` section covering the above plus the `intel.Update` deprecation.
- **Version pins** bumped v0.21.0 -> v0.22.0 (init scaffold, `action.yml` default ref, Makefile install-test version, README install snippets). `check-version-pins.sh` passes.
- **README**: analyzer table gains PyRisk and RSBuild (8 default analyzers, Rug-Pull is the 9th); cataloged-detections count updated to 221 (193 YAML + 28 analyzer-emitted); npm pre-install lockfiles listed; stale Docker example tags refreshed.
- **CLAUDE.md**: analyzer count and pipeline list brought in line.

No `VERSION` constant changes in code (version is injected by ldflags at build). Tag `v0.22.0` is pushed separately after this merges, then `verify-release.sh` runs against the published artifacts.

Gates: build, vet, lint (0), and the full `-race` suite all pass. Berry yarn.lock is detected and fails loudly rather than being parsed (a future layer).