### PR TITLE
Add pnpm-policy analyzer for pnpm supply-chain posture

### DIFF
--- a/aguara.go
+++ b/aguara.go
@@ -19,6 +19,7 @@ import (
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pattern"
 	"github.com/garagon/aguara/internal/engine/pkgmeta"
+	"github.com/garagon/aguara/internal/engine/pnpmpolicy"
 	"github.com/garagon/aguara/internal/engine/pyrisk"
 	"github.com/garagon/aguara/internal/engine/rsbuild"
 	"github.com/garagon/aguara/internal/engine/rugpull"
@@ -443,6 +444,7 @@ func (sc *Scanner) buildInternalScanner(toolName string) (*scanner.Scanner, erro
 	// co-presence YAML rules, so they must run in the library path too.
 	s.RegisterAnalyzer(pyrisk.New())
 	s.RegisterAnalyzer(rsbuild.New())
+	s.RegisterAnalyzer(pnpmpolicy.New())
 	// NLP and ToxicFlow are stateless, cheap to instantiate
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
@@ -590,6 +592,7 @@ func buildScanner(cfg *scanConfig) (*scanner.Scanner, []*rules.CompiledRule, err
 	s.RegisterAnalyzer(jsrisk.New())
 	s.RegisterAnalyzer(pyrisk.New())
 	s.RegisterAnalyzer(rsbuild.New())
+	s.RegisterAnalyzer(pnpmpolicy.New())
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
 	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())

--- a/aguara_pnpm_test.go
+++ b/aguara_pnpm_test.go
@@ -1,0 +1,54 @@
+package aguara_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/garagon/aguara"
+)
+
+// TestScanContentPnpmPolicy verifies the pnpm-policy analyzer is wired
+// into the public ScanContent path: a pnpm-workspace.yaml that disables
+// build approval surfaces PNPM_DANGEROUS_BUILDS_001 through the Go API.
+func TestScanContentPnpmPolicy(t *testing.T) {
+	result, err := aguara.ScanContent(
+		context.Background(),
+		"dangerouslyAllowAllBuilds: true\nminimumReleaseAge: 0\n",
+		"pnpm-workspace.yaml",
+	)
+	if err != nil {
+		t.Fatalf("ScanContent failed: %v", err)
+	}
+	want := map[string]bool{
+		"PNPM_DANGEROUS_BUILDS_001":         false,
+		"PNPM_MIN_RELEASE_AGE_DISABLED_001": false,
+	}
+	for _, f := range result.Findings {
+		if _, ok := want[f.RuleID]; ok {
+			want[f.RuleID] = true
+		}
+	}
+	for id, seen := range want {
+		if !seen {
+			t.Errorf("expected %s in ScanContent findings", id)
+		}
+	}
+}
+
+// TestScanContentPnpmPolicyNoFalsePositive confirms a hardened
+// pnpm-workspace.yaml emits no pnpm-policy findings through the API.
+func TestScanContentPnpmPolicyNoFalsePositive(t *testing.T) {
+	result, err := aguara.ScanContent(
+		context.Background(),
+		"minimumReleaseAge: 1440\nstrictDepBuilds: true\nblockExoticSubdeps: true\n",
+		"pnpm-workspace.yaml",
+	)
+	if err != nil {
+		t.Fatalf("ScanContent failed: %v", err)
+	}
+	for _, f := range result.Findings {
+		if f.Analyzer == "pnpm-policy" {
+			t.Errorf("unexpected pnpm-policy finding on hardened config: %s", f.RuleID)
+		}
+	}
+}

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -18,6 +18,7 @@ import (
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pattern"
 	"github.com/garagon/aguara/internal/engine/pkgmeta"
+	"github.com/garagon/aguara/internal/engine/pnpmpolicy"
 	"github.com/garagon/aguara/internal/engine/pyrisk"
 	"github.com/garagon/aguara/internal/engine/rsbuild"
 	"github.com/garagon/aguara/internal/engine/rugpull"
@@ -461,6 +462,7 @@ func buildScanner(compiled []*rules.CompiledRule, cfg config.Config, minSev scan
 	s.RegisterAnalyzer(jsrisk.New())
 	s.RegisterAnalyzer(pyrisk.New())
 	s.RegisterAnalyzer(rsbuild.New())
+	s.RegisterAnalyzer(pnpmpolicy.New())
 	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
 	s.RegisterAnalyzer(toxicflow.New())
 	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())

--- a/internal/engine/pnpmpolicy/metadata.go
+++ b/internal/engine/pnpmpolicy/metadata.go
@@ -1,0 +1,141 @@
+package pnpmpolicy
+
+import "github.com/garagon/aguara/internal/rulemeta"
+
+// RuleMetadata returns the catalog entries for every rule this analyzer
+// emits. Co-located with the analyzer so `aguara explain` and
+// `list-rules` stay in sync with what scan actually reports. Severity
+// and Category here MUST match the values the analyzer sets on each
+// emitted Finding (locked by rulecatalog's metadata-match test).
+func RuleMetadata() []rulemeta.Rule {
+	return []rulemeta.Rule{
+		{
+			ID:       RuleDangerousBuilds,
+			Name:     "pnpm dangerouslyAllowAllBuilds enabled",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPnpmPolicy,
+			Description: "pnpm-workspace.yaml sets dangerouslyAllowAllBuilds: true. This lets " +
+				"every dependency, direct or transitive, run install-time lifecycle scripts " +
+				"(preinstall / install / postinstall) without approval. It is the classic " +
+				"supply-chain malware entry point that pnpm's build-approval model exists to " +
+				"close, re-opened by a single flag.",
+			Remediation: "Remove dangerouslyAllowAllBuilds: true. Approve the specific packages " +
+				"that genuinely need to run build scripts via allowBuilds (or `pnpm approve-builds`), " +
+				"leaving everything else unable to execute install-time code.",
+		},
+		{
+			ID:       RuleStrictDepBuildsDisabled,
+			Name:     "pnpm strictDepBuilds disabled",
+			Severity: "MEDIUM",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPnpmPolicy,
+			Description: "pnpm-workspace.yaml sets strictDepBuilds: false (the v11 default is true). " +
+				"With strict dep builds off, a dependency that wants to run an unapproved build " +
+				"script produces a warning instead of failing the install, so unreviewed " +
+				"install-time code can slip through CI unnoticed.",
+			Remediation: "Remove strictDepBuilds: false (or set it to true) so an unapproved build " +
+				"script fails the install and forces an explicit allowBuilds decision.",
+		},
+		{
+			ID:       RuleExoticSubdepsDisabled,
+			Name:     "pnpm blockExoticSubdeps disabled",
+			Severity: "MEDIUM",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPnpmPolicy,
+			Description: "pnpm-workspace.yaml sets blockExoticSubdeps: false (the v11 default is true). " +
+				"This allows transitive dependencies to be resolved from exotic sources (direct git " +
+				"URLs, tarball URLs) rather than the registry, widening the set of code that can " +
+				"enter the dependency tree without registry-level provenance.",
+			Remediation: "Remove blockExoticSubdeps: false (or set it to true) so transitive " +
+				"dependencies must come from the configured registry. If a specific exotic subdep " +
+				"is required, vet it and pin it explicitly rather than disabling the block globally.",
+		},
+		{
+			ID:       RuleTrustLockfile,
+			Name:     "pnpm trustLockfile enabled",
+			Severity: "MEDIUM",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPnpmPolicy,
+			Description: "pnpm-workspace.yaml sets trustLockfile: true. pnpm then stops re-applying " +
+				"minimumReleaseAge and trustPolicy to entries already present in the loaded lockfile. " +
+				"In a closed repo this can be acceptable, but on an open-source project or any repo " +
+				"that takes outside contributions it raises the risk of lockfile poisoning, since a " +
+				"tampered lockfile entry skips supply-chain verification.",
+			Remediation: "Remove trustLockfile: true so pnpm keeps verifying lockfile entries against " +
+				"minimumReleaseAge and trustPolicy. Only consider enabling it in fully closed repos " +
+				"where the lockfile is trusted end to end.",
+		},
+		{
+			ID:       RuleMinReleaseAgeDisabled,
+			Name:     "pnpm minimumReleaseAge disabled",
+			Severity: "LOW",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPnpmPolicy,
+			Description: "pnpm-workspace.yaml sets minimumReleaseAge: 0, an explicit opt-out of the " +
+				"v11 default (1440 minutes). The release-age window blunts attacks that rely on a " +
+				"freshly published malicious version being installed within minutes; setting it to 0 " +
+				"removes that delay entirely.",
+			Remediation: "Remove minimumReleaseAge: 0 to fall back to the default window, or set a " +
+				"positive value (e.g. 1440 for one day) so newly published versions are not installed " +
+				"immediately.",
+		},
+		{
+			ID:       RuleMinReleaseAgeNonStrict,
+			Name:     "pnpm minimumReleaseAge not strictly enforced",
+			Severity: "LOW",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPnpmPolicy,
+			Description: "pnpm-workspace.yaml configures minimumReleaseAge with a positive value but " +
+				"also sets minimumReleaseAgeStrict: false. Non-strict mode lets pnpm fall back to a " +
+				"version that does not meet the age threshold when no compatible alternative exists, " +
+				"so the release-age protection can be silently bypassed.",
+			Remediation: "Set minimumReleaseAgeStrict: true (or remove the false override) so the " +
+				"release-age threshold is always enforced. Resolve version conflicts by pinning a " +
+				"compatible aged version rather than allowing a fresh fallback.",
+		},
+		{
+			ID:       RuleTrustPolicyOff,
+			Name:     "pnpm trustPolicy explicitly off",
+			Severity: "LOW",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPnpmPolicy,
+			Description: "pnpm-workspace.yaml explicitly sets trustPolicy: off. While off is the " +
+				"current built-in default, configuring it explicitly opts the project out of trust " +
+				"evidence checks (such as no-downgrade) that harden the lockfile against tampering. " +
+				"The analyzer only flags the explicit setting, never its absence.",
+			Remediation: "Consider a stricter trust policy such as no-downgrade, which blocks " +
+				"downgrades of trust evidence. If off is intentional, document why; the finding only " +
+				"surfaces because the opt-out is explicit.",
+		},
+		{
+			ID:       RuleLegacyBuildPolicy,
+			Name:     "pnpm legacy v10 build-policy setting",
+			Severity: "INFO",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPnpmPolicy,
+			Description: "pnpm-workspace.yaml uses a build-policy setting that pnpm v10 honored but " +
+				"v11 removed or replaced (onlyBuiltDependencies, neverBuiltDependencies, " +
+				"ignoredBuiltDependencies, ignoreDepScripts, onlyBuiltDependenciesFile). On v11 the " +
+				"setting no longer takes effect, so the intended build restriction may silently not " +
+				"apply. This is a migration nudge, not a vulnerability.",
+			Remediation: "Migrate the legacy setting to allowBuilds, which is the v11 mechanism for " +
+				"deciding which dependencies may run build scripts. Verify the resulting policy " +
+				"matches the original intent.",
+		},
+		{
+			ID:       RuleBuildApprovalPending,
+			Name:     "pnpm allowBuilds entry pending decision",
+			Severity: "MEDIUM",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPnpmPolicy,
+			Description: "pnpm-workspace.yaml has an allowBuilds entry with no explicit true/false " +
+				"decision (a null/empty placeholder). pnpm adds such placeholders for dependencies " +
+				"with build scripts so a human can decide whether to allow them; an undecided entry " +
+				"means a build script is still pending review.",
+			Remediation: "Set each placeholder allowBuilds entry to true (allow the build script) or " +
+				"false (block it) after reviewing what the package's install-time script does. Run " +
+				"`pnpm approve-builds` to make the decision interactively.",
+		},
+	}
+}

--- a/internal/engine/pnpmpolicy/pnpmpolicy.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy.go
@@ -1,0 +1,329 @@
+// Package pnpmpolicy is a small, auditable analyzer for pnpm
+// supply-chain posture. It does NOT resolve package@version against
+// threat intel (that is packagecheck's job); it reads the project's
+// pnpm-workspace.yaml and reports where the configured trust controls
+// have been weakened relative to pnpm v11 defaults.
+//
+// Design rules (locked in the spec):
+//   - Single file. Only pnpm-workspace.yaml is a target. No
+//     package.json read, no .npmrc, no cross-file correlation, no
+//     pnpm-version inference. Severities are fixed, so the catalog
+//     (explain / list-rules) and scan output never disagree.
+//   - Defaults are never findings. The analyzer fires only on an
+//     explicit value that is less safe than the v11 default; the
+//     absence of a setting is treated as the (secure) default and
+//     stays silent. This keeps it quiet on the millions of repos that
+//     simply do not opt into extra hardening.
+//   - yaml.Node parsing (not a flat struct) so: a single mis-typed
+//     field cannot blind the whole analyzer, dynamic values like
+//     ${AGE} are skipped rather than crashing, and every finding
+//     carries the exact line of the offending field.
+package pnpmpolicy
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/garagon/aguara/internal/rulemeta"
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+	"gopkg.in/yaml.v3"
+)
+
+// Rule IDs emitted by this analyzer.
+const (
+	RuleDangerousBuilds         = "PNPM_DANGEROUS_BUILDS_001"
+	RuleStrictDepBuildsDisabled = "PNPM_STRICT_DEP_BUILDS_DISABLED_001"
+	RuleExoticSubdepsDisabled   = "PNPM_EXOTIC_SUBDEPS_DISABLED_001"
+	RuleTrustLockfile           = "PNPM_TRUST_LOCKFILE_001"
+	RuleMinReleaseAgeDisabled   = "PNPM_MIN_RELEASE_AGE_DISABLED_001"
+	RuleMinReleaseAgeNonStrict  = "PNPM_MIN_RELEASE_AGE_NON_STRICT_001"
+	RuleTrustPolicyOff          = "PNPM_TRUST_POLICY_OFF_001"
+	RuleLegacyBuildPolicy       = "PNPM_LEGACY_BUILD_POLICY_001"
+	RuleBuildApprovalPending    = "PNPM_BUILD_APPROVAL_PENDING_001"
+)
+
+// AnalyzerName is the analyzer identifier surfaced on findings.
+const AnalyzerName = rulemeta.AnalyzerPnpmPolicy
+
+const category = "supply-chain"
+
+// legacyKeys are pnpm v10 build-policy settings removed or replaced in
+// v11. Presence is a migration nudge (INFO), not a vulnerability.
+var legacyKeys = []string{
+	"onlyBuiltDependencies",
+	"neverBuiltDependencies",
+	"ignoredBuiltDependencies",
+	"ignoreDepScripts",
+	"onlyBuiltDependenciesFile",
+}
+
+// Analyzer implements scanner.Analyzer.
+type Analyzer struct{}
+
+// New constructs the pnpm-policy analyzer.
+func New() *Analyzer { return &Analyzer{} }
+
+// Name returns the analyzer identifier.
+func (a *Analyzer) Name() string { return AnalyzerName }
+
+// Analyze reads pnpm-workspace.yaml and reports weakened supply-chain
+// controls. A non-target file, malformed YAML, or a file whose root is
+// not a mapping all return no findings (and never panic).
+func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.Finding, error) {
+	if !isTarget(target) {
+		return nil, nil
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(target.Content, &doc); err != nil {
+		// Malformed YAML: stay silent rather than guess or error.
+		return nil, nil
+	}
+	root := mappingRoot(&doc)
+	if root == nil {
+		return nil, nil
+	}
+	fields := topLevelFields(root)
+
+	src := strings.Split(string(target.Content), "\n")
+	rel := target.RelPath
+	if rel == "" {
+		rel = target.Path
+	}
+
+	var findings []types.Finding
+	emit := func(id, name, sev, desc string, line int, rem string) {
+		findings = append(findings, types.Finding{
+			RuleID:      id,
+			RuleName:    name,
+			Severity:    severity(sev),
+			Category:    category,
+			Description: desc,
+			FilePath:    rel,
+			Line:        line,
+			MatchedText: srcLine(src, line),
+			Remediation: rem,
+			Analyzer:    AnalyzerName,
+		})
+	}
+
+	// 1. dangerouslyAllowAllBuilds: true -> HIGH
+	if f, ok := fields["dangerouslyAllowAllBuilds"]; ok {
+		if b, parsed := yamlBool(f.value.Value); parsed && b {
+			emit(RuleDangerousBuilds, "pnpm dangerouslyAllowAllBuilds enabled", "HIGH",
+				"dangerouslyAllowAllBuilds: true lets every direct and transitive dependency run install-time lifecycle scripts without approval.",
+				f.line,
+				"Remove dangerouslyAllowAllBuilds: true and approve only the packages that need build scripts via allowBuilds (or `pnpm approve-builds`).")
+		}
+	}
+
+	// 2. strictDepBuilds: false -> MEDIUM (v11 default is true).
+	if f, ok := fields["strictDepBuilds"]; ok {
+		if b, parsed := yamlBool(f.value.Value); parsed && !b {
+			emit(RuleStrictDepBuildsDisabled, "pnpm strictDepBuilds disabled", "MEDIUM",
+				"strictDepBuilds: false downgrades an unapproved build script from an install failure to a warning, so unreviewed install-time code can pass CI.",
+				f.line,
+				"Remove strictDepBuilds: false (or set it to true) so an unapproved build script fails the install and forces an explicit allowBuilds decision.")
+		}
+	}
+
+	// 3. blockExoticSubdeps: false -> MEDIUM (v11 default is true).
+	if f, ok := fields["blockExoticSubdeps"]; ok {
+		if b, parsed := yamlBool(f.value.Value); parsed && !b {
+			emit(RuleExoticSubdepsDisabled, "pnpm blockExoticSubdeps disabled", "MEDIUM",
+				"blockExoticSubdeps: false allows transitive dependencies to resolve from git/tarball URLs instead of the registry, widening the code that can enter the tree without registry provenance.",
+				f.line,
+				"Remove blockExoticSubdeps: false (or set it to true). If a specific exotic subdep is required, vet and pin it explicitly rather than disabling the block globally.")
+		}
+	}
+
+	// 4. trustLockfile: true -> MEDIUM (v11 default is false).
+	if f, ok := fields["trustLockfile"]; ok {
+		if b, parsed := yamlBool(f.value.Value); parsed && b {
+			emit(RuleTrustLockfile, "pnpm trustLockfile enabled", "MEDIUM",
+				"trustLockfile: true stops pnpm re-applying minimumReleaseAge and trustPolicy to lockfile entries, raising lockfile-poisoning risk on repos that take outside contributions.",
+				f.line,
+				"Remove trustLockfile: true so pnpm keeps verifying lockfile entries. Only consider it in fully closed repos where the lockfile is trusted end to end.")
+		}
+	}
+
+	// 5 + 6. minimumReleaseAge / minimumReleaseAgeStrict.
+	minAgeSet, minAgeVal := false, 0
+	if f, ok := fields["minimumReleaseAge"]; ok {
+		if n, parsed := yamlInt(f.value.Value); parsed {
+			minAgeSet, minAgeVal = true, n
+			if n == 0 {
+				emit(RuleMinReleaseAgeDisabled, "pnpm minimumReleaseAge disabled", "LOW",
+					"minimumReleaseAge: 0 is an explicit opt-out of the v11 default (1440 minutes), removing the wait window that protects against freshly published malicious versions.",
+					f.line,
+					"Remove minimumReleaseAge: 0 to use the default window, or set a positive value (e.g. 1440 for one day).")
+			}
+		}
+	}
+	// 6 fires only when minimumReleaseAge is explicitly set to a positive
+	// value AND strict is explicitly false. Without an explicit positive
+	// age, `minimumReleaseAgeStrict: false` may just be declaring the v11
+	// compatibility default, so we stay silent.
+	if f, ok := fields["minimumReleaseAgeStrict"]; ok && minAgeSet && minAgeVal > 0 {
+		if b, parsed := yamlBool(f.value.Value); parsed && !b {
+			emit(RuleMinReleaseAgeNonStrict, "pnpm minimumReleaseAge not strictly enforced", "LOW",
+				"minimumReleaseAge is set to a positive value but minimumReleaseAgeStrict: false lets pnpm fall back to a version below the age threshold when no compatible alternative exists.",
+				f.line,
+				"Set minimumReleaseAgeStrict: true (or remove the false override) so the release-age threshold is always enforced.")
+		}
+	}
+
+	// 7. trustPolicy: off (explicit) -> LOW. Compared on the literal
+	// value because YAML resolves bare `off` as a boolean; we want the
+	// string token, and absence never fires.
+	if f, ok := fields["trustPolicy"]; ok {
+		if strings.EqualFold(strings.TrimSpace(f.value.Value), "off") {
+			emit(RuleTrustPolicyOff, "pnpm trustPolicy explicitly off", "LOW",
+				"trustPolicy: off is set explicitly, opting the project out of trust-evidence checks (such as no-downgrade) that harden the lockfile.",
+				f.line,
+				"Consider a stricter trust policy such as no-downgrade. If off is intentional, document why; the finding only surfaces because the opt-out is explicit.")
+		}
+	}
+
+	// 8. Legacy v10 build-policy settings -> INFO, one per present key.
+	for _, k := range legacyKeys {
+		if f, ok := fields[k]; ok {
+			emit(RuleLegacyBuildPolicy, "pnpm legacy v10 build-policy setting", "INFO",
+				fmt.Sprintf("%q is a pnpm v10 build-policy setting removed or replaced in v11; on v11 it no longer takes effect, so the intended build restriction may silently not apply.", k),
+				f.line,
+				"Migrate this setting to allowBuilds, the v11 mechanism for deciding which dependencies may run build scripts, and verify the resulting policy matches the original intent.")
+		}
+	}
+
+	// 9. allowBuilds entries left undecided (null/empty placeholder) ->
+	// MEDIUM, one per pending entry.
+	if f, ok := fields["allowBuilds"]; ok && f.value.Kind == yaml.MappingNode {
+		for i := 0; i+1 < len(f.value.Content); i += 2 {
+			keyNode, valNode := f.value.Content[i], f.value.Content[i+1]
+			if isNull(valNode) {
+				emit(RuleBuildApprovalPending, "pnpm allowBuilds entry pending decision", "MEDIUM",
+					fmt.Sprintf("allowBuilds entry %q has no explicit true/false decision; the package has a build script still pending review.", keyNode.Value),
+					keyNode.Line,
+					"Set this allowBuilds entry to true (allow) or false (block) after reviewing the package's install-time script, or run `pnpm approve-builds`.")
+			}
+		}
+	}
+
+	return findings, nil
+}
+
+// field pairs a top-level setting's value node with the line of its key
+// (where the finding points).
+type field struct {
+	value *yaml.Node
+	line  int
+}
+
+// topLevelFields indexes the root mapping by key. Later duplicate keys
+// win, mirroring how a YAML loader resolves them.
+func topLevelFields(root *yaml.Node) map[string]field {
+	out := make(map[string]field, len(root.Content)/2)
+	for i := 0; i+1 < len(root.Content); i += 2 {
+		k, v := root.Content[i], root.Content[i+1]
+		out[k.Value] = field{value: v, line: k.Line}
+	}
+	return out
+}
+
+// mappingRoot returns the top-level mapping node of a parsed document,
+// or nil if the document is empty or not a mapping at the root.
+func mappingRoot(doc *yaml.Node) *yaml.Node {
+	n := doc
+	if n.Kind == yaml.DocumentNode {
+		if len(n.Content) == 0 {
+			return nil
+		}
+		n = n.Content[0]
+	}
+	if n.Kind == yaml.MappingNode {
+		return n
+	}
+	return nil
+}
+
+// yamlBool interprets the YAML 1.1 boolean spellings pnpm config uses.
+// Returns (value, true) for a recognized boolean token, (false, false)
+// otherwise (dynamic values like ${X}, numbers, arbitrary strings).
+func yamlBool(s string) (bool, bool) {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "true", "yes", "on":
+		return true, true
+	case "false", "no", "off":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+// yamlInt parses an integer setting. Dynamic values (containing ${...})
+// and non-numeric values return ok=false so the analyzer stays silent
+// rather than guessing.
+func yamlInt(s string) (int, bool) {
+	s = strings.TrimSpace(s)
+	if strings.Contains(s, "${") {
+		return 0, false
+	}
+	n, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, false
+	}
+	return n, true
+}
+
+// isNull reports whether a value node is an undecided placeholder: an
+// explicit null/~, or an empty scalar (`key:` with nothing after it).
+func isNull(n *yaml.Node) bool {
+	if n == nil {
+		return true
+	}
+	if n.Tag == "!!null" {
+		return true
+	}
+	return n.Kind == yaml.ScalarNode && strings.TrimSpace(n.Value) == ""
+}
+
+// srcLine returns the trimmed source line (1-based) for MatchedText, or
+// "" when out of range.
+func srcLine(lines []string, n int) string {
+	if n < 1 || n > len(lines) {
+		return ""
+	}
+	return strings.TrimSpace(lines[n-1])
+}
+
+// severity maps the canonical string to a types.Severity. Unknown
+// strings degrade to INFO rather than panicking; the metadata strings
+// are all known so this is defensive only.
+func severity(s string) types.Severity {
+	sev, err := types.ParseSeverity(s)
+	if err != nil {
+		return types.SeverityInfo
+	}
+	return sev
+}
+
+// isTarget matches only pnpm-workspace.yaml (by base name, on either
+// the absolute or relative path).
+func isTarget(t *scanner.Target) bool {
+	if t == nil {
+		return false
+	}
+	for _, p := range []string{t.RelPath, t.Path} {
+		if p == "" {
+			continue
+		}
+		if filepath.Base(filepath.ToSlash(p)) == "pnpm-workspace.yaml" {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/engine/pnpmpolicy/pnpmpolicy.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy.go
@@ -264,11 +264,26 @@ type entry struct {
 // with YAML merge keys (`<<:`) expanded. Explicitly-written keys take
 // precedence over merged ones, and the first occurrence of a key wins
 // (explicit keys are visited before merges, mirroring YAML merge
-// semantics). Depth is bounded to defuse anchor cycles.
+// semantics).
 func flatten(node *yaml.Node, depth int) []entry {
+	return flattenVisited(node, depth, make(map[*yaml.Node]bool))
+}
+
+// flattenVisited is flatten with a visited-node set so a self-referential
+// or fan-out merge (e.g. `<<: [*d, *d, *d]` where *d merges itself)
+// expands each mapping node at most once. Merge keys are idempotent, so
+// skipping an already-seen node is semantically correct and bounds the
+// work to O(nodes) instead of exponential. Depth stays as a second
+// guard.
+func flattenVisited(node *yaml.Node, depth int, visited map[*yaml.Node]bool) []entry {
 	if node == nil || node.Kind != yaml.MappingNode || depth > maxMergeDepth {
 		return nil
 	}
+	if visited[node] {
+		return nil
+	}
+	visited[node] = true
+
 	var out []entry
 	seen := make(map[string]bool)
 	add := func(e entry) {
@@ -289,7 +304,7 @@ func flatten(node *yaml.Node, depth int) []entry {
 	}
 	for _, mn := range merges {
 		for _, tgt := range mergeTargets(mn) {
-			for _, e := range flatten(tgt, depth+1) {
+			for _, e := range flattenVisited(tgt, depth+1, visited) {
 				add(e)
 			}
 		}

--- a/internal/engine/pnpmpolicy/pnpmpolicy.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy.go
@@ -37,6 +37,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"unicode"
 
 	"github.com/garagon/aguara/internal/rulemeta"
 	"github.com/garagon/aguara/internal/scanner"
@@ -104,19 +105,26 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	}
 
 	// Flatten the root mapping with merge keys resolved, then index it
-	// by normalized key so kebab-case and camelCase resolve together.
-	// First-wins on the normalized key: flatten emits explicit keys
-	// before merged ones, so an explicit value wins over a merged one
-	// even when the two use different spellings of the same setting
-	// (e.g. explicit dangerouslyAllowAllBuilds vs merged
-	// dangerously-allow-all-builds).
+	// by normalized key so kebab-case and camelCase resolve to the same
+	// setting. Precedence mirrors pnpm's config loading:
+	//   - an explicit key always wins over a merged one;
+	//   - among explicit keys, the last value wins (later overrides);
+	//   - among merged keys, the first wins (YAML merge semantics).
 	entries := flatten(root, 0)
 	idx := make(map[string]entry, len(entries))
-	indexed := make(map[string]bool, len(entries))
+	explicitSet := make(map[string]bool, len(entries))
 	for _, e := range entries {
-		if nk := normalizeKey(e.key); !indexed[nk] {
-			indexed[nk] = true
-			idx[nk] = e
+		nk := normalizeKey(e.key)
+		if !e.merged {
+			idx[nk] = e // last explicit wins, and overrides any merged value
+			explicitSet[nk] = true
+			continue
+		}
+		if explicitSet[nk] {
+			continue // an explicit value already won
+		}
+		if _, ok := idx[nk]; !ok {
+			idx[nk] = e // first merged wins
 		}
 	}
 	get := func(name string) (entry, bool) {
@@ -238,7 +246,12 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	// MEDIUM, one per pending entry. The allowBuilds mapping is flattened
 	// too so entries supplied through a merge key are seen.
 	if e, ok := get("allowBuilds"); ok && e.value.Kind == yaml.MappingNode {
+		seenPkg := make(map[string]bool)
 		for _, ab := range flatten(e.value, 0) {
+			if seenPkg[ab.key] {
+				continue // a decision for this package already won
+			}
+			seenPkg[ab.key] = true
 			if isNull(ab.value) {
 				emit(RuleBuildApprovalPending, "pnpm allowBuilds entry pending decision", "MEDIUM",
 					fmt.Sprintf("allowBuilds entry %q has no explicit true/false decision; the package has a build script still pending review.", ab.key),
@@ -252,19 +265,22 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 }
 
 // entry is a resolved key/value pair: the value node, the line of the
-// key (where a finding points), and the original (un-normalized) key
-// text for display.
+// key (where a finding points), the original (un-normalized) key text
+// for display, and whether it came from a merge key rather than being
+// written directly at this mapping level (merged values lose to explicit
+// ones during indexing).
 type entry struct {
-	key   string
-	value *yaml.Node
-	line  int
+	key    string
+	value  *yaml.Node
+	line   int
+	merged bool
 }
 
-// flatten returns the key/value pairs of a mapping node in source order
-// with YAML merge keys (`<<:`) expanded. Explicitly-written keys take
-// precedence over merged ones, and the first occurrence of a key wins
-// (explicit keys are visited before merges, mirroring YAML merge
-// semantics).
+// flatten returns the key/value pairs of a mapping node in source order,
+// explicit keys first and then keys pulled in through YAML merge keys
+// (`<<:`), each tagged with merged. Duplicates are kept; precedence is
+// resolved by the caller's index so pnpm's last-wins (explicit) /
+// first-wins (merged) rules can be applied across spellings.
 func flatten(node *yaml.Node, depth int) []entry {
 	return flattenVisited(node, depth, make(map[*yaml.Node]bool))
 }
@@ -284,15 +300,7 @@ func flattenVisited(node *yaml.Node, depth int, visited map[*yaml.Node]bool) []e
 	}
 	visited[node] = true
 
-	var out []entry
-	seen := make(map[string]bool)
-	add := func(e entry) {
-		if !seen[e.key] {
-			seen[e.key] = true
-			out = append(out, e)
-		}
-	}
-
+	var out, merged []entry
 	var merges []*yaml.Node
 	for i := 0; i+1 < len(node.Content); i += 2 {
 		k, v := node.Content[i], node.Content[i+1]
@@ -300,16 +308,17 @@ func flattenVisited(node *yaml.Node, depth int, visited map[*yaml.Node]bool) []e
 			merges = append(merges, v)
 			continue
 		}
-		add(entry{key: k.Value, value: v, line: k.Line})
+		out = append(out, entry{key: k.Value, value: v, line: k.Line})
 	}
 	for _, mn := range merges {
 		for _, tgt := range mergeTargets(mn) {
 			for _, e := range flattenVisited(tgt, depth+1, visited) {
-				add(e)
+				e.merged = true // anything reached through a merge is merged from here
+				merged = append(merged, e)
 			}
 		}
 	}
-	return out
+	return append(out, merged...)
 }
 
 // mergeTargets resolves the value of a `<<` merge key to the mapping
@@ -341,12 +350,31 @@ func mergeTargets(n *yaml.Node) []*yaml.Node {
 	return nil
 }
 
-// normalizeKey folds a pnpm setting key to a canonical form so that
-// kebab-case and camelCase spellings of the same setting compare equal
-// (pnpm treats them as one). e.g. "block-exotic-subdeps" and
-// "blockExoticSubdeps" both fold to "blockexoticsubdeps".
+// normalizeKey folds a pnpm setting key from kebab-case to camelCase so
+// the two spellings pnpm actually accepts compare equal (it treats
+// "block-exotic-subdeps" and "blockExoticSubdeps" as one setting). The
+// fold is case-sensitive and only joins on hyphens, so an unrecognized
+// smushed spelling like "blockexoticsubdeps" or a mis-cased
+// "BlockExoticSubdeps" (which pnpm does NOT honor as that setting) does
+// not collapse onto the real key and produce a false finding.
 func normalizeKey(s string) string {
-	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(s)), "-", "")
+	s = strings.TrimSpace(s)
+	var b strings.Builder
+	b.Grow(len(s))
+	upNext := false
+	for _, r := range s {
+		if r == '-' {
+			upNext = true
+			continue
+		}
+		if upNext {
+			b.WriteRune(unicode.ToUpper(r))
+			upNext = false
+			continue
+		}
+		b.WriteRune(r)
+	}
+	return b.String()
 }
 
 // mappingRoot returns the top-level mapping node of a parsed document,

--- a/internal/engine/pnpmpolicy/pnpmpolicy.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy.go
@@ -350,15 +350,25 @@ func mergeTargets(n *yaml.Node) []*yaml.Node {
 	return nil
 }
 
-// normalizeKey folds a pnpm setting key from kebab-case to camelCase so
-// the two spellings pnpm actually accepts compare equal (it treats
-// "block-exotic-subdeps" and "blockExoticSubdeps" as one setting). The
-// fold is case-sensitive and only joins on hyphens, so an unrecognized
-// smushed spelling like "blockexoticsubdeps" or a mis-cased
-// "BlockExoticSubdeps" (which pnpm does NOT honor as that setting) does
-// not collapse onto the real key and produce a false finding.
+// normalizeKey folds a well-formed kebab-case pnpm setting key to
+// camelCase so the two spellings pnpm actually accepts compare equal (it
+// treats "block-exotic-subdeps" and "blockExoticSubdeps" as one
+// setting). The fold is case-sensitive and only joins single hyphens
+// between non-empty segments. A spelling pnpm does NOT honor as that
+// setting -- a smushed "blockexoticsubdeps", a mis-cased
+// "BlockExoticSubdeps", or a malformed hyphenation
+// ("block--exotic-subdeps", a leading/trailing hyphen) -- is returned
+// unchanged so it cannot collapse onto a real key and produce a false
+// finding.
 func normalizeKey(s string) string {
 	s = strings.TrimSpace(s)
+	if strings.Contains(s, "-") {
+		for _, seg := range strings.Split(s, "-") {
+			if seg == "" {
+				return s // leading/trailing/doubled hyphen: not a valid kebab key
+			}
+		}
+	}
 	var b strings.Builder
 	b.Grow(len(s))
 	upNext := false

--- a/internal/engine/pnpmpolicy/pnpmpolicy.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy.go
@@ -105,10 +105,19 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 
 	// Flatten the root mapping with merge keys resolved, then index it
 	// by normalized key so kebab-case and camelCase resolve together.
+	// First-wins on the normalized key: flatten emits explicit keys
+	// before merged ones, so an explicit value wins over a merged one
+	// even when the two use different spellings of the same setting
+	// (e.g. explicit dangerouslyAllowAllBuilds vs merged
+	// dangerously-allow-all-builds).
 	entries := flatten(root, 0)
 	idx := make(map[string]entry, len(entries))
+	indexed := make(map[string]bool, len(entries))
 	for _, e := range entries {
-		idx[normalizeKey(e.key)] = e
+		if nk := normalizeKey(e.key); !indexed[nk] {
+			indexed[nk] = true
+			idx[nk] = e
+		}
 	}
 	get := func(name string) (entry, bool) {
 		e, ok := idx[normalizeKey(name)]

--- a/internal/engine/pnpmpolicy/pnpmpolicy.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy.go
@@ -18,6 +18,17 @@
 //     field cannot blind the whole analyzer, dynamic values like
 //     ${AGE} are skipped rather than crashing, and every finding
 //     carries the exact line of the offending field.
+//
+// Key resolution mirrors what pnpm actually loads: setting keys are
+// matched case-insensitively with kebab-case and camelCase treated as
+// the same setting (pnpm normalizes `block-exotic-subdeps` and
+// `blockExoticSubdeps` to one value), and YAML merge keys (`<<:`) are
+// expanded before evaluation so a value supplied through an anchor is
+// not missed. Boolean values use YAML 1.1 spellings (true/false/yes/
+// no/on/off, matching the js-yaml loader pnpm uses); a value that is
+// not one of those tokens is treated as ambiguous and not evaluated,
+// rather than coerced, so an explicit "false" is never mis-flagged as
+// a dangerous opt-in.
 package pnpmpolicy
 
 import (
@@ -50,6 +61,10 @@ const (
 const AnalyzerName = rulemeta.AnalyzerPnpmPolicy
 
 const category = "supply-chain"
+
+// maxMergeDepth bounds YAML merge-key resolution (anchor cycles / deeply
+// nested merges) so a hostile file cannot cause unbounded recursion.
+const maxMergeDepth = 16
 
 // legacyKeys are pnpm v10 build-policy settings removed or replaced in
 // v11. Presence is a migration nudge (INFO), not a vulnerability.
@@ -87,7 +102,18 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	if root == nil {
 		return nil, nil
 	}
-	fields := topLevelFields(root)
+
+	// Flatten the root mapping with merge keys resolved, then index it
+	// by normalized key so kebab-case and camelCase resolve together.
+	entries := flatten(root, 0)
+	idx := make(map[string]entry, len(entries))
+	for _, e := range entries {
+		idx[normalizeKey(e.key)] = e
+	}
+	get := func(name string) (entry, bool) {
+		e, ok := idx[normalizeKey(name)]
+		return e, ok
+	}
 
 	src := strings.Split(string(target.Content), "\n")
 	rel := target.RelPath
@@ -112,54 +138,54 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	}
 
 	// 1. dangerouslyAllowAllBuilds: true -> HIGH
-	if f, ok := fields["dangerouslyAllowAllBuilds"]; ok {
-		if b, parsed := yamlBool(f.value.Value); parsed && b {
+	if e, ok := get("dangerouslyAllowAllBuilds"); ok {
+		if b, parsed := yamlBool(e.value.Value); parsed && b {
 			emit(RuleDangerousBuilds, "pnpm dangerouslyAllowAllBuilds enabled", "HIGH",
 				"dangerouslyAllowAllBuilds: true lets every direct and transitive dependency run install-time lifecycle scripts without approval.",
-				f.line,
+				e.line,
 				"Remove dangerouslyAllowAllBuilds: true and approve only the packages that need build scripts via allowBuilds (or `pnpm approve-builds`).")
 		}
 	}
 
 	// 2. strictDepBuilds: false -> MEDIUM (v11 default is true).
-	if f, ok := fields["strictDepBuilds"]; ok {
-		if b, parsed := yamlBool(f.value.Value); parsed && !b {
+	if e, ok := get("strictDepBuilds"); ok {
+		if b, parsed := yamlBool(e.value.Value); parsed && !b {
 			emit(RuleStrictDepBuildsDisabled, "pnpm strictDepBuilds disabled", "MEDIUM",
 				"strictDepBuilds: false downgrades an unapproved build script from an install failure to a warning, so unreviewed install-time code can pass CI.",
-				f.line,
+				e.line,
 				"Remove strictDepBuilds: false (or set it to true) so an unapproved build script fails the install and forces an explicit allowBuilds decision.")
 		}
 	}
 
 	// 3. blockExoticSubdeps: false -> MEDIUM (v11 default is true).
-	if f, ok := fields["blockExoticSubdeps"]; ok {
-		if b, parsed := yamlBool(f.value.Value); parsed && !b {
+	if e, ok := get("blockExoticSubdeps"); ok {
+		if b, parsed := yamlBool(e.value.Value); parsed && !b {
 			emit(RuleExoticSubdepsDisabled, "pnpm blockExoticSubdeps disabled", "MEDIUM",
 				"blockExoticSubdeps: false allows transitive dependencies to resolve from git/tarball URLs instead of the registry, widening the code that can enter the tree without registry provenance.",
-				f.line,
+				e.line,
 				"Remove blockExoticSubdeps: false (or set it to true). If a specific exotic subdep is required, vet and pin it explicitly rather than disabling the block globally.")
 		}
 	}
 
 	// 4. trustLockfile: true -> MEDIUM (v11 default is false).
-	if f, ok := fields["trustLockfile"]; ok {
-		if b, parsed := yamlBool(f.value.Value); parsed && b {
+	if e, ok := get("trustLockfile"); ok {
+		if b, parsed := yamlBool(e.value.Value); parsed && b {
 			emit(RuleTrustLockfile, "pnpm trustLockfile enabled", "MEDIUM",
 				"trustLockfile: true stops pnpm re-applying minimumReleaseAge and trustPolicy to lockfile entries, raising lockfile-poisoning risk on repos that take outside contributions.",
-				f.line,
+				e.line,
 				"Remove trustLockfile: true so pnpm keeps verifying lockfile entries. Only consider it in fully closed repos where the lockfile is trusted end to end.")
 		}
 	}
 
 	// 5 + 6. minimumReleaseAge / minimumReleaseAgeStrict.
 	minAgeSet, minAgeVal := false, 0
-	if f, ok := fields["minimumReleaseAge"]; ok {
-		if n, parsed := yamlInt(f.value.Value); parsed {
+	if e, ok := get("minimumReleaseAge"); ok {
+		if n, parsed := yamlInt(e.value.Value); parsed {
 			minAgeSet, minAgeVal = true, n
 			if n == 0 {
 				emit(RuleMinReleaseAgeDisabled, "pnpm minimumReleaseAge disabled", "LOW",
 					"minimumReleaseAge: 0 is an explicit opt-out of the v11 default (1440 minutes), removing the wait window that protects against freshly published malicious versions.",
-					f.line,
+					e.line,
 					"Remove minimumReleaseAge: 0 to use the default window, or set a positive value (e.g. 1440 for one day).")
 			}
 		}
@@ -168,46 +194,46 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	// value AND strict is explicitly false. Without an explicit positive
 	// age, `minimumReleaseAgeStrict: false` may just be declaring the v11
 	// compatibility default, so we stay silent.
-	if f, ok := fields["minimumReleaseAgeStrict"]; ok && minAgeSet && minAgeVal > 0 {
-		if b, parsed := yamlBool(f.value.Value); parsed && !b {
+	if e, ok := get("minimumReleaseAgeStrict"); ok && minAgeSet && minAgeVal > 0 {
+		if b, parsed := yamlBool(e.value.Value); parsed && !b {
 			emit(RuleMinReleaseAgeNonStrict, "pnpm minimumReleaseAge not strictly enforced", "LOW",
 				"minimumReleaseAge is set to a positive value but minimumReleaseAgeStrict: false lets pnpm fall back to a version below the age threshold when no compatible alternative exists.",
-				f.line,
+				e.line,
 				"Set minimumReleaseAgeStrict: true (or remove the false override) so the release-age threshold is always enforced.")
 		}
 	}
 
 	// 7. trustPolicy: off (explicit) -> LOW. Compared on the literal
-	// value because YAML resolves bare `off` as a boolean; we want the
-	// string token, and absence never fires.
-	if f, ok := fields["trustPolicy"]; ok {
-		if strings.EqualFold(strings.TrimSpace(f.value.Value), "off") {
+	// value because YAML resolves bare `off` as a string here; we want
+	// the token, and absence never fires.
+	if e, ok := get("trustPolicy"); ok {
+		if strings.EqualFold(strings.TrimSpace(e.value.Value), "off") {
 			emit(RuleTrustPolicyOff, "pnpm trustPolicy explicitly off", "LOW",
 				"trustPolicy: off is set explicitly, opting the project out of trust-evidence checks (such as no-downgrade) that harden the lockfile.",
-				f.line,
+				e.line,
 				"Consider a stricter trust policy such as no-downgrade. If off is intentional, document why; the finding only surfaces because the opt-out is explicit.")
 		}
 	}
 
 	// 8. Legacy v10 build-policy settings -> INFO, one per present key.
 	for _, k := range legacyKeys {
-		if f, ok := fields[k]; ok {
+		if e, ok := get(k); ok {
 			emit(RuleLegacyBuildPolicy, "pnpm legacy v10 build-policy setting", "INFO",
-				fmt.Sprintf("%q is a pnpm v10 build-policy setting removed or replaced in v11; on v11 it no longer takes effect, so the intended build restriction may silently not apply.", k),
-				f.line,
+				fmt.Sprintf("%q is a pnpm v10 build-policy setting removed or replaced in v11; on v11 it no longer takes effect, so the intended build restriction may silently not apply.", e.key),
+				e.line,
 				"Migrate this setting to allowBuilds, the v11 mechanism for deciding which dependencies may run build scripts, and verify the resulting policy matches the original intent.")
 		}
 	}
 
 	// 9. allowBuilds entries left undecided (null/empty placeholder) ->
-	// MEDIUM, one per pending entry.
-	if f, ok := fields["allowBuilds"]; ok && f.value.Kind == yaml.MappingNode {
-		for i := 0; i+1 < len(f.value.Content); i += 2 {
-			keyNode, valNode := f.value.Content[i], f.value.Content[i+1]
-			if isNull(valNode) {
+	// MEDIUM, one per pending entry. The allowBuilds mapping is flattened
+	// too so entries supplied through a merge key are seen.
+	if e, ok := get("allowBuilds"); ok && e.value.Kind == yaml.MappingNode {
+		for _, ab := range flatten(e.value, 0) {
+			if isNull(ab.value) {
 				emit(RuleBuildApprovalPending, "pnpm allowBuilds entry pending decision", "MEDIUM",
-					fmt.Sprintf("allowBuilds entry %q has no explicit true/false decision; the package has a build script still pending review.", keyNode.Value),
-					keyNode.Line,
+					fmt.Sprintf("allowBuilds entry %q has no explicit true/false decision; the package has a build script still pending review.", ab.key),
+					ab.line,
 					"Set this allowBuilds entry to true (allow) or false (block) after reviewing the package's install-time script, or run `pnpm approve-builds`.")
 			}
 		}
@@ -216,22 +242,87 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	return findings, nil
 }
 
-// field pairs a top-level setting's value node with the line of its key
-// (where the finding points).
-type field struct {
+// entry is a resolved key/value pair: the value node, the line of the
+// key (where a finding points), and the original (un-normalized) key
+// text for display.
+type entry struct {
+	key   string
 	value *yaml.Node
 	line  int
 }
 
-// topLevelFields indexes the root mapping by key. Later duplicate keys
-// win, mirroring how a YAML loader resolves them.
-func topLevelFields(root *yaml.Node) map[string]field {
-	out := make(map[string]field, len(root.Content)/2)
-	for i := 0; i+1 < len(root.Content); i += 2 {
-		k, v := root.Content[i], root.Content[i+1]
-		out[k.Value] = field{value: v, line: k.Line}
+// flatten returns the key/value pairs of a mapping node in source order
+// with YAML merge keys (`<<:`) expanded. Explicitly-written keys take
+// precedence over merged ones, and the first occurrence of a key wins
+// (explicit keys are visited before merges, mirroring YAML merge
+// semantics). Depth is bounded to defuse anchor cycles.
+func flatten(node *yaml.Node, depth int) []entry {
+	if node == nil || node.Kind != yaml.MappingNode || depth > maxMergeDepth {
+		return nil
+	}
+	var out []entry
+	seen := make(map[string]bool)
+	add := func(e entry) {
+		if !seen[e.key] {
+			seen[e.key] = true
+			out = append(out, e)
+		}
+	}
+
+	var merges []*yaml.Node
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		k, v := node.Content[i], node.Content[i+1]
+		if k.Tag == "!!merge" || k.Value == "<<" {
+			merges = append(merges, v)
+			continue
+		}
+		add(entry{key: k.Value, value: v, line: k.Line})
+	}
+	for _, mn := range merges {
+		for _, tgt := range mergeTargets(mn) {
+			for _, e := range flatten(tgt, depth+1) {
+				add(e)
+			}
+		}
 	}
 	return out
+}
+
+// mergeTargets resolves the value of a `<<` merge key to the mapping
+// node(s) it pulls in: an alias to a mapping, an inline mapping, or a
+// sequence of either.
+func mergeTargets(n *yaml.Node) []*yaml.Node {
+	if n == nil {
+		return nil
+	}
+	switch n.Kind {
+	case yaml.AliasNode:
+		return []*yaml.Node{n.Alias}
+	case yaml.MappingNode:
+		return []*yaml.Node{n}
+	case yaml.SequenceNode:
+		var out []*yaml.Node
+		for _, it := range n.Content {
+			switch it.Kind {
+			case yaml.AliasNode:
+				if it.Alias != nil {
+					out = append(out, it.Alias)
+				}
+			case yaml.MappingNode:
+				out = append(out, it)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// normalizeKey folds a pnpm setting key to a canonical form so that
+// kebab-case and camelCase spellings of the same setting compare equal
+// (pnpm treats them as one). e.g. "block-exotic-subdeps" and
+// "blockExoticSubdeps" both fold to "blockexoticsubdeps".
+func normalizeKey(s string) string {
+	return strings.ReplaceAll(strings.ToLower(strings.TrimSpace(s)), "-", "")
 }
 
 // mappingRoot returns the top-level mapping node of a parsed document,
@@ -252,7 +343,9 @@ func mappingRoot(doc *yaml.Node) *yaml.Node {
 
 // yamlBool interprets the YAML 1.1 boolean spellings pnpm config uses.
 // Returns (value, true) for a recognized boolean token, (false, false)
-// otherwise (dynamic values like ${X}, numbers, arbitrary strings).
+// otherwise (dynamic values like ${X}, numbers, arbitrary strings). A
+// non-boolean string is deliberately NOT coerced, so an explicit
+// "false" is never read as a dangerous opt-in.
 func yamlBool(s string) (bool, bool) {
 	switch strings.ToLower(strings.TrimSpace(s)) {
 	case "true", "yes", "on":

--- a/internal/engine/pnpmpolicy/pnpmpolicy_test.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy_test.go
@@ -193,6 +193,35 @@ dangerously-allow-all-builds: true
 	}
 }
 
+// TestUnrecognizedSpellingNotFlagged: pnpm only accepts kebab-case and
+// camelCase keys, so a smushed-lowercase or mis-cased spelling is a typo
+// pnpm ignores and must not produce a finding.
+func TestUnrecognizedSpellingNotFlagged(t *testing.T) {
+	for _, src := range []string{
+		"dangerouslyallowallbuilds: true\n", // no camel boundaries
+		"BlockExoticSubdeps: false\n",       // wrong leading case
+		"DANGEROUSLY_ALLOW_ALL_BUILDS: true\n",
+	} {
+		if got := ids(t, target, src); len(got) != 0 {
+			t.Fatalf("unrecognized key spelling must not fire, got %v on:\n%s", got, src)
+		}
+	}
+}
+
+// TestDuplicateExplicitSpellingLastWins: two explicit spellings of one
+// setting resolve to pnpm's last-wins, regardless of which spelling
+// comes second.
+func TestDuplicateExplicitSpellingLastWins(t *testing.T) {
+	// safe then unsafe -> unsafe wins -> fire.
+	if !fires(t, target, "dangerouslyAllowAllBuilds: false\ndangerously-allow-all-builds: true\n", RuleDangerousBuilds) {
+		t.Fatal("later explicit true must win over earlier explicit false")
+	}
+	// unsafe then safe -> safe wins -> no fire.
+	if fires(t, target, "dangerously-allow-all-builds: true\ndangerouslyAllowAllBuilds: false\n", RuleDangerousBuilds) {
+		t.Fatal("later explicit false must win over earlier explicit true")
+	}
+}
+
 // TestQuotedFalseNotFlagged: the spec's FP discipline requires that an
 // explicit intent-to-disable ("false") is never read as an opt-in.
 func TestQuotedFalseNotFlagged(t *testing.T) {

--- a/internal/engine/pnpmpolicy/pnpmpolicy_test.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy_test.go
@@ -142,6 +142,32 @@ dangerouslyAllowAllBuilds: false
 	}
 }
 
+// TestMixedSpellingMergePrecedence: an explicit value wins over a merged
+// one even when the two use different (kebab vs camel) spellings of the
+// same setting. pnpm treats the spellings as one setting, so an explicit
+// safe override must not be shadowed by a merged unsafe value, and an
+// explicit unsafe value must still be flagged.
+func TestMixedSpellingMergePrecedence(t *testing.T) {
+	// Merged unsafe (kebab) + explicit safe (camel) -> no finding.
+	safeWins := `defaults: &d
+  dangerously-allow-all-builds: true
+<<: *d
+dangerouslyAllowAllBuilds: false
+`
+	if fires(t, target, safeWins, RuleDangerousBuilds) {
+		t.Fatal("explicit camelCase false must win over merged kebab-case true")
+	}
+	// Merged safe (camel) + explicit unsafe (kebab) -> finding.
+	unsafeWins := `defaults: &d
+  dangerouslyAllowAllBuilds: false
+<<: *d
+dangerously-allow-all-builds: true
+`
+	if !fires(t, target, unsafeWins, RuleDangerousBuilds) {
+		t.Fatal("explicit kebab-case true must win over merged camelCase false")
+	}
+}
+
 // TestQuotedFalseNotFlagged: the spec's FP discipline requires that an
 // explicit intent-to-disable ("false") is never read as an opt-in.
 func TestQuotedFalseNotFlagged(t *testing.T) {

--- a/internal/engine/pnpmpolicy/pnpmpolicy_test.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy_test.go
@@ -87,6 +87,75 @@ func TestFalsePositives(t *testing.T) {
 	}
 }
 
+// TestKebabCaseKeys: pnpm normalizes kebab-case and camelCase setting
+// keys to the same value, so the analyzer must match both spellings.
+func TestKebabCaseKeys(t *testing.T) {
+	cases := []struct{ src, want string }{
+		{"dangerously-allow-all-builds: true\n", RuleDangerousBuilds},
+		{"block-exotic-subdeps: false\n", RuleExoticSubdepsDisabled},
+		{"trust-lockfile: true\n", RuleTrustLockfile},
+		{"minimum-release-age: 0\n", RuleMinReleaseAgeDisabled},
+		{"only-built-dependencies:\n  - esbuild\n", RuleLegacyBuildPolicy},
+		{"allow-builds:\n  sharp:\n", RuleBuildApprovalPending},
+	}
+	for _, c := range cases {
+		if !fires(t, target, c.src, c.want) {
+			t.Fatalf("kebab-case must fire %s on:\n%s", c.want, c.src)
+		}
+	}
+}
+
+// TestMergeKeysResolved: a setting supplied through a YAML merge key
+// (`<<: *anchor`) is applied by pnpm, so the analyzer must see it.
+func TestMergeKeysResolved(t *testing.T) {
+	src := `presets:
+  unsafe: &unsafe
+    dangerouslyAllowAllBuilds: true
+config:
+  <<: *unsafe
+`
+	// The merge happens inside `config:`, not at the root, so the root
+	// has no dangerous setting. Verify a root-level merge instead.
+	rootMerge := `defaults: &d
+  dangerouslyAllowAllBuilds: true
+<<: *d
+`
+	if !fires(t, target, rootMerge, RuleDangerousBuilds) {
+		t.Fatalf("root-level merge key must surface the merged dangerous setting")
+	}
+	// A nested merge under a non-pnpm key must NOT leak as a root setting.
+	if fires(t, target, src, RuleDangerousBuilds) {
+		t.Fatal("a merge under an unrelated key must not be read as a root setting")
+	}
+}
+
+// TestExplicitKeyWinsOverMerge: an explicit safe value overrides a
+// merged unsafe one (YAML merge precedence), so no finding fires.
+func TestExplicitKeyWinsOverMerge(t *testing.T) {
+	src := `defaults: &d
+  dangerouslyAllowAllBuilds: true
+<<: *d
+dangerouslyAllowAllBuilds: false
+`
+	if fires(t, target, src, RuleDangerousBuilds) {
+		t.Fatal("explicit dangerouslyAllowAllBuilds: false must win over the merged true")
+	}
+}
+
+// TestQuotedFalseNotFlagged: the spec's FP discipline requires that an
+// explicit intent-to-disable ("false") is never read as an opt-in.
+func TestQuotedFalseNotFlagged(t *testing.T) {
+	for _, src := range []string{
+		"dangerouslyAllowAllBuilds: \"false\"\n",
+		"dangerouslyAllowAllBuilds: no\n",
+		"dangerouslyAllowAllBuilds: off\n",
+	} {
+		if fires(t, target, src, RuleDangerousBuilds) {
+			t.Fatalf("a disable value must not fire HIGH:\n%s", src)
+		}
+	}
+}
+
 // TestNonStrictRequiresExplicitPositiveAge locks the spec's FP-discipline
 // rule: minimumReleaseAgeStrict: false on its own may just be declaring
 // the v11 compatibility default, so it must NOT fire without an explicit

--- a/internal/engine/pnpmpolicy/pnpmpolicy_test.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy_test.go
@@ -3,6 +3,7 @@ package pnpmpolicy
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/garagon/aguara/internal/scanner"
 )
@@ -126,6 +127,30 @@ config:
 	// A nested merge under a non-pnpm key must NOT leak as a root setting.
 	if fires(t, target, src, RuleDangerousBuilds) {
 		t.Fatal("a merge under an unrelated key must not be read as a root setting")
+	}
+}
+
+// TestMergeBombTerminates: a fan-out / self-referential merge must not
+// cause exponential or unbounded work. A crafted untrusted
+// pnpm-workspace.yaml should be analyzed in well under a second.
+func TestMergeBombTerminates(t *testing.T) {
+	// Self-referential anchor plus a fan-out merge sequence that would
+	// blow up if the same node were re-expanded per branch per depth.
+	src := `base: &b
+  dangerouslyAllowAllBuilds: true
+  <<: [*b, *b, *b, *b]
+<<: [*b, *b, *b, *b]
+`
+	done := make(chan map[string]bool, 1)
+	go func() { done <- ids(t, target, src) }()
+	select {
+	case got := <-done:
+		// And it must still resolve the merged setting correctly.
+		if !got[RuleDangerousBuilds] {
+			t.Fatal("merge bomb terminated but lost the merged dangerous setting")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("merge expansion did not terminate; possible exponential blowup")
 	}
 }
 

--- a/internal/engine/pnpmpolicy/pnpmpolicy_test.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy_test.go
@@ -198,9 +198,12 @@ dangerously-allow-all-builds: true
 // pnpm ignores and must not produce a finding.
 func TestUnrecognizedSpellingNotFlagged(t *testing.T) {
 	for _, src := range []string{
-		"dangerouslyallowallbuilds: true\n", // no camel boundaries
-		"BlockExoticSubdeps: false\n",       // wrong leading case
-		"DANGEROUSLY_ALLOW_ALL_BUILDS: true\n",
+		"dangerouslyallowallbuilds: true\n",     // no camel boundaries
+		"BlockExoticSubdeps: false\n",           // wrong leading case
+		"DANGEROUSLY_ALLOW_ALL_BUILDS: true\n",  // underscores, not kebab
+		"dangerously--allow-all-builds: true\n", // doubled hyphen
+		"dangerously-allow-all-builds-: true\n", // trailing hyphen
+		"-block-exotic-subdeps: false\n",        // leading hyphen
 	} {
 		if got := ids(t, target, src); len(got) != 0 {
 			t.Fatalf("unrecognized key spelling must not fire, got %v on:\n%s", got, src)

--- a/internal/engine/pnpmpolicy/pnpmpolicy_test.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy_test.go
@@ -239,6 +239,39 @@ func TestQuotedFalseNotFlagged(t *testing.T) {
 	}
 }
 
+// TestBooleanMatchesPnpmLoader locks the boolean model to pnpm's actual
+// config loader (js-yaml, YAML 1.1), where yes/no/on/off ARE booleans.
+// This deliberately differs from gopkg.in/yaml.v3 (which resolves
+// yes/off as strings): trusting the v3 tag here would diverge from pnpm
+// and miss real opt-ins like `dangerouslyAllowAllBuilds: yes`. A value
+// that is not a recognized boolean token is left un-evaluated.
+func TestBooleanMatchesPnpmLoader(t *testing.T) {
+	// yes/on resolve to true -> a truthy danger flag fires.
+	for _, v := range []string{"yes", "on", "true"} {
+		if !fires(t, target, "dangerouslyAllowAllBuilds: "+v+"\n", RuleDangerousBuilds) {
+			t.Fatalf("dangerouslyAllowAllBuilds: %s must fire (resolves true)", v)
+		}
+	}
+	// no/off resolve to false -> a flag whose UNSAFE value is false fires.
+	for _, v := range []string{"no", "off", "false"} {
+		if !fires(t, target, "strictDepBuilds: "+v+"\n", RuleStrictDepBuildsDisabled) {
+			t.Fatalf("strictDepBuilds: %s must fire (resolves false, the unsafe value)", v)
+		}
+	}
+	// A non-boolean token is ambiguous and not evaluated.
+	if got := ids(t, target, "dangerouslyAllowAllBuilds: maybe\n"); len(got) != 0 {
+		t.Fatalf("a non-boolean token must not be evaluated, got %v", got)
+	}
+}
+
+// TestQuotedZeroIsExplicitOptOut: a quoted "0" for minimumReleaseAge is
+// still an explicit 0 by intent, so it fires the disabled rule.
+func TestQuotedZeroIsExplicitOptOut(t *testing.T) {
+	if !fires(t, target, "minimumReleaseAge: \"0\"\n", RuleMinReleaseAgeDisabled) {
+		t.Fatal("minimumReleaseAge: \"0\" is an explicit opt-out and must fire")
+	}
+}
+
 // TestNonStrictRequiresExplicitPositiveAge locks the spec's FP-discipline
 // rule: minimumReleaseAgeStrict: false on its own may just be declaring
 // the v11 compatibility default, so it must NOT fire without an explicit

--- a/internal/engine/pnpmpolicy/pnpmpolicy_test.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy_test.go
@@ -1,0 +1,167 @@
+package pnpmpolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/garagon/aguara/internal/scanner"
+)
+
+// ids runs the analyzer over content presented as `name` and returns the
+// set of rule IDs emitted.
+func ids(t *testing.T, name, src string) map[string]bool {
+	t.Helper()
+	a := New()
+	f, err := a.Analyze(context.Background(), &scanner.Target{RelPath: name, Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	got := make(map[string]bool, len(f))
+	for _, x := range f {
+		got[x.RuleID] = true
+	}
+	return got
+}
+
+func fires(t *testing.T, name, src, id string) bool {
+	t.Helper()
+	return ids(t, name, src)[id]
+}
+
+const target = "pnpm-workspace.yaml"
+
+func TestTruePositives(t *testing.T) {
+	cases := []struct {
+		name, src, want string
+	}{
+		{"dangerous builds", "dangerouslyAllowAllBuilds: true\n", RuleDangerousBuilds},
+		{"strict dep builds off", "strictDepBuilds: false\n", RuleStrictDepBuildsDisabled},
+		{"exotic subdeps off", "blockExoticSubdeps: false\n", RuleExoticSubdepsDisabled},
+		{"trust lockfile on", "trustLockfile: true\n", RuleTrustLockfile},
+		{"min release age disabled", "minimumReleaseAge: 0\n", RuleMinReleaseAgeDisabled},
+		{
+			"min release age non-strict (with explicit positive age)",
+			"minimumReleaseAge: 1440\nminimumReleaseAgeStrict: false\n",
+			RuleMinReleaseAgeNonStrict,
+		},
+		{"trust policy explicitly off", "trustPolicy: off\n", RuleTrustPolicyOff},
+		{"legacy v10 setting", "onlyBuiltDependencies:\n  - esbuild\n", RuleLegacyBuildPolicy},
+		{"allow builds pending (null placeholder)", "allowBuilds:\n  sharp:\n", RuleBuildApprovalPending},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if !fires(t, target, c.src, c.want) {
+				t.Fatalf("expected %s to fire on:\n%s", c.want, c.src)
+			}
+		})
+	}
+}
+
+func TestFalsePositives(t *testing.T) {
+	cases := []struct {
+		name, file, src string
+	}{
+		// Wrong filename: never a target even with a tripping value.
+		{"not pnpm-workspace.yaml", "config.yaml", "dangerouslyAllowAllBuilds: true\n"},
+		{"random yaml", "docker-compose.yml", "trustLockfile: true\n"},
+		// Safe explicit values.
+		{"dangerous builds false", target, "dangerouslyAllowAllBuilds: false\n"},
+		{"strict dep builds true", target, "strictDepBuilds: true\n"},
+		{"block exotic subdeps true", target, "blockExoticSubdeps: true\n"},
+		{"trust lockfile false", target, "trustLockfile: false\n"},
+		{"min release age at default", target, "minimumReleaseAge: 1440\n"},
+		{"min release age positive", target, "minimumReleaseAge: 720\n"},
+		{"trust policy no-downgrade", target, "trustPolicy: no-downgrade\n"},
+		// Absence is the (secure) default: never a finding.
+		{"empty file", target, ""},
+		{"unrelated settings only", target, "packages:\n  - 'packages/*'\n"},
+		// allowBuilds with explicit decisions: nothing pending.
+		{"allow builds decided", target, "allowBuilds:\n  esbuild: true\n  sharp: false\n"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := ids(t, c.file, c.src); len(got) != 0 {
+				t.Fatalf("expected no findings, got %v on:\n%s", got, c.src)
+			}
+		})
+	}
+}
+
+// TestNonStrictRequiresExplicitPositiveAge locks the spec's FP-discipline
+// rule: minimumReleaseAgeStrict: false on its own may just be declaring
+// the v11 compatibility default, so it must NOT fire without an explicit
+// positive minimumReleaseAge in the same file.
+func TestNonStrictRequiresExplicitPositiveAge(t *testing.T) {
+	if fires(t, target, "minimumReleaseAgeStrict: false\n", RuleMinReleaseAgeNonStrict) {
+		t.Fatal("minimumReleaseAgeStrict: false alone must not fire (could be the v11 default)")
+	}
+	if fires(t, target, "minimumReleaseAge: 0\nminimumReleaseAgeStrict: false\n", RuleMinReleaseAgeNonStrict) {
+		t.Fatal("minimumReleaseAge: 0 is not a positive age; non-strict must not fire")
+	}
+	if !fires(t, target, "minimumReleaseAge: 1440\nminimumReleaseAgeStrict: false\n", RuleMinReleaseAgeNonStrict) {
+		t.Fatal("explicit positive age + non-strict must fire")
+	}
+}
+
+// TestLegacyIsInfoNotHigh confirms a v10 setting is reported as a
+// migration nudge (INFO), never as a HIGH vulnerability.
+func TestLegacyIsInfoNotHigh(t *testing.T) {
+	a := New()
+	f, err := a.Analyze(context.Background(), &scanner.Target{
+		RelPath: target,
+		Content: []byte("neverBuiltDependencies:\n  - fsevents\n"),
+	})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if len(f) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(f))
+	}
+	if f[0].RuleID != RuleLegacyBuildPolicy {
+		t.Fatalf("want %s, got %s", RuleLegacyBuildPolicy, f[0].RuleID)
+	}
+	if f[0].Severity.String() != "INFO" {
+		t.Fatalf("legacy finding must be INFO, got %s", f[0].Severity.String())
+	}
+}
+
+// TestDynamicValueNotEvaluated: a ${ENV} interpolation is not a concrete
+// opt-out, so minimumReleaseAge: ${AGE} must not fire the disabled rule.
+func TestDynamicValueNotEvaluated(t *testing.T) {
+	if fires(t, target, "minimumReleaseAge: ${AGE}\n", RuleMinReleaseAgeDisabled) {
+		t.Fatal("dynamic minimumReleaseAge must not be evaluated as 0")
+	}
+}
+
+// TestMalformedYAMLNoPanic: a syntactically broken file yields no
+// findings and does not panic.
+func TestMalformedYAMLNoPanic(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("analyzer panicked on malformed YAML: %v", r)
+		}
+	}()
+	if got := ids(t, target, "trustLockfile: true\n  : : broken\n\t- nope\n"); len(got) != 0 {
+		t.Fatalf("malformed YAML should yield no findings, got %v", got)
+	}
+}
+
+// TestFindingPointsAtField checks the finding carries the field's line
+// and source text, which is the whole point of the yaml.Node parser.
+func TestFindingPointsAtField(t *testing.T) {
+	a := New()
+	src := "packages:\n  - 'packages/*'\ndangerouslyAllowAllBuilds: true\n"
+	f, err := a.Analyze(context.Background(), &scanner.Target{RelPath: target, Content: []byte(src)})
+	if err != nil {
+		t.Fatalf("analyze: %v", err)
+	}
+	if len(f) != 1 {
+		t.Fatalf("want 1 finding, got %d", len(f))
+	}
+	if f[0].Line != 3 {
+		t.Fatalf("want line 3, got %d", f[0].Line)
+	}
+	if f[0].MatchedText != "dangerouslyAllowAllBuilds: true" {
+		t.Fatalf("unexpected matched text: %q", f[0].MatchedText)
+	}
+}

--- a/internal/rulecatalog/catalog.go
+++ b/internal/rulecatalog/catalog.go
@@ -22,6 +22,7 @@ import (
 	"github.com/garagon/aguara/internal/engine/jsrisk"
 	"github.com/garagon/aguara/internal/engine/nlp"
 	"github.com/garagon/aguara/internal/engine/pkgmeta"
+	"github.com/garagon/aguara/internal/engine/pnpmpolicy"
 	"github.com/garagon/aguara/internal/engine/pyrisk"
 	"github.com/garagon/aguara/internal/engine/rsbuild"
 	"github.com/garagon/aguara/internal/engine/rugpull"
@@ -121,6 +122,7 @@ func Build(opts Options) ([]rulemeta.Rule, error) {
 	out = append(out, jsrisk.RuleMetadata()...)
 	out = append(out, pyrisk.RuleMetadata()...)
 	out = append(out, rsbuild.RuleMetadata()...)
+	out = append(out, pnpmpolicy.RuleMetadata()...)
 	out = append(out, nlp.RuleMetadata()...)
 	out = append(out, toxicflow.RuleMetadata()...)
 	out = append(out, rugpull.RuleMetadata()...)

--- a/internal/rulecatalog/catalog_test.go
+++ b/internal/rulecatalog/catalog_test.go
@@ -27,13 +27,14 @@ func TestBuildIncludesYAMLAndAnalyzerRules(t *testing.T) {
 
 	// One representative ID per analyzer.
 	want := map[string]string{
-		"JS_DNS_TXT_EXFIL_001":  rulemeta.AnalyzerJSRisk,
-		"GHA_PWN_REQUEST_001":   rulemeta.AnalyzerCITrust,
-		"NPM_LIFECYCLE_GIT_001": rulemeta.AnalyzerPkgMeta,
-		"TOXIC_001":             rulemeta.AnalyzerToxicFlow,
-		"TOXIC_CROSS_001":       rulemeta.AnalyzerToxicFlow,
-		"NLP_HIDDEN_INSTRUCTION": rulemeta.AnalyzerNLP,
-		"AGENT_PERSISTENCE_001": rulemeta.AnalyzerJSRisk,
+		"JS_DNS_TXT_EXFIL_001":      rulemeta.AnalyzerJSRisk,
+		"GHA_PWN_REQUEST_001":       rulemeta.AnalyzerCITrust,
+		"NPM_LIFECYCLE_GIT_001":     rulemeta.AnalyzerPkgMeta,
+		"TOXIC_001":                 rulemeta.AnalyzerToxicFlow,
+		"TOXIC_CROSS_001":           rulemeta.AnalyzerToxicFlow,
+		"NLP_HIDDEN_INSTRUCTION":    rulemeta.AnalyzerNLP,
+		"AGENT_PERSISTENCE_001":     rulemeta.AnalyzerJSRisk,
+		"PNPM_DANGEROUS_BUILDS_001": rulemeta.AnalyzerPnpmPolicy,
 		// And one pattern rule from the YAML catalog (analyzer
 		// stays empty for these).
 		"PROMPT_INJECTION_001": rulemeta.AnalyzerPattern,
@@ -160,14 +161,25 @@ func TestAnalyzerMetadataMatchesEmittedSeverityAndCategory(t *testing.T) {
 		Category string
 	}
 	cases := map[string]want{
-		"TOXIC_001":             {Severity: "HIGH", Category: "toxic-flow"},
-		"TOXIC_002":             {Severity: "HIGH", Category: "toxic-flow"},
-		"TOXIC_003":             {Severity: "HIGH", Category: "toxic-flow"},
-		"TOXIC_CROSS_001":       {Severity: "HIGH", Category: "toxic-flow"},
-		"TOXIC_CROSS_002":       {Severity: "HIGH", Category: "toxic-flow"},
-		"TOXIC_CROSS_003":       {Severity: "HIGH", Category: "toxic-flow"},
-		"NLP_CRED_EXFIL_COMBO":  {Severity: "CRITICAL", Category: "exfiltration"},
-		"RUGPULL_001":           {Severity: "CRITICAL", Category: "rug-pull"},
+		"TOXIC_001":            {Severity: "HIGH", Category: "toxic-flow"},
+		"TOXIC_002":            {Severity: "HIGH", Category: "toxic-flow"},
+		"TOXIC_003":            {Severity: "HIGH", Category: "toxic-flow"},
+		"TOXIC_CROSS_001":      {Severity: "HIGH", Category: "toxic-flow"},
+		"TOXIC_CROSS_002":      {Severity: "HIGH", Category: "toxic-flow"},
+		"TOXIC_CROSS_003":      {Severity: "HIGH", Category: "toxic-flow"},
+		"NLP_CRED_EXFIL_COMBO": {Severity: "CRITICAL", Category: "exfiltration"},
+		"RUGPULL_001":          {Severity: "CRITICAL", Category: "rug-pull"},
+		// pnpm-policy emit sites (pnpmpolicy.go) -- fixed
+		// severities, all category "supply-chain".
+		"PNPM_DANGEROUS_BUILDS_001":           {Severity: "HIGH", Category: "supply-chain"},
+		"PNPM_STRICT_DEP_BUILDS_DISABLED_001": {Severity: "MEDIUM", Category: "supply-chain"},
+		"PNPM_EXOTIC_SUBDEPS_DISABLED_001":    {Severity: "MEDIUM", Category: "supply-chain"},
+		"PNPM_TRUST_LOCKFILE_001":             {Severity: "MEDIUM", Category: "supply-chain"},
+		"PNPM_MIN_RELEASE_AGE_DISABLED_001":   {Severity: "LOW", Category: "supply-chain"},
+		"PNPM_MIN_RELEASE_AGE_NON_STRICT_001": {Severity: "LOW", Category: "supply-chain"},
+		"PNPM_TRUST_POLICY_OFF_001":           {Severity: "LOW", Category: "supply-chain"},
+		"PNPM_LEGACY_BUILD_POLICY_001":        {Severity: "INFO", Category: "supply-chain"},
+		"PNPM_BUILD_APPROVAL_PENDING_001":     {Severity: "MEDIUM", Category: "supply-chain"},
 	}
 	for id, w := range cases {
 		rec, err := rulecatalog.FindByID(rulecatalog.Options{}, id)
@@ -263,6 +275,12 @@ func TestEveryAnalyzerEmittedIDHasCatalogEntry(t *testing.T) {
 		"TOXIC_CROSS_001", "TOXIC_CROSS_002", "TOXIC_CROSS_003",
 		// rug-pull analyzer (only fires with --monitor / WithStateDir).
 		"RUGPULL_001",
+		// pnpm-policy public consts.
+		"PNPM_DANGEROUS_BUILDS_001", "PNPM_STRICT_DEP_BUILDS_DISABLED_001",
+		"PNPM_EXOTIC_SUBDEPS_DISABLED_001", "PNPM_TRUST_LOCKFILE_001",
+		"PNPM_MIN_RELEASE_AGE_DISABLED_001", "PNPM_MIN_RELEASE_AGE_NON_STRICT_001",
+		"PNPM_TRUST_POLICY_OFF_001", "PNPM_LEGACY_BUILD_POLICY_001",
+		"PNPM_BUILD_APPROVAL_PENDING_001",
 	}
 	for _, id := range emitted {
 		_, err := rulecatalog.FindByID(rulecatalog.Options{}, id)

--- a/internal/rulemeta/rule.go
+++ b/internal/rulemeta/rule.go
@@ -57,13 +57,14 @@ type Rule struct {
 // (they show up in JSON output and in --filter args), so they're
 // short, lower-case, kebab-stable.
 const (
-	AnalyzerCITrust   = "ci-trust"
-	AnalyzerPkgMeta   = "pkgmeta"
-	AnalyzerJSRisk    = "jsrisk"
-	AnalyzerNLP       = "nlp"
-	AnalyzerToxicFlow = "toxicflow"
-	AnalyzerRugPull   = "rugpull"
-	AnalyzerPyRisk    = "pyrisk"
-	AnalyzerRSBuild   = "rsbuild"
-	AnalyzerPattern   = "" // YAML-driven rules; empty so JSON omits the field
+	AnalyzerCITrust    = "ci-trust"
+	AnalyzerPkgMeta    = "pkgmeta"
+	AnalyzerJSRisk     = "jsrisk"
+	AnalyzerNLP        = "nlp"
+	AnalyzerToxicFlow  = "toxicflow"
+	AnalyzerRugPull    = "rugpull"
+	AnalyzerPyRisk     = "pyrisk"
+	AnalyzerRSBuild    = "rsbuild"
+	AnalyzerPnpmPolicy = "pnpm-policy"
+	AnalyzerPattern    = "" // YAML-driven rules; empty so JSON omits the field
 )


### PR DESCRIPTION
Aguara already answers "does this lockfile pin a known-malicious version?". This adds the next question: "is the project actually using pnpm's supply-chain controls, or has it turned them off?"

A new `pnpm-policy` analyzer reads `pnpm-workspace.yaml` and flags settings that weaken pnpm v11's built-in protections. It runs as part of `scan` and `audit`, and every rule is explainable via `aguara explain`.

| Rule | Severity | Trigger |
|---|---|---|
| `PNPM_DANGEROUS_BUILDS_001` | HIGH | `dangerouslyAllowAllBuilds: true` |
| `PNPM_STRICT_DEP_BUILDS_DISABLED_001` | MEDIUM | `strictDepBuilds: false` |
| `PNPM_EXOTIC_SUBDEPS_DISABLED_001` | MEDIUM | `blockExoticSubdeps: false` |
| `PNPM_TRUST_LOCKFILE_001` | MEDIUM | `trustLockfile: true` |
| `PNPM_BUILD_APPROVAL_PENDING_001` | MEDIUM | undecided `allowBuilds` entry |
| `PNPM_MIN_RELEASE_AGE_DISABLED_001` | LOW | `minimumReleaseAge: 0` |
| `PNPM_MIN_RELEASE_AGE_NON_STRICT_001` | LOW | positive age + `minimumReleaseAgeStrict: false` |
| `PNPM_TRUST_POLICY_OFF_001` | LOW | `trustPolicy: off` (explicit) |
| `PNPM_LEGACY_BUILD_POLICY_001` | INFO | removed pnpm v10 build-policy settings |

**Low false positives by design.** A missing setting is treated as the secure pnpm v11 default and never reported; the analyzer only fires on an explicit value that is less safe than the default. `minimumReleaseAgeStrict: false` is reported only alongside an explicit positive `minimumReleaseAge`. Key matching mirrors pnpm's own config loading: kebab-case and camelCase resolve to the same setting, and YAML merge keys (`<<:`) are expanded before evaluation.
