### PR TITLE
Add npm-policy checks for npm v12 install trust

### DIFF
--- a/internal/engine/engine.go
+++ b/internal/engine/engine.go
@@ -29,6 +29,7 @@ import (
 	"github.com/garagon/aguara/internal/engine/ci"
 	"github.com/garagon/aguara/internal/engine/jsrisk"
 	"github.com/garagon/aguara/internal/engine/nlp"
+	"github.com/garagon/aguara/internal/engine/npmpolicy"
 	"github.com/garagon/aguara/internal/engine/pkgmeta"
 	"github.com/garagon/aguara/internal/engine/pnpmpolicy"
 	"github.com/garagon/aguara/internal/engine/pyrisk"
@@ -52,6 +53,7 @@ func DefaultAnalyzers() []scanner.Analyzer {
 		jsrisk.New(),
 		pyrisk.New(),
 		rsbuild.New(),
+		npmpolicy.New(),
 		pnpmpolicy.New(),
 		agentpolicy.New(),
 		nlp.NewInjectionAnalyzer(),
@@ -80,6 +82,7 @@ func RuleMetadata() []rulemeta.Rule {
 	out = append(out, jsrisk.RuleMetadata()...)
 	out = append(out, pyrisk.RuleMetadata()...)
 	out = append(out, rsbuild.RuleMetadata()...)
+	out = append(out, npmpolicy.RuleMetadata()...)
 	out = append(out, pnpmpolicy.RuleMetadata()...)
 	out = append(out, agentpolicy.RuleMetadata()...)
 	out = append(out, nlp.RuleMetadata()...)

--- a/internal/engine/npmpolicy/metadata.go
+++ b/internal/engine/npmpolicy/metadata.go
@@ -1,0 +1,84 @@
+package npmpolicy
+
+import "github.com/garagon/aguara/internal/rulemeta"
+
+// RuleMetadata returns the catalog entries for every rule this analyzer
+// emits. Co-located with the analyzer so `aguara explain` and
+// `list-rules` stay in sync with what scan actually reports. Severity
+// and Category here MUST match the values the analyzer sets on each
+// emitted Finding (locked by rulecatalog's metadata-match test).
+func RuleMetadata() []rulemeta.Rule {
+	return []rulemeta.Rule{
+		{
+			ID:       RuleDangerousAllScripts,
+			Name:     "npm dangerously-allow-all-scripts enabled",
+			Severity: "HIGH",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerNpmPolicy,
+			Description: ".npmrc sets dangerously-allow-all-scripts=true, bypassing npm's " +
+				"allowScripts policy entirely: every dependency install script (preinstall / " +
+				"install / postinstall) runs regardless of whether it was approved or denied. " +
+				"npm documents the flag as a migration escape hatch whose use is strongly " +
+				"discouraged. Under the npm v12 trust model (dependency scripts blocked unless " +
+				"approved), this single committed line re-opens the classic supply-chain " +
+				"malware entry point for everyone who clones the repository.",
+			Remediation: "Remove dangerously-allow-all-scripts from the committed .npmrc. Approve " +
+				"the specific packages that genuinely need install scripts with `npm " +
+				"approve-scripts <pkg>` (writing pinned allowScripts entries to package.json), " +
+				"leaving everything else blocked.",
+		},
+		{
+			ID:       RuleAllowScriptsUnpinned,
+			Name:     "npm allowScripts approval not version-pinned",
+			Severity: "MEDIUM",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerNpmPolicy,
+			Description: "The allowScripts policy approves a package's install scripts by name " +
+				"only (or .npmrc sets allow-scripts-pin=false, which makes `npm approve-scripts` " +
+				"write such entries). A name-only `true` entry approves every future version of " +
+				"the package, so a compromised release published tomorrow inherits the approval " +
+				"that was granted to the version someone actually reviewed. npm's default is to " +
+				"pin approvals as name@version. Name-only entries with value false are denies " +
+				"(npm deny-scripts always writes them name-only) and are not flagged.",
+			Remediation: "Re-approve with pinning enabled (the default): remove the name-only " +
+				"entry and run `npm approve-scripts <pkg>` so the approval is written as " +
+				"name@version, then re-review on version bumps. Remove allow-scripts-pin=false " +
+				"from .npmrc if present.",
+		},
+		{
+			ID:       RuleAllowGitRelaxed,
+			Name:     "npm git-dependency resolution pinned open",
+			Severity: "MEDIUM",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerNpmPolicy,
+			Description: ".npmrc sets allow-git to \"all\" or \"root\", explicitly keeping git " +
+				"dependency resolution enabled. npm v12 defaults allow-git to \"none\" because " +
+				"resolving a git dependency is a code-execution path: the dependency's own " +
+				".npmrc can override the git executable, which runs even under " +
+				"--ignore-scripts. A committed value pins the relaxed behavior through the v12 " +
+				"upgrade for everyone who clones (\"root\" bounds it to direct dependencies; " +
+				"\"all\" includes transitive ones).",
+			Remediation: "Remove allow-git from the committed .npmrc so the npm v12 default " +
+				"(none) applies, or replace git dependencies with registry versions. If a git " +
+				"dependency is genuinely required, prefer allow-git=root over all, and treat " +
+				"the exception as a reviewed trust decision.",
+		},
+		{
+			ID:       RuleAllowRemoteRelaxed,
+			Name:     "npm remote-tarball resolution pinned open",
+			Severity: "MEDIUM",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerNpmPolicy,
+			Description: ".npmrc sets allow-remote to \"all\" or \"root\", explicitly keeping " +
+				"remote-URL tarball resolution enabled. npm v12 defaults allow-remote to " +
+				"\"none\": a tarball URL bypasses the registry's versioning, provenance, and " +
+				"advisory surface entirely, so v12 makes consuming one an explicit decision. A " +
+				"committed value pins the relaxed behavior through the upgrade (\"root\" bounds " +
+				"it to direct dependencies; \"all\" includes transitive ones).",
+			Remediation: "Remove allow-remote from the committed .npmrc so the npm v12 default " +
+				"(none) applies, or replace URL tarball dependencies with registry versions. If " +
+				"one is genuinely required, prefer allow-remote=root over all, and pin the " +
+				"exact tarball.",
+		},
+	}
+}

--- a/internal/engine/npmpolicy/npmpolicy.go
+++ b/internal/engine/npmpolicy/npmpolicy.go
@@ -1,0 +1,384 @@
+// Package npmpolicy is a small, auditable analyzer for npm
+// supply-chain posture under the npm v12 trust model. It does NOT
+// resolve package@version against threat intel (that is packagecheck's
+// job); it reads the project's committed npm configuration and reports
+// where the v12 trust controls have been weakened or pinned open.
+//
+// npm v12 (announced 2026-06-09, estimated July 2026; preparable on npm
+// 11.16.0+) makes three install-time decisions explicit: dependency
+// install scripts run only when approved in the package.json
+// `allowScripts` policy, git dependencies resolve only under
+// `allow-git`, and remote-tarball dependencies only under
+// `allow-remote`. All three are configured in files a repository ships,
+// which makes them posture the repo can weaken for everyone who clones.
+//
+// Design rules (mirroring pnpm-policy):
+//   - Two targets, matched by base name: `package.json` (the
+//     `allowScripts` policy field) and `.npmrc` (project config).
+//     No cross-file correlation, no npm-version inference. Severities
+//     are fixed so the catalog and scan output never disagree.
+//   - Defaults are never findings. The analyzer fires only on an
+//     explicit value that is less safe than the npm v12 baseline;
+//     absence stays silent.
+//   - Only shapes npm actually honors fire (ground-truthed against npm
+//     11.16.0, 2026-06-10):
+//   - `allowScripts` entries are written by `npm approve-scripts` as
+//     pinned `name@version: true`. A name-only entry with value `true`
+//     allows every future version (written when `allow-scripts-pin` is
+//     false). A name-only entry with value `false` is a DENY (`npm
+//     deny-scripts` always writes name-only) and must never fire.
+//   - There is no wildcard approve: `npm approve-scripts '*'` is
+//     rejected, so a literal "*" key is not a shape npm honors and is
+//     not flagged. The real approve-all is the
+//     `dangerously-allow-all-scripts` escape hatch in .npmrc.
+//   - `allow-git` / `allow-remote` accept "all" | "none" | "root"
+//     ("root" = direct dependencies only). Their npm 11.x default is
+//     "all"; npm v12 flips both to "none". An explicit value in a
+//     committed .npmrc pins the relaxed behavior through the upgrade.
+//
+// .npmrc parsing is deliberately narrow: top-level `key=value` lines
+// (npm's ini dialect), `#`/`;` comments ignored, a bare `key` line
+// reads as true (ini semantics), surrounding quotes stripped, exact
+// lowercase keys only, and values containing `${...}` env expansion are
+// treated as ambiguous and skipped rather than guessed. Lines inside an
+// `[section]` are ignored (npm does not read our keys from sections).
+package npmpolicy
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/garagon/aguara/internal/rulemeta"
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+)
+
+// Rule IDs emitted by this analyzer.
+const (
+	RuleDangerousAllScripts  = "NPM_DANGEROUS_ALL_SCRIPTS_001"
+	RuleAllowScriptsUnpinned = "NPM_ALLOW_SCRIPTS_UNPINNED_001"
+	RuleAllowGitRelaxed      = "NPM_ALLOW_GIT_RELAXED_001"
+	RuleAllowRemoteRelaxed   = "NPM_ALLOW_REMOTE_RELAXED_001"
+)
+
+// AnalyzerName is the analyzer identifier surfaced on findings.
+const AnalyzerName = rulemeta.AnalyzerNpmPolicy
+
+// findingConfidence: the keys are exact and the values explicit; the
+// only uncertainty is whether the file is consumed by the npm version
+// in use. High, mirroring agent-policy's posture findings.
+const findingConfidence = 0.9
+
+// Analyzer implements scanner.Analyzer.
+type Analyzer struct{}
+
+// New constructs the npm-policy analyzer.
+func New() *Analyzer { return &Analyzer{} }
+
+// Name returns the analyzer identifier.
+func (a *Analyzer) Name() string { return AnalyzerName }
+
+// Analyze inspects package.json (allowScripts policy) and project
+// .npmrc files for npm v12 trust-model weakenings. Non-target files,
+// malformed input, and absent settings all return no findings.
+func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.Finding, error) {
+	switch filepath.Base(filepath.ToSlash(target.RelPath)) {
+	case "package.json":
+		return a.analyzePackageJSON(target), nil
+	case ".npmrc":
+		return a.analyzeNpmrc(target), nil
+	default:
+		return nil, nil
+	}
+}
+
+// ---------------------------------------------------------------------------
+// package.json: the allowScripts policy field
+
+// analyzePackageJSON flags name-only allowScripts entries whose value is
+// true: they approve install scripts for every future version of the
+// package, where `npm approve-scripts` would have written a pinned
+// `name@version` entry. Deny entries (value false) and pinned allows
+// never fire.
+func (a *Analyzer) analyzePackageJSON(target *scanner.Target) []types.Finding {
+	// Decode the root as a raw map and look up the exact "allowScripts"
+	// key: encoding/json struct fields match case-insensitively, but npm
+	// reads manifest keys case-sensitively, so a mis-cased field like
+	// "AllowScripts" is inert for npm and must stay silent here.
+	var root map[string]json.RawMessage
+	if err := json.Unmarshal(target.Content, &root); err != nil {
+		return nil // malformed JSON: stay silent rather than guess
+	}
+	rawPolicy, ok := root["allowScripts"]
+	if !ok {
+		return nil
+	}
+	var policy map[string]json.RawMessage
+	if err := json.Unmarshal(rawPolicy, &policy); err != nil || len(policy) == 0 {
+		return nil // wrong type or empty: not a shape npm honors
+	}
+
+	// Iterate in sorted key order: Go map order is random, and the
+	// scanner deduplicates findings by (file, rule, line), so minified
+	// manifests with several entries on one line must emit
+	// deterministically across runs.
+	keys := make([]string, 0, len(policy))
+	for k := range policy {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	var findings []types.Finding
+	for _, key := range keys {
+		raw := policy[key]
+		if strings.TrimSpace(string(raw)) != "true" {
+			continue // false = deny (always name-only); non-bool = not a shape npm writes
+		}
+		if isPinnedEntry(key) {
+			continue // name@version: the shape approve-scripts writes by default
+		}
+		if !plausiblePackageName(key) {
+			// Ground truth npm 11.16.0: an entry like "*" is not a glob;
+			// it could only match a package literally named "*", which
+			// cannot exist, so the entry is inert and never flagged.
+			continue
+		}
+		findings = append(findings, a.finding(
+			RuleAllowScriptsUnpinned, target,
+			allowScriptsEntryLine(target.Content, key),
+			fmt.Sprintf("allowScripts entry %q is name-only with value true: install scripts are approved for every future version of the package, not the version that was reviewed.", key),
+			key+": true",
+		))
+	}
+	return findings
+}
+
+// plausiblePackageName reports whether key could name a real npm
+// package (letters, digits, @scope/ separators, ., _, -). Keys with
+// glob or whitespace characters cannot match any installable package,
+// so npm's allowScripts evaluation never honors them.
+func plausiblePackageName(key string) bool {
+	if key == "" {
+		return false
+	}
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '@' || r == '/' || r == '.' || r == '_' || r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isPinnedEntry reports whether an allowScripts key carries a version
+// pin (`name@version`, including scoped `@scope/name@version`). A
+// scoped name's leading "@" is not a pin.
+func isPinnedEntry(key string) bool {
+	return strings.LastIndex(key, "@") > 0
+}
+
+// ---------------------------------------------------------------------------
+// .npmrc: project config
+
+// analyzeNpmrc evaluates the project .npmrc. npm's ini config applies
+// last-wins precedence for repeated top-level keys (ground truth npm
+// 11.16.0: `allow-git=all` followed by `allow-git=none` is effectively
+// "none"), so values are collected first and each key is evaluated once
+// on its final value. For boolean keys, both a bare `key` line and an
+// empty `key=` assignment read as true (also ground-truthed); for the
+// enum keys an empty value is not a relaxation and stays silent.
+func (a *Analyzer) analyzeNpmrc(target *scanner.Target) []types.Finding {
+	type kv struct {
+		val  string
+		bare bool
+		line int
+		raw  string
+	}
+	last := make(map[string]kv, 4)
+	inSection := false
+	for i, rawLine := range strings.Split(string(target.Content), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") {
+			inSection = true // npm does not read these keys from ini sections
+			continue
+		}
+		if inSection {
+			continue
+		}
+		key, val, bare := splitNpmrcLine(line)
+		switch key {
+		case "dangerously-allow-all-scripts", "allow-scripts-pin", "allow-git", "allow-remote":
+			last[key] = kv{val: val, bare: bare, line: i + 1, raw: line}
+		}
+	}
+
+	var findings []types.Finding
+	for key, e := range last {
+		if strings.Contains(e.val, "${") {
+			continue // env-expanded value: ambiguous, skip rather than guess
+		}
+		switch key {
+		case "dangerously-allow-all-scripts":
+			// Boolean: bare key, empty assignment, and explicit true all
+			// read as enabled in npm's ini dialect.
+			if e.bare || e.val == "" || e.val == "true" {
+				findings = append(findings, a.finding(
+					RuleDangerousAllScripts, target, e.line,
+					"dangerously-allow-all-scripts=true bypasses the allowScripts policy entirely: every dependency install script runs regardless of approval or denial. npm documents it as a migration escape hatch whose use is strongly discouraged.",
+					e.raw,
+				))
+			}
+		case "allow-scripts-pin":
+			if e.val == "false" {
+				findings = append(findings, a.finding(
+					RuleAllowScriptsUnpinned, target, e.line,
+					"allow-scripts-pin=false makes `npm approve-scripts` write name-only allowScripts entries, approving install scripts for every future version instead of the version that was reviewed.",
+					e.raw,
+				))
+			}
+		case "allow-git":
+			if e.val == "all" || e.val == "root" {
+				findings = append(findings, a.finding(
+					RuleAllowGitRelaxed, target, e.line,
+					fmt.Sprintf("allow-git=%s pins git-dependency resolution open; npm v12 defaults it to \"none\" because a git dependency's own .npmrc can override the git executable, a code-execution path that survives --ignore-scripts. %s", e.val, relaxScope(e.val)),
+					e.raw,
+				))
+			}
+		case "allow-remote":
+			if e.val == "all" || e.val == "root" {
+				findings = append(findings, a.finding(
+					RuleAllowRemoteRelaxed, target, e.line,
+					fmt.Sprintf("allow-remote=%s pins remote-tarball dependency resolution open; npm v12 defaults it to \"none\" so unreviewed URL sources need an explicit decision. %s", e.val, relaxScope(e.val)),
+					e.raw,
+				))
+			}
+		}
+	}
+	return findings
+}
+
+// relaxScope phrases how far a "all"/"root" value opens resolution.
+func relaxScope(val string) string {
+	if val == "root" {
+		return "\"root\" limits this to direct dependencies, a bounded but still explicit relaxation."
+	}
+	return "\"all\" extends this to transitive dependencies as well."
+}
+
+// splitNpmrcLine splits an .npmrc line into key, value, and whether the
+// line was a bare key (which npm's ini dialect reads as true).
+//
+// Ground truth against npm 11.16.0:
+//   - inline comments on unquoted values are stripped regardless of
+//     preceding whitespace (`allow-git=all#note` reads as "all");
+//   - a fully quoted value is unquoted (`allow-git="all"` reads "all");
+//   - a quoted value followed by trailing content keeps its quotes
+//     literally (`allow-git="all" # temporary` reads the string
+//     `"all"`, which is not a valid enum value, so the setting is NOT
+//     honored). Such values are returned verbatim so they never match
+//     our enum/boolean comparisons.
+func splitNpmrcLine(line string) (key, val string, bare bool) {
+	eq := strings.Index(line, "=")
+	if eq < 0 {
+		k := line
+		if i := strings.IndexAny(k, "#;"); i >= 0 {
+			k = k[:i]
+		}
+		return strings.TrimSpace(k), "", true
+	}
+	key = strings.TrimSpace(line[:eq])
+	raw := strings.TrimSpace(line[eq+1:])
+	if len(raw) >= 2 && (raw[0] == '"' || raw[0] == '\'') {
+		q := raw[0]
+		if raw[len(raw)-1] == q && strings.IndexByte(raw[1:len(raw)-1], q) < 0 {
+			return key, raw[1 : len(raw)-1], false // fully quoted: unquote
+		}
+		return key, raw, false // quoted + trailing junk: kept literal by npm
+	}
+	if i := strings.IndexAny(raw, "#;"); i >= 0 {
+		raw = strings.TrimSpace(raw[:i])
+	}
+	return key, raw, false
+}
+
+// ---------------------------------------------------------------------------
+
+// finding assembles a Finding with metadata derived from the catalog,
+// so emit-site name/severity/category cannot drift from explain output.
+func (a *Analyzer) finding(ruleID string, target *scanner.Target, line int, desc, matched string) types.Finding {
+	meta := ruleIndex[ruleID]
+	return types.Finding{
+		RuleID:      ruleID,
+		RuleName:    meta.Name,
+		Severity:    meta.SeverityLevel(),
+		Category:    meta.Category,
+		FilePath:    target.RelPath,
+		Line:        line,
+		Description: desc,
+		MatchedText: matched,
+		Remediation: meta.Remediation,
+		Analyzer:    AnalyzerName,
+		Confidence:  findingConfidence,
+	}
+}
+
+// allowScriptsEntryLine locates an allowScripts entry key in the raw
+// manifest. It tries the literal spelling first, then the
+// JSON-escaped-slash spelling (`@scope\/pkg`, produced by some
+// serializers and decoded identically by json.Unmarshal), and finally
+// falls back to the allowScripts block itself so the finding always
+// carries a valid 1-based line.
+func allowScriptsEntryLine(content []byte, key string) int {
+	if l := lineOfAfter(content, `"allowScripts"`, `"`+key+`"`); l > 0 {
+		return l
+	}
+	escaped := strings.ReplaceAll(key, "/", `\/`)
+	if escaped != key {
+		if l := lineOfAfter(content, `"allowScripts"`, `"`+escaped+`"`); l > 0 {
+			return l
+		}
+	}
+	if l := lineOfAfter(content, `"allowScripts"`, `"allowScripts"`); l > 0 {
+		return l
+	}
+	// Exotic but valid JSON encodings (e.g. a unicode-escaped property
+	// name) can defeat every literal anchor; keep the 1-based contract.
+	return 1
+}
+
+// lineOfAfter locates needle at or after the first occurrence of
+// anchor and returns its 1-based line number (0 when not found). The
+// anchor keeps allowScripts findings pointing inside the policy block
+// even when the same package name appears earlier in the manifest
+// (for example under dependencies).
+func lineOfAfter(content []byte, anchor, needle string) int {
+	text := string(content)
+	start := strings.Index(text, anchor)
+	if start < 0 {
+		return 0
+	}
+	idx := strings.Index(text[start:], needle)
+	if idx < 0 {
+		return 0
+	}
+	return strings.Count(text[:start+idx], "\n") + 1
+}
+
+// ruleIndex is built once from RuleMetadata so finding() lookups are
+// O(1) and guaranteed present (rulecatalog tests lock the set).
+var ruleIndex = func() map[string]rulemeta.Rule {
+	m := make(map[string]rulemeta.Rule)
+	for _, r := range RuleMetadata() {
+		m[r.ID] = r
+	}
+	return m
+}()

--- a/internal/engine/npmpolicy/npmpolicy_test.go
+++ b/internal/engine/npmpolicy/npmpolicy_test.go
@@ -1,0 +1,340 @@
+package npmpolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+)
+
+func analyze(t *testing.T, relPath, content string) []types.Finding {
+	t.Helper()
+	a := New()
+	out, err := a.Analyze(context.Background(), &scanner.Target{
+		RelPath: relPath,
+		Content: []byte(content),
+	})
+	if err != nil {
+		t.Fatalf("Analyze returned error: %v", err)
+	}
+	return out
+}
+
+func ids(fs []types.Finding) []string {
+	var out []string
+	for _, f := range fs {
+		out = append(out, f.RuleID)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// package.json: allowScripts policy
+
+func TestPackageJSON_PinnedAllowNeverFires(t *testing.T) {
+	for _, doc := range []string{
+		`{"allowScripts": {"esbuild@0.28.0": true}}`,
+		`{"allowScripts": {"@scope/pkg@1.2.3": true}}`,
+	} {
+		if fs := analyze(t, "package.json", doc); len(fs) != 0 {
+			t.Errorf("pinned allow fired: %v on %s", ids(fs), doc)
+		}
+	}
+}
+
+func TestPackageJSON_NameOnlyTrueFires(t *testing.T) {
+	doc := `{
+  "name": "x",
+  "allowScripts": {
+    "esbuild": true
+  }
+}`
+	fs := analyze(t, "package.json", doc)
+	if len(fs) != 1 || fs[0].RuleID != RuleAllowScriptsUnpinned {
+		t.Fatalf("want 1 UNPINNED finding, got %v", ids(fs))
+	}
+	if fs[0].Line != 4 {
+		t.Errorf("want line 4, got %d", fs[0].Line)
+	}
+	if fs[0].Severity != types.SeverityMedium {
+		t.Errorf("want MEDIUM, got %v", fs[0].Severity)
+	}
+}
+
+func TestPackageJSON_ScopedNameOnlyTrueFires(t *testing.T) {
+	fs := analyze(t, "package.json", `{"allowScripts": {"@scope/pkg": true}}`)
+	if len(fs) != 1 || fs[0].RuleID != RuleAllowScriptsUnpinned {
+		t.Fatalf("scoped name-only allow should fire UNPINNED, got %v", ids(fs))
+	}
+}
+
+func TestPackageJSON_DenyEntriesNeverFire(t *testing.T) {
+	// npm deny-scripts always writes name-only entries with value false.
+	// Ground truth npm 11.16.0: {"esbuild": false}. A deny is a
+	// hardening decision and must never be flagged.
+	for _, doc := range []string{
+		`{"allowScripts": {"esbuild": false}}`,
+		`{"allowScripts": {"@scope/pkg": false}}`,
+		`{"allowScripts": {"esbuild@0.28.0": false}}`,
+	} {
+		if fs := analyze(t, "package.json", doc); len(fs) != 0 {
+			t.Errorf("deny entry fired: %v on %s", ids(fs), doc)
+		}
+	}
+}
+
+func TestPackageJSON_AbsenceAndOddShapesStaySilent(t *testing.T) {
+	for _, doc := range []string{
+		`{"name": "x"}`,                        // no allowScripts
+		`{"allowScripts": {}}`,                 // empty policy
+		`{"allowScripts": {"esbuild": "yes"}}`, // non-bool value: not a shape npm writes
+		`{"allowScripts": ["esbuild"]}`,        // wrong type: unmarshal fails, silent
+		`{not json`,                            // malformed
+		`{"allowScripts": {"*": true}}`,        // wildcard: inert, npm matches no package (ground truth 11.16.0)
+		`{"AllowScripts": {"pkg": true}}`,      // mis-cased field: npm reads keys case-sensitively, inert
+		`{"allowscripts": {"pkg": true}}`,      // mis-cased field, lowercase variant
+		`{"allowScripts": {"pkg name": true}}`, // whitespace: cannot name a package
+	} {
+		if fs := analyze(t, "package.json", doc); len(fs) != 0 {
+			t.Errorf("unexpected findings %v on %s", ids(fs), doc)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// .npmrc
+
+func TestNpmrc_DangerousAllScripts(t *testing.T) {
+	fs := analyze(t, ".npmrc", "registry=https://registry.npmjs.org\ndangerously-allow-all-scripts=true\n")
+	if len(fs) != 1 || fs[0].RuleID != RuleDangerousAllScripts {
+		t.Fatalf("want DANGEROUS finding, got %v", ids(fs))
+	}
+	if fs[0].Line != 2 {
+		t.Errorf("want line 2, got %d", fs[0].Line)
+	}
+	if fs[0].Severity != types.SeverityHigh {
+		t.Errorf("want HIGH, got %v", fs[0].Severity)
+	}
+}
+
+func TestNpmrc_BareKeyReadsAsTrue(t *testing.T) {
+	// npm's ini dialect reads a bare `key` line as key=true.
+	fs := analyze(t, ".npmrc", "dangerously-allow-all-scripts\n")
+	if len(fs) != 1 || fs[0].RuleID != RuleDangerousAllScripts {
+		t.Fatalf("bare key should fire, got %v", ids(fs))
+	}
+}
+
+func TestNpmrc_ExplicitFalseStaysSilent(t *testing.T) {
+	for _, line := range []string{
+		"dangerously-allow-all-scripts=false",
+		"allow-scripts-pin=true",
+		"allow-git=none",
+		"allow-remote=none",
+	} {
+		if fs := analyze(t, ".npmrc", line+"\n"); len(fs) != 0 {
+			t.Errorf("secure value fired: %v on %q", ids(fs), line)
+		}
+	}
+}
+
+func TestNpmrc_AllowScriptsPinDisabled(t *testing.T) {
+	fs := analyze(t, ".npmrc", "allow-scripts-pin=false\n")
+	if len(fs) != 1 || fs[0].RuleID != RuleAllowScriptsUnpinned {
+		t.Fatalf("want UNPINNED finding, got %v", ids(fs))
+	}
+}
+
+func TestNpmrc_AllowGitAndRemoteRelaxed(t *testing.T) {
+	cases := []struct {
+		line string
+		rule string
+	}{
+		{"allow-git=all", RuleAllowGitRelaxed},
+		{"allow-git=root", RuleAllowGitRelaxed},
+		{"allow-remote=all", RuleAllowRemoteRelaxed},
+		{"allow-remote=root", RuleAllowRemoteRelaxed},
+		{`allow-git="all"`, RuleAllowGitRelaxed},     // quoted value
+		{"  allow-git = all  ", RuleAllowGitRelaxed}, // whitespace
+	}
+	for _, c := range cases {
+		fs := analyze(t, ".npmrc", c.line+"\n")
+		if len(fs) != 1 || fs[0].RuleID != c.rule {
+			t.Errorf("%q: want %s, got %v", c.line, c.rule, ids(fs))
+		}
+		if len(fs) == 1 && fs[0].Severity != types.SeverityMedium {
+			t.Errorf("%q: want MEDIUM, got %v", c.line, fs[0].Severity)
+		}
+	}
+}
+
+func TestNpmrc_NonHonoredShapesStaySilent(t *testing.T) {
+	for _, content := range []string{
+		"# dangerously-allow-all-scripts=true\n", // comment
+		"; allow-git=all\n",                      // ini comment
+		"allow-git=${ALLOW_GIT}\n",               // env expansion: ambiguous
+		"allow-git=ALL\n",                        // npm enum values are lowercase
+		"allow-git=everything\n",                 // not a documented value
+		"[section]\nallow-git=all\n",             // sectioned: npm does not read it
+		"some-other-key=true\n",                  // unrelated key
+		"allow-git=\"all\" # temporary\n",        // quoted+comment: npm keeps quotes, enum not honored
+		"",                                       // empty file
+	} {
+		if fs := analyze(t, ".npmrc", content); len(fs) != 0 {
+			t.Errorf("non-honored shape fired: %v on %q", ids(fs), content)
+		}
+	}
+}
+
+func TestNpmrc_InlineCommentsDoNotMaskValues(t *testing.T) {
+	// Ground truth npm 11.16.0: inline comments are stripped from the
+	// value, with or without preceding whitespace, so the relaxed
+	// setting is still honored and must still fire.
+	cases := []struct {
+		line string
+		rule string
+	}{
+		{"allow-git=all # temporary exception", RuleAllowGitRelaxed},
+		{"dangerously-allow-all-scripts=true ; migration", RuleDangerousAllScripts},
+		{"allow-git=all#nospace", RuleAllowGitRelaxed},
+		{"allow-remote=root	# tab comment", RuleAllowRemoteRelaxed},
+	}
+	for _, c := range cases {
+		fs := analyze(t, ".npmrc", c.line+"\n")
+		if len(fs) != 1 || fs[0].RuleID != c.rule {
+			t.Errorf("%q: want %s, got %v", c.line, c.rule, ids(fs))
+		}
+	}
+}
+
+func TestPackageJSON_LineAnchorsInsideAllowScripts(t *testing.T) {
+	// The same package name appears under dependencies first; the
+	// finding must point at the allowScripts entry, not the dependency.
+	doc := `{
+  "name": "x",
+  "dependencies": {
+    "left-pad": "^1.3.0"
+  },
+  "allowScripts": {
+    "left-pad": true
+  }
+}`
+	fs := analyze(t, "package.json", doc)
+	if len(fs) != 1 {
+		t.Fatalf("want 1 finding, got %v", ids(fs))
+	}
+	if fs[0].Line != 7 {
+		t.Errorf("want line 7 (allowScripts entry), got %d", fs[0].Line)
+	}
+}
+
+func TestNpmrc_LastWinsPrecedence(t *testing.T) {
+	// Ground truth npm 11.16.0: repeated top-level keys resolve to the
+	// LAST occurrence. A dangerous value overridden later by a safe one
+	// must stay silent; a safe value overridden by a dangerous one fires
+	// at the dangerous line.
+	if fs := analyze(t, ".npmrc", "allow-git=all\nallow-git=none\n"); len(fs) != 0 {
+		t.Errorf("overridden-to-safe fired: %v", ids(fs))
+	}
+	fs := analyze(t, ".npmrc", "allow-git=none\nallow-git=all\n")
+	if len(fs) != 1 || fs[0].Line != 2 {
+		t.Errorf("overridden-to-dangerous: want 1 finding at line 2, got %v (line %d)", ids(fs), func() int {
+			if len(fs) > 0 {
+				return fs[0].Line
+			}
+			return 0
+		}())
+	}
+}
+
+func TestNpmrc_EmptyBooleanAssignmentReadsAsTrue(t *testing.T) {
+	// Ground truth npm 11.16.0: `dangerously-allow-all-scripts=` (empty
+	// value) is read as true, same as a bare key.
+	fs := analyze(t, ".npmrc", "dangerously-allow-all-scripts=\n")
+	if len(fs) != 1 || fs[0].RuleID != RuleDangerousAllScripts {
+		t.Fatalf("empty boolean assignment should fire, got %v", ids(fs))
+	}
+	// Empty ENUM assignment is not a relaxation and stays silent.
+	if fs := analyze(t, ".npmrc", "allow-git=\n"); len(fs) != 0 {
+		t.Errorf("empty enum assignment fired: %v", ids(fs))
+	}
+}
+
+func TestPackageJSON_EscapedSlashKeyStillCarriesLine(t *testing.T) {
+	// Some serializers escape slashes in JSON strings; json.Unmarshal
+	// decodes "@scope\/pkg" to "@scope/pkg". The finding must still
+	// point at the entry's line, never line 0.
+	doc := "{\n  \"allowScripts\": {\n    \"@scope\\/pkg\": true\n  }\n}"
+	fs := analyze(t, "package.json", doc)
+	if len(fs) != 1 {
+		t.Fatalf("want 1 finding, got %v", ids(fs))
+	}
+	if fs[0].Line != 3 {
+		t.Errorf("want line 3, got %d", fs[0].Line)
+	}
+}
+
+func TestNpmrc_MultipleFindingsCarryLines(t *testing.T) {
+	content := "allow-git=all\n# comment\nallow-remote=all\ndangerously-allow-all-scripts=true\n"
+	fs := analyze(t, ".npmrc", content)
+	if len(fs) != 3 {
+		t.Fatalf("want 3 findings, got %v", ids(fs))
+	}
+	wantLines := map[string]int{
+		RuleAllowGitRelaxed:     1,
+		RuleAllowRemoteRelaxed:  3,
+		RuleDangerousAllScripts: 4,
+	}
+	for _, f := range fs {
+		if f.Line != wantLines[f.RuleID] {
+			t.Errorf("%s: want line %d, got %d", f.RuleID, wantLines[f.RuleID], f.Line)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+
+func TestNonTargetFilesReturnNil(t *testing.T) {
+	for _, p := range []string{"main.go", "pnpm-workspace.yaml", "npmrc", "config/.npmrc.bak"} {
+		if fs := analyze(t, p, "allow-git=all\n"); len(fs) != 0 {
+			t.Errorf("non-target %q fired: %v", p, ids(fs))
+		}
+	}
+	// nested package.json and .npmrc ARE targets (workspace layouts)
+	if fs := analyze(t, "packages/app/.npmrc", "allow-git=all\n"); len(fs) != 1 {
+		t.Errorf("nested .npmrc should be a target, got %v", ids(fs))
+	}
+}
+
+func TestFindingMetadataMatchesCatalog(t *testing.T) {
+	// Every emitted finding must carry the catalog's name/severity/
+	// category so explain and scan never disagree.
+	fs := analyze(t, ".npmrc", "dangerously-allow-all-scripts=true\nallow-git=all\nallow-remote=root\nallow-scripts-pin=false\n")
+	if len(fs) != 4 {
+		t.Fatalf("want 4 findings, got %v", ids(fs))
+	}
+	byID := make(map[string]types.Finding)
+	for _, f := range fs {
+		byID[f.RuleID] = f
+	}
+	for _, r := range RuleMetadata() {
+		f, ok := byID[r.ID]
+		if !ok {
+			t.Errorf("rule %s not exercised", r.ID)
+			continue
+		}
+		if f.RuleName != r.Name {
+			t.Errorf("%s: name %q != catalog %q", r.ID, f.RuleName, r.Name)
+		}
+		if f.Severity != r.SeverityLevel() {
+			t.Errorf("%s: severity %v != catalog %v", r.ID, f.Severity, r.SeverityLevel())
+		}
+		if f.Category != r.Category {
+			t.Errorf("%s: category %q != catalog %q", r.ID, f.Category, r.Category)
+		}
+		if f.Analyzer != AnalyzerName {
+			t.Errorf("%s: analyzer %q != %q", r.ID, f.Analyzer, AnalyzerName)
+		}
+	}
+}

--- a/internal/rulemeta/rule.go
+++ b/internal/rulemeta/rule.go
@@ -69,6 +69,7 @@ const (
 	AnalyzerRSBuild     = "rsbuild"
 	AnalyzerPnpmPolicy  = "pnpm-policy"
 	AnalyzerAgentPolicy = "agent-policy"
+	AnalyzerNpmPolicy   = "npm-policy"
 	AnalyzerPattern     = "" // YAML-driven rules; empty so JSON omits the field
 )
 


### PR DESCRIPTION
npm v12 is moving install-time trust into explicit project policy.

Dependency install scripts, git dependencies, and remote tarballs will no longer behave as implicit defaults in the same way. Repositories can now carry configuration that decides which install-time behavior is trusted by everyone who clones the project.

This adds a new `npm-policy` analyzer so Aguara can review those trust decisions before install.

**What this checks**

- `NPM_DANGEROUS_ALL_SCRIPTS_001` (HIGH): committed `dangerously-allow-all-scripts=true`, which allows every dependency install script to run.
- `NPM_ALLOW_SCRIPTS_UNPINNED_001` (MEDIUM): name-only `allowScripts` approvals, or `allow-scripts-pin=false`, which approve future package versions instead of the reviewed version.
- `NPM_ALLOW_GIT_RELAXED_001` (MEDIUM): committed `allow-git=all|root`, relaxing npm v12's default of blocking git dependency resolution.
- `NPM_ALLOW_REMOTE_RELAXED_001` (MEDIUM): committed `allow-remote=all|root`, relaxing npm v12's default of blocking remote URL tarballs.

**What stays quiet**

A missing setting never fires. Repos that simply use npm defaults stay clean.

The analyzer reports only explicit project choices that broaden install-time trust.

**Implementation notes**

- Reads `package.json` and project `.npmrc`.
- Keeps the same posture model as `pnpm-policy`: explicit weakening is a finding; absence is not.
- Parser behavior was checked against npm 11.16.0 behavior for `allowScripts`, `.npmrc` values, repeated keys, comments, empty boolean assignments, and case sensitivity.
- Catalog grows to 248 detections: 193 YAML + 55 analyzer-emitted.

This is PR 1 for npm v12 readiness. Follow-ups will cover non-registry dependency posture and docs.
