### PR TITLE
Release prep v0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,90 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-06-07
+
+Expands Aguara's offline coverage of supply-chain behavioral attack
+chains, informed by the Red Hat / Miasma npm worm. Six new behavioral
+detections span the chain from install-time execution through second
+stages, repository-as-control channels, host trust tampering, and
+destructive cleanup. Intel freshness is now visible in `check` /
+`audit` / `status`, and the JavaScript analyzer is faster. Everything
+stays deterministic and offline: no package execution, no network calls
+during a scan. Existing rule IDs, severities, and the `Severity`
+JSON encoding are unchanged.
+
+### Added
+
+- **npm lifecycle scripts that run local JavaScript** (`SUPPLY_026`,
+  pkgmeta analyzer). Flags a `package.json` whose install-time lifecycle
+  hooks (`preinstall` / `install` / `postinstall` / `prepare` and the
+  related pre/post keys) execute a local `.js` / `.cjs` / `.mjs` file,
+  `node -e`, or a `bun` stage. This is the entry point of the Miasma
+  chain, where a published package runs its own code the moment it is
+  installed.
+- **Node-to-Bun second-stage execution** (`JS_BUN_SECOND_STAGE_001`,
+  jsrisk). Flags package code that shells out to the Bun runtime as a
+  second stage and pairs it with a strong supply-chain signal
+  (obfuscator-shape payload, CI/cloud secret read, or a network exfil
+  sink). Running an ordinary Bun command never fires on its own.
+  CRITICAL when a secret read and an exfil sink are both present.
+- **Repository used as a payload or command channel**
+  (`JS_GITHUB_C2_001`, jsrisk). Flags code that writes or controls
+  GitHub-hosted content (a GraphQL write mutation, an Octokit write
+  method, or a REST contents / git-data write to `api.github.com`) and
+  pairs it with a strong partner that a normal release bot does not
+  carry. CRITICAL when a non-GitHub credential is also read.
+- **Sudoers privilege tampering** (`JS_SUDOERS_TAMPER_001`, jsrisk).
+  Flags a real write to `/etc/sudoers` or `/etc/sudoers.d/*`, whether a
+  bound filesystem write or a bound shell redirect / `tee` / `sed -i`.
+  CRITICAL when the written content grants passwordless or unrestricted
+  sudo. Validation-only (`visudo -c`) and `chmod` without a write do not
+  match.
+- **Host trust surface tampering** (`JS_HOST_TRUST_TAMPER_001`, jsrisk).
+  Flags a write to the dynamic linker preload (`/etc/ld.so.preload`), a
+  CA certificate store, the SSH daemon config, the global shell profile,
+  or name resolution (`/etc/hosts`, `/etc/resolv.conf`) pointed at a
+  sensitive domain.
+- **Destructive wipe of sensitive paths** (`JS_WIPER_TRIPWIRE_001`,
+  jsrisk). Flags a real deletion of a credential store
+  (`.ssh` / `.aws` / `.gnupg` / `.kube` / `.azure` / `.docker` / gcloud),
+  agent or editor trust (`.claude` / `CLAUDE.md` / `.cursorrules` /
+  `.vscode`), shell history, an evidence log, or a honeytoken, plus a
+  broad wipe of `$HOME` / `~` / `/root` / root. Detection is by the
+  actual delete capability of the call (a non-recursive `rm`, an
+  `unlink`, or a `fs/promises` call that has no such method cannot
+  destroy a directory), through a bound `fs` / `fs-extra` / `rimraf`
+  delete or a bound shell `rm` / `unlink` / `rmdir` / `find -delete`.
+  Build and cache cleanup (`node_modules`, `dist`, `/tmp`) does not
+  match. CRITICAL on a broad home or root wipe, on deleting two distinct
+  credential stores, or when paired with a strong partner.
+
+This closes the chain end to end: install hook, second stage, control
+channel, host tampering, destructive cleanup. Coverage is static and
+chain-gated, not a claim of complete worm detection.
+
+### Changed
+
+- **Advisory intel freshness is now visible.** `aguara check`,
+  `aguara audit`, and `aguara status` show the age and source of the
+  embedded or refreshed advisory intel, and JSON output gains an
+  `age_days` field and a real `stale` flag. This is informational only:
+  it never changes exit codes, `--fail-on`, or a verdict, and under
+  `--ci` the freshness note goes to stderr so stdout stays clean.
+- **Faster JavaScript risk analysis.** The jsrisk analyzer now masks
+  comments, regex-literal bodies, and string interiors in a single
+  shared pass, so code-token signals (network sinks, child-process
+  spawns, env reads, obfuscation shape) no longer match inside comments
+  or strings. The shared pass is about 8% faster than before with far
+  fewer allocations. No rule or severity change.
+
+### Notes
+
+- Rule catalog is now 193 YAML rules plus 34 analyzer-emitted rules
+  (227 cataloged) across 9 scan analyzers. The new detections are
+  emitted by the existing `pkgmeta` and `jsrisk` analyzers; no new
+  analyzer was added.
+
 ## [0.22.2] - 2026-06-03
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.22.0 (2026-05-29). 193 YAML rules + 34 analyzer-emitted (227 cataloged), 13 categories, 9 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic, and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
+Aguara v0.23.0 (2026-06-07). 193 YAML rules + 34 analyzer-emitted (227 cataloged), 13 categories, 9 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic, and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
 
 Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, multi-arch `linux/amd64+arm64`, runs as non-root UID 10001, base images digest-pinned, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
@@ -153,7 +153,7 @@ When any of these values change, update ALL references across the vault:
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)
 - Watch skill count (currently 28,000+)
-- Version number (currently v0.22.0)
+- Version number (currently v0.23.0)
 
 Use `Grep` to find all occurrences before updating.
 

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.22.2
+INSTALL_SH_TEST_VERSION ?= v0.23.0
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ brew install garagon/tap/aguara
 ### Docker
 
 ```bash
-docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.22.2 check /repo
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.23.0 check /repo
 ```
 
 Multi-arch (`linux/amd64` + `linux/arm64`), runs as non-root UID 10001, base images digest-pinned, and signed at the digest with Cosign plus SPDX SBOM and SLSA provenance attestations. Pin a specific release tag for reproducibility.
@@ -199,7 +199,7 @@ Multi-arch (`linux/amd64` + `linux/arm64`), runs as non-root UID 10001, base ima
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.22.2 sh
+  | VERSION=v0.23.0 sh
 ```
 
 `install.sh` downloads `checksums.txt` and verifies the archive's SHA256 against it, aborting if neither `sha256sum` nor `shasum` is available. This catches a tampered archive at the registry layer but does not verify the Cosign signature on `checksums.txt` itself; for full keyless-signature verification on the curl-pipe path, follow the Cosign step in [Verifying signed releases](#verifying-signed-releases). Default install location is `~/.local/bin`; override with `INSTALL_DIR` for CI or containers.
@@ -207,11 +207,11 @@ curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
 ### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.22.2
+- uses: garagon/aguara@v0.23.0
   with:
     path: .
     fail-on: high
-    version: v0.22.2
+    version: v0.23.0
 ```
 
 Both pins are required: the action ref pins the composite action and its install script, and `version:` pins the Aguara binary it installs. Setting both keeps the workflow reproducible and dependabot-friendly. See [`action.yml`](action.yml) for all inputs.
@@ -249,15 +249,15 @@ GitHub Code Scanning, GitLab SAST, and plain Docker-in-CI examples are below.
 
 ```yaml
 # GitHub Action with SARIF upload (needs security-events: write)
-- uses: garagon/aguara@v0.22.2
-  with: { path: ., severity: medium, fail-on: high, version: v0.22.2 }
+- uses: garagon/aguara@v0.23.0
+  with: { path: ., severity: medium, fail-on: high, version: v0.23.0 }
 ```
 
 ```yaml
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.22.2 sh
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.23.0 sh
     - aguara scan . --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:
@@ -311,7 +311,7 @@ A separate `aguara check` / `aguara audit` path inspects installed package trees
 Every release is signed with [Cosign](https://github.com/sigstore/cosign) keyless, ships an SPDX SBOM per archive, and is built with `-trimpath` for reproducibility. The container image is signed at the digest with SBOM + SLSA provenance attestations.
 
 ```bash
-VERSION=v0.22.2
+VERSION=v0.23.0
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
@@ -359,7 +359,7 @@ Suppress individual findings inline with `# aguara-ignore RULE_ID` (also `-next-
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale and is not a supported surface for v0.22.2. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
+Aguara Watch is being reworked. The previous public observatory is stale and is not a supported surface for v0.23.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.22.2"
+        DEFAULT_REF="v0.23.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.22.2 tag rather than `@v1`
+// The action ref is pinned to the v0.23.0 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.22.2
+        uses: garagon/aguara@v0.23.0
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.22.2
+          version: v0.23.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
Prepares the v0.23.0 minor release. This is the prep PR; no tag is created here.

**What ships in v0.23.0**

Six new behavioral detections that expand offline coverage of supply-chain attack chains, informed by the Red Hat / Miasma npm worm. They span the chain from install-time execution to destructive cleanup:

- `SUPPLY_026` (pkgmeta) - npm lifecycle scripts that run local JavaScript
- `JS_BUN_SECOND_STAGE_001` - Node-to-Bun second-stage execution
- `JS_GITHUB_C2_001` - repository used as a payload or command channel
- `JS_SUDOERS_TAMPER_001` - sudoers privilege tampering
- `JS_HOST_TRUST_TAMPER_001` - host trust surface tampering
- `JS_WIPER_TRIPWIRE_001` - destructive wipe of sensitive paths

Plus advisory intel freshness visibility in `check` / `audit` / `status`, and a faster jsrisk pass (one shared comment/string/regex mask). Everything stays deterministic and offline.

**This PR**

- CHANGELOG `[0.23.0]` entry
- Version pins bumped v0.22.2 -> v0.23.0 (init template, action default ref, Makefile, README snippets); `check-version-pins.sh` agrees on v0.23.0
- CLAUDE.md project-status and data-consistency version bumped

No code logic changes in this prep PR; the release contents were already landed in prior commits. Catalog stays 193 YAML + 34 analyzer-emitted (227 cataloged).

**After merge:** tag `v0.23.0` (only on your confirmation), then `VERSION=v0.23.0 .github/scripts/verify-release.sh`, then rewrite the GitHub release body.
