### PR TITLE
Show how fresh Aguara's advisory intel is

### DIFF
--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -128,6 +128,10 @@ func runAudit(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("audit: check phase: %w", err)
 	}
+	// Set age/stale once on the check result; the AuditResult copies this
+	// IntelSummary and the nested Check pointer shares it, so JSON and
+	// terminal stay consistent.
+	applyIntelFreshness(&checkResult.Intel, time.Now().UTC())
 
 	// 2. Run the content scan.
 	scanResult, err := auditRunScan(cmd, target)
@@ -435,9 +439,13 @@ func writeAuditTerminal(result *AuditResult) error {
 		}
 	}
 
-	fmt.Printf("\n%sIntel:%s mode=%s snapshot=%s sources=%v generated=%s\n",
-		bold, reset, result.Intel.Mode, result.Intel.Snapshot,
-		result.Intel.Sources, result.Intel.GeneratedAt.Format(time.DateOnly))
+	// Provenance line, unified with `aguara check`. Suppressed under --ci
+	// (stdout stays verdict + findings); a stale local cache still notes
+	// to stderr inside printIntelFreshness.
+	if !flagAuditCI {
+		fmt.Println()
+	}
+	printIntelFreshness(result.Intel, flagAuditCI)
 
 	verdictColor := green
 	if result.Verdict.ThresholdExceeded {

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/garagon/aguara/internal/incident"
 	"github.com/garagon/aguara/internal/intel"
@@ -16,13 +17,13 @@ import (
 )
 
 var (
-	flagCheckPath        string
-	flagCheckEcosystems  []string
-	flagCheckFailOn      string
-	flagCheckCI          bool
-	flagCheckFresh       bool
-	flagCheckAllowStale  bool
-	flagCheckInsecure    bool
+	flagCheckPath       string
+	flagCheckEcosystems []string
+	flagCheckFailOn     string
+	flagCheckCI         bool
+	flagCheckFresh      bool
+	flagCheckAllowStale bool
+	flagCheckInsecure   bool
 )
 
 const (
@@ -148,6 +149,7 @@ func runCheck(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	applyIntelFreshness(&result.Intel, time.Now().UTC())
 
 	if flagFormat == "json" {
 		if err := writeCheckJSON(result); err != nil {
@@ -165,10 +167,10 @@ func runCheck(cmd *cobra.Command, args []string) error {
 // resolveCheckPathArg picks the effective scan path from the positional
 // argument or the --path flag and rejects ambiguous combinations.
 //
-//   no positional, no --path  -> "" (legacy default: site-packages auto-discovery)
-//   no positional, --path X   -> X
-//   positional X, no --path   -> X
-//   positional X, --path Y    -> explicit error (ambiguity)
+//	no positional, no --path  -> "" (legacy default: site-packages auto-discovery)
+//	no positional, --path X   -> X
+//	positional X, no --path   -> X
+//	positional X, --path Y    -> explicit error (ambiguity)
 //
 // The explicit-error case is the deliberate choice this command makes
 // vs the silent flag-wins semantics 'audit' uses. Picking one form
@@ -220,7 +222,7 @@ func applyCheckCIDefaults() {
 // resolveCheckIntel uses that list to scope a --fresh refresh to
 // only what the user is checking.
 type checkPlan struct {
-	rootPath          string // the path the user passed (may be "")
+	rootPath            string // the path the user passed (may be "")
 	runPython           bool
 	pythonPath          string
 	runNPM              bool
@@ -974,6 +976,11 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 		fmt.Printf("Packages read: %d  |  .pth files scanned: %d\n\n", result.PackagesRead, result.PthScanned)
 	}
 
+	// Provenance line: which intel answered this scan, and how old it is.
+	// Suppressed under --ci to keep stdout to findings (a stale local
+	// cache still earns a stderr note inside printIntelFreshness).
+	printIntelFreshness(result.Intel, flagCheckCI)
+
 	if len(result.Findings) == 0 {
 		green := "\033[32m"
 		reset := "\033[0m"
@@ -1170,6 +1177,7 @@ func resolveCheckIntel(ctx context.Context, ecosystems []string) (*incident.Inte
 			Snapshots:     snaps,
 			Mode:          "online",
 			SnapshotLabel: "remote-fresh",
+			GeneratedAt:   snap.GeneratedAt,
 		}, nil
 	}
 
@@ -1202,6 +1210,9 @@ func localOrEmbeddedOverride(store *intel.Store) *incident.IntelOverride {
 		Snapshots:     snaps,
 		Mode:          "offline",
 		SnapshotLabel: "local-verified",
+		// Age must reflect the local cache, not the (possibly newer)
+		// embedded layer beneath it, so a stale cache reads as stale.
+		GeneratedAt: snap.GeneratedAt,
 	}
 }
 

--- a/cmd/aguara/commands/intel_freshness.go
+++ b/cmd/aguara/commands/intel_freshness.go
@@ -1,0 +1,128 @@
+package commands
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/garagon/aguara/internal/incident"
+)
+
+// intelStaleAfterDays is the age past which a user-fetched local /
+// verified intel cache is treated as stale. The threshold is a CLI policy
+// (the incident layer deliberately leaves IntelSummary.Stale unset so it
+// does not own a freshness policy). Embedded intel is never stale: it
+// ships with the binary, so its age is provenance, not an operational
+// state the user neglected. Staleness is informational only -- it never
+// affects exit codes, --fail-on, or the audit verdict.
+const intelStaleAfterDays = 30
+
+// applyIntelFreshness fills in AgeDays and Stale on an IntelSummary from
+// its GeneratedAt relative to now. Only a non-embedded snapshot (a
+// user-fetched local/verified/remote cache) can be stale. Pure given
+// `now`, so it is unit-testable without a clock.
+func applyIntelFreshness(s *incident.IntelSummary, now time.Time) {
+	if s == nil || s.GeneratedAt.IsZero() {
+		return
+	}
+	s.AgeDays = ageDaysSince(s.GeneratedAt, now)
+	// Only a user-held local cache can be "stale": the stale note tells
+	// the user to run `aguara update`, which only helps for local intel.
+	// Embedded ships with the binary; remote-fresh was just fetched (if
+	// the signed bundle itself is old, that is server-side, not a cache
+	// the user neglected). So neither is ever flagged stale.
+	s.Stale = (s.Snapshot == "local" || s.Snapshot == "local-verified") && s.AgeDays > intelStaleAfterDays
+}
+
+// ageDaysSince returns the whole-day age of t relative to now (0 for a
+// zero or future timestamp).
+func ageDaysSince(t, now time.Time) int {
+	if t.IsZero() {
+		return 0
+	}
+	age := now.Sub(t)
+	if age < 0 {
+		age = 0
+	}
+	return int(age / (24 * time.Hour))
+}
+
+// intelSourceLabel maps an IntelSummary.Snapshot value to friendly text.
+func intelSourceLabel(snapshot string) string {
+	switch snapshot {
+	case "embedded":
+		return "embedded"
+	case "local":
+		return "local"
+	case "local-verified":
+		return "local verified"
+	case "remote-fresh":
+		return "remote (fresh)"
+	case "":
+		return "embedded"
+	default:
+		return snapshot
+	}
+}
+
+// humanizeAgeDays renders a whole-day age as a relative phrase.
+func humanizeAgeDays(d int) string {
+	switch {
+	case d <= 0:
+		return "today"
+	case d == 1:
+		return "1 day ago"
+	default:
+		return fmt.Sprintf("%d days ago", d)
+	}
+}
+
+// intelFreshnessLine is the single-line provenance summary shown in
+// check / audit terminal output, e.g.
+//
+//	Intel: embedded · generated 2026-06-01 (2 days ago) · sources: manual, osv
+func intelFreshnessLine(s incident.IntelSummary) string {
+	gen := "unknown"
+	rel := ""
+	if !s.GeneratedAt.IsZero() {
+		gen = s.GeneratedAt.Format("2006-01-02")
+		rel = " (" + humanizeAgeDays(s.AgeDays) + ")"
+	}
+	sources := "none"
+	if len(s.Sources) > 0 {
+		sources = strings.Join(s.Sources, ", ")
+	}
+	return fmt.Sprintf("Intel: %s · generated %s%s · sources: %s",
+		intelSourceLabel(s.Snapshot), gen, rel, sources)
+}
+
+// intelStaleNote is the factual, non-alarmist note shown when a local
+// cache is stale.
+func intelStaleNote() string {
+	return fmt.Sprintf("Note: local intel is older than %d days; run `aguara update` to refresh.", intelStaleAfterDays)
+}
+
+// printIntelFreshness writes the provenance line for a check/audit run.
+// Outside CI it prints the line (and a stale note) to stdout. Under --ci
+// stdout stays clean -- only a genuinely stale local cache earns a single
+// note, and that goes to stderr so it never pollutes parsed output or
+// affects the exit code.
+func printIntelFreshness(s incident.IntelSummary, ci bool) {
+	fprintIntelFreshness(os.Stdout, os.Stderr, s, ci)
+}
+
+// fprintIntelFreshness is the testable core of printIntelFreshness.
+func fprintIntelFreshness(stdout, stderr io.Writer, s incident.IntelSummary, ci bool) {
+	if ci {
+		if s.Stale {
+			fmt.Fprintln(stderr, intelStaleNote())
+		}
+		return
+	}
+	fmt.Fprintln(stdout, intelFreshnessLine(s))
+	if s.Stale {
+		fmt.Fprintln(stdout, intelStaleNote())
+	}
+}

--- a/cmd/aguara/commands/intel_freshness_test.go
+++ b/cmd/aguara/commands/intel_freshness_test.go
@@ -1,0 +1,129 @@
+package commands
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/garagon/aguara/internal/incident"
+)
+
+func TestApplyIntelFreshness(t *testing.T) {
+	now := time.Date(2026, 6, 3, 12, 0, 0, 0, time.UTC)
+	day := func(n int) time.Time { return now.AddDate(0, 0, -n) }
+
+	cases := []struct {
+		name        string
+		snapshot    string
+		generatedAt time.Time
+		wantAge     int
+		wantStale   bool
+	}{
+		{"embedded recent", "embedded", day(2), 2, false},
+		// Embedded is never stale, no matter how old (it ships with the binary).
+		{"embedded ancient never stale", "embedded", day(400), 400, false},
+		{"local-verified fresh", "local-verified", day(5), 5, false},
+		{"local-verified at threshold not stale", "local-verified", day(30), 30, false},
+		{"local-verified over threshold stale", "local-verified", day(31), 31, true},
+		{"local old stale", "local", day(100), 100, true},
+		{"remote-fresh not stale", "remote-fresh", day(0), 0, false},
+		// A just-fetched bundle is never "stale" even if its own
+		// generated_at is old; `aguara update` would not change anything.
+		{"remote-fresh old never stale", "remote-fresh", day(120), 120, false},
+		{"plain local old stale", "local", day(45), 45, true},
+		{"zero time is a no-op", "local-verified", time.Time{}, 0, false},
+		{"future time clamps to zero age", "local-verified", now.AddDate(0, 0, 5), 0, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s := &incident.IntelSummary{Snapshot: c.snapshot, GeneratedAt: c.generatedAt}
+			applyIntelFreshness(s, now)
+			if s.AgeDays != c.wantAge {
+				t.Errorf("AgeDays = %d, want %d", s.AgeDays, c.wantAge)
+			}
+			if s.Stale != c.wantStale {
+				t.Errorf("Stale = %v, want %v", s.Stale, c.wantStale)
+			}
+		})
+	}
+}
+
+func TestApplyIntelFreshnessNilSafe(t *testing.T) {
+	applyIntelFreshness(nil, time.Now()) // must not panic
+}
+
+func TestHumanizeAgeDays(t *testing.T) {
+	cases := map[int]string{0: "today", 1: "1 day ago", 2: "2 days ago", 33: "33 days ago"}
+	for d, want := range cases {
+		if got := humanizeAgeDays(d); got != want {
+			t.Errorf("humanizeAgeDays(%d) = %q, want %q", d, got, want)
+		}
+	}
+}
+
+func TestIntelFreshnessLine(t *testing.T) {
+	s := incident.IntelSummary{
+		Snapshot:    "embedded",
+		GeneratedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		AgeDays:     2,
+		Sources:     []string{"manual", "osv"},
+	}
+	got := intelFreshnessLine(s)
+	want := "Intel: embedded · generated 2026-06-01 (2 days ago) · sources: manual, osv"
+	if got != want {
+		t.Errorf("line = %q, want %q", got, want)
+	}
+}
+
+func TestFprintIntelFreshness(t *testing.T) {
+	fresh := incident.IntelSummary{
+		Snapshot: "local-verified", GeneratedAt: time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC),
+		AgeDays: 2, Sources: []string{"manual"}, Stale: false,
+	}
+	stale := incident.IntelSummary{
+		Snapshot: "local-verified", GeneratedAt: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
+		AgeDays: 33, Sources: []string{"manual"}, Stale: true,
+	}
+
+	t.Run("non-ci prints the line on stdout", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		fprintIntelFreshness(&out, &errb, fresh, false)
+		if !strings.Contains(out.String(), "Intel: local verified") {
+			t.Errorf("stdout missing intel line: %q", out.String())
+		}
+		if errb.Len() != 0 {
+			t.Errorf("stderr should be empty, got %q", errb.String())
+		}
+	})
+
+	t.Run("non-ci stale adds note on stdout", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		fprintIntelFreshness(&out, &errb, stale, false)
+		if !strings.Contains(out.String(), "older than 30 days") {
+			t.Errorf("stdout missing stale note: %q", out.String())
+		}
+	})
+
+	t.Run("ci suppresses the line on stdout", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		fprintIntelFreshness(&out, &errb, fresh, true)
+		if out.Len() != 0 {
+			t.Errorf("ci stdout must be empty, got %q", out.String())
+		}
+		if errb.Len() != 0 {
+			t.Errorf("ci stderr should be empty for fresh intel, got %q", errb.String())
+		}
+	})
+
+	t.Run("ci stale notes on stderr only", func(t *testing.T) {
+		var out, errb bytes.Buffer
+		fprintIntelFreshness(&out, &errb, stale, true)
+		if out.Len() != 0 {
+			t.Errorf("ci stdout must stay clean, got %q", out.String())
+		}
+		if !strings.Contains(errb.String(), "older than 30 days") {
+			t.Errorf("ci stderr missing stale note: %q", errb.String())
+		}
+	})
+}

--- a/cmd/aguara/commands/status.go
+++ b/cmd/aguara/commands/status.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/garagon/aguara/internal/incident"
 	"github.com/garagon/aguara/internal/intel"
@@ -26,14 +27,18 @@ func init() {
 
 func runStatus(cmd *cobra.Command, args []string) error {
 	w := os.Stdout
+	now := time.Now().UTC()
 
 	fmt.Fprintf(w, "Aguara %s (commit %s)\n\n", Version, Commit)
 
 	fmt.Fprintf(w, "Threat intel:\n")
 	for _, snap := range incident.EmbeddedSnapshots() {
 		label := snapshotLabel(snap)
-		fmt.Fprintf(w, "  Embedded (%s): %s, %d records\n",
-			label, snap.GeneratedAt.Format("2006-01-02"), len(snap.Records))
+		// Embedded intel ships with the binary: show its age for
+		// provenance, never a stale warning.
+		fmt.Fprintf(w, "  Embedded (%s): %s (%s), %d records\n",
+			label, snap.GeneratedAt.Format("2006-01-02"),
+			humanizeAgeDays(ageDaysSince(snap.GeneratedAt, now)), len(snap.Records))
 	}
 
 	store, err := intel.DefaultStore()
@@ -47,10 +52,16 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	st := store.Status()
 	switch {
 	case st.HasSnapshot:
-		fmt.Fprintf(w, "  Local:    %s, %d records (%s)\n",
+		ageDays := ageDaysSince(st.GeneratedAt, now)
+		fmt.Fprintf(w, "  Local:    %s (%s), %d records (%s)\n",
 			st.GeneratedAt.Format("2006-01-02 15:04 UTC"),
-			st.RecordCount, st.Path,
+			humanizeAgeDays(ageDays), st.RecordCount, st.Path,
 		)
+		// The local cache is user-fetched, so it can be stale (unlike
+		// embedded). Same 30-day policy as check/audit; informational.
+		if ageDays > intelStaleAfterDays {
+			fmt.Fprintf(w, "            %s\n", intelStaleNote())
+		}
 	case st.LastUpdateErr != "":
 		fmt.Fprintf(w, "  Local:    error reading %s: %s\n", st.Path, st.LastUpdateErr)
 	default:

--- a/internal/incident/checker.go
+++ b/internal/incident/checker.go
@@ -80,8 +80,14 @@ type IntelSummary struct {
 	Mode        string    `json:"mode"`
 	Snapshot    string    `json:"snapshot"`
 	GeneratedAt time.Time `json:"generated_at"`
-	Sources     []string  `json:"sources"`
-	Stale       bool      `json:"stale"`
+	// AgeDays is the whole-day age of GeneratedAt. Filled by the CLI
+	// (the freshness policy lives there), 0 when unset.
+	AgeDays int      `json:"age_days"`
+	Sources []string `json:"sources"`
+	// Stale is true only for a user-fetched local/verified cache older
+	// than the CLI's threshold; embedded intel is never stale. Set by the
+	// CLI. Informational only: it never affects exit codes or verdicts.
+	Stale bool `json:"stale"`
 }
 
 // InstalledPackage is a package parsed from dist-info METADATA.
@@ -112,7 +118,15 @@ type CheckOptions struct {
 type IntelOverride struct {
 	Snapshots     []intel.Snapshot
 	Mode          string // "offline" | "online"
-	SnapshotLabel string // "embedded" | "local" | "remote-fresh"
+	SnapshotLabel string // "embedded" | "local" | "local-verified" | "remote-fresh"
+	// GeneratedAt is the timestamp of the snapshot the SnapshotLabel
+	// names (e.g. the local verified cache), not the newest snapshot in
+	// the set. When a local/fetched cache is layered over the (possibly
+	// newer) embedded snapshots, the summary's age must reflect the
+	// labeled cache so a stale local cache is reported as stale even
+	// when the embedded layer is fresher. Zero -> intelSummaryFor falls
+	// back to the newest GeneratedAt across Snapshots.
+	GeneratedAt time.Time
 }
 
 // Check scans a Python environment for compromised packages and artifacts.

--- a/internal/incident/intel_adapter.go
+++ b/internal/incident/intel_adapter.go
@@ -115,6 +115,13 @@ func intelSummaryFor(opts CheckOptions) IntelSummary {
 			sources = append(sources, kind)
 		}
 	}
+	// When the override names a specific snapshot (e.g. the local
+	// verified cache), report THAT snapshot's age rather than the newest
+	// across the layered set. Otherwise a stale local cache would look
+	// fresh whenever the embedded layer underneath it is newer.
+	if opts.Intel != nil && !opts.Intel.GeneratedAt.IsZero() {
+		generatedAt = opts.Intel.GeneratedAt
+	}
 	return IntelSummary{
 		Mode:        mode,
 		Snapshot:    label,

--- a/internal/incident/intel_adapter_test.go
+++ b/internal/incident/intel_adapter_test.go
@@ -175,3 +175,44 @@ func TestKnownCompromisedSnapshotKindCompromised(t *testing.T) {
 			rec.ID, rec.Name, rec.Kind)
 	}
 }
+
+// TestIntelSummaryForOverride_LabeledTimestampWinsOverNewerEmbedded locks
+// the freshness coherence fix: when a local verified cache is layered over
+// newer embedded snapshots, the summary must report the LOCAL cache's age
+// (so a stale cache reads as stale), not the newer embedded timestamp.
+func TestIntelSummaryForOverride_LabeledTimestampWinsOverNewerEmbedded(t *testing.T) {
+	oldCache := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	newerEmbedded := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	ov := &incident.IntelOverride{
+		Snapshots: []intel.Snapshot{
+			{GeneratedAt: newerEmbedded, Sources: []intel.SourceMeta{{Kind: intel.SourceManual}}},
+			{GeneratedAt: oldCache, Sources: []intel.SourceMeta{{Kind: intel.SourceOSV}}},
+		},
+		Mode:          "offline",
+		SnapshotLabel: "local-verified",
+		GeneratedAt:   oldCache,
+	}
+	got := incident.IntelSummaryForOverride(ov)
+	require.Equal(t, "local-verified", got.Snapshot)
+	require.Truef(t, got.GeneratedAt.Equal(oldCache),
+		"summary GeneratedAt must be the labeled local cache %s, not the newer embedded %s; got %s",
+		oldCache.Format("2006-01-02"), newerEmbedded.Format("2006-01-02"), got.GeneratedAt.Format("2006-01-02"))
+}
+
+// TestIntelSummaryForOverride_FallsBackToNewestWhenUnset confirms the
+// embedded path (no per-label timestamp) still uses the newest snapshot.
+func TestIntelSummaryForOverride_FallsBackToNewestWhenUnset(t *testing.T) {
+	oldSnap := time.Date(2026, 4, 1, 0, 0, 0, 0, time.UTC)
+	newerSnap := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	ov := &incident.IntelOverride{
+		Snapshots: []intel.Snapshot{
+			{GeneratedAt: oldSnap, Sources: []intel.SourceMeta{{Kind: intel.SourceManual}}},
+			{GeneratedAt: newerSnap, Sources: []intel.SourceMeta{{Kind: intel.SourceOSV}}},
+		},
+		SnapshotLabel: "embedded",
+	}
+	got := incident.IntelSummaryForOverride(ov)
+	require.Truef(t, got.GeneratedAt.Equal(newerSnap),
+		"unset override GeneratedAt must fall back to newest snapshot %s; got %s",
+		newerSnap.Format("2006-01-02"), got.GeneratedAt.Format("2006-01-02"))
+}


### PR DESCRIPTION
## What

Aguara uses advisory intel to flag known-compromised packages. It ships with an embedded snapshot and can refresh from a signed bundle.

Until now, the terminal output did not clearly show which intel answered a run or how old that intel was. This PR adds that context.

`aguara check` and `aguara audit` now print a one-line summary:

```text
Intel: embedded · generated 2026-06-01 (2 days ago) · sources: manual, osv
```

`aguara status` now shows the age of embedded and local snapshots, and JSON output gains `age_days` plus a real `stale` flag.

## Why it matters

When someone reviews a package or repo before install, "how current is the data behind this result?" is a fair question.

Showing intel age and source answers it without requiring another command.

## Behavior

- Informational only. Freshness never changes exit codes, `--fail-on`, or the audit verdict. Findings still decide CI behavior.
- Embedded intel ships with the binary, so it is shown with its age but never labeled stale.
- Local intel fetched with `aguara update` can be marked stale once it is older than 30 days.
- In CI (`--ci`), the freshness line stays off stdout to avoid noise; a stale local cache prints one factual note on stderr.

## Validation

- `make build`
- `make test`
- `make vet`
- `make lint`
