### PR TITLE
Add npm v12 readiness findings for non-registry dependencies

### DIFF
--- a/internal/engine/pkgmeta/metadata.go
+++ b/internal/engine/pkgmeta/metadata.go
@@ -73,6 +73,35 @@ func RuleMetadata() []rulemeta.Rule {
 				"CI job) that does not execute install/build/test scripts. Trusted " +
 				"publishing should only run from a vetted, minimal-scope environment.",
 		},
+		{
+			ID:       RuleGitInstallTrust,
+			Name:     "npm v12 readiness: git dependency needs install trust",
+			Severity: "INFO",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPkgMeta,
+			Description: "package.json declares a dependency that resolves from a git source. " +
+				"npm v12 defaults allow-git to \"none\", so installing this project under v12 " +
+				"will require an explicit install-trust exception for git dependencies. This " +
+				"is readiness information, not an attack signal: it identifies the trust " +
+				"exceptions a team must review before the upgrade.",
+			Remediation: "Replace git sources with registry versions where possible. For the " +
+				"ones that remain, grant a reviewed exception (prefer allow-git=root over " +
+				"all) so the v12 upgrade does not break installs or silently broaden trust.",
+		},
+		{
+			ID:       RuleRemoteInstallTrust,
+			Name:     "npm v12 readiness: remote tarball needs install trust",
+			Severity: "INFO",
+			Category: "supply-chain",
+			Analyzer: rulemeta.AnalyzerPkgMeta,
+			Description: "package.json declares a dependency that resolves from a remote URL " +
+				"tarball. npm v12 defaults allow-remote to \"none\", so installing this " +
+				"project under v12 will require an explicit install-trust exception for " +
+				"remote tarballs. This is readiness information, not an attack signal.",
+			Remediation: "Replace URL tarballs with registry versions where possible. For the " +
+				"ones that remain, pin the exact tarball and grant a reviewed exception " +
+				"(prefer allow-remote=root over all) before upgrading to npm v12.",
+		},
 	}
 }
 

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -29,10 +29,12 @@ const AnalyzerName = "pkgmeta"
 
 // Rule IDs emitted by this analyzer.
 const (
-	RuleLifecycleGit     = "NPM_LIFECYCLE_GIT_001"
-	RuleOptionalGit      = "NPM_OPTIONAL_GIT_001"
-	RulePublishSurface   = "NPM_PUBLISH_SURFACE_001"
-	RuleLocalJSLifecycle = "SUPPLY_026"
+	RuleLifecycleGit       = "NPM_LIFECYCLE_GIT_001"
+	RuleOptionalGit        = "NPM_OPTIONAL_GIT_001"
+	RulePublishSurface     = "NPM_PUBLISH_SURFACE_001"
+	RuleLocalJSLifecycle   = "SUPPLY_026"
+	RuleGitInstallTrust    = "NPM_GIT_INSTALL_TRUST_001"
+	RuleRemoteInstallTrust = "NPM_REMOTE_INSTALL_TRUST_001"
 )
 
 // localJSLifecycleKeys are the lifecycle hooks where a package running its
@@ -230,6 +232,195 @@ func findDepLine(raw []byte, section, name string) int {
 
 // --- classifiers ---
 
+// isRemoteTarballDep reports whether a dependency value points at a
+// remote URL tarball: an http(s) URL that is not a git source. npm v12
+// defaults allow-remote to "none", so resolving one requires an
+// explicit install-trust exception.
+func isRemoteTarballDep(version string) bool {
+	v := strings.ToLower(strings.TrimSpace(version))
+	if !strings.HasPrefix(v, "http://") && !strings.HasPrefix(v, "https://") {
+		return false
+	}
+	return !isGitDep(version)
+}
+
+// detectInstallTrustReadiness emits the npm v12 readiness findings:
+// INFO-severity, per dependency, for sources npm v12 will no longer
+// resolve without an explicit trust exception (allow-git /
+// allow-remote). This is posture information, not an attack signal: it
+// tells a team which exceptions the project will need before the v12
+// upgrade, and it never fails a build on default thresholds.
+//
+// Suppression mirrors this file's existing philosophy of one finding
+// per concern:
+//   - git readiness is suppressed entirely when a lifecycle script is
+//     present (NPM_LIFECYCLE_GIT_001 already covers every git dep with
+//     higher severity) and skips optionalDependencies (covered by
+//     NPM_OPTIONAL_GIT_001);
+//   - remote-tarball readiness has no stronger sibling and always
+//     fires. file:, link: and workspace: sources are NOT findings:
+//     npm v12 keeps allow-file / allow-directory at their current
+//     defaults.
+func detectInstallTrustReadiness(pkg *manifest) []types.Finding {
+	sections := []struct {
+		name string
+		deps map[string]string
+	}{
+		{"dependencies", pkg.Dependencies},
+		{"devDependencies", pkg.DevDependencies},
+		{"optionalDependencies", pkg.OptionalDependencies},
+		{"peerDependencies", pkg.PeerDependencies},
+	}
+	gitCovered := hasLifecycleScript(pkg.Scripts)
+	var findings []types.Finding
+	for _, sec := range sections {
+		names := make([]string, 0, len(sec.deps))
+		for n := range sec.deps {
+			names = append(names, n)
+		}
+		sort.Strings(names)
+		for _, n := range names {
+			v := sec.deps[n]
+			ref := sec.name + "." + n
+			switch {
+			case isGitDep(v):
+				if gitCovered || sec.name == "optionalDependencies" {
+					continue // a stronger git rule already covers this dep
+				}
+				safe := sanitizeTarballURL(v)
+				findings = append(findings, types.Finding{
+					RuleID:   RuleGitInstallTrust,
+					RuleName: ruleInfo[RuleGitInstallTrust].Name,
+					Severity: types.SeverityInfo,
+					Category: ruleInfo[RuleGitInstallTrust].Category,
+					Description: ref + " resolves from a git source (" + safe + "). npm v12 " +
+						"readiness: npm v12 defaults allow-git to \"none\", so installing this " +
+						"project will require an explicit install-trust exception for git " +
+						"dependencies.",
+					FilePath:    pkg.path,
+					Line:        findDepLine(pkg.raw, sec.name, n),
+					MatchedText: ref + " = " + safe,
+					Analyzer:    AnalyzerName,
+					Confidence:  0.9,
+					Remediation: "Replace the git source with a registry version where possible. " +
+						"If it is genuinely required, grant a reviewed exception (prefer " +
+						"allow-git=root over all) before upgrading to npm v12.",
+				})
+			case isRemoteTarballDep(v):
+				safe := sanitizeTarballURL(v)
+				findings = append(findings, types.Finding{
+					RuleID:   RuleRemoteInstallTrust,
+					RuleName: ruleInfo[RuleRemoteInstallTrust].Name,
+					Severity: types.SeverityInfo,
+					Category: ruleInfo[RuleRemoteInstallTrust].Category,
+					Description: ref + " resolves from a remote URL tarball (" + safe + "). npm " +
+						"v12 readiness: npm v12 defaults allow-remote to \"none\", so installing " +
+						"this project will require an explicit install-trust exception for " +
+						"remote tarballs.",
+					FilePath:    pkg.path,
+					Line:        findDepLine(pkg.raw, sec.name, n),
+					MatchedText: ref + " = " + safe,
+					Analyzer:    AnalyzerName,
+					Confidence:  0.9,
+					Remediation: "Replace the URL tarball with a registry version where " +
+						"possible. If it is genuinely required, pin the exact tarball and " +
+						"grant a reviewed exception (prefer allow-remote=root over all) before " +
+						"upgrading to npm v12.",
+				})
+			}
+		}
+	}
+	return findings
+}
+
+// isHostedGitDomainURL reports whether an http(s) URL matches a shape
+// npm's hosted-git-info resolves as a git spec. The host comparison
+// strips userinfo and port (ground truth: "https://token@github.com/
+// org/repo.git" and "https://github.com:443/org/repo.git" both gate as
+// EALLOWGIT). Path handling approximates hosted-git-info's templates,
+// bounded to the shapes ground-truthed against npm 11.16.0:
+//
+//	github.com/owner/repo[.git][/tree/...]  -> git
+//	github.com/owner/repo/tarball|archive|releases/... -> remote
+//	codeload.github.com/...                  -> remote (not in the set)
+//	gist.github.com/<id>                     -> git
+//	gitlab.com/group[/subgroup...]/repo      -> git (unless /-/ archive paths)
+//	bitbucket.org/owner/repo                 -> git
+//
+// The approximation is deliberately bounded rather than a full
+// hosted-git-info port; an exotic hosted endpoint that escapes it
+// classifies as remote, and the cost is INFO-level readiness advice
+// naming allow-remote instead of allow-git.
+func isHostedGitDomainURL(u string) bool {
+	rest := u[strings.Index(u, "://")+3:]
+	host := rest
+	path := ""
+	if i := strings.IndexByte(rest, '/'); i >= 0 {
+		host = rest[:i]
+		path = strings.Trim(rest[i+1:], "/")
+	}
+	if i := strings.LastIndexByte(host, '@'); i >= 0 {
+		host = host[i+1:] // strip userinfo
+	}
+	if i := strings.IndexByte(host, ':'); i >= 0 {
+		host = host[:i] // strip port
+	}
+	host = strings.TrimPrefix(host, "www.")
+	segs := 0
+	if path != "" {
+		segs = strings.Count(path, "/") + 1
+	}
+	switch host {
+	case "github.com":
+		path = strings.TrimSuffix(path, ".git")
+		if segs == 2 {
+			return true
+		}
+		// owner/repo/tree/<committish...> is a git ref; tarball/,
+		// archive/, releases/ and anything else are download endpoints.
+		if segs > 2 {
+			parts := strings.SplitN(path, "/", 4)
+			return parts[2] == "tree"
+		}
+		return false
+	case "gist.github.com":
+		return segs >= 1
+	case "gitlab.com":
+		// Subgroups give variable depth; gitlab's download endpoints
+		// live under "/-/" (e.g. /-/archive/...).
+		return segs >= 2 && !strings.Contains("/"+path+"/", "/-/")
+	case "bitbucket.org":
+		return segs == 2
+	}
+	return false
+}
+
+// hasTarballExt reports whether a URL path ends in an archive extension
+// npm fetches as a remote tarball even on hosted-git domains (ground
+// truth: /archive/x.tar.gz, /releases/download/.../pkg.tgz and .zip all
+// gate as EALLOWREMOTE).
+func hasTarballExt(u string) bool {
+	for _, ext := range []string{".tgz", ".tar.gz", ".tar", ".zip"} {
+		if strings.HasSuffix(u, ext) {
+			return true
+		}
+	}
+	return false
+}
+
+// sanitizeTarballURL prepares a remote source spec (tarball or git URL) for inclusion in
+// finding output: userinfo is stripped (via sanitizeGitURL) and the
+// query string is removed entirely, because signed URLs and
+// query-string auth (?token=..., ?X-Amz-Signature=...) carry
+// credentials that must not be copied into Description/MatchedText.
+func sanitizeTarballURL(version string) string {
+	safe := sanitizeGitURL(version)
+	if i := strings.Index(safe, "?"); i >= 0 {
+		safe = safe[:i] + "?[query removed]"
+	}
+	return safe
+}
+
 // isGitDep reports whether a dependency value points at a git source rather
 // than the npm registry. npm accepts several shorthand forms; we cover the
 // ones that actually resolve to executable git content during install.
@@ -245,6 +436,11 @@ func isGitDep(version string) bool {
 	if i := strings.Index(noFrag, "#"); i >= 0 {
 		noFrag = noFrag[:i]
 	}
+	// Strip a query string as well: "repo.git?token=x" is still a git
+	// URL to npm.
+	if i := strings.Index(noFrag, "?"); i >= 0 {
+		noFrag = noFrag[:i]
+	}
 	switch {
 	case strings.HasPrefix(lower, "git+"):
 		return true
@@ -258,12 +454,20 @@ func isGitDep(version string) bool {
 		return true
 	case strings.HasPrefix(lower, "gist:"):
 		return true
-	// Any HTTP(S) URL ending in .git resolves as a git dependency in npm.
-	// Covers github.com, gitlab.com, bitbucket.org, gitea instances, and
-	// self-hosted hosts. The .git suffix on a real URL is unambiguous;
-	// it does not collide with registry or filesystem specs.
-	case strings.Contains(noFrag, "://") && strings.HasSuffix(noFrag, ".git"):
+	case strings.HasPrefix(lower, "ssh://"):
+		// Ground truth npm 11.16.0: ssh:// specs resolve as git
+		// (EALLOWGIT).
 		return true
+	case strings.HasPrefix(lower, "http://"), strings.HasPrefix(lower, "https://"):
+		// Ground truth npm 11.16.0: a plain http(s) URL is a git spec
+		// ONLY when hosted-git-info recognizes the host (github.com,
+		// gist.github.com, gitlab.com, bitbucket.org - any path depth,
+		// including /tree/<branch> and gitlab subgroups) and the path is
+		// not an archive download (.tgz/.tar.gz/.tar/.zip, which gate as
+		// EALLOWREMOTE even on those hosts). A .git suffix on an unknown
+		// host is still a REMOTE dependency (EALLOWREMOTE) unless the
+		// spec uses an explicit git+ scheme.
+		return isHostedGitDomainURL(noFrag) && !hasTarballExt(noFrag)
 	}
 	// owner/repo or owner/repo#ref shorthand. Strip the #fragment first so
 	// a valid semver-fragment shorthand like "owner/repo#semver:^1.2.3"
@@ -597,6 +801,7 @@ func detect(pkg *manifest) []types.Finding {
 	var out []types.Finding
 	out = append(out, detectLifecycleGit(pkg)...)
 	out = append(out, detectOptionalGit(pkg)...)
+	out = append(out, detectInstallTrustReadiness(pkg)...)
 	if f := detectPublishSurface(pkg); f != nil {
 		out = append(out, *f)
 	}
@@ -681,7 +886,7 @@ func detectLifecycleGit(pkg *manifest) []types.Finding {
 		if d.Section == "optionalDependencies" && isSuspiciousPackageName(d.Name) {
 			sev = types.SeverityCritical
 		}
-		safeVersion := sanitizeGitURL(d.Version)
+		safeVersion := sanitizeTarballURL(d.Version)
 		findings = append(findings, types.Finding{
 			RuleID:   RuleLifecycleGit,
 			RuleName: ruleInfo[RuleLifecycleGit].Name,
@@ -737,7 +942,7 @@ func detectOptionalGit(pkg *manifest) []types.Finding {
 		if isSuspiciousPackageName(n) {
 			sev = types.SeverityHigh
 		}
-		safeVersion := sanitizeGitURL(v)
+		safeVersion := sanitizeTarballURL(v)
 		findings = append(findings, types.Finding{
 			RuleID:   RuleOptionalGit,
 			RuleName: ruleInfo[RuleOptionalGit].Name,

--- a/internal/engine/pkgmeta/npm_test.go
+++ b/internal/engine/pkgmeta/npm_test.go
@@ -810,11 +810,35 @@ func TestIsGitDep_NonGitHubHosts(t *testing.T) {
 		{"https://gitlab.com/group/pkg.git", true},
 		{"https://gitlab.com/group/pkg.git#abc1234", true},
 		{"https://bitbucket.org/team/pkg.git", true},
-		{"https://git.example.com/team/pkg.git", true},
-		{"https://git.example.com/team/pkg.git#v1", true},
+		// Ground truth npm 11.16.0: a .git URL on an UNKNOWN host is a
+		// remote dependency (EALLOWREMOTE), not git - npm only treats
+		// http(s) as git via hosted-git-info domains or a git+ scheme.
+		{"https://git.example.com/team/pkg.git", false},
+		{"https://git.example.com/team/pkg.git#v1", false},
+		{"git+https://git.example.com/team/pkg.git", true},
 		{"ssh://git@gitlab.com/group/pkg.git", true},
-		// Non-.git HTTPS URLs are not git deps (could be tarball etc.).
-		{"https://gitlab.com/group/pkg", false},
+		// Repo-root HTTPS URLs on hosted-git domains ARE git deps:
+		// ground truth npm 11.16.0 normalizes them to git+https specs
+		// and gates them with EALLOWGIT, not EALLOWREMOTE.
+		{"https://gitlab.com/group/pkg", true},
+		{"https://github.com/owner/repo", true},
+		// Deeper paths on the same hosts stay remote tarballs
+		// (EALLOWREMOTE): archives, release downloads, tarball
+		// endpoints, codeload.
+		{"https://github.com/org/repo/archive/main.tar.gz", false},
+		{"https://github.com/org/repo/releases/download/v1/pkg.tgz", false},
+		{"https://github.com/org/repo/tarball/main", false},
+		{"https://codeload.github.com/org/repo/tar.gz/main", false},
+		// /tree/<ref> is a git committish (EALLOWGIT).
+		{"https://github.com/org/repo/tree/main", true},
+		// userinfo and port do not change the classification.
+		{"https://token123@github.com/org/repo.git", true},
+		{"https://github.com:443/org/repo.git", true},
+		// gitlab subgroups are git; gitlab /-/ download endpoints are not.
+		{"https://gitlab.com/group/subgroup/repo", true},
+		{"https://gitlab.com/group/repo/-/archive/main/repo-main.tar.gz", false},
+		// Unknown hosts without .git stay non-git.
+		{"https://git.example.com/group/pkg", false},
 		// HTTPS to a registry-shaped URL is not a git dep.
 		{"https://registry.npmjs.org/some-pkg/-/some-pkg-1.0.0.tgz", false},
 	}
@@ -1159,5 +1183,173 @@ func TestLocalJSLifecycle_LineAnchoredToScripts(t *testing.T) {
 	}
 	if line != 6 {
 		t.Errorf("SUPPLY_026 line = %d, want 6 (scripts entry, not the dep on line 3)", line)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// npm v12 install-trust readiness
+
+func readinessIDs(fs []types.Finding) (git, remote int) {
+	for _, f := range fs {
+		switch f.RuleID {
+		case RuleGitInstallTrust:
+			git++
+		case RuleRemoteInstallTrust:
+			remote++
+		}
+	}
+	return
+}
+
+func TestInstallTrustReadiness_GitAndRemoteDeps(t *testing.T) {
+	doc := `{
+  "name": "x",
+  "dependencies": {
+    "a": "github:owner/repo",
+    "b": "https://example.com/pkg-1.0.0.tgz",
+    "c": "^1.0.0"
+  },
+  "devDependencies": {
+    "d": "git+https://github.com/o/r.git"
+  }
+}`
+	fs := analyze(t, "package.json", doc)
+	git, remote := readinessIDs(fs)
+	if git != 2 || remote != 1 {
+		t.Fatalf("want 2 git + 1 remote readiness findings, got git=%d remote=%d (%v)", git, remote, func() []string {
+			var o []string
+			for _, f := range fs {
+				o = append(o, f.RuleID)
+			}
+			return o
+		}())
+	}
+	for _, f := range fs {
+		if f.RuleID == RuleGitInstallTrust || f.RuleID == RuleRemoteInstallTrust {
+			if f.Severity != types.SeverityInfo {
+				t.Errorf("%s: want INFO, got %v", f.RuleID, f.Severity)
+			}
+			if f.Line == 0 {
+				t.Errorf("%s: missing line anchor", f.RuleID)
+			}
+		}
+	}
+}
+
+func TestInstallTrustReadiness_SuppressedByStrongerGitRules(t *testing.T) {
+	// With a lifecycle script present, NPM_LIFECYCLE_GIT_001 covers every
+	// git dep at higher severity; git readiness stays silent. Remote
+	// readiness has no stronger sibling and still fires.
+	doc := `{
+  "name": "x",
+  "scripts": {"postinstall": "node setup.js"},
+  "dependencies": {
+    "a": "github:owner/repo",
+    "b": "https://example.com/pkg-1.0.0.tgz"
+  }
+}`
+	fs := analyze(t, "package.json", doc)
+	git, remote := readinessIDs(fs)
+	if git != 0 {
+		t.Errorf("git readiness should be suppressed under lifecycle scripts, got %d", git)
+	}
+	if remote != 1 {
+		t.Errorf("want 1 remote readiness finding, got %d", remote)
+	}
+	// optionalDependencies git deps stay with NPM_OPTIONAL_GIT_001 only.
+	doc2 := `{"name":"x","optionalDependencies":{"a":"github:owner/repo"}}`
+	fs2 := analyze(t, "package.json", doc2)
+	git2, _ := readinessIDs(fs2)
+	if git2 != 0 {
+		t.Errorf("optionalDependencies git dep should not double-fire readiness, got %d", git2)
+	}
+	hasOptional := false
+	for _, f := range fs2 {
+		if f.RuleID == RuleOptionalGit {
+			hasOptional = true
+		}
+	}
+	if !hasOptional {
+		t.Errorf("NPM_OPTIONAL_GIT_001 expected for optional git dep")
+	}
+}
+
+func TestInstallTrustReadiness_LocalSourcesStaySilent(t *testing.T) {
+	// npm v12 keeps allow-file / allow-directory defaults, so file:,
+	// link:, workspace: and local paths are not readiness findings.
+	doc := `{
+  "name": "x",
+  "dependencies": {
+    "a": "file:../local",
+    "b": "link:../linked",
+    "c": "workspace:*",
+    "d": "./vendored",
+    "e": "^2.0.0"
+  }
+}`
+	fs := analyze(t, "package.json", doc)
+	git, remote := readinessIDs(fs)
+	if git != 0 || remote != 0 {
+		t.Errorf("local sources fired readiness: git=%d remote=%d", git, remote)
+	}
+}
+
+func TestInstallTrustReadiness_RemoteURLCredentialsRedacted(t *testing.T) {
+	// Signed URLs and query-string auth must never reach finding output.
+	doc := `{"name":"x","dependencies":{"blob":"https://user:secret@cdn.example.com/blob.tgz?token=hunter2supersecret"}}`
+	fs := analyze(t, "package.json", doc)
+	for _, f := range fs {
+		if f.RuleID != RuleRemoteInstallTrust {
+			continue
+		}
+		for _, field := range []string{f.Description, f.MatchedText} {
+			if containsAny(field, "hunter2supersecret", "secret@") {
+				t.Fatalf("credential leaked into finding output: %q", field)
+			}
+		}
+		return
+	}
+	t.Fatal("expected a remote readiness finding")
+}
+
+func TestInstallTrustReadiness_GitURLCredentialsRedacted(t *testing.T) {
+	doc := `{"name":"x","dependencies":{"viz":"git+https://cdn.example.com/repo.git?token=hunter2supersecret"}}`
+	fs := analyze(t, "package.json", doc)
+	for _, f := range fs {
+		if f.RuleID != RuleGitInstallTrust {
+			continue
+		}
+		if containsAny(f.Description+f.MatchedText, "hunter2supersecret") {
+			t.Fatalf("credential leaked into git readiness output")
+		}
+		return
+	}
+	t.Fatal("expected a git readiness finding")
+}
+
+func containsAny(s string, subs ...string) bool {
+	for _, sub := range subs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestInstallTrustReadiness_HostedHTTPSURLsAreGitNotRemote(t *testing.T) {
+	// Ground truth npm 11.16.0: a bare https URL on a known git host is
+	// normalized to a git spec and gated by EALLOWGIT, so the readiness
+	// advice must point at allow-git, not allow-remote.
+	doc := `{"name":"x","dependencies":{
+  "a": "https://github.com/org/repo",
+  "b": "https://gitlab.com/org/repo",
+  "c": "https://cdn.example.com/repo.git?token=secret123abc",
+  "d": "https://cdn.example.com/pkg-1.0.0.tgz"
+}}`
+	fs := analyze(t, "package.json", doc)
+	git, remote := readinessIDs(fs)
+	// c (.git on unknown host) is a REMOTE dep per npm ground truth.
+	if git != 2 || remote != 2 {
+		t.Fatalf("want 2 git + 2 remote, got git=%d remote=%d", git, remote)
 	}
 }


### PR DESCRIPTION
npm v12 will stop resolving git dependencies and remote tarballs without an explicit trust exception. A project that declares them today needs those exceptions reviewed before the upgrade.

This turns those declarations into readiness information, not attack signals:

- `NPM_GIT_INSTALL_TRUST_001` (INFO): a dependency resolves from a git source and will need `allow-git`.
- `NPM_REMOTE_INSTALL_TRUST_001` (INFO): a dependency resolves from a remote URL tarball and will need `allow-remote`.

**What this tells a team**

Each finding points at the exact dependency line and says what npm v12 will require. INFO severity never fails default CI thresholds: the findings inform the migration, they do not block it.

**What stays quiet**

`file:`, `link:` and `workspace:` sources are not findings - npm v12 keeps those defaults. Git readiness is suppressed where a stronger git rule already covers the dependency, so each concern produces one finding.

**Implementation notes**

- URL classification follows npm's actual install gates, verified against npm 11.16.0: repository URLs on hosted git domains (any userinfo/port, `/tree/` refs, gitlab subgroups) need `allow-git`; archive, tarball and release-download paths need `allow-remote`; a `.git` URL on an unknown host is a remote dependency unless it uses a `git+` scheme.
- That last point corrects a pre-existing classification in the git-dependency rules, with the existing tests updated to match npm's behavior.
- Credentialed source URLs (`?token=...`, signed URLs, userinfo) are redacted before they reach finding output, including in the existing lifecycle and optional-git rules.
- Catalog grows to 250 detections: 193 YAML + 57 analyzer-emitted.

PR 2 of 3 for npm v12 readiness. Docs and the readiness story follow.
