### PR TITLE
Complete Red Hat/Miasma npm intel coverage

### DIFF
--- a/internal/incident/compromised.go
+++ b/internal/incident/compromised.go
@@ -622,22 +622,28 @@ var KnownCompromised = []CompromisedPackage{
 	// ~4.2 MB credential-stealing payload ("Miasma", a Mini Shai-Hulud
 	// derivative).
 	//
-	// Coverage note: Aikido's report headlines "96 malicious versions
-	// across 32 packages" but its body enumerates 63 specific
-	// package@version tuples (the 32 packages below). Those 63 are the
-	// only versions we can verify, so they are the only ones listed.
-	// We deliberately do NOT synthesise the ~33 unenumerated versions
-	// and do NOT widen to a range-only whole-package match: the
-	// legitimate @redhat-cloud-services packages have many clean
-	// releases, so a guessed range would false-positive real installs.
-	// A neighbour version (e.g. chrome@2.3.0) must stay clean. If the
-	// full list is later published, extend the Versions slices here.
+	// Coverage note: Aikido's initial report headlined "96 malicious
+	// versions across 32 packages" but its body enumerated only 63
+	// specific tuples. The full enumeration of all 96 versions is now
+	// published as machine-readable OSV / GitHub Security Advisory
+	// records (source: ghsa-malware), so every version below is taken
+	// directly from OSV rather than synthesised. Each malicious version
+	// is an exact (ecosystem, name, version) pin: we do NOT widen to a
+	// range-only whole-package match, because the legitimate
+	// @redhat-cloud-services packages have many clean releases and a
+	// guessed range would false-positive real installs. A neighbour
+	// version (e.g. chrome@2.3.0, or the clean gap types@3.6.3) must
+	// stay clean. To refresh: query api.osv.dev/v1/query per package and
+	// take affected[].versions verbatim.
 	//
-	// Source: https://www.aikido.dev/blog/red-hat-npm-packages-compromised-credential-stealing-worm
+	// Sources:
+	//   - https://api.osv.dev/v1/query (npm, @redhat-cloud-services/*; ghsa-malware)
+	//   - https://www.microsoft.com/en-us/security/blog/2026/06/02/preinstall-persistence-inside-red-hat-npm-miasma-credential-stealing-campaign/
+	//   - https://www.aikido.dev/blog/red-hat-npm-packages-compromised-credential-stealing-worm
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/chrome",
-		Versions:  []string{"2.3.1", "2.3.2"},
+		Versions:  []string{"2.3.1", "2.3.2", "2.3.4"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -646,7 +652,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/compliance-client",
-		Versions:  []string{"4.0.3", "4.0.4"},
+		Versions:  []string{"4.0.3", "4.0.4", "4.0.6"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -655,7 +661,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/config-manager-client",
-		Versions:  []string{"5.0.4", "5.0.5"},
+		Versions:  []string{"5.0.4", "5.0.5", "5.0.7"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -664,7 +670,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/entitlements-client",
-		Versions:  []string{"4.0.11", "4.0.12"},
+		Versions:  []string{"4.0.11", "4.0.12", "4.0.14"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -673,7 +679,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/eslint-config-redhat-cloud-services",
-		Versions:  []string{"3.2.1", "3.2.2"},
+		Versions:  []string{"3.2.1", "3.2.2", "3.2.4"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -682,7 +688,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/frontend-components",
-		Versions:  []string{"7.7.2", "7.7.3"},
+		Versions:  []string{"7.7.2", "7.7.3", "7.7.5"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -691,7 +697,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/frontend-components-advisor-components",
-		Versions:  []string{"3.8.2"},
+		Versions:  []string{"3.8.2", "3.8.4", "3.8.6"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -700,7 +706,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/frontend-components-config",
-		Versions:  []string{"6.11.3", "6.11.4"},
+		Versions:  []string{"6.11.3", "6.11.4", "6.11.6"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -709,7 +715,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/frontend-components-config-utilities",
-		Versions:  []string{"4.11.2", "4.11.3"},
+		Versions:  []string{"4.11.2", "4.11.3", "4.11.5"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -718,7 +724,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/frontend-components-notifications",
-		Versions:  []string{"6.9.2", "6.9.3"},
+		Versions:  []string{"6.9.2", "6.9.3", "6.9.5"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -727,7 +733,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/frontend-components-remediations",
-		Versions:  []string{"4.9.2", "4.9.3"},
+		Versions:  []string{"4.9.2", "4.9.3", "4.9.5"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -736,7 +742,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/frontend-components-testing",
-		Versions:  []string{"1.2.1", "1.2.2"},
+		Versions:  []string{"1.2.1", "1.2.2", "1.2.4"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -745,7 +751,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/frontend-components-translations",
-		Versions:  []string{"4.4.1", "4.4.2"},
+		Versions:  []string{"4.4.1", "4.4.2", "4.4.4"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -754,7 +760,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/frontend-components-utilities",
-		Versions:  []string{"7.4.1", "7.4.2"},
+		Versions:  []string{"7.4.1", "7.4.2", "7.4.4"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -763,7 +769,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/hcc-feo-mcp",
-		Versions:  []string{"0.3.1", "0.3.2"},
+		Versions:  []string{"0.3.1", "0.3.2", "0.3.4"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -772,7 +778,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/hcc-kessel-mcp",
-		Versions:  []string{"0.3.1", "0.3.2"},
+		Versions:  []string{"0.3.1", "0.3.2", "0.3.4"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -781,7 +787,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/hcc-pf-mcp",
-		Versions:  []string{"0.6.1", "0.6.2"},
+		Versions:  []string{"0.6.1", "0.6.2", "0.6.4"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -790,7 +796,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/host-inventory-client",
-		Versions:  []string{"5.0.3", "5.0.4"},
+		Versions:  []string{"5.0.3", "5.0.4", "5.0.6"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -799,7 +805,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/insights-client",
-		Versions:  []string{"4.0.4", "4.0.5"},
+		Versions:  []string{"4.0.4", "4.0.5", "4.0.7"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -808,7 +814,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/integrations-client",
-		Versions:  []string{"6.0.4", "6.0.5"},
+		Versions:  []string{"6.0.4", "6.0.5", "6.0.7"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -817,7 +823,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/javascript-clients-shared",
-		Versions:  []string{"2.0.8", "2.0.9"},
+		Versions:  []string{"2.0.8", "2.0.9", "2.0.11"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -826,7 +832,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/notifications-client",
-		Versions:  []string{"6.1.4", "6.1.5"},
+		Versions:  []string{"6.1.4", "6.1.5", "6.1.7"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -835,7 +841,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/patch-client",
-		Versions:  []string{"4.0.4", "4.0.5"},
+		Versions:  []string{"4.0.4", "4.0.5", "4.0.7"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -844,7 +850,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/quickstarts-client",
-		Versions:  []string{"4.0.11", "4.0.12"},
+		Versions:  []string{"4.0.11", "4.0.12", "4.0.14"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -853,7 +859,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/rbac-client",
-		Versions:  []string{"9.0.3", "9.0.4"},
+		Versions:  []string{"9.0.3", "9.0.4", "9.0.6"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -862,7 +868,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/remediations-client",
-		Versions:  []string{"4.0.4", "4.0.5"},
+		Versions:  []string{"4.0.4", "4.0.5", "4.0.7"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -871,7 +877,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/rule-components",
-		Versions:  []string{"4.7.2", "4.7.3"},
+		Versions:  []string{"4.7.2", "4.7.3", "4.7.5"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -880,7 +886,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/sources-client",
-		Versions:  []string{"3.0.10", "3.0.11"},
+		Versions:  []string{"3.0.10", "3.0.11", "3.0.13"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -889,7 +895,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/topological-inventory-client",
-		Versions:  []string{"3.0.10", "3.0.11"},
+		Versions:  []string{"3.0.10", "3.0.11", "3.0.13"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -898,7 +904,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/tsc-transform-imports",
-		Versions:  []string{"1.2.2"},
+		Versions:  []string{"1.2.2", "1.2.4", "1.2.6"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,
@@ -916,7 +922,7 @@ var KnownCompromised = []CompromisedPackage{
 	{
 		Ecosystem: EcosystemNPM,
 		Name:      "@redhat-cloud-services/vulnerabilities-client",
-		Versions:  []string{"2.1.8", "2.1.9"},
+		Versions:  []string{"2.1.8", "2.1.9", "2.1.11"},
 		Advisory:  miasmaAdvisory,
 		Date:      "2026-06-01",
 		Summary:   miasmaSummary,

--- a/internal/incident/redhat_miasma_test.go
+++ b/internal/incident/redhat_miasma_test.go
@@ -119,9 +119,10 @@ func TestMiasma_YarnLockHit(t *testing.T) {
 func TestMiasma_NeighborVersionClean(t *testing.T) {
 	dir := t.TempDir()
 	nm := filepath.Join(dir, "node_modules")
-	writeNPMPackage(t, nm, "@redhat-cloud-services/chrome", "2.3.0")      // clean neighbor
-	writeNPMPackage(t, nm, "@redhat-cloud-services/rbac-client", "9.0.2") // clean neighbor
-	writeNPMPackage(t, nm, "@redhat-cloud-services/types", "3.6.3")       // clean gap between pinned versions
+	writeNPMPackage(t, nm, "@redhat-cloud-services/chrome", "2.3.0")                        // clean neighbor
+	writeNPMPackage(t, nm, "@redhat-cloud-services/rbac-client", "9.0.2")                   // clean neighbor
+	writeNPMPackage(t, nm, "@redhat-cloud-services/types", "3.6.3")                         // clean gap between pinned versions
+	writeNPMPackage(t, nm, "@redhat-cloud-services/frontend-components-utilities", "7.4.3") // clean gap between 7.4.2 and 7.4.4
 
 	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
 	if err != nil {
@@ -147,6 +148,62 @@ func TestMiasma_CleanSimilarScopeClean(t *testing.T) {
 	}
 	if len(result.Findings) != 0 {
 		t.Errorf("clean / similar-name packages must not flag, got: %+v", result.Findings)
+	}
+}
+
+// TestMiasma_NewVersionsFire covers the versions added from the OSV /
+// GitHub Security Advisory enumeration (the third malicious version per
+// package, beyond the 63 originally enumerated by Aikido). Each must
+// flag CRITICAL with the Miasma advisory.
+func TestMiasma_NewVersionsFire(t *testing.T) {
+	cases := []struct{ name, version string }{
+		{"@redhat-cloud-services/frontend-components-utilities", "7.4.4"},
+		{"@redhat-cloud-services/chrome", "2.3.4"},
+		{"@redhat-cloud-services/tsc-transform-imports", "1.2.6"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name+"@"+tc.version, func(t *testing.T) {
+			dir := t.TempDir()
+			nm := filepath.Join(dir, "node_modules")
+			writeNPMPackage(t, nm, tc.name, tc.version)
+
+			result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
+			if err != nil {
+				t.Fatalf("CheckNPM error: %v", err)
+			}
+			if got := len(result.Findings); got != 1 {
+				t.Fatalf("expected 1 finding, got %d: %+v", got, result.Findings)
+			}
+			f := result.Findings[0]
+			if f.Severity != incident.SevCritical {
+				t.Errorf("expected CRITICAL, got %q", f.Severity)
+			}
+			want := tc.name + " " + tc.version + " is a known compromised npm package (" + miasmaAdvisory + ")"
+			if f.Title != want {
+				t.Errorf("title = %q, want %q", f.Title, want)
+			}
+		})
+	}
+}
+
+// TestMiasma_AdvisoryVersionCount locks the full Microsoft/OSV
+// enumeration: 32 packages, 96 malicious versions under the single
+// Miasma advisory. Guards against an accidental drop or a future
+// regen that silently changes the surface.
+func TestMiasma_AdvisoryVersionCount(t *testing.T) {
+	pkgs, versions := 0, 0
+	for _, p := range incident.KnownCompromised {
+		if p.Advisory != miasmaAdvisory {
+			continue
+		}
+		pkgs++
+		versions += len(p.Versions)
+	}
+	if pkgs != 32 {
+		t.Errorf("Miasma package count = %d, want 32", pkgs)
+	}
+	if versions != 96 {
+		t.Errorf("Miasma version count = %d, want 96", versions)
 	}
 }
 


### PR DESCRIPTION
## What

Completes Aguara's built-in Red Hat/Miasma npm compromise coverage.

`aguara check` already flagged the affected `@redhat-cloud-services/*` packages from the initial Aikido report. This PR expands the same advisory, `AIKIDO-2026-06-01-redhat-miasma`, from 63 to 96 known-compromised versions across the same 32 packages.

The added versions come from machine-readable OSV / GitHub Security Advisory records, so the update is based on verifiable advisory data rather than reconstructed blog summaries.

## What changed

- Adds the remaining 33 OSV-confirmed versions to the existing Miasma advisory.
- Keeps exact `(ecosystem, package, version)` matching.
- Keeps clean neighbouring versions clean, including gaps between compromised releases.
- Does not add version ranges.
- Does not remove any previously listed version.

## Tests

Newly covered versions now flag `CRITICAL`:

- `@redhat-cloud-services/frontend-components-utilities@7.4.4`
- `@redhat-cloud-services/chrome@2.3.4`
- `@redhat-cloud-services/tsc-transform-imports@1.2.6`

Clean gap coverage:

- `@redhat-cloud-services/frontend-components-utilities@7.4.3` stays clean.

The advisory is also count-locked at 32 packages / 96 versions.

## Validation

- `make build`
- `make test`
- `make vet`
- `make lint`
