### PR TITLE
Release prep v0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,15 @@
 All notable changes to Aguara are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
-## [Unreleased]
+## [0.25.0] - 2026-06-11
 
 npm v12 (estimated July 2026) makes install-time trust explicit:
 dependency install scripts, git dependencies, and remote tarballs stop
 behaving as implicit defaults. Aguara now reviews those trust decisions
-before install.
+before install, in CI, and before an agent inherits them. Everything
+stays deterministic and offline: no package execution, no network calls
+during a scan. Existing rule IDs, severities, and the `Severity` JSON
+encoding are unchanged.
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.24.0 (2026-06-10; main carries unreleased npm v12 round: #212 npm-policy + #213 install-trust readiness). 193 YAML rules + 57 analyzer-emitted (250 cataloged), 13 YAML categories (+ analyzer categories incl. agent-trust), 12 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, npmpolicy, pnpmpolicy, agentpolicy, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic v1 / yarn.lock Berry v2+ / bun.lock text - all with `npm:` alias resolution to the real package - and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
+Aguara v0.25.0 (2026-06-11; aggregates the npm v12 install-trust round: #212 npm-policy analyzer, #213 readiness findings, #214 docs). 193 YAML rules + 57 analyzer-emitted (250 cataloged), 13 YAML categories (+ analyzer categories incl. agent-trust), 12 scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, rsbuild, npmpolicy, pnpmpolicy, agentpolicy, NLP, toxicflow, rugpull) plus the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic v1 / yarn.lock Berry v2+ / bun.lock text - all with `npm:` alias resolution to the real package - and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
 
 Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, multi-arch `linux/amd64+arm64`, runs as non-root UID 10001, base images digest-pinned, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
@@ -158,7 +158,7 @@ When any of these values change, update ALL references across the vault:
 - Coverage (currently 80%)
 - Star/fork count (currently 48/6)
 - Watch skill count (currently 28,000+)
-- Version number (currently v0.24.0)
+- Version number (currently v0.25.0)
 
 Use `Grep` to find all occurrences before updating.
 

--- a/Makefile
+++ b/Makefile
@@ -100,7 +100,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.24.0
+INSTALL_SH_TEST_VERSION ?= v0.25.0
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ brew install garagon/tap/aguara
 ### Docker
 
 ```bash
-docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.24.0 check /repo
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.25.0 check /repo
 ```
 
 Multi-arch (`linux/amd64` + `linux/arm64`), runs as non-root UID 10001, base images digest-pinned, and signed at the digest with Cosign plus SPDX SBOM and SLSA provenance attestations. Pin a specific release tag for reproducibility.
@@ -234,7 +234,7 @@ Multi-arch (`linux/amd64` + `linux/arm64`), runs as non-root UID 10001, base ima
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.24.0 sh
+  | VERSION=v0.25.0 sh
 ```
 
 `install.sh` downloads `checksums.txt` and verifies the archive's SHA256 against it, aborting if neither `sha256sum` nor `shasum` is available. This catches a tampered archive at the registry layer but does not verify the Cosign signature on `checksums.txt` itself; for full keyless-signature verification on the curl-pipe path, follow the Cosign step in [Verifying signed releases](#verifying-signed-releases). Default install location is `~/.local/bin`; override with `INSTALL_DIR` for CI or containers.
@@ -242,11 +242,11 @@ curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
 ### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.24.0
+- uses: garagon/aguara@v0.25.0
   with:
     path: .
     fail-on: high
-    version: v0.24.0
+    version: v0.25.0
 ```
 
 Both pins are required: the action ref pins the composite action and its install script, and `version:` pins the Aguara binary it installs. Setting both keeps the workflow reproducible and dependabot-friendly. See [`action.yml`](action.yml) for all inputs.
@@ -284,15 +284,15 @@ GitHub Code Scanning, GitLab SAST, and plain Docker-in-CI examples are below.
 
 ```yaml
 # GitHub Action with SARIF upload (needs security-events: write)
-- uses: garagon/aguara@v0.24.0
-  with: { path: ., severity: medium, fail-on: high, version: v0.24.0 }
+- uses: garagon/aguara@v0.25.0
+  with: { path: ., severity: medium, fail-on: high, version: v0.25.0 }
 ```
 
 ```yaml
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.24.0 sh
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.25.0 sh
     - aguara scan . --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:
@@ -349,7 +349,7 @@ A separate `aguara check` / `aguara audit` path inspects installed package trees
 Every release is signed with [Cosign](https://github.com/sigstore/cosign) keyless, ships an SPDX SBOM per archive, and is built with `-trimpath` for reproducibility. The container image is signed at the digest with SBOM + SLSA provenance attestations.
 
 ```bash
-VERSION=v0.24.0
+VERSION=v0.25.0
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
@@ -397,7 +397,7 @@ Suppress individual findings inline with `# aguara-ignore RULE_ID` (also `-next-
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale and is not a supported surface for v0.24.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
+Aguara Watch is being reworked. The previous public observatory is stale and is not a supported surface for v0.25.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.24.0"
+        DEFAULT_REF="v0.25.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -202,7 +202,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.24.0 tag rather than `@v1`
+// The action ref is pinned to the v0.25.0 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -231,7 +231,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.24.0
+        uses: garagon/aguara@v0.25.0
         with:
           path: .
           fail-on: high
@@ -240,7 +240,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.24.0
+          version: v0.25.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
Prepares v0.25.0.

This release makes Aguara the first scanner that reviews npm v12's explicit install-trust model. npm v12 (estimated July 2026) stops running dependency scripts, resolving git dependencies, and fetching remote tarballs as quiet defaults; the decisions move into files the repository ships.

Aguara now covers both sides of that change:

- It flags committed policy that broadens install trust: the `dangerously-allow-all-scripts` escape hatch, approvals that cover every future version of a package instead of the reviewed one, and `allow-git` / `allow-remote` pinned open against the v12 defaults.
- It gives teams a readiness list for the upgrade: INFO findings that name which git and remote-tarball dependencies will need explicit trust exceptions, without failing any build.

The result is install-time trust reviewed before install, before CI runs it, and before an agent inherits it.

This PR only prepares the release:
- cuts the changelog to v0.25.0
- bumps version pins
- keeps the tag/publish step separate

No runtime changes are added in this PR; the shipped functionality (#212, #213, #214) is already on main. Catalog: 250 detections.
