### PR TITLE
Centralize the analyzer registry and derive finding metadata from the rule catalog

### DIFF
--- a/aguara.go
+++ b/aguara.go
@@ -14,16 +14,9 @@ import (
 	"golang.org/x/text/unicode/norm"
 
 	"github.com/garagon/aguara/discover"
-	"github.com/garagon/aguara/internal/engine/ci"
-	"github.com/garagon/aguara/internal/engine/jsrisk"
-	"github.com/garagon/aguara/internal/engine/nlp"
+	"github.com/garagon/aguara/internal/engine"
 	"github.com/garagon/aguara/internal/engine/pattern"
-	"github.com/garagon/aguara/internal/engine/pkgmeta"
-	"github.com/garagon/aguara/internal/engine/pnpmpolicy"
-	"github.com/garagon/aguara/internal/engine/pyrisk"
-	"github.com/garagon/aguara/internal/engine/rsbuild"
 	"github.com/garagon/aguara/internal/engine/rugpull"
-	"github.com/garagon/aguara/internal/engine/toxicflow"
 	"github.com/garagon/aguara/internal/rulecatalog"
 	"github.com/garagon/aguara/internal/rules"
 	"github.com/garagon/aguara/internal/rules/builtin"
@@ -429,26 +422,11 @@ func (sc *Scanner) buildInternalScanner(toolName string) (*scanner.Scanner, erro
 
 	// Reuse pre-compiled pattern matcher (the expensive part: regex + AC automaton)
 	s.RegisterAnalyzer(sc.matcher)
-	// CI trust analyzer parses workflow YAML — runs before toxicflow so its
-	// chain findings can be deduped/correlated alongside leaf signals.
-	s.RegisterAnalyzer(ci.New())
-	// pkgmeta inspects package.json for npm lifecycle / git-source chains.
-	s.RegisterAnalyzer(pkgmeta.New())
-	// jsrisk scans JavaScript for obfuscation, daemonization, CI secret
-	// exfil sinks, runner-process memory access, and Claude / VS Code
-	// persistence references.
-	s.RegisterAnalyzer(jsrisk.New())
-	// pyrisk binds a remote-JS fetch to a node -e/--eval execution sink in
-	// Python install hooks; rsbuild binds a wallet/keystore read to a
-	// network sink in Cargo build scripts. Both replace the retired
-	// co-presence YAML rules, so they must run in the library path too.
-	s.RegisterAnalyzer(pyrisk.New())
-	s.RegisterAnalyzer(rsbuild.New())
-	s.RegisterAnalyzer(pnpmpolicy.New())
-	// NLP and ToxicFlow are stateless, cheap to instantiate
-	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
-	s.RegisterAnalyzer(toxicflow.New())
-	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())
+	// The default analyzer set (ci-trust, pkgmeta, jsrisk, pyrisk,
+	// rsbuild, pnpm-policy, NLP, toxicflow + the cross-file accumulator)
+	// is owned by internal/engine so the CLI and both library paths
+	// always register the same pipeline.
+	engine.RegisterDefaults(s)
 
 	// Rug-pull: fresh state store per scan for thread safety
 	if sc.cfg.stateDir != "" {
@@ -495,8 +473,8 @@ func redactSensitiveFindings(findings []Finding) {
 }
 
 type compileResult struct {
-	compiled         []*rules.CompiledRule
-	toolScopedRules  map[string]scanner.ToolScopedRule
+	compiled        []*rules.CompiledRule
+	toolScopedRules map[string]scanner.ToolScopedRule
 }
 
 // loadAndCompile loads built-in (and optionally custom) rules, compiles them,
@@ -587,15 +565,7 @@ func buildScanner(cfg *scanConfig) (*scanner.Scanner, []*rules.CompiledRule, err
 	}
 
 	s.RegisterAnalyzer(pattern.NewMatcher(cr.compiled))
-	s.RegisterAnalyzer(ci.New())
-	s.RegisterAnalyzer(pkgmeta.New())
-	s.RegisterAnalyzer(jsrisk.New())
-	s.RegisterAnalyzer(pyrisk.New())
-	s.RegisterAnalyzer(rsbuild.New())
-	s.RegisterAnalyzer(pnpmpolicy.New())
-	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
-	s.RegisterAnalyzer(toxicflow.New())
-	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())
+	engine.RegisterDefaults(s)
 
 	// Enable rug-pull detection when stateDir is provided
 	if cfg.stateDir != "" {

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -13,16 +13,9 @@ import (
 	"github.com/garagon/aguara/discover"
 	"github.com/garagon/aguara/internal/baseline"
 	"github.com/garagon/aguara/internal/config"
-	"github.com/garagon/aguara/internal/engine/ci"
-	"github.com/garagon/aguara/internal/engine/jsrisk"
-	"github.com/garagon/aguara/internal/engine/nlp"
+	"github.com/garagon/aguara/internal/engine"
 	"github.com/garagon/aguara/internal/engine/pattern"
-	"github.com/garagon/aguara/internal/engine/pkgmeta"
-	"github.com/garagon/aguara/internal/engine/pnpmpolicy"
-	"github.com/garagon/aguara/internal/engine/pyrisk"
-	"github.com/garagon/aguara/internal/engine/rsbuild"
 	"github.com/garagon/aguara/internal/engine/rugpull"
-	"github.com/garagon/aguara/internal/engine/toxicflow"
 	"github.com/garagon/aguara/internal/output"
 	"github.com/garagon/aguara/internal/rules"
 	"github.com/garagon/aguara/internal/rules/builtin"
@@ -457,15 +450,7 @@ func buildScanner(compiled []*rules.CompiledRule, cfg config.Config, minSev scan
 	}
 
 	s.RegisterAnalyzer(pattern.NewMatcher(compiled))
-	s.RegisterAnalyzer(ci.New())
-	s.RegisterAnalyzer(pkgmeta.New())
-	s.RegisterAnalyzer(jsrisk.New())
-	s.RegisterAnalyzer(pyrisk.New())
-	s.RegisterAnalyzer(rsbuild.New())
-	s.RegisterAnalyzer(pnpmpolicy.New())
-	s.RegisterAnalyzer(nlp.NewInjectionAnalyzer())
-	s.RegisterAnalyzer(toxicflow.New())
-	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())
+	engine.RegisterDefaults(s)
 
 	var store *state.Store
 	if flagMonitor {

--- a/internal/engine/ci/metadata.go
+++ b/internal/engine/ci/metadata.go
@@ -10,7 +10,7 @@ func RuleMetadata() []rulemeta.Rule {
 	return []rulemeta.Rule{
 		{
 			ID:       RulePwnRequest,
-			Name:     "Pull-request-target with PR-controlled checkout",
+			Name:     "pull_request_target executes untrusted PR code",
 			Severity: "HIGH",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerCITrust,
@@ -28,7 +28,7 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 		{
 			ID:       RuleCache,
-			Name:     "Pull-request-target cache poisoning chain",
+			Name:     "Untrusted PR workflow can write cache consumed by privileged workflows",
 			Severity: "HIGH",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerCITrust,
@@ -43,7 +43,7 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 		{
 			ID:       RuleOIDC,
-			Name:     "OIDC token grant on install/build/test chain",
+			Name:     "OIDC token available in a job that executes install/build/test code",
 			Severity: "HIGH",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerCITrust,
@@ -59,7 +59,7 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 		{
 			ID:       RuleCheckout,
-			Name:     "Pull-request-target head-ref checkout without persist-credentials: false",
+			Name:     "Privileged workflow checks out PR code with persisted credentials",
 			Severity: "HIGH",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerCITrust,
@@ -73,3 +73,8 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 	}
 }
+
+// ruleInfo indexes this analyzer's catalog metadata by rule ID so emit
+// sites derive RuleName / Severity / Category from the single source of
+// truth instead of duplicating the strings.
+var ruleInfo = rulemeta.Index(RuleMetadata())

--- a/internal/engine/ci/workflow.go
+++ b/internal/engine/ci/workflow.go
@@ -615,9 +615,9 @@ func detectPwnRequest(wf *workflow, j *job) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RulePwnRequest,
-		RuleName: "pull_request_target executes untrusted PR code",
+		RuleName: ruleInfo[RulePwnRequest].Name,
 		Severity: sev,
-		Category: "supply-chain",
+		Category: ruleInfo[RulePwnRequest].Category,
 		Description: "Workflow runs on pull_request_target (privileged) and checks out " +
 			"the PR head ref while the same job installs, builds, tests, or runs " +
 			"PR-controlled code. This is the classic pwn-request chain that turns " +
@@ -651,9 +651,9 @@ func detectCache(wf *workflow, j *job) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RuleCache,
-		RuleName: "Untrusted PR workflow can write cache consumed by privileged workflows",
+		RuleName: ruleInfo[RuleCache].Name,
 		Severity: sev,
-		Category: "supply-chain",
+		Category: ruleInfo[RuleCache].Category,
 		Description: "pull_request_target jobs that check out PR code AND populate the " +
 			"GitHub Actions cache can poison cache entries consumed later by privileged " +
 			"workflows. Cache writes are not constrained by the workflow's GITHUB_TOKEN " +
@@ -694,9 +694,9 @@ func detectOIDC(wf *workflow, j *job, eff perms) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RuleOIDC,
-		RuleName: "OIDC token available in a job that executes install/build/test code",
+		RuleName: ruleInfo[RuleOIDC].Name,
 		Severity: sev,
-		Category: "supply-chain",
+		Category: ruleInfo[RuleOIDC].Category,
 		Description: "id-token: write (or write-all) is granted on a job that also installs, " +
 			"builds, tests, or runs scripts. The OIDC token is exposed for the lifetime of " +
 			"the job, so any compromised dependency lifecycle script can mint a trusted " +
@@ -725,9 +725,9 @@ func detectCheckout(wf *workflow, j *job) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RuleCheckout,
-		RuleName: "Privileged workflow checks out PR code with persisted credentials",
-		Severity: types.SeverityHigh,
-		Category: "supply-chain",
+		RuleName: ruleInfo[RuleCheckout].Name,
+		Severity: ruleInfo[RuleCheckout].SeverityLevel(),
+		Category: ruleInfo[RuleCheckout].Category,
 		Description: "actions/checkout in a pull_request_target job is fetching the PR head " +
 			"ref while leaving persist-credentials at its default (true). That leaves the " +
 			"job's GITHUB_TOKEN in .git/config, where any subsequent step executing PR code " +

--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -1,0 +1,86 @@
+// Package engine is the single source of truth for the default
+// analyzer set. Every entry point that builds a scanner (the CLI's
+// scan command and both library constructors in the root package)
+// registers the same analyzers in the same pipeline order through
+// RegisterDefaults, and the rule catalog (explain / list-rules)
+// aggregates every analyzer's metadata through RuleMetadata.
+//
+// Before this package existed, adding one analyzer meant editing four
+// registration sites plus the catalog by hand, and a missed site meant
+// the CLI and the library silently disagreed about what a scan runs.
+// Now an analyzer is added exactly once, here.
+//
+// Two analyzers intentionally stay caller-wired and are NOT part of
+// RegisterDefaults:
+//
+//   - the pattern matcher, because it is built from compiled YAML rules
+//     (and the library path reuses a pre-compiled matcher, the
+//     expensive part: regex + Aho-Corasick automaton);
+//   - rug-pull, because it only joins when the caller provides a state
+//     store (--monitor on the CLI, WithStateDir in the library).
+//
+// Their metadata is still aggregated here (rug-pull through
+// RuleMetadata; pattern rules come from the YAML catalog, not from an
+// analyzer).
+package engine
+
+import (
+	"github.com/garagon/aguara/internal/engine/ci"
+	"github.com/garagon/aguara/internal/engine/jsrisk"
+	"github.com/garagon/aguara/internal/engine/nlp"
+	"github.com/garagon/aguara/internal/engine/pkgmeta"
+	"github.com/garagon/aguara/internal/engine/pnpmpolicy"
+	"github.com/garagon/aguara/internal/engine/pyrisk"
+	"github.com/garagon/aguara/internal/engine/rsbuild"
+	"github.com/garagon/aguara/internal/engine/rugpull"
+	"github.com/garagon/aguara/internal/engine/toxicflow"
+	"github.com/garagon/aguara/internal/rulemeta"
+	"github.com/garagon/aguara/internal/scanner"
+)
+
+// DefaultAnalyzers returns fresh instances of the stateless analyzers
+// every scan runs, in pipeline order. The order is part of the
+// contract: ci-trust runs before toxicflow so its chain findings can be
+// deduped and correlated alongside leaf signals, and the slice runs
+// after the caller-registered pattern matcher and before the optional
+// rug-pull analyzer.
+func DefaultAnalyzers() []scanner.Analyzer {
+	return []scanner.Analyzer{
+		ci.New(),
+		pkgmeta.New(),
+		jsrisk.New(),
+		pyrisk.New(),
+		rsbuild.New(),
+		pnpmpolicy.New(),
+		nlp.NewInjectionAnalyzer(),
+		toxicflow.New(),
+	}
+}
+
+// RegisterDefaults registers the default analyzer set plus the
+// cross-file correlation accumulator on s. Callers register the pattern
+// matcher before this and the optional rug-pull analyzer after it.
+func RegisterDefaults(s *scanner.Scanner) {
+	for _, a := range DefaultAnalyzers() {
+		s.RegisterAnalyzer(a)
+	}
+	s.SetCrossFileAccumulator(toxicflow.NewCrossFileAnalyzer())
+}
+
+// RuleMetadata returns the catalog entries for every analyzer-emitted
+// rule, including rug-pull (whose analyzer is registered conditionally
+// at runtime but whose rule is always explainable). Pattern-matcher
+// rules are not listed here; they come from the compiled YAML catalog.
+func RuleMetadata() []rulemeta.Rule {
+	var out []rulemeta.Rule
+	out = append(out, ci.RuleMetadata()...)
+	out = append(out, pkgmeta.RuleMetadata()...)
+	out = append(out, jsrisk.RuleMetadata()...)
+	out = append(out, pyrisk.RuleMetadata()...)
+	out = append(out, rsbuild.RuleMetadata()...)
+	out = append(out, pnpmpolicy.RuleMetadata()...)
+	out = append(out, nlp.RuleMetadata()...)
+	out = append(out, toxicflow.RuleMetadata()...)
+	out = append(out, rugpull.RuleMetadata()...)
+	return out
+}

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -1272,9 +1272,9 @@ func detectGitHubC2(path string, m *metrics) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RuleGitHubC2,
-		RuleName: "GitHub used as payload or command channel",
+		RuleName: ruleInfo[RuleGitHubC2].Name,
 		Severity: sev,
-		Category: "supply-chain",
+		Category: ruleInfo[RuleGitHubC2].Category,
 		Description: "JavaScript writes or controls GitHub-hosted content (" + m.GitHubChannelKind +
 			") and pairs it with a supply-chain signal: obfuscation, local execution, " +
 			"persistence, a non-GitHub credential read, or an exfil sink. This is GitHub used " +
@@ -1940,9 +1940,9 @@ func detectHostTamper(path string, m *metrics, content []byte) []types.Finding {
 		}
 		out = append(out, types.Finding{
 			RuleID:   RuleSudoersTamper,
-			RuleName: "Sudoers privilege tampering",
+			RuleName: ruleInfo[RuleSudoersTamper].Name,
 			Severity: sev,
-			Category: "supply-chain",
+			Category: ruleInfo[RuleSudoersTamper].Category,
 			Description: "Package JavaScript writes to /etc/sudoers or /etc/sudoers.d/* " +
 				"during install or runtime, changing who can run commands as root. A bound " +
 				"fs write or a shell redirect/tee/sed -i targets the sudoers surface. " +
@@ -2002,9 +2002,9 @@ func detectHostTamper(path string, m *metrics, content []byte) []types.Finding {
 		}
 		out = append(out, types.Finding{
 			RuleID:   RuleHostTrustTamper,
-			RuleName: "Host trust surface tampering",
+			RuleName: ruleInfo[RuleHostTrustTamper].Name,
 			Severity: sev,
-			Category: "supply-chain",
+			Category: ruleInfo[RuleHostTrustTamper].Category,
 			Description: "Package JavaScript writes to a host trust surface: the dynamic " +
 				"linker preload (/etc/ld.so.preload), a CA certificate store, the SSH daemon " +
 				"config, the global shell profile, or name resolution (/etc/hosts, " +
@@ -3020,9 +3020,9 @@ func detectWiperTripwire(path string, m *metrics, content []byte) *types.Finding
 	}
 	return &types.Finding{
 		RuleID:   RuleWiperTripwire,
-		RuleName: "Destructive wipe of sensitive paths",
+		RuleName: ruleInfo[RuleWiperTripwire].Name,
 		Severity: sev,
-		Category: "supply-chain",
+		Category: ruleInfo[RuleWiperTripwire].Category,
 		Description: "Package JavaScript performs a REAL destructive delete of a sensitive " +
 			"path -- a credential store (.ssh/.aws/.gnupg/.kube/...), agent/editor trust " +
 			"(.claude/.vscode/...), shell history, an evidence log, or a honeytoken -- or a " +
@@ -4398,9 +4398,9 @@ func detectBunSecondStage(path string, m *metrics) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RuleBunSecondStage,
-		RuleName: "Bun second-stage execution",
+		RuleName: ruleInfo[RuleBunSecondStage].Name,
 		Severity: sev,
-		Category: "supply-chain",
+		Category: ruleInfo[RuleBunSecondStage].Category,
 		Description: "JavaScript runs the Bun runtime as a second stage alongside a " +
 			"supply-chain signal: an obfuscator-shape payload, a CI/cloud secret read, or a " +
 			"network exfil sink. The Red Hat/Miasma worm used a Node preinstall hook to " +
@@ -5752,9 +5752,9 @@ func detectDNSTXTExfil(path string, m *metrics, content []byte) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RuleDNSTXTExfil,
-		RuleName: "DNS TXT exfiltration chain in JavaScript",
+		RuleName: ruleInfo[RuleDNSTXTExfil].Name,
 		Severity: sev,
-		Category: "supply-chain",
+		Category: ruleInfo[RuleDNSTXTExfil].Category,
 		Description: "JavaScript invokes resolveTxt against the Node dns module and " +
 			"pairs it with at least one further exfiltration signal: a CI / cloud " +
 			"secret read, an envs.txt credential stage, a tar.gz archive staged " +
@@ -5817,9 +5817,9 @@ func detectObfuscation(path string, m *metrics) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RuleObfuscation,
-		RuleName: "Large obfuscated JavaScript payload",
+		RuleName: ruleInfo[RuleObfuscation].Name,
 		Severity: sev,
-		Category: "supply-chain",
+		Category: ruleInfo[RuleObfuscation].Category,
 		Description: "JavaScript file matches the static shape of an obfuscator-emitted " +
 			"payload (hex identifier density, dispatcher calls, or a while(!![]) loop) " +
 			"in combination with at least one further signal. Payloads with this shape are " +
@@ -5856,9 +5856,9 @@ func detectDaemon(path string, m *metrics) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RuleDaemon,
-		RuleName: "Detached background execution from JavaScript",
+		RuleName: ruleInfo[RuleDaemon].Name,
 		Severity: sev,
-		Category: "supply-chain",
+		Category: ruleInfo[RuleDaemon].Category,
 		Description: "JavaScript spawns a child process with detached: true and either " +
 			"stdio ignored or .unref() called. That keeps the spawned process alive past " +
 			"the parent's exit, which is the standard shape for install-time payloads that " +
@@ -5890,9 +5890,9 @@ func detectCISecretHarvest(path string, m *metrics) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RuleCISecretHarvest,
-		RuleName: "CI credential harvesting with network or registry sink",
-		Severity: types.SeverityCritical,
-		Category: "supply-chain",
+		RuleName: ruleInfo[RuleCISecretHarvest].Name,
+		Severity: ruleInfo[RuleCISecretHarvest].SeverityLevel(),
+		Category: ruleInfo[RuleCISecretHarvest].Category,
 		Description: "JavaScript reads a CI / cloud token (e.g. " + m.CISecretMatched +
 			") and then routes it to a network, npm registry, GitHub API, or session-exfil " +
 			"sink. Whatever the wrapper looks like, this is the credential-exfil shape used " +
@@ -5928,9 +5928,9 @@ func detectProcMemOIDC(path string, m *metrics) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RuleProcMemOIDC,
-		RuleName: "Runner process memory access combined with OIDC token reference",
-		Severity: types.SeverityCritical,
-		Category: "supply-chain",
+		RuleName: ruleInfo[RuleProcMemOIDC].Name,
+		Severity: ruleInfo[RuleProcMemOIDC].SeverityLevel(),
+		Category: ruleInfo[RuleProcMemOIDC].Category,
 		Description: "JavaScript accesses /proc/<pid>/mem|maps|cmdline-style paths and " +
 			"references ACTIONS_ID_TOKEN_REQUEST_* or Runner.Worker. Reading another " +
 			"process's memory to steal an OIDC token is a runner-pivot shape with no " +
@@ -5961,9 +5961,9 @@ func detectAgentPersistence(path string, m *metrics) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RuleAgentPersistence,
-		RuleName: "Persistence through Claude Code or VS Code workspace automation",
+		RuleName: ruleInfo[RuleAgentPersistence].Name,
 		Severity: sev,
-		Category: "supply-chain",
+		Category: ruleInfo[RuleAgentPersistence].Category,
 		Description: "File references " + m.AgentPathMatched + ", an automation surface that " +
 			"executes on workspace open. Writing to or invoking these paths from package " +
 			"code installs persistence that survives reinstall and is invisible outside the " +

--- a/internal/engine/jsrisk/metadata.go
+++ b/internal/engine/jsrisk/metadata.go
@@ -11,7 +11,7 @@ func RuleMetadata() []rulemeta.Rule {
 	return []rulemeta.Rule{
 		{
 			ID:       RuleObfuscation,
-			Name:     "Obfuscator-shape JavaScript payload",
+			Name:     "Large obfuscated JavaScript payload",
 			Severity: "MEDIUM",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerJSRisk,
@@ -26,7 +26,7 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 		{
 			ID:       RuleDaemon,
-			Name:     "Install-time daemonization via child_process",
+			Name:     "Detached background execution from JavaScript",
 			Severity: "HIGH",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerJSRisk,
@@ -40,7 +40,7 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 		{
 			ID:   RuleCISecretHarvest,
-			Name: "CI secret harvest: process.env read + network sink",
+			Name: "CI credential harvesting with network or registry sink",
 			// Emit site (jsrisk.go) ships SeverityCritical for
 			// this rule; the catalog mirrors that so list-rules /
 			// explain triage stays aligned with scan findings.
@@ -57,7 +57,7 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 		{
 			ID:       RuleProcMemOIDC,
-			Name:     "Runner-process memory pivot to extract OIDC tokens",
+			Name:     "Runner process memory access combined with OIDC token reference",
 			Severity: "CRITICAL",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerJSRisk,
@@ -71,7 +71,7 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 		{
 			ID:       RuleAgentPersistence,
-			Name:     "Claude Code / VS Code workspace persistence",
+			Name:     "Persistence through Claude Code or VS Code workspace automation",
 			Severity: "HIGH",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerJSRisk,
@@ -85,7 +85,7 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 		{
 			ID:       RuleDNSTXTExfil,
-			Name:     "DNS TXT credential exfiltration chain",
+			Name:     "DNS TXT exfiltration chain in JavaScript",
 			Severity: "HIGH",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerJSRisk,
@@ -204,3 +204,8 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 	}
 }
+
+// ruleInfo indexes this analyzer's catalog metadata by rule ID so emit
+// sites derive RuleName / Severity / Category from the single source of
+// truth instead of duplicating the strings.
+var ruleInfo = rulemeta.Index(RuleMetadata())

--- a/internal/engine/pkgmeta/metadata.go
+++ b/internal/engine/pkgmeta/metadata.go
@@ -9,7 +9,7 @@ func RuleMetadata() []rulemeta.Rule {
 	return []rulemeta.Rule{
 		{
 			ID:       RuleLifecycleGit,
-			Name:     "npm install-time lifecycle script with git-sourced dependency",
+			Name:     "Git dependency can execute lifecycle code during install",
 			Severity: "HIGH",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerPkgMeta,
@@ -26,7 +26,7 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 		{
 			ID:       RuleOptionalGit,
-			Name:     "git-sourced optionalDependency",
+			Name:     "Optional dependency resolves executable code from git",
 			Severity: "MEDIUM",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerPkgMeta,
@@ -60,7 +60,7 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 		{
 			ID:       RulePublishSurface,
-			Name:     "publishConfig + install/build/test + trusted publishing reference",
+			Name:     "Package publish surface exposed to install-time code",
 			Severity: "HIGH",
 			Category: "supply-chain",
 			Analyzer: rulemeta.AnalyzerPkgMeta,
@@ -75,3 +75,8 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 	}
 }
+
+// ruleInfo indexes this analyzer's catalog metadata by rule ID so emit
+// sites derive RuleName / Severity / Category from the single source of
+// truth instead of duplicating the strings.
+var ruleInfo = rulemeta.Index(RuleMetadata())

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -626,9 +626,9 @@ func detectLocalJSLifecycle(pkg *manifest) []types.Finding {
 		}
 		findings = append(findings, types.Finding{
 			RuleID:   RuleLocalJSLifecycle,
-			RuleName: "npm lifecycle script executes local JavaScript",
-			Severity: types.SeverityHigh,
-			Category: "supply-chain",
+			RuleName: ruleInfo[RuleLocalJSLifecycle].Name,
+			Severity: ruleInfo[RuleLocalJSLifecycle].SeverityLevel(),
+			Category: ruleInfo[RuleLocalJSLifecycle].Category,
 			Description: "package.json runs " + runtime + " on local JavaScript from the `" + key +
 				"` lifecycle script, which npm executes automatically during install. " +
 				"Install-time execution of a package's own JS is the first hop of supply-chain " +
@@ -684,9 +684,9 @@ func detectLifecycleGit(pkg *manifest) []types.Finding {
 		safeVersion := sanitizeGitURL(d.Version)
 		findings = append(findings, types.Finding{
 			RuleID:   RuleLifecycleGit,
-			RuleName: "Git dependency can execute lifecycle code during install",
+			RuleName: ruleInfo[RuleLifecycleGit].Name,
 			Severity: sev,
-			Category: "supply-chain",
+			Category: ruleInfo[RuleLifecycleGit].Category,
 			Description: "package.json pulls " + d.Name + " from a git source (" + safeVersion +
 				") and defines an npm install-time lifecycle script. On `npm install`, " +
 				"the git ref can change between resolutions and the lifecycle script will " +
@@ -740,9 +740,9 @@ func detectOptionalGit(pkg *manifest) []types.Finding {
 		safeVersion := sanitizeGitURL(v)
 		findings = append(findings, types.Finding{
 			RuleID:   RuleOptionalGit,
-			RuleName: "Optional dependency resolves executable code from git",
+			RuleName: ruleInfo[RuleOptionalGit].Name,
 			Severity: sev,
-			Category: "supply-chain",
+			Category: ruleInfo[RuleOptionalGit].Category,
 			Description: "optionalDependencies." + n + " resolves to a git source (" + safeVersion +
 				"). Optional dependencies install silently when resolution succeeds, so a " +
 				"mutable git ref here is a quieter supply-chain entry point than the same " +
@@ -787,9 +787,9 @@ func detectPublishSurface(pkg *manifest) *types.Finding {
 	}
 	return &types.Finding{
 		RuleID:   RulePublishSurface,
-		RuleName: "Package publish surface exposed to install-time code",
-		Severity: types.SeverityHigh,
-		Category: "supply-chain",
+		RuleName: ruleInfo[RulePublishSurface].Name,
+		Severity: ruleInfo[RulePublishSurface].SeverityLevel(),
+		Category: ruleInfo[RulePublishSurface].Category,
 		Description: "package.json defines a publish surface (publishConfig or a publish " +
 			"script) alongside install/build/test scripts and references provenance / " +
 			"trusted-publishing / OIDC. Install-time scripts running in the same context " +

--- a/internal/engine/pnpmpolicy/metadata.go
+++ b/internal/engine/pnpmpolicy/metadata.go
@@ -139,3 +139,8 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 	}
 }
+
+// ruleInfo indexes this analyzer's catalog metadata by rule ID so emit
+// sites derive RuleName / Severity / Category from the single source of
+// truth instead of duplicating the strings.
+var ruleInfo = rulemeta.Index(RuleMetadata())

--- a/internal/engine/pnpmpolicy/pnpmpolicy.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy.go
@@ -64,8 +64,6 @@ const (
 // AnalyzerName is the analyzer identifier surfaced on findings.
 const AnalyzerName = rulemeta.AnalyzerPnpmPolicy
 
-const category = "supply-chain"
-
 // maxMergeDepth bounds YAML merge-key resolution (anchor cycles / deeply
 // nested merges) so a hostile file cannot cause unbounded recursion.
 const maxMergeDepth = 16
@@ -144,12 +142,12 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	}
 
 	var findings []types.Finding
-	emit := func(id, name, sev, desc string, line int, rem string) {
+	emit := func(id, desc string, line int, rem string) {
 		findings = append(findings, types.Finding{
 			RuleID:      id,
-			RuleName:    name,
-			Severity:    severity(sev),
-			Category:    category,
+			RuleName:    ruleInfo[id].Name,
+			Severity:    ruleInfo[id].SeverityLevel(),
+			Category:    ruleInfo[id].Category,
 			Description: desc,
 			FilePath:    rel,
 			Line:        line,
@@ -162,7 +160,7 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	// 1. dangerouslyAllowAllBuilds: true -> HIGH
 	if e, ok := get("dangerouslyAllowAllBuilds"); ok {
 		if b, parsed := yamlBool(e.value.Value); parsed && b {
-			emit(RuleDangerousBuilds, "pnpm dangerouslyAllowAllBuilds enabled", "HIGH",
+			emit(RuleDangerousBuilds,
 				"dangerouslyAllowAllBuilds: true lets every direct and transitive dependency run install-time lifecycle scripts without approval.",
 				e.line,
 				"Remove dangerouslyAllowAllBuilds: true and approve only the packages that need build scripts via allowBuilds (or `pnpm approve-builds`).")
@@ -172,7 +170,7 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	// 2. strictDepBuilds: false -> MEDIUM (v11 default is true).
 	if e, ok := get("strictDepBuilds"); ok {
 		if b, parsed := yamlBool(e.value.Value); parsed && !b {
-			emit(RuleStrictDepBuildsDisabled, "pnpm strictDepBuilds disabled", "MEDIUM",
+			emit(RuleStrictDepBuildsDisabled,
 				"strictDepBuilds: false downgrades an unapproved build script from an install failure to a warning, so unreviewed install-time code can pass CI.",
 				e.line,
 				"Remove strictDepBuilds: false (or set it to true) so an unapproved build script fails the install and forces an explicit allowBuilds decision.")
@@ -182,7 +180,7 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	// 3. blockExoticSubdeps: false -> MEDIUM (v11 default is true).
 	if e, ok := get("blockExoticSubdeps"); ok {
 		if b, parsed := yamlBool(e.value.Value); parsed && !b {
-			emit(RuleExoticSubdepsDisabled, "pnpm blockExoticSubdeps disabled", "MEDIUM",
+			emit(RuleExoticSubdepsDisabled,
 				"blockExoticSubdeps: false allows transitive dependencies to resolve from git/tarball URLs instead of the registry, widening the code that can enter the tree without registry provenance.",
 				e.line,
 				"Remove blockExoticSubdeps: false (or set it to true). If a specific exotic subdep is required, vet and pin it explicitly rather than disabling the block globally.")
@@ -192,7 +190,7 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	// 4. trustLockfile: true -> MEDIUM (v11 default is false).
 	if e, ok := get("trustLockfile"); ok {
 		if b, parsed := yamlBool(e.value.Value); parsed && b {
-			emit(RuleTrustLockfile, "pnpm trustLockfile enabled", "MEDIUM",
+			emit(RuleTrustLockfile,
 				"trustLockfile: true stops pnpm re-applying minimumReleaseAge and trustPolicy to lockfile entries, raising lockfile-poisoning risk on repos that take outside contributions.",
 				e.line,
 				"Remove trustLockfile: true so pnpm keeps verifying lockfile entries. Only consider it in fully closed repos where the lockfile is trusted end to end.")
@@ -205,7 +203,7 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 		if n, parsed := yamlInt(e.value.Value); parsed {
 			minAgeSet, minAgeVal = true, n
 			if n == 0 {
-				emit(RuleMinReleaseAgeDisabled, "pnpm minimumReleaseAge disabled", "LOW",
+				emit(RuleMinReleaseAgeDisabled,
 					"minimumReleaseAge: 0 is an explicit opt-out of the v11 default (1440 minutes), removing the wait window that protects against freshly published malicious versions.",
 					e.line,
 					"Remove minimumReleaseAge: 0 to use the default window, or set a positive value (e.g. 1440 for one day).")
@@ -218,7 +216,7 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	// compatibility default, so we stay silent.
 	if e, ok := get("minimumReleaseAgeStrict"); ok && minAgeSet && minAgeVal > 0 {
 		if b, parsed := yamlBool(e.value.Value); parsed && !b {
-			emit(RuleMinReleaseAgeNonStrict, "pnpm minimumReleaseAge not strictly enforced", "LOW",
+			emit(RuleMinReleaseAgeNonStrict,
 				"minimumReleaseAge is set to a positive value but minimumReleaseAgeStrict: false lets pnpm fall back to a version below the age threshold when no compatible alternative exists.",
 				e.line,
 				"Set minimumReleaseAgeStrict: true (or remove the false override) so the release-age threshold is always enforced.")
@@ -230,7 +228,7 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	// the token, and absence never fires.
 	if e, ok := get("trustPolicy"); ok {
 		if strings.EqualFold(strings.TrimSpace(e.value.Value), "off") {
-			emit(RuleTrustPolicyOff, "pnpm trustPolicy explicitly off", "LOW",
+			emit(RuleTrustPolicyOff,
 				"trustPolicy: off is set explicitly, opting the project out of trust-evidence checks (such as no-downgrade) that harden the lockfile.",
 				e.line,
 				"Consider a stricter trust policy such as no-downgrade. If off is intentional, document why; the finding only surfaces because the opt-out is explicit.")
@@ -240,7 +238,7 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	// 8. Legacy v10 build-policy settings -> INFO, one per present key.
 	for _, k := range legacyKeys {
 		if e, ok := get(k); ok {
-			emit(RuleLegacyBuildPolicy, "pnpm legacy v10 build-policy setting", "INFO",
+			emit(RuleLegacyBuildPolicy,
 				fmt.Sprintf("%q is a pnpm v10 build-policy setting removed or replaced in v11; on v11 it no longer takes effect, so the intended build restriction may silently not apply.", e.key),
 				e.line,
 				"Migrate this setting to allowBuilds, the v11 mechanism for deciding which dependencies may run build scripts, and verify the resulting policy matches the original intent.")
@@ -258,7 +256,7 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 			}
 			seenPkg[ab.key] = true
 			if isNull(ab.value) {
-				emit(RuleBuildApprovalPending, "pnpm allowBuilds entry pending decision", "MEDIUM",
+				emit(RuleBuildApprovalPending,
 					fmt.Sprintf("allowBuilds entry %q has no explicit true/false decision; the package has a build script still pending review.", ab.key),
 					ab.line,
 					"Set this allowBuilds entry to true (allow) or false (block) after reviewing the package's install-time script, or run `pnpm approve-builds`.")
@@ -421,17 +419,6 @@ func srcLine(lines []string, n int) string {
 		return ""
 	}
 	return strings.TrimSpace(lines[n-1])
-}
-
-// severity maps the canonical string to a types.Severity. Unknown
-// strings degrade to INFO rather than panicking; the metadata strings
-// are all known so this is defensive only.
-func severity(s string) types.Severity {
-	sev, err := types.ParseSeverity(s)
-	if err != nil {
-		return types.SeverityInfo
-	}
-	return sev
 }
 
 // isTarget matches only pnpm-workspace.yaml (by base name, on either

--- a/internal/engine/pyrisk/metadata.go
+++ b/internal/engine/pyrisk/metadata.go
@@ -30,3 +30,8 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 	}
 }
+
+// ruleInfo indexes this analyzer's catalog metadata by rule ID so emit
+// sites derive RuleName / Severity / Category from the single source of
+// truth instead of duplicating the strings.
+var ruleInfo = rulemeta.Index(RuleMetadata())

--- a/internal/engine/pyrisk/pyrisk.go
+++ b/internal/engine/pyrisk/pyrisk.go
@@ -132,9 +132,9 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 			if _, ok := taint[payload]; ok {
 				return []types.Finding{{
 					RuleID:      RulePyImportTimeRemoteJS,
-					RuleName:    "PyPI import-time remote JavaScript execution",
-					Severity:    types.SeverityCritical,
-					Category:    "supply-chain",
+					RuleName:    ruleInfo[RulePyImportTimeRemoteJS].Name,
+					Severity:    ruleInfo[RulePyImportTimeRemoteJS].SeverityLevel(),
+					Category:    ruleInfo[RulePyImportTimeRemoteJS].Category,
 					Description: "A remote JavaScript payload fetched at install/import time is passed to node -e: the value executed traces back to the download.",
 					FilePath:    target.RelPath,
 					Line:        ln.num,

--- a/internal/engine/rsbuild/metadata.go
+++ b/internal/engine/rsbuild/metadata.go
@@ -31,3 +31,8 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 	}
 }
+
+// ruleInfo indexes this analyzer's catalog metadata by rule ID so emit
+// sites derive RuleName / Severity / Category from the single source of
+// truth instead of duplicating the strings.
+var ruleInfo = rulemeta.Index(RuleMetadata())

--- a/internal/engine/rsbuild/rsbuild.go
+++ b/internal/engine/rsbuild/rsbuild.go
@@ -111,9 +111,9 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 		if networkSinkRe.MatchString(ln.text) && sinkSendsTainted(ln.text, taint) {
 			return []types.Finding{{
 				RuleID:      RuleBuildWalletExfil,
-				RuleName:    "Rust build.rs wallet/keystore exfiltration",
-				Severity:    types.SeverityCritical,
-				Category:    "supply-chain",
+				RuleName:    ruleInfo[RuleBuildWalletExfil].Name,
+				Severity:    ruleInfo[RuleBuildWalletExfil].SeverityLevel(),
+				Category:    ruleInfo[RuleBuildWalletExfil].Category,
 				Description: "A Cargo build script reads wallet/keystore material and sends it over the network: the value reaching the network sink traces back to the keystore read.",
 				FilePath:    target.RelPath,
 				Line:        ln.num,

--- a/internal/engine/rugpull/metadata.go
+++ b/internal/engine/rugpull/metadata.go
@@ -35,3 +35,8 @@ func RuleMetadata() []rulemeta.Rule {
 		},
 	}
 }
+
+// ruleInfo indexes this analyzer's catalog metadata by rule ID so emit
+// sites derive RuleName / Severity / Category from the single source of
+// truth instead of duplicating the strings.
+var ruleInfo = rulemeta.Index(RuleMetadata())

--- a/internal/engine/rugpull/rugpull.go
+++ b/internal/engine/rugpull/rugpull.go
@@ -85,9 +85,9 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 
 		findings = append(findings, types.Finding{
 			RuleID:      "RUGPULL_001",
-			RuleName:    "Tool description changed with dangerous content",
-			Severity:    types.SeverityCritical,
-			Category:    "rug-pull",
+			RuleName:    ruleInfo["RUGPULL_001"].Name,
+			Severity:    ruleInfo["RUGPULL_001"].SeverityLevel(),
+			Category:    ruleInfo["RUGPULL_001"].Category,
 			Description: "File content changed since last scan and now contains suspicious patterns. This may indicate a rug-pull attack where a previously safe tool becomes malicious.",
 			FilePath:    target.RelPath,
 			Line:        lineNum,

--- a/internal/rulecatalog/catalog.go
+++ b/internal/rulecatalog/catalog.go
@@ -18,15 +18,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/garagon/aguara/internal/engine/ci"
-	"github.com/garagon/aguara/internal/engine/jsrisk"
-	"github.com/garagon/aguara/internal/engine/nlp"
-	"github.com/garagon/aguara/internal/engine/pkgmeta"
-	"github.com/garagon/aguara/internal/engine/pnpmpolicy"
-	"github.com/garagon/aguara/internal/engine/pyrisk"
-	"github.com/garagon/aguara/internal/engine/rsbuild"
-	"github.com/garagon/aguara/internal/engine/rugpull"
-	"github.com/garagon/aguara/internal/engine/toxicflow"
+	"github.com/garagon/aguara/internal/engine"
 	"github.com/garagon/aguara/internal/rulemeta"
 	"github.com/garagon/aguara/internal/rules"
 	"github.com/garagon/aguara/internal/rules/builtin"
@@ -112,20 +104,14 @@ func Build(opts Options) ([]rulemeta.Rule, error) {
 		out = append(out, fromCompiledRule(r))
 	}
 
-	// 4. Analyzer-emitted rules. Order doesn't matter; the sort
-	// at the end establishes the canonical ordering. rugpull is
-	// in the catalog unconditionally even though the analyzer
-	// only runs with --monitor / WithStateDir, so `aguara explain
-	// RUGPULL_001` works without first enabling the detector.
-	out = append(out, ci.RuleMetadata()...)
-	out = append(out, pkgmeta.RuleMetadata()...)
-	out = append(out, jsrisk.RuleMetadata()...)
-	out = append(out, pyrisk.RuleMetadata()...)
-	out = append(out, rsbuild.RuleMetadata()...)
-	out = append(out, pnpmpolicy.RuleMetadata()...)
-	out = append(out, nlp.RuleMetadata()...)
-	out = append(out, toxicflow.RuleMetadata()...)
-	out = append(out, rugpull.RuleMetadata()...)
+	// 4. Analyzer-emitted rules, aggregated by the engine registry
+	// (the same single source of truth the scanner pipelines register
+	// from). Order doesn't matter; the sort at the end establishes the
+	// canonical ordering. rugpull is in the catalog unconditionally
+	// even though the analyzer only runs with --monitor / WithStateDir,
+	// so `aguara explain RUGPULL_001` works without first enabling the
+	// detector.
+	out = append(out, engine.RuleMetadata()...)
 
 	// 5. --disable-rule filter. Applied AFTER merge so users can
 	// disable analyzer rules too (same UX as YAML rules).

--- a/internal/rulemeta/rule.go
+++ b/internal/rulemeta/rule.go
@@ -21,6 +21,8 @@
 // strings.
 package rulemeta
 
+import "github.com/garagon/aguara/internal/types"
+
 // Rule is the neutral metadata shape for a detection rule.
 //
 // Field semantics:
@@ -68,3 +70,27 @@ const (
 	AnalyzerPnpmPolicy = "pnpm-policy"
 	AnalyzerPattern    = "" // YAML-driven rules; empty so JSON omits the field
 )
+
+// Index returns the rules keyed by ID. Analyzers use it to derive their
+// emit-site RuleName / Severity / Category from their own RuleMetadata()
+// instead of duplicating the strings, so scan output and the catalog
+// (explain / list-rules) cannot drift apart.
+func Index(rules []Rule) map[string]Rule {
+	out := make(map[string]Rule, len(rules))
+	for _, r := range rules {
+		out[r.ID] = r
+	}
+	return out
+}
+
+// SeverityLevel returns the types.Severity for the rule's canonical
+// severity string. Unknown strings degrade to INFO rather than
+// panicking; metadata severities are static and locked by the catalog
+// tests, so this is defensive only.
+func (r Rule) SeverityLevel() types.Severity {
+	sev, err := types.ParseSeverity(r.Severity)
+	if err != nil {
+		return types.SeverityInfo
+	}
+	return sev
+}


### PR DESCRIPTION
Two structural improvements with no behavior change to scan output:

- **Single analyzer registry.** The CLI and both library entry points registered the default analyzer set by hand at four call sites, with the rule catalog keeping its own list. `internal/engine` now owns the set: every pipeline registers the same analyzers in the same order, and adding an analyzer is a one-line change.
- **Finding metadata derives from the catalog.** Analyzers duplicated each rule's name, severity, and category at every emit site. The two copies had drifted for 13 rules - scan findings showed one rule name while `aguara explain` showed another. Emit sites now derive these fields from the analyzer's own catalog metadata, so scan output and `explain`/`list-rules` can no longer disagree. The drifted catalog names were aligned to what scan already emits, keeping scan output byte-identical (verified over a 1,600-finding corpus).

No new rules, no severity changes, no detection changes.
