### PR TITLE
Release prep v0.22.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.22.1] - 2026-06-01
+
+Offline detection for the Red Hat / Miasma npm compromise reported on
+2026-06-01. `aguara check` and `aguara audit` flag the affected
+`@redhat-cloud-services/*` packages by exact package and version, with no
+package execution and no registry lookup during the scan. This is a
+focused incident-response patch; rule IDs, severities, and
+offline-by-default behavior are otherwise unchanged.
+
+### Added
+
+- **Red Hat / Miasma npm compromise intel.** Adds the advisory
+  `AIKIDO-2026-06-01-redhat-miasma` to the built-in known-compromised
+  list, covering the 32 affected `@redhat-cloud-services/*` packages and
+  the malicious versions enumerated in the public report. The malicious
+  releases declared a `preinstall` hook running `node index.js` and
+  shipped an obfuscated install-time payload that harvested CI/OIDC
+  tokens, npm/PyPI publish tokens, cloud credentials, Vault tokens,
+  kubeconfig, SSH/GPG keys, Docker registry credentials, and `.env`
+  files, published via GitHub Actions OIDC trusted-publishing abuse.
+  Detection works across `node_modules`, `package-lock.json`,
+  `pnpm-lock.yaml`, and `yarn.lock` (classic). Matching is exact by
+  (ecosystem, package, version), so neighbouring clean releases stay
+  clean.
+
 ## [0.22.0] - 2026-05-29
 
 Check more npm projects before install, and reduce false positives on

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.22.0
+INSTALL_SH_TEST_VERSION ?= v0.22.1
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ brew install garagon/tap/aguara
 ### Docker
 
 ```bash
-docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.22.0 check /repo
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.22.1 check /repo
 ```
 
 The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 10001, base images are digest-pinned, and the image is signed at the digest with Cosign plus SPDX SBOM and SLSA provenance attestations. Tag a specific release for reproducibility.
@@ -69,14 +69,14 @@ The image is multi-arch (`linux/amd64` and `linux/arm64`), runs as non-root UID 
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.22.0 sh
+  | VERSION=v0.22.1 sh
 ```
 
 `install.sh` downloads `checksums.txt` from the release and verifies the archive's SHA256 against it, aborting if neither `sha256sum` nor `shasum` is available. This catches a tampered or corrupted archive at the registry layer, but it does not verify the Cosign signature on `checksums.txt` itself. For full keyless-signature verification on the curl-pipe path, follow up with the Cosign step in [Verifying signed releases](#verifying-signed-releases). Default install location is `~/.local/bin`. Override for CI or containers:
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.22.0 INSTALL_DIR=/usr/local/bin sh
+  | VERSION=v0.22.1 INSTALL_DIR=/usr/local/bin sh
 ```
 
 ### From source
@@ -96,7 +96,7 @@ Every release is signed with [Cosign](https://github.com/sigstore/cosign) keyles
 **Verify the release archive**:
 
 ```bash
-VERSION=v0.22.0
+VERSION=v0.22.1
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
@@ -358,11 +358,11 @@ aguara discover --format json
 ### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.22.0
+- uses: garagon/aguara@v0.22.1
   with:
     path: .
     fail-on: high
-    version: v0.22.0
+    version: v0.22.1
 ```
 
 Both pins (the action ref AND the `version:` input) are required. The action ref alone pins only the composite action and its install script; `version:` pins the Aguara binary the action installs. Setting both makes the workflow reproducible and dependabot-friendly: when a new release lands, the bot updates both together.
@@ -370,12 +370,12 @@ Both pins (the action ref AND the `version:` input) are required. The action ref
 Scans your repository, uploads findings to GitHub Code Scanning, and optionally fails the build:
 
 ```yaml
-- uses: garagon/aguara@v0.22.0
+- uses: garagon/aguara@v0.22.1
   with:
     path: ./mcp-server/
     severity: medium
     fail-on: high
-    version: v0.22.0
+    version: v0.22.1
 ```
 
 All inputs are optional. See [`action.yml`](action.yml) for the full list.
@@ -395,7 +395,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 
 ```yaml
 - name: Scan for security issues
-  run: docker run --rm -v "${{ github.workspace }}:/scan:ro" ghcr.io/garagon/aguara:0.22.0 scan /scan --ci
+  run: docker run --rm -v "${{ github.workspace }}:/scan:ro" ghcr.io/garagon/aguara:0.22.1 scan /scan --ci
 ```
 
 ### Manual / GitLab CI
@@ -404,7 +404,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitHub Actions (without the action)
 - name: Scan skills for security issues
   run: |
-    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.22.0 sh
+    curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.22.1 sh
     aguara scan .claude/skills/ --ci
 ```
 
@@ -412,7 +412,7 @@ All inputs are optional. See [`action.yml`](action.yml) for the full list.
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.22.0 sh
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.22.1 sh
     - aguara scan .claude/skills/ --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:
@@ -623,7 +623,7 @@ See the [mcp-aguara README](https://github.com/garagon/mcp-aguara) for install, 
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.22.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
+Aguara Watch is being reworked. The previous public observatory is stale, so it is not a supported product surface for v0.22.1. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
 
 ## Enterprise use
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.22.0"
+        DEFAULT_REF="v0.22.1"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.22.0 tag rather than `@v1`
+// The action ref is pinned to the v0.22.1 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.22.0
+        uses: garagon/aguara@v0.22.1
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.22.0
+          version: v0.22.1
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
## What

Release prep for v0.22.1, a focused incident-response patch.

- Adds the `[0.22.1]` CHANGELOG entry for the Red Hat / Miasma npm compromise intel (merged in #189).
- Bumps the release version pins from v0.22.0 to v0.22.1: `init` scaffolded workflow (action ref + binary version), `action.yml` default ref, the Makefile install.sh acceptance-test version, and the README install snippets.

`check-version-pins.sh` passes on v0.22.1, and build / vet / lint / test (race) are green.
