### PR TITLE
Resolve unambiguous npm: aliases in pnpm-lock.yaml

### DIFF
--- a/internal/incident/trapdoor_pnpm_test.go
+++ b/internal/incident/trapdoor_pnpm_test.go
@@ -93,3 +93,51 @@ func TestTrapDoor_PnpmWholePackageRangeFlagged(t *testing.T) {
 		t.Errorf("hit advisory = %q, want SOCKET-2026-05-24-trapdoor", res.Hits[0].Record.ID)
 	}
 }
+
+// TestTrapDoor_PnpmNpmAliasResolvedViaEmbeddedIntel proves the npm:
+// alias path end to end against the REAL embedded snapshots: the
+// compromised TrapDoor package is installed under an innocent local
+// alias ("safe-bootstrap"), but the lockfile key encodes the real
+// registry target, so the parser resolves it to dev-env-bootstrapper
+// and the advisory still fires. Without alias resolution this scans
+// clean -- the exact false negative PR2 closes.
+func TestTrapDoor_PnpmNpmAliasResolvedViaEmbeddedIntel(t *testing.T) {
+	dir := t.TempDir()
+	lock := "lockfileVersion: '9.0'\n\n" +
+		"importers:\n" +
+		"  .:\n" +
+		"    dependencies:\n" +
+		"      safe-bootstrap:\n" +
+		"        specifier: npm:dev-env-bootstrapper@1.0.12\n" +
+		"        version: dev-env-bootstrapper@1.0.12\n\n" +
+		"packages:\n" +
+		"  safe-bootstrap@npm:dev-env-bootstrapper@1.0.12:\n" +
+		"    resolution: {integrity: sha512-FAKE_FIXTURE_DO_NOT_VERIFY==}\n\n" +
+		"snapshots:\n" +
+		"  safe-bootstrap@npm:dev-env-bootstrapper@1.0.12: {}\n"
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-lock.yaml"), []byte(lock), 0o644); err != nil {
+		t.Fatalf("write pnpm-lock.yaml: %v", err)
+	}
+
+	matcher := intel.NewMatcher(incident.EmbeddedSnapshots()...)
+	targets, err := packagecheck.Discover(dir, []string{intel.EcosystemNPM})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	res, err := (&packagecheck.Runner{Matcher: matcher}).Run(targets)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Hits) != 1 {
+		t.Fatalf("expected 1 pnpm hit via alias, got %d: %+v", len(res.Hits), res.Hits)
+	}
+	if res.Hits[0].Ref.Name != "dev-env-bootstrapper" {
+		t.Errorf("hit name = %q, want dev-env-bootstrapper (alias must not leak as safe-bootstrap)", res.Hits[0].Ref.Name)
+	}
+	if res.Hits[0].Record.ID != "SOCKET-2026-05-24-trapdoor" {
+		t.Errorf("hit advisory = %q, want SOCKET-2026-05-24-trapdoor", res.Hits[0].Record.ID)
+	}
+	if len(res.Ecosystems) != 1 || res.Ecosystems[0].Source != "pnpm-lock.yaml" {
+		t.Errorf("ecosystem summary = %+v, want one pnpm-lock.yaml entry", res.Ecosystems)
+	}
+}

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -135,26 +135,38 @@ func ParsePNPMLock(target Target) ([]PackageRef, error) {
 // Conservative by design: better to under-emit than to surface false
 // positives on shapes pnpm uses for non-registry packages.
 func parsePnpmPackageKey(key string) (string, string, bool) {
-	// npm: alias entries resolve to a DIFFERENT real registry package
-	// than the local dependency name. The user may have installed
-	// `safe-ipc@npm:node-ipc@9.2.3`, but the package that must be
-	// matched against npm advisories is node-ipc@9.2.3, not safe-ipc.
-	// Route these to a dedicated resolver before the normal path; the
-	// "@npm:" token never appears in a non-alias key (peer suffixes
-	// are "(pkg@ver)", non-registry sources start with file:/link:/...).
+	// Older lockfiles prefix entries with "/". Strip before the
+	// source-prefix checks so "/file:..." and "file:..." are
+	// treated identically. Done FIRST so every classification below
+	// (leading-prefix rejection, npm-alias routing) sees the same key.
+	key = strings.TrimPrefix(key, "/")
+
+	// Hard reject non-registry sources whose key STARTS with the
+	// protocol. Each prefix is a literal pnpm spec; no wildcards. This
+	// runs before npm-alias routing so a slash-prefixed local key like
+	// "/file:safe@npm:node-ipc@9.2.3" (now "file:safe@npm:...") is
+	// rejected as the file dependency it is, not resolved to the npm
+	// package buried in its path.
+	for _, prefix := range []string{
+		"file:", "link:", "workspace:", "github:", "git:", "http:", "https:",
+	} {
+		if strings.HasPrefix(key, prefix) {
+			return "", "", false
+		}
+	}
+
 	// An alias pointing at a NON-registry source
 	// ("alias@workspace:...", "alias@file:...", "alias@github:...") is
 	// not addressable in the npm registry. The FIRST protocol in the key
-	// determines the source, so this rejection runs BEFORE the npm-alias
-	// routing: a key like "local-safe@file:safe@npm:node-ipc@9.2.3" is a
-	// file dependency whose path merely contains "@npm:", not an npm
+	// determines the source, so this rejection also runs BEFORE the
+	// npm-alias routing: a key like "local-safe@file:safe@npm:node-ipc@9.2.3"
+	// is a file dependency whose path merely contains "@npm:", not an npm
 	// alias, and must not resolve to a node-ipc advisory hit. The alias
-	// NAME precedes the protocol, so the leading-prefix rejection further
-	// down would miss it and the modern parser would emit a junk
-	// (alias, "file:...") ref. A package name cannot contain ":", so
-	// "@<protocol>:" only appears in alias-shaped keys; reject here. A
-	// real npm alias never contains these tokens (its real spec is a
-	// plain registry name@version), so genuine aliases pass through.
+	// NAME precedes the protocol here (so the leading-prefix rejection
+	// above does not catch it), but a package name cannot contain ":", so
+	// "@<protocol>:" only appears in alias-shaped keys. A real npm alias
+	// never contains these tokens (its real spec is a plain registry
+	// name@version), so genuine aliases pass through.
 	for _, p := range []string{
 		"@workspace:", "@file:", "@link:", "@github:", "@git:", "@http:", "@https:", "@jsr:",
 	} {
@@ -163,23 +175,12 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 		}
 	}
 
+	// npm: alias entries resolve to a DIFFERENT real registry package
+	// than the local dependency name. The user may have installed
+	// `safe-ipc@npm:node-ipc@9.2.3`, but the package that must be matched
+	// against npm advisories is node-ipc@9.2.3, not safe-ipc.
 	if strings.Contains(key, "@npm:") {
 		return parsePnpmAliasPackageKey(key)
-	}
-
-	// Older lockfiles prefix entries with "/". Strip before the
-	// source-prefix checks so "/file:..." and "file:..." are
-	// treated identically.
-	key = strings.TrimPrefix(key, "/")
-
-	// Hard reject non-registry sources. Each prefix is a literal
-	// pnpm spec; no wildcards.
-	for _, prefix := range []string{
-		"file:", "link:", "workspace:", "github:", "git:", "http:", "https:",
-	} {
-		if strings.HasPrefix(key, prefix) {
-			return "", "", false
-		}
 	}
 
 	// Strip the parens-style peer-dep suffix from the key BEFORE

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -215,32 +215,34 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 		version string
 	)
 	if strings.HasPrefix(key, "@") {
-		// Slash count discriminates modern vs v5 for scoped keys:
-		//   1 slash  -> "@scope/pkg@version" or "@scope/pkg" (modern)
-		//   2+ slashes -> "@scope/pkg/version[_peer@...]" (v5)
-		// Without this check, a v5 key with a peer-dep suffix
-		// containing "@" (e.g. "@types/node/20.5.0_typescript@5.0.0")
-		// would route through the modern branch and pick the peer
-		// "@" as the version separator, producing
-		// (name="@types/node/20.5.0_typescript", version="5.0.0").
-		switch strings.Count(key, "/") {
-		case 1:
-			// Modern scoped form. The "@" AFTER the first slash
-			// is the package/version boundary; any later "@"
-			// belongs to a peer-dep suffix.
-			slash := strings.IndexByte(key, '/')
-			if rel := strings.IndexByte(key[slash:], '@'); rel >= 0 {
-				at := slash + rel
+		// Scoped key. After the scope's "/" the package/version
+		// boundary is the next "@" -- but ONLY if it precedes the next
+		// "/". This single rule distinguishes all three scoped shapes
+		// without a slash count:
+		//   modern  "@scope/pkg@1.2.3"          -> "@" before any 2nd "/"
+		//   alias   "@local/safe@npm:@s/e@1.2.3"-> "@npm:" before the
+		//                                          real package's "/"
+		//                                          (so scoped-alias ->
+		//                                          scoped-real resolves)
+		//   v5      "@scope/pkg/1.2.3[_peer@v]"  -> a "/" comes first,
+		//                                          so any "@" is a peer
+		//                                          suffix, not the
+		//                                          boundary
+		// The version field is classified (npm: alias / non-registry /
+		// plain) after this split, so picking the boundary "@" here is
+		// all that is needed.
+		slash := strings.IndexByte(key, '/')
+		if slash >= 0 {
+			rest := key[slash+1:]
+			atRel := strings.IndexByte(rest, '@')
+			slashRel := strings.IndexByte(rest, '/')
+			if atRel >= 0 && (slashRel < 0 || atRel < slashRel) {
+				at := slash + 1 + atRel
 				name = key[:at]
 				version = key[at+1:]
 			}
-			// No "@" after the slash -> "@scope/pkg" without
-			// a version. Leave name="" so the v5 fallback below
-			// rejects via the >= 2 slashes guard.
-		default:
-			// 0 slashes -> malformed scoped (just "@something").
-			// >= 2 slashes -> v5 form; leave name="" for v5
-			//                slash-fallback below.
+			// else: v5 slash form, or "@scope/pkg" without a version
+			// -> leave name="" for the v5 fallback / rejection below.
 		}
 	} else {
 		firstAt := strings.IndexByte(key, '@')

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -3,12 +3,23 @@ package packagecheck
 import (
 	"fmt"
 	"os"
+	"regexp"
 	"sort"
 	"strings"
 
 	"github.com/garagon/aguara/internal/intel"
 	"gopkg.in/yaml.v3"
 )
+
+// exactNpmVersionRe matches an exact, fully-resolved npm version: three
+// numeric components with an optional prerelease/build suffix
+// (1.2.3, 10.0.0-alpha.1, 2.1.5+build.7). It deliberately rejects range
+// operators (^, ~, >, <, =, *, x), dist-tags (latest, next), and
+// partial versions (9.2) so an alias whose right-hand side is not a
+// pinned registry version is skipped rather than matched. pnpm always
+// records resolved exact versions in the packages map, so this is the
+// only form a real alias entry takes.
+var exactNpmVersionRe = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-Za-z.+-]+)?$`)
 
 // ParsePNPMLock reads a pnpm-lock.yaml file and returns the declared
 // npm packages. pnpm installs from the npm registry, so refs land in
@@ -124,6 +135,32 @@ func ParsePNPMLock(target Target) ([]PackageRef, error) {
 // Conservative by design: better to under-emit than to surface false
 // positives on shapes pnpm uses for non-registry packages.
 func parsePnpmPackageKey(key string) (string, string, bool) {
+	// npm: alias entries resolve to a DIFFERENT real registry package
+	// than the local dependency name. The user may have installed
+	// `safe-ipc@npm:node-ipc@9.2.3`, but the package that must be
+	// matched against npm advisories is node-ipc@9.2.3, not safe-ipc.
+	// Route these to a dedicated resolver before the normal path; the
+	// "@npm:" token never appears in a non-alias key (peer suffixes
+	// are "(pkg@ver)", non-registry sources start with file:/link:/...).
+	if strings.Contains(key, "@npm:") {
+		return parsePnpmAliasPackageKey(key)
+	}
+
+	// An alias pointing at a NON-registry source
+	// ("alias@workspace:...", "alias@file:...", "alias@github:...") is
+	// not addressable in the npm registry. Unlike a bare "file:..." key,
+	// the alias NAME precedes the protocol, so the leading-prefix
+	// rejection below would miss it and the modern parser would emit a
+	// junk (alias, "workspace:...") ref. A package name cannot contain
+	// ":", so "@<protocol>:" only appears in alias keys; reject here.
+	for _, p := range []string{
+		"@workspace:", "@file:", "@link:", "@github:", "@git:", "@http:", "@https:", "@jsr:",
+	} {
+		if strings.Contains(key, p) {
+			return "", "", false
+		}
+	}
+
 	// Older lockfiles prefix entries with "/". Strip before the
 	// source-prefix checks so "/file:..." and "file:..." are
 	// treated identically.
@@ -253,6 +290,100 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 	if i := strings.IndexAny(version, "_("); i >= 0 {
 		version = version[:i]
 	}
+	if version == "" {
+		return "", "", false
+	}
+	return name, version, true
+}
+
+// parsePnpmAliasPackageKey resolves an npm: alias package key to the
+// REAL registry package it points at. pnpm lets a dependency be
+// installed under a different local name:
+//
+//	pnpm add safe-ipc@npm:node-ipc@9.2.3
+//
+// which lands in the lockfile packages map as a key shaped like
+//
+//	safe-ipc@npm:node-ipc@9.2.3                          (unscoped real)
+//	@local/safe-ipc@npm:node-ipc@9.2.3                   (scoped alias)
+//	safe-rbac@npm:@redhat-cloud-services/rbac-client@2.1.5 (scoped real)
+//	/safe-ipc@npm:node-ipc@9.2.3                         (older slash form)
+//	safe-react@npm:react@18.2.0(@types/react@18.0.0)     (real + peer suffix)
+//
+// The alias (left of "@npm:") is intentionally discarded: matching
+// against npm advisories must use the real package (node-ipc@9.2.3), or
+// a compromised registry package hides behind an innocent local name.
+//
+// Only an UNAMBIGUOUS alias with an exact pinned version is resolved.
+// Returns ok=false when the right-hand side lacks a version, carries a
+// range/dist-tag instead of an exact version, is an empty or malformed
+// spec, or is not the npm registry. Same discipline as the rest of the
+// parser: under-report before false-positive.
+func parsePnpmAliasPackageKey(key string) (string, string, bool) {
+	key = strings.TrimPrefix(key, "/")
+
+	idx := strings.Index(key, "@npm:")
+	if idx < 0 {
+		return "", "", false
+	}
+	real := key[idx+len("@npm:"):]
+
+	// Strip a peer-dep suffix "(peer@version)" before extracting the
+	// real (name, version): the peer wrapper sits after the version and
+	// can itself be scoped, so removing it first keeps the boundary scan
+	// simple.
+	if i := strings.IndexByte(real, '('); i >= 0 {
+		real = real[:i]
+	}
+	if real == "" {
+		return "", "", false
+	}
+
+	name, version, ok := parseModernRegistrySpec(real)
+	if !ok {
+		return "", "", false
+	}
+	// Strip a pre-v9 underscore peer suffix from the version itself.
+	if i := strings.IndexByte(version, '_'); i >= 0 {
+		version = version[:i]
+	}
+	// Only an exact, resolved version is matchable; ranges and dist-tags
+	// would false-positive against advisories for unrelated versions.
+	if !exactNpmVersionRe.MatchString(version) {
+		return "", "", false
+	}
+	return name, version, true
+}
+
+// parseModernRegistrySpec splits a modern npm registry spec
+// ("node-ipc@9.2.3", "@scope/pkg@1.2.3") into (name, version). It is the
+// resolved RIGHT-hand side of an npm: alias, which pnpm always writes in
+// modern (name@version) form, never the legacy slash form. Returns
+// ok=false for a missing version or a malformed scoped spec.
+func parseModernRegistrySpec(spec string) (string, string, bool) {
+	if strings.HasPrefix(spec, "@") {
+		// Scoped: the package/version boundary is the "@" AFTER the
+		// single "/" in "@scope/pkg".
+		slash := strings.IndexByte(spec, '/')
+		if slash < 0 {
+			return "", "", false
+		}
+		rel := strings.IndexByte(spec[slash:], '@')
+		if rel < 0 {
+			return "", "", false // "@scope/pkg" with no version
+		}
+		at := slash + rel
+		name, version := spec[:at], spec[at+1:]
+		if name == "" || version == "" {
+			return "", "", false
+		}
+		return name, version, true
+	}
+	at := strings.IndexByte(spec, '@')
+	if at <= 0 {
+		return "", "", false // bare name, no version
+	}
+	name, version := spec[:at], spec[at+1:]
 	if version == "" {
 		return "", "", false
 	}

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -141,6 +141,23 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 	// (leading-prefix rejection, npm-alias routing) sees the same key.
 	key = strings.TrimPrefix(key, "/")
 
+	// Strip the parens-style peer-dep suffix up front, BEFORE any
+	// source/alias classification. v9+ encodes resolved peer deps as
+	// "name@version(peer@version)", and the peer can itself carry a
+	// protocol ("foo@1.0.0(bar@npm:baz@2.0.0)") or be scoped
+	// ("@commitlint/cli@19.6.1(@types/node@22.10.2)"). The suffix
+	// belongs to the PEER, not this package: leaving it in would make
+	// the "@npm:" / "@<protocol>:" tests below misread a peer's
+	// protocol as this package's and either misroute the key to the
+	// alias parser (dropping the real package) or reject it. The suffix
+	// is always after the version, so removing it here is safe; a scoped
+	// peer also adds an extra "/" that would otherwise fool the v5
+	// slash-count heuristic. The underscore-style suffix is removed
+	// downstream from the version string itself.
+	if i := strings.IndexByte(key, '('); i >= 0 {
+		key = key[:i]
+	}
+
 	// Hard reject non-registry sources whose key STARTS with the
 	// protocol. Each prefix is a literal pnpm spec; no wildcards. This
 	// runs before npm-alias routing so a slash-prefixed local key like
@@ -183,19 +200,8 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 		return parsePnpmAliasPackageKey(key)
 	}
 
-	// Strip the parens-style peer-dep suffix from the key BEFORE
-	// classifying scoped vs unscoped. v9+ encodes resolved peer
-	// deps as "name@version(peer@version)" and the peer can itself
-	// be scoped ("@commitlint/cli@19.6.1(@types/node@22.10.2)").
-	// A scoped peer adds an extra "/" to the key, which would fool
-	// the scoped slash-count heuristic into treating the key as v5
-	// slash-form and splitting on the wrong "/". The peer suffix
-	// is always after the version, so removing it pre-classification
-	// is safe; the underscore-style suffix is removed downstream
-	// from the version string itself.
-	if i := strings.IndexByte(key, '('); i >= 0 {
-		key = key[:i]
-	}
+	// (The parens-style peer-dep suffix was already stripped at the top
+	// of the function, before source/alias classification.)
 
 	// Two pnpm key formats coexist in the wild:
 	//

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -172,36 +172,15 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 		}
 	}
 
-	// An alias pointing at a NON-registry source
-	// ("alias@workspace:...", "alias@file:...", "alias@github:...") is
-	// not addressable in the npm registry. The FIRST protocol in the key
-	// determines the source, so this rejection also runs BEFORE the
-	// npm-alias routing: a key like "local-safe@file:safe@npm:node-ipc@9.2.3"
-	// is a file dependency whose path merely contains "@npm:", not an npm
-	// alias, and must not resolve to a node-ipc advisory hit. The alias
-	// NAME precedes the protocol here (so the leading-prefix rejection
-	// above does not catch it), but a package name cannot contain ":", so
-	// "@<protocol>:" only appears in alias-shaped keys. A real npm alias
-	// never contains these tokens (its real spec is a plain registry
-	// name@version), so genuine aliases pass through.
-	for _, p := range []string{
-		"@workspace:", "@file:", "@link:", "@github:", "@git:", "@http:", "@https:", "@jsr:",
-	} {
-		if strings.Contains(key, p) {
-			return "", "", false
-		}
-	}
-
-	// npm: alias entries resolve to a DIFFERENT real registry package
-	// than the local dependency name. The user may have installed
-	// `safe-ipc@npm:node-ipc@9.2.3`, but the package that must be matched
-	// against npm advisories is node-ipc@9.2.3, not safe-ipc.
-	if strings.Contains(key, "@npm:") {
-		return parsePnpmAliasPackageKey(key)
-	}
-
-	// (The parens-style peer-dep suffix was already stripped at the top
-	// of the function, before source/alias classification.)
+	// Source/alias classification happens AFTER the (name, version)
+	// split below, on the VERSION FIELD specifically (the text right
+	// after the package name's "@"). That is where pnpm records the
+	// install source: "npm:real@ver" for an alias, "workspace:" / "file:"
+	// / ... for a non-registry alias, or a plain version otherwise.
+	// Classifying the version field rather than substring-matching the
+	// whole key means a protocol that appears only in a peer suffix
+	// ("foo@1.0.0(bar@npm:baz@2.0.0)", "foo@1.0.0_bar@npm:baz@2.0.0") or
+	// a local path is never mistaken for THIS package's source.
 
 	// Two pnpm key formats coexist in the wild:
 	//
@@ -295,12 +274,32 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 		return "", "", false
 	}
 
+	// The version field carries the install source.
+	//
+	//   "npm:real@ver" -> alias to a DIFFERENT real registry package;
+	//                     resolve and match the REAL package, discarding
+	//                     the local alias name.
+	//   "file:" / "link:" / "workspace:" / "github:" / "git:" / "http(s):"
+	//   / "jsr:" -> alias to a non-registry source; not matchable.
+	//   anything else -> a plain (possibly peer-decorated) version.
+	if real, isAlias := strings.CutPrefix(version, "npm:"); isAlias {
+		return parseNpmAliasTarget(real)
+	}
+	for _, proto := range []string{
+		"file:", "link:", "workspace:", "github:", "git:", "http:", "https:", "jsr:",
+	} {
+		if strings.HasPrefix(version, proto) {
+			return "", "", false
+		}
+	}
+
 	// Strip peer-dep / build-hook suffix. Two encodings exist in
 	// the wild:
 	//   pre-v9: "react@18.2.0_react-dom@18.2.0"   (underscore separator)
 	//   v9+:    "react@18.2.0(peer-dep@1.0.0)"    (paren wrapper)
-	// SemVer build metadata uses "+", which is preserved.
-	if i := strings.IndexAny(version, "_("); i >= 0 {
+	// SemVer build metadata uses "+", which is preserved. (The paren
+	// form was already stripped from the key at the top of the function.)
+	if i := strings.IndexByte(version, '_'); i >= 0 {
 		version = version[:i]
 	}
 	if version == "" {
@@ -309,50 +308,36 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 	return name, version, true
 }
 
-// parsePnpmAliasPackageKey resolves an npm: alias package key to the
-// REAL registry package it points at. pnpm lets a dependency be
-// installed under a different local name:
+// parseNpmAliasTarget resolves the REAL registry package an npm: alias
+// points at, from the spec on the RIGHT of "npm:". pnpm lets a
+// dependency be installed under a different local name:
 //
 //	pnpm add safe-ipc@npm:node-ipc@9.2.3
 //
-// which lands in the lockfile packages map as a key shaped like
+// which lands in the lockfile packages map as "safe-ipc@npm:node-ipc@9.2.3";
+// after the (name, version) split the version field is "npm:node-ipc@9.2.3"
+// and this function receives "node-ipc@9.2.3". The alias name is
+// intentionally discarded: matching against npm advisories must use the
+// real package (node-ipc@9.2.3), or a compromised registry package hides
+// behind an innocent local name.
 //
-//	safe-ipc@npm:node-ipc@9.2.3                          (unscoped real)
-//	@local/safe-ipc@npm:node-ipc@9.2.3                   (scoped alias)
-//	safe-rbac@npm:@redhat-cloud-services/rbac-client@2.1.5 (scoped real)
-//	/safe-ipc@npm:node-ipc@9.2.3                         (older slash form)
-//	safe-react@npm:react@18.2.0(@types/react@18.0.0)     (real + peer suffix)
+// Forms handled (the paren peer suffix was already stripped from the key
+// upstream):
 //
-// The alias (left of "@npm:") is intentionally discarded: matching
-// against npm advisories must use the real package (node-ipc@9.2.3), or
-// a compromised registry package hides behind an innocent local name.
+//	node-ipc@9.2.3                              (unscoped real)
+//	@redhat-cloud-services/rbac-client@2.1.5    (scoped real)
+//	react@18.2.0_react-dom@18.2.0               (underscore peer suffix)
 //
 // Only an UNAMBIGUOUS alias with an exact pinned version is resolved.
-// Returns ok=false when the right-hand side lacks a version, carries a
-// range/dist-tag instead of an exact version, is an empty or malformed
-// spec, or is not the npm registry. Same discipline as the rest of the
-// parser: under-report before false-positive.
-func parsePnpmAliasPackageKey(key string) (string, string, bool) {
-	key = strings.TrimPrefix(key, "/")
-
-	idx := strings.Index(key, "@npm:")
-	if idx < 0 {
+// Returns ok=false when the spec lacks a version, carries a range or
+// dist-tag instead of an exact version, or is empty/malformed. Same
+// discipline as the rest of the parser: under-report before
+// false-positive.
+func parseNpmAliasTarget(spec string) (string, string, bool) {
+	if spec == "" {
 		return "", "", false
 	}
-	real := key[idx+len("@npm:"):]
-
-	// Strip a peer-dep suffix "(peer@version)" before extracting the
-	// real (name, version): the peer wrapper sits after the version and
-	// can itself be scoped, so removing it first keeps the boundary scan
-	// simple.
-	if i := strings.IndexByte(real, '('); i >= 0 {
-		real = real[:i]
-	}
-	if real == "" {
-		return "", "", false
-	}
-
-	name, version, ok := parseModernRegistrySpec(real)
+	name, version, ok := parseModernRegistrySpec(spec)
 	if !ok {
 		return "", "", false
 	}

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -43,8 +43,8 @@ var exactNpmVersionRe = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-
 // in the package keys are handled deterministically.
 //
 // Non-registry sources (workspace:, file:, link:, github:, git:,
-// http://, https://) are skipped — they are not addressable in the
-// npm registry and matching them against npm advisories would
+// http://, https://, jsr:) are skipped — they are not addressable in
+// the npm registry and matching them against npm advisories would
 // false-positive on name collisions.
 func ParsePNPMLock(target Target) ([]PackageRef, error) {
 	data, err := os.ReadFile(target.Path)
@@ -126,7 +126,7 @@ func ParsePNPMLock(target Target) ([]PackageRef, error) {
 //
 //   - bare names without a version ("node-ipc", "node-ipc@")
 //   - non-registry sources (file:, link:, workspace:, github:, git:,
-//     http:, https:): these are not addressable in the npm registry
+//     http:, https:, jsr:): these are not addressable in the npm registry
 //     and matching them against npm OSV records would false-positive
 //     on name collisions (e.g. a local "lodash" link would inherit
 //     every lodash advisory).
@@ -165,7 +165,7 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 	// rejected as the file dependency it is, not resolved to the npm
 	// package buried in its path.
 	for _, prefix := range []string{
-		"file:", "link:", "workspace:", "github:", "git:", "http:", "https:",
+		"file:", "link:", "workspace:", "github:", "git:", "http:", "https:", "jsr:",
 	} {
 		if strings.HasPrefix(key, prefix) {
 			return "", "", false

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -142,23 +142,29 @@ func parsePnpmPackageKey(key string) (string, string, bool) {
 	// Route these to a dedicated resolver before the normal path; the
 	// "@npm:" token never appears in a non-alias key (peer suffixes
 	// are "(pkg@ver)", non-registry sources start with file:/link:/...).
-	if strings.Contains(key, "@npm:") {
-		return parsePnpmAliasPackageKey(key)
-	}
-
 	// An alias pointing at a NON-registry source
 	// ("alias@workspace:...", "alias@file:...", "alias@github:...") is
-	// not addressable in the npm registry. Unlike a bare "file:..." key,
-	// the alias NAME precedes the protocol, so the leading-prefix
-	// rejection below would miss it and the modern parser would emit a
-	// junk (alias, "workspace:...") ref. A package name cannot contain
-	// ":", so "@<protocol>:" only appears in alias keys; reject here.
+	// not addressable in the npm registry. The FIRST protocol in the key
+	// determines the source, so this rejection runs BEFORE the npm-alias
+	// routing: a key like "local-safe@file:safe@npm:node-ipc@9.2.3" is a
+	// file dependency whose path merely contains "@npm:", not an npm
+	// alias, and must not resolve to a node-ipc advisory hit. The alias
+	// NAME precedes the protocol, so the leading-prefix rejection further
+	// down would miss it and the modern parser would emit a junk
+	// (alias, "file:...") ref. A package name cannot contain ":", so
+	// "@<protocol>:" only appears in alias-shaped keys; reject here. A
+	// real npm alias never contains these tokens (its real spec is a
+	// plain registry name@version), so genuine aliases pass through.
 	for _, p := range []string{
 		"@workspace:", "@file:", "@link:", "@github:", "@git:", "@http:", "@https:", "@jsr:",
 	} {
 		if strings.Contains(key, p) {
 			return "", "", false
 		}
+	}
+
+	if strings.Contains(key, "@npm:") {
+		return parsePnpmAliasPackageKey(key)
 	}
 
 	// Older lockfiles prefix entries with "/". Strip before the

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -98,6 +98,12 @@ func TestParsePnpmPackageKey(t *testing.T) {
 		// "@npm:": after the leading "/" is stripped it starts with
 		// "file:", so it is rejected before alias routing.
 		{"slash file: prefix with npm in path", "/file:safe@npm:node-ipc@9.2.3", "", "", false},
+		// A protocol token that appears only in the PEER suffix belongs
+		// to the peer, not this package: the real package is still parsed
+		// normally and must not be dropped or misrouted to the alias path.
+		{"normal pkg, peer is an npm alias", "foo@1.0.0(bar@npm:baz@2.0.0)", "foo", "1.0.0", true},
+		{"normal pkg, peer is a file dep", "foo@1.0.0(bar@file:../baz)", "foo", "1.0.0", true},
+		{"real npm alias with scoped peer suffix", "safe-react@npm:react@18.2.0(@types/react@18.0.0)", "react", "18.2.0", true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -35,6 +35,11 @@ func TestParsePnpmPackageKey(t *testing.T) {
 		{"github: ref", "github:user/repo", "", "", false},
 		{"git: ref", "git:user/repo", "", "", false},
 		{"https: ref", "https://example.com/pkg", "", "", false},
+		// jsr: is a non-registry source like the others; a bare top-level
+		// jsr: key must skip, not emit a bogus npm ref.
+		{"jsr: ref", "jsr:node-ipc@9.2.3", "", "", false},
+		{"jsr: scoped ref", "jsr:@scope/pkg@1.0.0", "", "", false},
+		{"jsr: slash-prefixed", "/jsr:node-ipc@9.2.3", "", "", false},
 
 		// Legacy v5 slash-separator format
 		{"v5 unscoped", "/lodash/4.17.21", "lodash", "4.17.21", true},

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -88,6 +88,12 @@ func TestParsePnpmPackageKey(t *testing.T) {
 		{"alias workspace target", "safe@workspace:node-ipc@9.2.3", "", "", false},
 		{"alias file target", "safe@file:../node-ipc", "", "", false},
 		{"alias github target", "safe@github:user/repo", "", "", false},
+		// A file dependency whose PATH contains "@npm:" must be treated
+		// as the file dep it is (first protocol wins), not resolved to
+		// the npm package in the path. Otherwise a local directory turns
+		// into a false advisory hit.
+		{"file dep with npm in path", "local-safe@file:safe@npm:node-ipc@9.2.3", "", "", false},
+		{"link dep with npm in path", "local@link:vendor@npm:node-ipc@9.2.3", "", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -94,6 +94,10 @@ func TestParsePnpmPackageKey(t *testing.T) {
 		// into a false advisory hit.
 		{"file dep with npm in path", "local-safe@file:safe@npm:node-ipc@9.2.3", "", "", false},
 		{"link dep with npm in path", "local@link:vendor@npm:node-ipc@9.2.3", "", "", false},
+		// Slash-prefixed bare non-registry key whose path contains
+		// "@npm:": after the leading "/" is stripped it starts with
+		// "file:", so it is rejected before alias routing.
+		{"slash file: prefix with npm in path", "/file:safe@npm:node-ipc@9.2.3", "", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -103,6 +103,8 @@ func TestParsePnpmPackageKey(t *testing.T) {
 		// normally and must not be dropped or misrouted to the alias path.
 		{"normal pkg, peer is an npm alias", "foo@1.0.0(bar@npm:baz@2.0.0)", "foo", "1.0.0", true},
 		{"normal pkg, peer is a file dep", "foo@1.0.0(bar@file:../baz)", "foo", "1.0.0", true},
+		{"normal pkg, underscore peer is an npm alias", "foo@1.0.0_bar@npm:baz@2.0.0", "foo", "1.0.0", true},
+		{"normal pkg, underscore peer is a file dep", "foo@1.0.0_bar@file:../baz", "foo", "1.0.0", true},
 		{"real npm alias with scoped peer suffix", "safe-react@npm:react@18.2.0(@types/react@18.0.0)", "react", "18.2.0", true},
 	}
 	for _, tc := range cases {

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -67,6 +67,8 @@ func TestParsePnpmPackageKey(t *testing.T) {
 		{"alias unscoped real", "safe-ipc@npm:node-ipc@9.2.3", "node-ipc", "9.2.3", true},
 		{"alias scoped real", "safe-rbac@npm:@redhat-cloud-services/rbac-client@2.1.5", "@redhat-cloud-services/rbac-client", "2.1.5", true},
 		{"scoped alias unscoped real", "@local/safe-ipc@npm:node-ipc@9.2.3", "node-ipc", "9.2.3", true},
+		{"scoped alias scoped real", "@local/safe@npm:@scope/evil@1.2.3", "@scope/evil", "1.2.3", true},
+		{"scoped alias scoped real + peer", "@local/safe@npm:@scope/evil@1.2.3(@types/node@22.0.0)", "@scope/evil", "1.2.3", true},
 		{"alias slash-prefixed", "/safe-ipc@npm:node-ipc@9.2.3", "node-ipc", "9.2.3", true},
 		{"alias real + scoped peer paren", "safe-react@npm:react@18.2.0(@types/react@18.0.0)", "react", "18.2.0", true},
 		{"alias real + underscore peer", "safe-react@npm:react@18.2.0_react-dom@18.2.0", "react", "18.2.0", true},

--- a/internal/packagecheck/pnpm_test.go
+++ b/internal/packagecheck/pnpm_test.go
@@ -61,6 +61,33 @@ func TestParsePnpmPackageKey(t *testing.T) {
 		{"empty string", "", "", "", false},
 		{"bare scope without version", "@scope/pkg", "", "", false},
 		{"slash with empty version", "/lodash/", "", "", false},
+
+		// npm: alias entries -> resolve to the REAL registry package,
+		// discarding the local alias name.
+		{"alias unscoped real", "safe-ipc@npm:node-ipc@9.2.3", "node-ipc", "9.2.3", true},
+		{"alias scoped real", "safe-rbac@npm:@redhat-cloud-services/rbac-client@2.1.5", "@redhat-cloud-services/rbac-client", "2.1.5", true},
+		{"scoped alias unscoped real", "@local/safe-ipc@npm:node-ipc@9.2.3", "node-ipc", "9.2.3", true},
+		{"alias slash-prefixed", "/safe-ipc@npm:node-ipc@9.2.3", "node-ipc", "9.2.3", true},
+		{"alias real + scoped peer paren", "safe-react@npm:react@18.2.0(@types/react@18.0.0)", "react", "18.2.0", true},
+		{"alias real + underscore peer", "safe-react@npm:react@18.2.0_react-dom@18.2.0", "react", "18.2.0", true},
+		{"alias real prerelease", "safe@npm:preact@10.0.0-alpha.1", "preact", "10.0.0-alpha.1", true},
+
+		// npm: alias entries that are NOT unambiguously resolvable.
+		{"alias real no version", "safe@npm:node-ipc", "", "", false},
+		{"alias real caret range", "safe@npm:node-ipc@^9.2.0", "", "", false},
+		{"alias real tilde range", "safe@npm:node-ipc@~9.2.0", "", "", false},
+		{"alias real x-range", "safe@npm:node-ipc@9.2.x", "", "", false},
+		{"alias real dist-tag", "safe@npm:node-ipc@latest", "", "", false},
+		{"alias real partial version", "safe@npm:node-ipc@9.2", "", "", false},
+		{"alias empty real", "safe@npm:", "", "", false},
+		{"alias scoped real no version", "safe@npm:@scope/pkg", "", "", false},
+		{"alias scoped real empty version", "safe@npm:@scope/pkg@", "", "", false},
+		// A non-npm alias target (alias@workspace:/file:/github:) does not
+		// contain "@npm:", so it never routes through the alias path and
+		// the normal non-registry rejection applies.
+		{"alias workspace target", "safe@workspace:node-ipc@9.2.3", "", "", false},
+		{"alias file target", "safe@file:../node-ipc", "", "", false},
+		{"alias github target", "safe@github:user/repo", "", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -126,6 +153,59 @@ packages:
 	require.Equal(t, "20.5.0", refs[0].Version)
 	require.Equal(t, "@vitejs/plugin-react", refs[1].Name)
 	require.Equal(t, "4.0.0", refs[1].Version)
+}
+
+func TestParsePNPMLock_ResolvesNpmAlias(t *testing.T) {
+	// A dependency installed under a local alias name must be matched
+	// against the REAL registry package, not the alias.
+	dir := t.TempDir()
+	lock := filepath.Join(dir, "pnpm-lock.yaml")
+	require.NoError(t, os.WriteFile(lock, []byte(`lockfileVersion: '9.0'
+
+packages:
+  safe-ipc@npm:node-ipc@9.2.3:
+    resolution:
+      integrity: sha512-stub==
+`), 0o644))
+
+	refs, err := ParsePNPMLock(Target{
+		Ecosystem: intel.EcosystemNPM,
+		Path:      lock,
+		Source:    "pnpm-lock.yaml",
+	})
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	require.Equal(t, "node-ipc", refs[0].Name, "alias must resolve to the real registry package")
+	require.Equal(t, "9.2.3", refs[0].Version)
+	require.Equal(t, "pnpm-lock.yaml", refs[0].Source)
+}
+
+func TestParsePNPMLock_DedupsAliasAndRealEntry(t *testing.T) {
+	// When the same real package appears both directly and behind an
+	// alias, the existing (name, version) dedup must collapse them to a
+	// single ref so packages_read / findings are not inflated.
+	dir := t.TempDir()
+	lock := filepath.Join(dir, "pnpm-lock.yaml")
+	require.NoError(t, os.WriteFile(lock, []byte(`lockfileVersion: '9.0'
+
+packages:
+  node-ipc@9.2.3:
+    resolution:
+      integrity: sha512-stub==
+  safe-ipc@npm:node-ipc@9.2.3:
+    resolution:
+      integrity: sha512-stub==
+`), 0o644))
+
+	refs, err := ParsePNPMLock(Target{
+		Ecosystem: intel.EcosystemNPM,
+		Path:      lock,
+		Source:    "pnpm-lock.yaml",
+	})
+	require.NoError(t, err)
+	require.Len(t, refs, 1, "alias + real entry for the same package must dedup to one ref")
+	require.Equal(t, "node-ipc", refs[0].Name)
+	require.Equal(t, "9.2.3", refs[0].Version)
 }
 
 func TestParsePNPMLock_IgnoresWorkspaceAndFileRefs(t *testing.T) {

--- a/internal/packagecheck/runner_test.go
+++ b/internal/packagecheck/runner_test.go
@@ -64,6 +64,50 @@ func TestRunner_RunReportsHitsAndEcosystemSummary(t *testing.T) {
 	}
 }
 
+func TestRunner_ResolvesNpmAliasToRealCompromisedPackage(t *testing.T) {
+	// The fixture installs node-ipc@9.2.3 under the local alias
+	// "safe-ipc". The matcher knows only the REAL package node-ipc@9.2.3.
+	// The runner must still report a hit, proving the alias was resolved
+	// to the real registry package rather than the innocent local name.
+	snap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		GeneratedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		Records: []intel.Record{{
+			ID:        "MAL-TEST-NPM-node-ipc",
+			Ecosystem: intel.EcosystemNPM,
+			Name:      "node-ipc",
+			Kind:      intel.KindMalicious,
+			Versions:  []string{"9.2.3"},
+		}},
+	}
+	runner := &Runner{Matcher: intel.NewMatcher(snap)}
+
+	targets, err := Discover(filepath.Join("testdata", "pnpm-alias-compromised"), []string{intel.EcosystemNPM})
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	res, err := runner.Run(targets)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if len(res.Hits) != 1 {
+		t.Fatalf("hits = %d, want 1 (hits=%+v)", len(res.Hits), res.Hits)
+	}
+	if got := res.Hits[0].Ref.Name; got != "node-ipc" {
+		t.Errorf("hit ref name = %q, want node-ipc (the alias must NOT leak as safe-ipc)", got)
+	}
+	if got := res.Hits[0].Ref.Version; got != "9.2.3" {
+		t.Errorf("hit ref version = %q, want 9.2.3", got)
+	}
+	if got := res.Hits[0].Ref.Source; got != "pnpm-lock.yaml" {
+		t.Errorf("hit ref source = %q, want pnpm-lock.yaml", got)
+	}
+	if er := res.Ecosystems[0]; er.PackagesRead != 2 {
+		t.Errorf("packages_read = %d, want 2 (node-ipc via alias + lodash)", er.PackagesRead)
+	}
+}
+
 func TestRunner_CleanProjectReturnsZeroFindings(t *testing.T) {
 	// The matcher knows about a malicious package the fixture does
 	// NOT carry. Expect zero hits, one EcosystemResult with

--- a/internal/packagecheck/testdata/pnpm-alias-compromised/pnpm-lock.yaml
+++ b/internal/packagecheck/testdata/pnpm-alias-compromised/pnpm-lock.yaml
@@ -1,0 +1,27 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+  .:
+    dependencies:
+      safe-ipc:
+        specifier: npm:node-ipc@9.2.3
+        version: node-ipc@9.2.3
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
+packages:
+  safe-ipc@npm:node-ipc@9.2.3:
+    resolution: {integrity: sha512-FAKE_FIXTURE_DO_NOT_VERIFY==}
+    engines: {node: '>=8.0.0'}
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-FAKE_FIXTURE_DO_NOT_VERIFY==}
+
+snapshots:
+  safe-ipc@npm:node-ipc@9.2.3: {}
+  lodash@4.17.21: {}


### PR DESCRIPTION
A pnpm dependency can be installed under a local alias that points at a different real registry package:

```
pnpm add safe-ipc@npm:node-ipc@9.2.3
```

The lockfile keys this as `safe-ipc@npm:node-ipc@9.2.3`, so Aguara previously read the package name as `safe-ipc` and never matched the `node-ipc@9.2.3` advisory. A compromised registry package could hide behind an innocent local name.

Aguara now resolves these aliases to the real package (`node-ipc@9.2.3`) and matches it against npm advisories, so a compromised registry package can't hide behind a local dependency name. Unscoped and scoped aliases, scoped real targets, leading-slash and peer-decorated keys are all handled.

**Conservative by design.** Only an unambiguous alias with an exact pinned version is resolved. Aliases missing a version, carrying a range or dist-tag, malformed, or pointing at a non-registry source (`workspace:`/`file:`/`link:`/`github:`/`git:`/`http(s):`/`jsr:`) are skipped rather than guessed - under-report before false-positive. Alias and direct entries for the same package dedup to one.
