### PR TITLE
pnpm-policy: match only the camelCase keys pnpm honors in pnpm-workspace.yaml

### DIFF
--- a/internal/engine/pnpmpolicy/pnpmpolicy.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy.go
@@ -19,16 +19,20 @@
 //     ${AGE} are skipped rather than crashing, and every finding
 //     carries the exact line of the offending field.
 //
-// Key resolution mirrors what pnpm actually loads: setting keys are
-// matched case-insensitively with kebab-case and camelCase treated as
-// the same setting (pnpm normalizes `block-exotic-subdeps` and
-// `blockExoticSubdeps` to one value), and YAML merge keys (`<<:`) are
-// expanded before evaluation so a value supplied through an anchor is
-// not missed. Boolean values use YAML 1.1 spellings (true/false/yes/
-// no/on/off, matching the js-yaml loader pnpm uses); a value that is
-// not one of those tokens is treated as ambiguous and not evaluated,
-// rather than coerced, so an explicit "false" is never mis-flagged as
-// a dangerous opt-in.
+// Key resolution mirrors what pnpm actually loads: setting keys match
+// the exact camelCase spelling pnpm honors in pnpm-workspace.yaml.
+// Ground-truthed against pnpm 11.5.2 (2026-06-09): a kebab-case key
+// (`block-exotic-subdeps: false`) in pnpm-workspace.yaml is silently
+// IGNORED by pnpm -- `pnpm config list` does not load it and install
+// emits no warning -- so flagging it as a weakened setting would be a
+// false positive (the secure default still applies). Kebab-case is the
+// .npmrc spelling, not the workspace-file spelling. YAML merge keys
+// (`<<:`) are expanded before evaluation so a value supplied through an
+// anchor is not missed. Boolean values use YAML 1.1 spellings
+// (true/false/yes/no/on/off, matching the js-yaml loader pnpm uses); a
+// value that is not one of those tokens is treated as ambiguous and not
+// evaluated, rather than coerced, so an explicit "false" is never
+// mis-flagged as a dangerous opt-in.
 package pnpmpolicy
 
 import (
@@ -37,7 +41,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/garagon/aguara/internal/rulemeta"
 	"github.com/garagon/aguara/internal/scanner"
@@ -105,8 +108,10 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	}
 
 	// Flatten the root mapping with merge keys resolved, then index it
-	// by normalized key so kebab-case and camelCase resolve to the same
-	// setting. Precedence mirrors pnpm's config loading:
+	// by exact key. Only the camelCase spelling pnpm honors in
+	// pnpm-workspace.yaml matches; a kebab-case key is ignored by pnpm
+	// there (ground truth: pnpm 11.5.2), so it must not produce a
+	// finding. Precedence mirrors pnpm's config loading:
 	//   - an explicit key always wins over a merged one;
 	//   - among explicit keys, the last value wins (later overrides);
 	//   - among merged keys, the first wins (YAML merge semantics).
@@ -114,21 +119,21 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	idx := make(map[string]entry, len(entries))
 	explicitSet := make(map[string]bool, len(entries))
 	for _, e := range entries {
-		nk := normalizeKey(e.key)
+		k := strings.TrimSpace(e.key)
 		if !e.merged {
-			idx[nk] = e // last explicit wins, and overrides any merged value
-			explicitSet[nk] = true
+			idx[k] = e // last explicit wins, and overrides any merged value
+			explicitSet[k] = true
 			continue
 		}
-		if explicitSet[nk] {
+		if explicitSet[k] {
 			continue // an explicit value already won
 		}
-		if _, ok := idx[nk]; !ok {
-			idx[nk] = e // first merged wins
+		if _, ok := idx[k]; !ok {
+			idx[k] = e // first merged wins
 		}
 	}
 	get := func(name string) (entry, bool) {
-		e, ok := idx[normalizeKey(name)]
+		e, ok := idx[name]
 		return e, ok
 	}
 
@@ -348,43 +353,6 @@ func mergeTargets(n *yaml.Node) []*yaml.Node {
 		return out
 	}
 	return nil
-}
-
-// normalizeKey folds a well-formed kebab-case pnpm setting key to
-// camelCase so the two spellings pnpm actually accepts compare equal (it
-// treats "block-exotic-subdeps" and "blockExoticSubdeps" as one
-// setting). The fold is case-sensitive and only joins single hyphens
-// between non-empty segments. A spelling pnpm does NOT honor as that
-// setting -- a smushed "blockexoticsubdeps", a mis-cased
-// "BlockExoticSubdeps", or a malformed hyphenation
-// ("block--exotic-subdeps", a leading/trailing hyphen) -- is returned
-// unchanged so it cannot collapse onto a real key and produce a false
-// finding.
-func normalizeKey(s string) string {
-	s = strings.TrimSpace(s)
-	if strings.Contains(s, "-") {
-		for _, seg := range strings.Split(s, "-") {
-			if seg == "" {
-				return s // leading/trailing/doubled hyphen: not a valid kebab key
-			}
-		}
-	}
-	var b strings.Builder
-	b.Grow(len(s))
-	upNext := false
-	for _, r := range s {
-		if r == '-' {
-			upNext = true
-			continue
-		}
-		if upNext {
-			b.WriteRune(unicode.ToUpper(r))
-			upNext = false
-			continue
-		}
-		b.WriteRune(r)
-	}
-	return b.String()
 }
 
 // mappingRoot returns the top-level mapping node of a parsed document,

--- a/internal/engine/pnpmpolicy/pnpmpolicy_test.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy_test.go
@@ -88,20 +88,24 @@ func TestFalsePositives(t *testing.T) {
 	}
 }
 
-// TestKebabCaseKeys: pnpm normalizes kebab-case and camelCase setting
-// keys to the same value, so the analyzer must match both spellings.
-func TestKebabCaseKeys(t *testing.T) {
-	cases := []struct{ src, want string }{
-		{"dangerously-allow-all-builds: true\n", RuleDangerousBuilds},
-		{"block-exotic-subdeps: false\n", RuleExoticSubdepsDisabled},
-		{"trust-lockfile: true\n", RuleTrustLockfile},
-		{"minimum-release-age: 0\n", RuleMinReleaseAgeDisabled},
-		{"only-built-dependencies:\n  - esbuild\n", RuleLegacyBuildPolicy},
-		{"allow-builds:\n  sharp:\n", RuleBuildApprovalPending},
-	}
-	for _, c := range cases {
-		if !fires(t, target, c.src, c.want) {
-			t.Fatalf("kebab-case must fire %s on:\n%s", c.want, c.src)
+// TestKebabCaseKeysIgnored: pnpm silently IGNORES kebab-case keys in
+// pnpm-workspace.yaml (ground truth: pnpm 11.5.2, 2026-06-09 -- `pnpm
+// config list` does not load them and install emits no warning; kebab
+// is the .npmrc spelling, not the workspace-file spelling). A kebab key
+// therefore leaves the secure default in effect and must NOT fire.
+func TestKebabCaseKeysIgnored(t *testing.T) {
+	for _, src := range []string{
+		"dangerously-allow-all-builds: true\n",
+		"block-exotic-subdeps: false\n",
+		"trust-lockfile: true\n",
+		"minimum-release-age: 0\n",
+		"strict-dep-builds: false\n",
+		"trust-policy: off\n",
+		"only-built-dependencies:\n  - esbuild\n",
+		"allow-builds:\n  sharp:\n",
+	} {
+		if got := ids(t, target, src); len(got) != 0 {
+			t.Fatalf("kebab-case key is ignored by pnpm and must not fire, got %v on:\n%s", got, src)
 		}
 	}
 }
@@ -167,61 +171,54 @@ dangerouslyAllowAllBuilds: false
 	}
 }
 
-// TestMixedSpellingMergePrecedence: an explicit value wins over a merged
-// one even when the two use different (kebab vs camel) spellings of the
-// same setting. pnpm treats the spellings as one setting, so an explicit
-// safe override must not be shadowed by a merged unsafe value, and an
-// explicit unsafe value must still be flagged.
-func TestMixedSpellingMergePrecedence(t *testing.T) {
-	// Merged unsafe (kebab) + explicit safe (camel) -> no finding.
-	safeWins := `defaults: &d
-  dangerously-allow-all-builds: true
+// TestKebabDoesNotShadowCamel: a kebab key is a separate, ignored key,
+// so it never overrides the camelCase value pnpm actually loads -- in
+// either direction.
+func TestKebabDoesNotShadowCamel(t *testing.T) {
+	// Merged camel true (loaded by pnpm) + explicit kebab false
+	// (ignored by pnpm) -> the dangerous setting IS in effect -> fire.
+	stillDangerous := `defaults: &d
+  dangerouslyAllowAllBuilds: true
 <<: *d
-dangerouslyAllowAllBuilds: false
+dangerously-allow-all-builds: false
 `
-	if fires(t, target, safeWins, RuleDangerousBuilds) {
-		t.Fatal("explicit camelCase false must win over merged kebab-case true")
+	if !fires(t, target, stillDangerous, RuleDangerousBuilds) {
+		t.Fatal("ignored kebab false must not mask the merged camelCase true pnpm loads")
 	}
-	// Merged safe (camel) + explicit unsafe (kebab) -> finding.
-	unsafeWins := `defaults: &d
-  dangerouslyAllowAllBuilds: false
-<<: *d
-dangerously-allow-all-builds: true
-`
-	if !fires(t, target, unsafeWins, RuleDangerousBuilds) {
-		t.Fatal("explicit kebab-case true must win over merged camelCase false")
+	// Explicit camel false + kebab true -> pnpm loads only the safe
+	// false -> no finding.
+	safe := "dangerouslyAllowAllBuilds: false\ndangerously-allow-all-builds: true\n"
+	if fires(t, target, safe, RuleDangerousBuilds) {
+		t.Fatal("ignored kebab true must not override the explicit camelCase false")
 	}
 }
 
-// TestUnrecognizedSpellingNotFlagged: pnpm only accepts kebab-case and
-// camelCase keys, so a smushed-lowercase or mis-cased spelling is a typo
-// pnpm ignores and must not produce a finding.
+// TestDuplicateCamelKeyLastWins: duplicate camelCase keys resolve to the
+// later value, mirroring how a YAML loader applies duplicates.
+func TestDuplicateCamelKeyLastWins(t *testing.T) {
+	if !fires(t, target, "dangerouslyAllowAllBuilds: false\ndangerouslyAllowAllBuilds: true\n", RuleDangerousBuilds) {
+		t.Fatal("later duplicate true must win over earlier false")
+	}
+	if fires(t, target, "dangerouslyAllowAllBuilds: true\ndangerouslyAllowAllBuilds: false\n", RuleDangerousBuilds) {
+		t.Fatal("later duplicate false must win over earlier true")
+	}
+}
+
+// TestUnrecognizedSpellingNotFlagged: only the exact camelCase spelling
+// pnpm honors in pnpm-workspace.yaml matches; any other spelling is a
+// key pnpm ignores there and must not produce a finding.
 func TestUnrecognizedSpellingNotFlagged(t *testing.T) {
 	for _, src := range []string{
 		"dangerouslyallowallbuilds: true\n",     // no camel boundaries
 		"BlockExoticSubdeps: false\n",           // wrong leading case
-		"DANGEROUSLY_ALLOW_ALL_BUILDS: true\n",  // underscores, not kebab
-		"dangerously--allow-all-builds: true\n", // doubled hyphen
+		"DANGEROUSLY_ALLOW_ALL_BUILDS: true\n",  // underscores
+		"dangerously--allow-all-builds: true\n", // malformed hyphenation
 		"dangerously-allow-all-builds-: true\n", // trailing hyphen
 		"-block-exotic-subdeps: false\n",        // leading hyphen
 	} {
 		if got := ids(t, target, src); len(got) != 0 {
 			t.Fatalf("unrecognized key spelling must not fire, got %v on:\n%s", got, src)
 		}
-	}
-}
-
-// TestDuplicateExplicitSpellingLastWins: two explicit spellings of one
-// setting resolve to pnpm's last-wins, regardless of which spelling
-// comes second.
-func TestDuplicateExplicitSpellingLastWins(t *testing.T) {
-	// safe then unsafe -> unsafe wins -> fire.
-	if !fires(t, target, "dangerouslyAllowAllBuilds: false\ndangerously-allow-all-builds: true\n", RuleDangerousBuilds) {
-		t.Fatal("later explicit true must win over earlier explicit false")
-	}
-	// unsafe then safe -> safe wins -> no fire.
-	if fires(t, target, "dangerously-allow-all-builds: true\ndangerouslyAllowAllBuilds: false\n", RuleDangerousBuilds) {
-		t.Fatal("later explicit false must win over earlier explicit true")
 	}
 }
 


### PR DESCRIPTION
Verified against real pnpm 11.5.2: a kebab-case setting key in `pnpm-workspace.yaml` is silently ignored by pnpm (`pnpm config list` does not load it, and install emits no warning). Kebab-case is the `.npmrc` spelling; the workspace file uses camelCase.

The analyzer previously treated both spellings as the same setting, so `dangerously-allow-all-builds: true` was flagged HIGH even though pnpm ignores that line and the secure default is still in effect - a false positive on a config that does not change pnpm's behavior.

Posture findings now fire only on the exact camelCase keys pnpm honors in `pnpm-workspace.yaml`. Kebab-case keys join the ignored-spelling cases, and a regression test locks that an ignored kebab key never shadows the camelCase value pnpm actually loads, in either direction.
