### PR TITLE
Release prep v0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,52 +5,29 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [0.24.0] - 2026-06-10
 
-Aguara now checks the trust layer around AI agents and pnpm projects.
-A new agent-policy analyzer reads a repo's Claude Code configuration and
-flags settings that are dangerous to inherit from a clone; pnpm posture
-checks verify a project uses pnpm v11's supply-chain controls; and
-`pnpm-lock.yaml` parsing is hardened so an alias-shaped lockfile entry
-cannot hide a compromised registry package behind a local dependency
-name.
+Extends Aguara's trust layer in both directions: what an AI agent is
+about to obey, and what a package manager is about to install. On the
+agent side, a cloned repo's Claude Code settings are now vetted before
+their hooks and helpers run, and agent instruction files like
+`.cursorrules` and `AGENTS.md` are treated as the high-trust prompt
+surfaces they are. On the package side, pnpm projects are checked for
+weakened supply-chain policy, and Bun and Yarn Berry lockfiles join the
+pre-install parsers, so every major npm-family lockfile can now be
+audited before a single install script runs. The rule catalog grows to
+244 cataloged detections (193 YAML + 51 analyzer-emitted) and gains an
+`agent-trust` category. Everything stays deterministic and offline:
+no package execution, no network calls during a scan. Existing rule
+IDs, severities, and the `Severity` JSON encoding are unchanged.
 
 ### Added
 
-- **bun.lock and yarn Berry lockfile parsing** (`aguara check` /
-  `aguara audit`). A freshly cloned Bun or Yarn v2+ project can now be
-  audited before install: `bun.lock` (the text lockfile) and `yarn.lock`
-  Berry (v2+) join the existing `pnpm-lock.yaml` / `package-lock.json` /
-  classic `yarn.lock` parsers. Both resolve `npm:` aliases to the real
-  registry package -- Bun records it as the resolved first element, Berry
-  as the `resolution:` field -- so a compromised package cannot hide
-  behind a local alias. Conservative, like the other npm parsers: only
-  exact registry tuples are emitted; git/file/workspace/patch sources and
-  ranges are skipped, and results dedupe on (name, version). A Berry
-  lockfile previously errored out as unsupported; it is now parsed.
-  The legacy binary `bun.lockb` is not parsed (it cannot be read without
-  running Bun); a repo whose only lockfile is `bun.lockb` fails with a
-  clear message to commit the text `bun.lock` instead, rather than
-  passing as audited with zero packages read.
-
-- **Agent instruction files treated as a high-trust prompt-injection
-  surface.** Files an AI editor auto-loads and follows as directives --
-  `.cursorrules`, `.windsurfrules`, `.clinerules`, `AGENTS.md`, and
-  `copilot-instructions.md` -- are now run through the prompt-injection
-  (NLP) analyzer even when they have no `.md` extension, and a finding in
-  one is weighted up rather than getting the documentation penalty a
-  README receives. An injected directive in these files is what the agent
-  actually obeys, so the same payload scores higher here than in prose.
-  No new rules or analyzer. The directory-scoped Cursor and Windsurf rule
-  formats (`.cursor/rules/*.mdc`, `.windsurf/rules/*`) and pattern-rule
-  coverage of the extensionless files are a follow-up. `CLAUDE.md` is
-  intentionally left out for now, since it is so widely used for
-  legitimate project instructions that flagging it would be noisy.
-
-- **agent-policy analyzer** (`internal/engine/agentpolicy/`), the
-  eleventh scan analyzer. Reads `.claude/settings.json` /
-  `settings.local.json` and flags Claude Code host configuration that is
-  dangerous to inherit from a cloned repo (after the one-time
-  workspace-trust prompt, its hooks and helpers run automatically), with
-  eight new rules in a new `agent-trust` category:
+- **agent-policy analyzer** (`internal/engine/agentpolicy/`). A cloned
+  repo can ship a `.claude/settings.json` that Claude Code loads when
+  the workspace is trusted; from then on its hooks and credential
+  helpers run automatically. The new analyzer reads
+  `.claude/settings.json` / `settings.local.json` and flags host
+  configuration that is dangerous to inherit from someone else's repo,
+  with eight new rules in the new `agent-trust` category:
   - `AGENTCFG_HOOK_FETCH_EXEC_001` (CRITICAL): a hook command downloads
     and runs remote code (`curl | sh`, `eval $(curl ...)`), executed
     automatically when a session opens in the repo.
@@ -58,7 +35,7 @@ name.
     code-execution variable (`NODE_OPTIONS --require`, `LD_PRELOAD`,
     `BASH_ENV`, and similar).
   - `AGENTCFG_BYPASS_PERMS_001` (HIGH): `permissions.defaultMode` is
-    `bypassPermissions`, pre-disabling the tool-approval prompt.
+    `bypassPermissions`, weakening tool approval for the workspace.
   - `AGENTCFG_MCP_AUTOAPPROVE_001` (MEDIUM):
     `enableAllProjectMcpServers: true` auto-loads every `.mcp.json`
     server.
@@ -69,17 +46,35 @@ name.
   - `AGENTCFG_HELPER_REPO_SCRIPT_001` (MEDIUM): a credential helper
     (`apiKeyHelper`, `awsAuthRefresh`) runs a repo-shipped script.
   - `AGENTCFG_PERMS_WEAK_MODE_001` (LOW): `defaultMode` is `acceptEdits`
-    or `auto` shipped as a project default.
+    shipped as a project default.
 
   A missing setting is treated as the secure default and never fires;
   the analyzer judges the dangerous shape of a value, not the presence
-  of hooks or permissions. Malformed JSON is silent. Rule catalog grows
-  to 244 cataloged detections (193 YAML + 51 analyzer-emitted).
+  of hooks or permissions. Claude Code is the first agent-policy
+  surface; the same posture applies to other agent host configs.
 
-- **pnpm-policy analyzer** (`internal/engine/pnpmpolicy/`), the tenth
-  scan analyzer. Reads `pnpm-workspace.yaml` and flags supply-chain
-  settings weakened below the pnpm v11 defaults, with nine new rules
-  (all category `supply-chain`):
+- **Agent instruction files treated as a high-trust prompt surface.**
+  Files agentic coding tools load as persistent context --
+  `.cursorrules`, `.windsurfrules`, `.clinerules`, `AGENTS.md`, and
+  `copilot-instructions.md` -- are now run through the prompt-injection
+  (NLP) analyzer even when they have no `.md` extension, and a finding
+  in one is weighted up rather than getting the documentation penalty a
+  README receives. An injected directive in these files is closer to
+  the agent's operating instructions than to prose, so the same payload
+  scores higher here. The directory-scoped Cursor and Windsurf rule
+  formats (`.cursor/rules/*.mdc`, `.windsurf/rules/*`) and pattern-rule
+  coverage of the extensionless files are a follow-up. `CLAUDE.md` is
+  intentionally left out for now: it is so widely used for legitimate
+  project instructions that flagging it needs a dedicated
+  false-positive pass first.
+
+- **pnpm-policy analyzer** (`internal/engine/pnpmpolicy/`). pnpm v11
+  ships real supply-chain controls -- build-script approval, a release
+  age window, exotic-source blocking -- but a single
+  `pnpm-workspace.yaml` line can quietly turn them off. The new
+  analyzer reads `pnpm-workspace.yaml` and flags settings weakened
+  below the v11 defaults, with nine new rules (all category
+  `supply-chain`):
   - `PNPM_DANGEROUS_BUILDS_001` (HIGH): `dangerouslyAllowAllBuilds: true`
     lets every dependency run install-time lifecycle scripts without
     approval.
@@ -104,8 +99,23 @@ name.
   `pnpm-workspace.yaml` match (verified against pnpm 11.5.2: a
   kebab-case key there is silently ignored by pnpm, so flagging it
   would be a false positive). YAML merge keys (`<<:`) are expanded, and
-  each finding points at the exact line. Rule catalog grows to 236
-  cataloged detections (193 YAML + 43 analyzer-emitted).
+  each finding points at the exact line.
+
+- **bun.lock and yarn Berry lockfile parsing** (`aguara check` /
+  `aguara audit`). A freshly cloned Bun or Yarn v2+ project can now be
+  audited before install: `bun.lock` (the text lockfile) and `yarn.lock`
+  Berry (v2+) join the existing `pnpm-lock.yaml` / `package-lock.json` /
+  classic `yarn.lock` parsers. Both resolve `npm:` aliases to the real
+  registry package -- Bun records it as the resolved first element, Berry
+  as the `resolution:` field -- so a compromised package cannot hide
+  behind a local alias. Conservative, like the other npm parsers: only
+  exact registry tuples are emitted; git/file/workspace/patch sources and
+  ranges are skipped, and results dedupe on (name, version). A Berry
+  lockfile previously errored out as unsupported; it is now parsed.
+  The legacy binary `bun.lockb` is not parsed (it cannot be read without
+  running Bun); a repo whose only lockfile is `bun.lockb` fails with a
+  clear message to commit the text `bun.lock` instead, rather than
+  passing as audited with zero packages read.
 
 - **`npm:` alias resolution in `pnpm-lock.yaml`** (`aguara check` /
   `aguara audit`). An alias-shaped lockfile entry such as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to Aguara are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.24.0] - 2026-06-10
 
 Aguara now checks the trust layer around AI agents and pnpm projects.
 A new agent-policy analyzer reads a repo's Claude Code configuration and

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.23.0 (2026-06-07; main carries unreleased #203 pnpm-policy + #204 pnpm aliases + #207 engine registry + agentpolicy). 193 YAML rules + 51 analyzer-emitted (244 cataloged), 13 YAML categories (+ analyzer categories incl. agent-trust), 11 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, pnpmpolicy, agentpolicy, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic v1 / yarn.lock Berry v2+ / bun.lock text - all with `npm:` alias resolution to the real package - and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
+Aguara v0.24.0 (2026-06-10; aggregates #203/#204/#206 pnpm posture + alias resolution, #207 engine registry refactor, #208 agent-policy, #209 bun/yarn-berry lockfiles, #210 instruction-file weighting). 193 YAML rules + 51 analyzer-emitted (244 cataloged), 13 YAML categories (+ analyzer categories incl. agent-trust), 11 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, pnpmpolicy, agentpolicy, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic v1 / yarn.lock Berry v2+ / bun.lock text - all with `npm:` alias resolution to the real package - and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
 
 Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, multi-arch `linux/amd64+arm64`, runs as non-root UID 10001, base images digest-pinned, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
@@ -157,7 +157,7 @@ When any of these values change, update ALL references across the vault:
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)
 - Watch skill count (currently 28,000+)
-- Version number (currently v0.23.0)
+- Version number (currently v0.24.0)
 
 Use `Grep` to find all occurrences before updating.
 

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.23.0
+INSTALL_SH_TEST_VERSION ?= v0.24.0
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ brew install garagon/tap/aguara
 ### Docker
 
 ```bash
-docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.23.0 check /repo
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.24.0 check /repo
 ```
 
 Multi-arch (`linux/amd64` + `linux/arm64`), runs as non-root UID 10001, base images digest-pinned, and signed at the digest with Cosign plus SPDX SBOM and SLSA provenance attestations. Pin a specific release tag for reproducibility.
@@ -234,7 +234,7 @@ Multi-arch (`linux/amd64` + `linux/arm64`), runs as non-root UID 10001, base ima
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.23.0 sh
+  | VERSION=v0.24.0 sh
 ```
 
 `install.sh` downloads `checksums.txt` and verifies the archive's SHA256 against it, aborting if neither `sha256sum` nor `shasum` is available. This catches a tampered archive at the registry layer but does not verify the Cosign signature on `checksums.txt` itself; for full keyless-signature verification on the curl-pipe path, follow the Cosign step in [Verifying signed releases](#verifying-signed-releases). Default install location is `~/.local/bin`; override with `INSTALL_DIR` for CI or containers.
@@ -242,11 +242,11 @@ curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
 ### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.23.0
+- uses: garagon/aguara@v0.24.0
   with:
     path: .
     fail-on: high
-    version: v0.23.0
+    version: v0.24.0
 ```
 
 Both pins are required: the action ref pins the composite action and its install script, and `version:` pins the Aguara binary it installs. Setting both keeps the workflow reproducible and dependabot-friendly. See [`action.yml`](action.yml) for all inputs.
@@ -284,15 +284,15 @@ GitHub Code Scanning, GitLab SAST, and plain Docker-in-CI examples are below.
 
 ```yaml
 # GitHub Action with SARIF upload (needs security-events: write)
-- uses: garagon/aguara@v0.23.0
-  with: { path: ., severity: medium, fail-on: high, version: v0.23.0 }
+- uses: garagon/aguara@v0.24.0
+  with: { path: ., severity: medium, fail-on: high, version: v0.24.0 }
 ```
 
 ```yaml
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.23.0 sh
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.24.0 sh
     - aguara scan . --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:
@@ -337,7 +337,7 @@ Eleven scan analyzers run per file (ten by default; rug-pull joins with `--monit
 | RSBuild | Cargo build-script scanner | `build.rs` reading wallet/keystore material and sending it to a network sink (flow-sensitive) |
 | Pnpm Policy | `pnpm-workspace.yaml` YAML | pnpm supply-chain settings weakened below the v11 defaults (build approval, release age, exotic sources, trust policy) |
 | Agent Policy | `.claude/settings.json` JSON | Claude Code host config that is dangerous to inherit from a cloned repo: hooks that fetch-and-execute, code-injection env vars, `bypassPermissions`, MCP auto-approval, dangerous allow rules, repo-shipped credential helpers |
-| NLP | Goldmark AST + JSON/YAML | Prompt injection, tool poisoning, proximity-weighted keyword classification |
+| NLP | Goldmark AST + JSON/YAML | Prompt injection, tool poisoning, proximity-weighted keyword classification. Agent instruction files (`.cursorrules`, `.windsurfrules`, `.clinerules`, `AGENTS.md`, `copilot-instructions.md`) are scanned even without a `.md` extension and weighted as high-trust prompt surfaces |
 | Toxic Flow | Capability correlation | Dangerous source/sink combinations within a file and across files in a directory |
 | Rug-Pull | SHA256 change tracking | Tool descriptions that change between scans (`--monitor`) |
 
@@ -348,7 +348,7 @@ A separate `aguara check` / `aguara audit` path inspects installed package trees
 Every release is signed with [Cosign](https://github.com/sigstore/cosign) keyless, ships an SPDX SBOM per archive, and is built with `-trimpath` for reproducibility. The container image is signed at the digest with SBOM + SLSA provenance attestations.
 
 ```bash
-VERSION=v0.23.0
+VERSION=v0.24.0
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
@@ -396,7 +396,7 @@ Suppress individual findings inline with `# aguara-ignore RULE_ID` (also `-next-
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale and is not a supported surface for v0.23.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
+Aguara Watch is being reworked. The previous public observatory is stale and is not a supported surface for v0.24.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.23.0"
+        DEFAULT_REF="v0.24.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.23.0 tag rather than `@v1`
+// The action ref is pinned to the v0.24.0 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.23.0
+        uses: garagon/aguara@v0.24.0
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.23.0
+          version: v0.24.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
Prepares v0.24.0.

This release expands Aguara's trust-layer coverage in two places that now matter more for software teams: the agent layer and the package layer.

On the agent side, Aguara now checks repository files that can shape how AI coding tools behave. It flags risky Claude Code project settings, treats agent instruction files like .cursorrules and AGENTS.md as high-trust prompt surfaces, and gives those findings the weight they deserve because they are closer to operating instructions than ordinary documentation.

On the package side, Aguara now covers more projects before install. It checks pnpm security posture, resolves npm aliases in pnpm-lock.yaml, and adds pre-install coverage for Bun and Yarn Berry lockfiles with the same conservative rule: emit only exact registry package/version tuples.

The result is a stronger local trust check before a repo is installed, trusted by an agent, or promoted into CI.

This PR only prepares the release:
- cuts the changelog to v0.24.0
- bumps version pins
- updates docs and catalog counts
- keeps the tag/publish step separate

No runtime changes are added in this PR; the shipped functionality is already on main.
