### PR TITLE
Measure which advisory records range matching would actually unlock

### DIFF
--- a/internal/intel/osvimport/osvimport.go
+++ b/internal/intel/osvimport/osvimport.go
@@ -77,8 +77,9 @@ type osvRecord struct {
 }
 
 type osvAffected struct {
-	Package  osvPackage `json:"package"`
-	Versions []string   `json:"versions,omitempty"`
+	Package  osvPackage        `json:"package"`
+	Versions []string          `json:"versions,omitempty"`
+	Ranges   []json.RawMessage `json:"ranges,omitempty"`
 }
 
 type osvPackage struct {
@@ -279,6 +280,16 @@ const (
 	// StatusKept: the record survives the filter and becomes an
 	// intel.Record in the snapshot.
 	StatusKept
+	// StatusRangesOnlyMalicious: like StatusRangesOnly (only version
+	// ranges, no exact versions, so the record is dropped from the
+	// snapshot today), but the record ALSO passes the malicious
+	// signal-or-keyword gate. This is the population range-aware
+	// matching (spec C3) would unlock; splitting it from
+	// StatusRangesOnly lets measurement tooling report
+	// `malicious AND ranges-only` per ecosystem without changing what
+	// the importer keeps. Appended at the end of the enum so existing
+	// status values are stable.
+	StatusRangesOnlyMalicious
 )
 
 // ClassifyForEcosystem walks a raw OSV record and reports how a
@@ -316,10 +327,20 @@ func ClassifyForEcosystem(raw []byte, targetEcosystem string) (intel.Record, Rec
 	if osv.Withdrawn != "" {
 		return intel.Record{}, StatusWithdrawn
 	}
+	malicious := hasHighConfidenceSignal(osv) || hasKeywordMatch(osv)
 	if len(aff.Versions) == 0 {
+		// Dropped either way (the matcher consumes exact versions, and
+		// ranges are gated per ecosystem); the status split only
+		// reports whether range support would make this record
+		// eligible for the snapshot. A record with neither versions
+		// nor ranges has nothing range support could unlock, so it
+		// stays in the plain ranges-only bucket regardless of signal.
+		if malicious && len(aff.Ranges) > 0 {
+			return intel.Record{}, StatusRangesOnlyMalicious
+		}
 		return intel.Record{}, StatusRangesOnly
 	}
-	if !hasHighConfidenceSignal(osv) && !hasKeywordMatch(osv) {
+	if !malicious {
 		return intel.Record{}, StatusNeither
 	}
 	return intel.Record{

--- a/internal/intel/osvimport/osvimport_test.go
+++ b/internal/intel/osvimport/osvimport_test.go
@@ -30,6 +30,12 @@ type osvRecordFixture struct {
 type affectedFixture struct {
 	Package  packageFixture `json:"package"`
 	Versions []string       `json:"versions,omitempty"`
+	Ranges   []rangeFixture `json:"ranges,omitempty"`
+}
+
+type rangeFixture struct {
+	Type   string              `json:"type"`
+	Events []map[string]string `json:"events"`
 }
 
 type packageFixture struct {
@@ -449,14 +455,14 @@ func TestImportAcceptsAllEightCanonicalEcosystems(t *testing.T) {
 // as `--ecosystem crates.io`.
 func TestImportAcceptsAliases(t *testing.T) {
 	aliasToCanonical := map[string]string{
-		"python":  "PyPI",
-		"rust":    "crates.io",
-		"cargo":   "crates.io",
-		"java":    "Maven",
-		"dotnet":  "NuGet",
-		"ruby":    "RubyGems",
-		"php":     "Packagist",
-		"golang":  "Go",
+		"python": "PyPI",
+		"rust":   "crates.io",
+		"cargo":  "crates.io",
+		"java":   "Maven",
+		"dotnet": "NuGet",
+		"ruby":   "RubyGems",
+		"php":    "Packagist",
+		"golang": "Go",
 	}
 	for alias, canon := range aliasToCanonical {
 		t.Run(alias, func(t *testing.T) {
@@ -506,9 +512,40 @@ func TestClassifyForEcosystem_FunnelStatuses(t *testing.T) {
 		_, status := osvimport.ClassifyForEcosystem(mustMarshal(t, rec), "RubyGems")
 		require.Equal(t, osvimport.StatusWithdrawn, status)
 	})
-	t.Run("ranges only", func(t *testing.T) {
+	t.Run("ranges only, malicious signal", func(t *testing.T) {
+		// MAL- prefixed: passes the signal gate, but carries no exact
+		// versions. Still dropped from the snapshot; the dedicated
+		// status reports the population range-aware matching (spec C3)
+		// would unlock.
 		rec := osvRecordFixture{
 			ID: "MAL-3",
+			Affected: []affectedFixture{{
+				Package: packageFixture{Name: "x", Ecosystem: "Go"},
+				Ranges: []rangeFixture{{Type: "SEMVER",
+					Events: []map[string]string{{"introduced": "0"}}}},
+			}},
+		}
+		_, status := osvimport.ClassifyForEcosystem(mustMarshal(t, rec), "Go")
+		require.Equal(t, osvimport.StatusRangesOnlyMalicious, status)
+	})
+	t.Run("malicious with neither versions nor ranges", func(t *testing.T) {
+		// Nothing range support could unlock: stays in the plain
+		// ranges-only bucket so the C3 measurement is not skewed.
+		rec := osvRecordFixture{
+			ID: "MAL-4",
+			Affected: []affectedFixture{{
+				Package: packageFixture{Name: "x", Ecosystem: "Go"},
+			}},
+		}
+		_, status := osvimport.ClassifyForEcosystem(mustMarshal(t, rec), "Go")
+		require.Equal(t, osvimport.StatusRangesOnly, status)
+	})
+	t.Run("ranges only, no malicious signal", func(t *testing.T) {
+		// CVE-flavoured ranges-only record: dropped, and range support
+		// would NOT make it eligible (fails the malicious gate).
+		rec := osvRecordFixture{
+			ID:      "GO-2026-0001",
+			Summary: "Some generic vulnerability",
 			Affected: []affectedFixture{{
 				Package: packageFixture{Name: "x", Ecosystem: "Go"},
 			}},

--- a/tools/measure-intel/main.go
+++ b/tools/measure-intel/main.go
@@ -290,12 +290,23 @@ type ecosystemReport struct {
 	EcosystemMatchedRecords  int `json:"ecosystem_matched_records"`
 	WithdrawnRecords         int `json:"withdrawn_records"`
 	RangesOnlyDroppedRecords int `json:"ranges_only_dropped_records"`
-	SignalOrKeywordKept      int `json:"signal_or_keyword_kept_records"`
-	NeitherDroppedRecords    int `json:"neither_dropped_records"`
-	FinalKeptRecords         int `json:"final_kept_records"`
+	// RangesOnlyMaliciousRecords: the subset of ranges-only records
+	// that also pass the malicious signal-or-keyword gate. This is the
+	// population range-aware matching (spec C3) would unlock per
+	// ecosystem.
+	RangesOnlyMaliciousRecords int `json:"ranges_only_malicious_records"`
+	// RangesOnlyMaliciousAllVersions: the subset of malicious
+	// ranges-only records whose every range is the "all versions"
+	// shape (introduced 0/absent, no fixed, no last_affected). These
+	// need NO version-ordering grammar to match: any installed version
+	// is affected. The C3 cost/benefit hinges on this split.
+	RangesOnlyMaliciousAllVersions int `json:"ranges_only_malicious_all_versions"`
+	SignalOrKeywordKept            int `json:"signal_or_keyword_kept_records"`
+	NeitherDroppedRecords          int `json:"neither_dropped_records"`
+	FinalKeptRecords               int `json:"final_kept_records"`
 	// Timing
-	ParseDurationMS    int64 `json:"parse_duration_ms"`
-	RenderDurationMS   int64 `json:"render_duration_ms"`
+	ParseDurationMS  int64 `json:"parse_duration_ms"`
+	RenderDurationMS int64 `json:"render_duration_ms"`
 }
 
 func measure(job measureJob) (ecosystemReport, error) {
@@ -344,6 +355,13 @@ func measure(job measureJob) (ecosystemReport, error) {
 		case osvimport.StatusRangesOnly:
 			r.EcosystemMatchedRecords++
 			r.RangesOnlyDroppedRecords++
+		case osvimport.StatusRangesOnlyMalicious:
+			r.EcosystemMatchedRecords++
+			r.RangesOnlyDroppedRecords++
+			r.RangesOnlyMaliciousRecords++
+			if rangesAreAllVersions(data, job.ecosystem) {
+				r.RangesOnlyMaliciousAllVersions++
+			}
 		case osvimport.StatusNeither:
 			r.EcosystemMatchedRecords++
 			r.NeitherDroppedRecords++
@@ -398,18 +416,68 @@ func readZipEntry(entry *zip.File) ([]byte, error) {
 	return io.ReadAll(io.LimitReader(rc, cap))
 }
 
+// rangesAreAllVersions reports whether EVERY range on the target
+// ecosystem's affected entry is the "all versions" shape: an
+// introduced event of "0" (or absent) with no fixed and no
+// last_affected. Such records affect every version of the package and
+// need no version-ordering grammar to match. Pure data inspection -
+// this does NOT mirror importer filter logic.
+func rangesAreAllVersions(raw []byte, ecosystem string) bool {
+	var rec struct {
+		Affected []struct {
+			Package struct {
+				Ecosystem string `json:"ecosystem"`
+			} `json:"package"`
+			Ranges []struct {
+				Events []map[string]string `json:"events"`
+			} `json:"ranges"`
+		} `json:"affected"`
+	}
+	if err := json.Unmarshal(raw, &rec); err != nil {
+		return false
+	}
+	eco := strings.ToLower(strings.TrimSpace(ecosystem))
+	sawRange := false
+	for _, aff := range rec.Affected {
+		if strings.ToLower(strings.TrimSpace(aff.Package.Ecosystem)) != eco {
+			continue
+		}
+		for _, rg := range aff.Ranges {
+			sawRange = true
+			for _, ev := range rg.Events {
+				// Allowlist: the only event compatible with the
+				// "all versions" shape is introduced 0/absent. Any
+				// other key (fixed, last_affected, limit, or future
+				// additions) bounds the range and requires version
+				// ordering.
+				for k, v := range ev {
+					if k != "introduced" {
+						return false
+					}
+					if v != "" && v != "0" {
+						return false
+					}
+				}
+			}
+		}
+	}
+	return sawRange
+}
+
 func renderMarkdown(w io.Writer, reports []ecosystemReport) error {
 	var buf bytes.Buffer
-	fmt.Fprintln(&buf, "| Ecosystem | Zip (MB) | Total | Matched | Withdrawn | Ranges-only | Neither | Kept (final) | Gz blob (MB) | Parse (s) |")
-	fmt.Fprintln(&buf, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
+	fmt.Fprintln(&buf, "| Ecosystem | Zip (MB) | Total | Matched | Withdrawn | Ranges-only | Ranges-only MALICIOUS | ...of which ALL-VERSIONS | Neither | Kept (final) | Gz blob (MB) | Parse (s) |")
+	fmt.Fprintln(&buf, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
 	for _, r := range reports {
-		fmt.Fprintf(&buf, "| %s | %.1f | %d | %d | %d | %d | %d | **%d** | %.2f | %.1f |\n",
+		fmt.Fprintf(&buf, "| %s | %.1f | %d | %d | %d | %d | **%d** | **%d** | %d | **%d** | %.2f | %.1f |\n",
 			r.Ecosystem,
 			float64(r.ZipCompressedBytes)/1024/1024,
 			r.TotalRecords,
 			r.EcosystemMatchedRecords,
 			r.WithdrawnRecords,
 			r.RangesOnlyDroppedRecords,
+			r.RangesOnlyMaliciousRecords,
+			r.RangesOnlyMaliciousAllVersions,
 			r.NeitherDroppedRecords,
 			r.FinalKeptRecords,
 			float64(r.GeneratedSourceBytes)/1024/1024,
@@ -419,6 +487,8 @@ func renderMarkdown(w io.Writer, reports []ecosystemReport) error {
 	fmt.Fprintln(&buf)
 	fmt.Fprintln(&buf, "Columns:")
 	fmt.Fprintln(&buf, "- **Total**: every JSON record in the zip.")
+	fmt.Fprintln(&buf, "- **Ranges-only MALICIOUS**: ranges-only records that ALSO pass the malicious signal/keyword gate - the population range-aware matching (spec C3) would unlock.")
+	fmt.Fprintln(&buf, "- **...of which ALL-VERSIONS**: malicious ranges-only records whose every range is introduced-0 with no fixed/last_affected. Matching these needs no version-ordering grammar: every version is affected.")
 	fmt.Fprintln(&buf, "- **Matched**: records whose `affected[].package.ecosystem` matches the target.")
 	fmt.Fprintln(&buf, "- **Withdrawn**: OSV-retracted; counted in Matched, passed through as tombstones (not in Kept).")
 	fmt.Fprintln(&buf, "- **Ranges-only**: matched records dropped because the runtime matcher cannot consume version ranges yet.")


### PR DESCRIPTION
Range-aware matching has been on the roadmap as the biggest detection lever (#105). Before building per-ecosystem version comparators, this PR measures what they would actually buy - and the answer redirects the work.

**The measurement gap**

The import funnel classified ranges-only records before the malicious-signal gate, so "ranges-only dropped" conflated CVE-flavoured advisories (which the malicious-only policy drops regardless) with malicious records that range support would unlock. The decisive number, malicious AND ranges-only, was unmeasurable.

**What changed**

- `ClassifyForEcosystem` evaluates the signal gate independently of the versions shape and reports a dedicated status, `StatusRangesOnlyMalicious`. Both ranges-only statuses remain dropped from the snapshot: production behavior is unchanged.
- `measure-intel` reports two new columns: malicious ranges-only, and the subset whose every range is the "all versions" shape (`introduced` 0/absent, no `fixed`, no `last_affected`, no `limit`) - records that need no version-ordering grammar to match.

**What the numbers say (measured 2026-06-11)**

| Ecosystem | malicious ∩ ranges-only | of which all-versions |
|---|---:|---:|
| npm | 197,286 | 196,191 (99.4%) |
| PyPI | 6,377 | 6,373 (99.9%) |
| Go | 33 | 18 |
| crates.io / Maven / Packagist | 5 / 2 / 2 | - |
| NuGet / RubyGems | 0 / 0 | - |

Three conclusions: range matching is not a version-grammar problem (99%+ of malicious ranges say "every version is malicious"); the real gap is at import, where 197K npm and 6.4K PyPI malicious records are dropped for carrying no exact versions; and per-ecosystem comparator work would buy ~42 records total outside npm and PyPI.

Follow-ups: import-side support plus a grammar-free all-versions matching fast-path for npm and PyPI, with snapshot size measured before the embed decision.
