### PR TITLE
Match packages where every version is malicious, without version grammars

### DIFF
--- a/cmd/aguara/commands/status.go
+++ b/cmd/aguara/commands/status.go
@@ -36,9 +36,13 @@ func runStatus(cmd *cobra.Command, args []string) error {
 		label := snapshotLabel(snap)
 		// Embedded intel ships with the binary: show its age for
 		// provenance, never a stale warning.
-		fmt.Fprintf(w, "  Embedded (%s): %s (%s), %d records\n",
+		extra := ""
+		if n := len(snap.AllVersions); n > 0 {
+			extra = fmt.Sprintf(" + %d all-versions entries", n)
+		}
+		fmt.Fprintf(w, "  Embedded (%s): %s (%s), %d records%s\n",
 			label, snap.GeneratedAt.Format("2006-01-02"),
-			humanizeAgeDays(ageDaysSince(snap.GeneratedAt, now)), len(snap.Records))
+			humanizeAgeDays(ageDaysSince(snap.GeneratedAt, now)), len(snap.Records), extra)
 	}
 
 	store, err := intel.DefaultStore()

--- a/internal/incident/checker_test.go
+++ b/internal/incident/checker_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/internal/incident/npm_test.go
+++ b/internal/incident/npm_test.go
@@ -278,13 +278,13 @@ func TestCheckNPM_MiniShaiHulud_NeighborVersionDoesNotFalsePositive(t *testing.T
 	// against accidental range expansion when adding manual intel.
 	dir := t.TempDir()
 	nm := filepath.Join(dir, "node_modules")
-	writeNPMPackage(t, nm, "@antv/g2", "5.4.8")                   // current latest, clean
-	writeNPMPackage(t, nm, "@antv/g6", "5.1.1")                   // current latest, clean
-	writeNPMPackage(t, nm, "size-sensor", "1.0.3")                // current latest, clean
-	writeNPMPackage(t, nm, "@antv/data-set", "0.11.8")            // current latest, clean
-	writeNPMPackage(t, nm, "echarts-for-react", "3.0.6")          // current latest, clean
-	writeNPMPackage(t, nm, "@antv/g-image-exporter", "1.0.42")    // current latest, clean
-	writeNPMPackage(t, nm, "@antv/infographic", "0.2.19")         // current latest, clean
+	writeNPMPackage(t, nm, "@antv/g2", "5.4.8")                // current latest, clean
+	writeNPMPackage(t, nm, "@antv/g6", "5.1.1")                // current latest, clean
+	writeNPMPackage(t, nm, "size-sensor", "1.0.3")             // current latest, clean
+	writeNPMPackage(t, nm, "@antv/data-set", "0.11.8")         // current latest, clean
+	writeNPMPackage(t, nm, "echarts-for-react", "3.0.6")       // current latest, clean
+	writeNPMPackage(t, nm, "@antv/g-image-exporter", "1.0.42") // current latest, clean
+	writeNPMPackage(t, nm, "@antv/infographic", "0.2.19")      // current latest, clean
 
 	result, err := incident.CheckNPM(incident.CheckOptions{Path: nm})
 	if err != nil {

--- a/internal/intel/ecosystem.go
+++ b/internal/intel/ecosystem.go
@@ -96,8 +96,8 @@ var ecosystemRegistry = []EcosystemSpec{
 	},
 }
 
-func nameLowerTrim(s string) string     { return strings.ToLower(strings.TrimSpace(s)) }
-func nameTrimKeepCase(s string) string  { return strings.TrimSpace(s) }
+func nameLowerTrim(s string) string    { return strings.ToLower(strings.TrimSpace(s)) }
+func nameTrimKeepCase(s string) string { return strings.TrimSpace(s) }
 
 // CanonicaliseEcosystem maps a user-provided ecosystem alias to its
 // OSV bucket key. Returns "" when the value is not in the registry,

--- a/internal/intel/matcher.go
+++ b/internal/intel/matcher.go
@@ -48,6 +48,14 @@ type Matcher struct {
 	// A separator that can never appear in a package name keeps
 	// the key collision-free without a real composite-key type.
 	byKey map[string][]*Record
+	// allVersions maps indexKey(ecosystem, name) to the advisory IDs
+	// of its AllVersionsEntry rows: every version of the package is
+	// malicious, no version comparison needed. Distinct advisory IDs
+	// are all kept (mirroring the Records contract: separate IDs are
+	// useful provenance for cross-source correlation); duplicates are
+	// collapsed and tombstones (withdrawn records with the same ID)
+	// remove individual IDs.
+	allVersions map[string][]string
 }
 
 // NewMatcher builds a Matcher from the given snapshots. Withdrawn
@@ -70,7 +78,10 @@ type Matcher struct {
 // are useful provenance (e.g. one OSV ID, one Socket ID) and must
 // both surface so cross-source correlation works.
 func NewMatcher(snapshots ...Snapshot) *Matcher {
-	m := &Matcher{byKey: make(map[string][]*Record)}
+	m := &Matcher{
+		byKey:       make(map[string][]*Record),
+		allVersions: make(map[string][]string),
+	}
 
 	// First pass: collect tombstones. Any (ecosystem, name, ID)
 	// tuple that has a Withdrawn record in any snapshot is dead --
@@ -125,6 +136,29 @@ func NewMatcher(snapshots ...Snapshot) *Matcher {
 			m.byKey[key] = append(m.byKey[key], &recCopy)
 		}
 	}
+
+	// All-versions entries: distinct advisory IDs per (ecosystem,
+	// name) are all kept, in snapshot order (manual-first), with
+	// duplicates collapsed; a tombstone for the same (key, ID) kills
+	// that ID just like it kills a record.
+	seenEntry := make(map[string]struct{})
+	for _, snap := range snapshots {
+		for _, e := range snap.AllVersions {
+			key := indexKey(e.Ecosystem, e.Name)
+			if key == "" || e.ID == "" {
+				continue
+			}
+			idKey := key + "\x00" + e.ID
+			if _, dead := tombstones[idKey]; dead {
+				continue
+			}
+			if _, dup := seenEntry[idKey]; dup {
+				continue
+			}
+			seenEntry[idKey] = struct{}{}
+			m.allVersions[key] = append(m.allVersions[key], e.ID)
+		}
+	}
 	return m
 }
 
@@ -171,7 +205,7 @@ func unionVersions(a, b []string) []string {
 // can show the on-disk location without the caller threading it back
 // through.
 func (m *Matcher) MatchPackage(in MatchInput) []Match {
-	if m == nil || len(m.byKey) == 0 {
+	if m == nil || (len(m.byKey) == 0 && len(m.allVersions) == 0) {
 		return nil
 	}
 	key := indexKey(in.Ecosystem, in.Name)
@@ -179,9 +213,6 @@ func (m *Matcher) MatchPackage(in MatchInput) []Match {
 		return nil
 	}
 	candidates := m.byKey[key]
-	if len(candidates) == 0 {
-		return nil
-	}
 	allowRanges := ecosystemSupportsRanges(normalizeEcosystem(in.Ecosystem))
 	var out []Match
 	for _, rec := range candidates {
@@ -203,7 +234,40 @@ func (m *Matcher) MatchPackage(in MatchInput) []Match {
 		}
 		out = append(out, Match{Record: *rec, Path: in.Path})
 	}
+
+	// All-versions entry: any installed version of this package is
+	// malicious; no version comparison is involved. Skipped when a
+	// full record with the same advisory ID already matched, so one
+	// advisory never produces two findings.
+	for _, id := range m.allVersions[key] {
+		dup := false
+		for _, mt := range out {
+			if mt.Record.ID == id {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			out = append(out, Match{Record: synthesizeAllVersionsRecord(id, in), Path: in.Path})
+		}
+	}
 	return out
+}
+
+// synthesizeAllVersionsRecord builds the user-facing record for an
+// all-versions match. Summary and reference are derived from the
+// advisory ID so the stored entry stays three strings.
+func synthesizeAllVersionsRecord(id string, in MatchInput) Record {
+	return Record{
+		ID:        id,
+		Ecosystem: normalizeEcosystem(in.Ecosystem),
+		Name:      in.Name,
+		Kind:      KindMalicious,
+		Summary:   "Every version of " + in.Name + " is marked malicious (" + id + ").",
+		References: []string{
+			"https://osv.dev/vulnerability/" + id,
+		},
+	}
 }
 
 // ecosystemSupportsRanges reports whether MatchPackage will evaluate

--- a/internal/intel/matcher_test.go
+++ b/internal/intel/matcher_test.go
@@ -477,3 +477,105 @@ func TestMatcherDistinctIDsExactAndRangeBothMatch(t *testing.T) {
 	require.Len(t, hit, 2, "distinct IDs (manual exact + OSV range) both surface at the matcher layer")
 	require.Equal(t, "SOCKET-2026-05-24-trapdoor", hit[0].Record.ID, "manual advisory keeps first/display priority")
 }
+
+// ---------------------------------------------------------------------------
+// All-versions entries (C3-A)
+
+func TestMatcher_AllVersionsEntryMatchesAnyVersion(t *testing.T) {
+	snap := intel.Snapshot{AllVersions: []intel.AllVersionsEntry{
+		{ID: "MAL-2026-0001", Ecosystem: intel.EcosystemNPM, Name: "evil-pkg"},
+	}}
+	m := intel.NewMatcher(snap)
+	for _, v := range []string{"0.0.1", "9.9.9", "1.0.0-beta.1", "not-even-semver"} {
+		got := m.MatchPackage(intel.MatchInput{Ecosystem: "npm", Name: "evil-pkg", Version: v})
+		if len(got) != 1 {
+			t.Fatalf("version %q: want 1 match, got %d", v, len(got))
+		}
+		rec := got[0].Record
+		if rec.ID != "MAL-2026-0001" || rec.Kind != intel.KindMalicious {
+			t.Errorf("unexpected record: %+v", rec)
+		}
+		if rec.Summary == "" || len(rec.References) == 0 {
+			t.Errorf("synthesized record must carry summary and reference: %+v", rec)
+		}
+	}
+	// Different package stays silent.
+	if got := m.MatchPackage(intel.MatchInput{Ecosystem: "npm", Name: "good-pkg", Version: "1.0.0"}); len(got) != 0 {
+		t.Errorf("unrelated package matched: %v", got)
+	}
+}
+
+func TestMatcher_AllVersionsTombstoned(t *testing.T) {
+	live := intel.Snapshot{AllVersions: []intel.AllVersionsEntry{
+		{ID: "MAL-X", Ecosystem: intel.EcosystemNPM, Name: "pkg"},
+	}}
+	retract := intel.Snapshot{Records: []intel.Record{
+		{ID: "MAL-X", Ecosystem: intel.EcosystemNPM, Name: "pkg", Withdrawn: true},
+	}}
+	m := intel.NewMatcher(live, retract)
+	if got := m.MatchPackage(intel.MatchInput{Ecosystem: "npm", Name: "pkg", Version: "1.0.0"}); len(got) != 0 {
+		t.Errorf("tombstoned all-versions entry still matched: %v", got)
+	}
+}
+
+func TestMatcher_AllVersionsDedupesAgainstRecordWithSameID(t *testing.T) {
+	snap := intel.Snapshot{
+		Records: []intel.Record{
+			{ID: "MAL-X", Ecosystem: intel.EcosystemNPM, Name: "pkg", Kind: intel.KindMalicious, Versions: []string{"1.0.0"}},
+		},
+		AllVersions: []intel.AllVersionsEntry{
+			{ID: "MAL-X", Ecosystem: intel.EcosystemNPM, Name: "pkg"},
+		},
+	}
+	m := intel.NewMatcher(snap)
+	// Exact version hit: the record matches; the entry must not add a
+	// second finding for the same advisory.
+	got := m.MatchPackage(intel.MatchInput{Ecosystem: "npm", Name: "pkg", Version: "1.0.0"})
+	if len(got) != 1 {
+		t.Fatalf("want 1 match, got %d", len(got))
+	}
+	// Non-listed version: the record misses, the entry covers it.
+	got = m.MatchPackage(intel.MatchInput{Ecosystem: "npm", Name: "pkg", Version: "2.0.0"})
+	if len(got) != 1 {
+		t.Fatalf("want 1 entry match for unlisted version, got %d", len(got))
+	}
+}
+
+func TestMatcher_AllVersionsKeepsDistinctIDs(t *testing.T) {
+	// Mirrors the Records contract: distinct advisory IDs for the same
+	// package are useful provenance and all surface, manual-first;
+	// exact duplicates collapse.
+	manual := intel.Snapshot{AllVersions: []intel.AllVersionsEntry{
+		{ID: "MANUAL-1", Ecosystem: intel.EcosystemNPM, Name: "pkg"},
+	}}
+	osv := intel.Snapshot{AllVersions: []intel.AllVersionsEntry{
+		{ID: "MAL-2", Ecosystem: intel.EcosystemNPM, Name: "pkg"},
+		{ID: "MANUAL-1", Ecosystem: intel.EcosystemNPM, Name: "pkg"}, // duplicate: collapsed
+	}}
+	m := intel.NewMatcher(manual, osv)
+	got := m.MatchPackage(intel.MatchInput{Ecosystem: "npm", Name: "pkg", Version: "1.0.0"})
+	if len(got) != 2 || got[0].Record.ID != "MANUAL-1" || got[1].Record.ID != "MAL-2" {
+		t.Fatalf("want [MANUAL-1, MAL-2], got %v", got)
+	}
+}
+
+func TestSnapshot_AllVersionsRoundTrip(t *testing.T) {
+	snap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		AllVersions: []intel.AllVersionsEntry{
+			{ID: "MAL-1", Ecosystem: intel.EcosystemNPM, Name: "a"},
+			{ID: "MAL-2", Ecosystem: "pypi", Name: "b"},
+		},
+	}
+	gz, err := intel.EncodeSnapshotGZIP(snap)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	back, err := intel.DecodeSnapshotGZIP(gz)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(back.AllVersions) != 2 || back.AllVersions[0] != snap.AllVersions[0] {
+		t.Fatalf("round trip lost entries: %+v", back.AllVersions)
+	}
+}

--- a/internal/intel/osvimport/osvimport.go
+++ b/internal/intel/osvimport/osvimport.go
@@ -77,9 +77,78 @@ type osvRecord struct {
 }
 
 type osvAffected struct {
-	Package  osvPackage        `json:"package"`
-	Versions []string          `json:"versions,omitempty"`
-	Ranges   []json.RawMessage `json:"ranges,omitempty"`
+	Package  osvPackage `json:"package"`
+	Versions []string   `json:"versions,omitempty"`
+	Ranges   []osvRange `json:"ranges,omitempty"`
+}
+
+type osvRange struct {
+	Type   string              `json:"type"`
+	Events []map[string]string `json:"events"`
+}
+
+// rangesAllVersionsShape reports whether every range consists solely
+// of introduced 0/absent events: the "every version is malicious"
+// shape. Any other event key (fixed, last_affected, limit, future
+// additions) bounds the range and disqualifies the record from the
+// compact all-versions encoding.
+func rangesAllVersionsShape(in []osvRange) bool {
+	if len(in) == 0 {
+		return false
+	}
+	for _, r := range in {
+		introduced := false
+		for _, ev := range r.Events {
+			for k, v := range ev {
+				if k != "introduced" {
+					return false
+				}
+				if v != "" && v != "0" {
+					return false
+				}
+				introduced = true
+			}
+		}
+		// A range with no events (or only empty maps) asserts
+		// nothing; flagging every version from it would invent
+		// coverage OSV never stated.
+		if !introduced {
+			return false
+		}
+	}
+	return true
+}
+
+// convertRanges maps OSV ranges onto intel.VersionRange. Each OSV
+// range may carry several introduced/fixed event pairs; OSV events
+// come ordered, so pairs are formed sequentially: an introduced event
+// opens a range, a fixed/last_affected event closes it.
+func convertRanges(in []osvRange) []intel.VersionRange {
+	var out []intel.VersionRange
+	for _, r := range in {
+		cur := intel.VersionRange{Type: r.Type}
+		open := false
+		for _, ev := range r.Events {
+			if v, ok := ev["introduced"]; ok {
+				if open {
+					out = append(out, cur)
+					cur = intel.VersionRange{Type: r.Type}
+				}
+				cur.Introduced = v
+				open = true
+			}
+			if v, ok := ev["fixed"]; ok {
+				cur.Fixed = v
+			}
+			if v, ok := ev["last_affected"]; ok {
+				cur.LastAffected = v
+			}
+		}
+		if open {
+			out = append(out, cur)
+		}
+	}
+	return out
 }
 
 type osvPackage struct {
@@ -146,16 +215,19 @@ func Import(raw [][]byte, opts Options) (intel.Snapshot, error) {
 	}}
 
 	for _, b := range raw {
-		rec, ok := convertOSVRecord(b, ecoFilter)
+		rec, entries, ok := convertOSVRecord(b, ecoFilter)
 		if !ok {
 			continue
 		}
 		snap.Records = append(snap.Records, rec...)
+		snap.AllVersions = append(snap.AllVersions, entries...)
 	}
 
 	// Stable order for reproducible builds: ecosystem, name, ID.
 	// Without this the embedded snapshot would re-shuffle on every
 	// regeneration even when the upstream OSV slice is identical.
+	snap.AllVersions = SortAndDedupeAllVersions(snap.AllVersions)
+
 	sort.SliceStable(snap.Records, func(i, j int) bool {
 		a, b := snap.Records[i], snap.Records[j]
 		if a.Ecosystem != b.Ecosystem {
@@ -179,16 +251,16 @@ func Import(raw [][]byte, opts Options) (intel.Snapshot, error) {
 //
 // Returns (records, true) on a kept advisory; (nil, false) on
 // anything dropped by the filter.
-func convertOSVRecord(raw []byte, ecoFilter map[string]struct{}) ([]intel.Record, bool) {
+func convertOSVRecord(raw []byte, ecoFilter map[string]struct{}) ([]intel.Record, []intel.AllVersionsEntry, bool) {
 	var osv osvRecord
 	if err := json.Unmarshal(raw, &osv); err != nil {
 		// Malformed record: drop rather than abort the whole
 		// import. A single bad row in a 100k-record OSV dump
 		// must not deny-of-service the rest of the snapshot.
-		return nil, false
+		return nil, nil, false
 	}
 	if osv.ID == "" || len(osv.Affected) == 0 {
-		return nil, false
+		return nil, nil, false
 	}
 
 	// A withdrawn-in-OSV record passes through as a withdrawn
@@ -203,6 +275,7 @@ func convertOSVRecord(raw []byte, ecoFilter map[string]struct{}) ([]intel.Record
 	keywordHit := hasKeywordMatch(osv)
 
 	var out []intel.Record
+	var entries []intel.AllVersionsEntry
 	for _, aff := range osv.Affected {
 		eco := canonicaliseEcosystem(aff.Package.Ecosystem)
 		if eco == "" {
@@ -221,9 +294,20 @@ func convertOSVRecord(raw []byte, ecoFilter map[string]struct{}) ([]intel.Record
 		// copy keeps matching forever after the retraction.
 		if !withdrawn {
 			if len(aff.Versions) == 0 {
-				// Runtime matcher consults exact Versions only;
-				// a ranges-only live record is unreachable.
-				// Skip rather than emit dead data.
+				// No exact versions. If the record is malicious and
+				// every range is the all-versions shape, it becomes a
+				// compact AllVersionsEntry: an exact (ecosystem, name)
+				// lookup is its whole evaluation, no version grammar
+				// involved. Bounded malicious ranges remain skipped
+				// here (C3-B territory); CVE-flavoured records are
+				// dropped as before.
+				if (signal || keywordHit) && rangesAllVersionsShape(aff.Ranges) {
+					entries = append(entries, intel.AllVersionsEntry{
+						ID:        osv.ID,
+						Ecosystem: eco,
+						Name:      aff.Package.Name,
+					})
+				}
 				continue
 			}
 			// Filter: keep when there is a high-confidence
@@ -247,10 +331,10 @@ func convertOSVRecord(raw []byte, ecoFilter map[string]struct{}) ([]intel.Record
 			Withdrawn:  withdrawn,
 		})
 	}
-	if len(out) == 0 {
-		return nil, false
+	if len(out) == 0 && len(entries) == 0 {
+		return nil, nil, false
 	}
-	return out, true
+	return out, entries, true
 }
 
 // RecordStatus is the per-record verdict the filter funnel produces.
@@ -280,16 +364,19 @@ const (
 	// StatusKept: the record survives the filter and becomes an
 	// intel.Record in the snapshot.
 	StatusKept
-	// StatusRangesOnlyMalicious: like StatusRangesOnly (only version
-	// ranges, no exact versions, so the record is dropped from the
-	// snapshot today), but the record ALSO passes the malicious
-	// signal-or-keyword gate. This is the population range-aware
-	// matching (spec C3) would unlock; splitting it from
-	// StatusRangesOnly lets measurement tooling report
-	// `malicious AND ranges-only` per ecosystem without changing what
-	// the importer keeps. Appended at the end of the enum so existing
-	// status values are stable.
+	// StatusRangesOnlyMalicious: only version ranges with REAL
+	// bounds (fixed / last_affected / non-zero introduced), no exact
+	// versions, and the record passes the malicious gate. Dropped
+	// from the snapshot today; this is the bounded-range residual
+	// (C3-B). Appended after StatusKept so existing status values
+	// are stable.
 	StatusRangesOnlyMalicious
+	// StatusAllVersionsKept: no exact versions, malicious, and every
+	// range is the all-versions shape (introduced 0/absent, nothing
+	// else). The importer KEEPS these as compact
+	// Snapshot.AllVersions entries (C3-A), so measurement tooling
+	// must count them as kept intel, not dropped.
+	StatusAllVersionsKept
 )
 
 // ClassifyForEcosystem walks a raw OSV record and reports how a
@@ -336,7 +423,23 @@ func ClassifyForEcosystem(raw []byte, targetEcosystem string) (intel.Record, Rec
 		// nor ranges has nothing range support could unlock, so it
 		// stays in the plain ranges-only bucket regardless of signal.
 		if malicious && len(aff.Ranges) > 0 {
-			return intel.Record{}, StatusRangesOnlyMalicious
+			rec := intel.Record{
+				ID:         osv.ID,
+				Aliases:    append([]string(nil), osv.Aliases...),
+				Ecosystem:  canon,
+				Name:       aff.Package.Name,
+				Kind:       intel.KindMalicious,
+				Summary:    pickSummary(osv),
+				Ranges:     convertRanges(aff.Ranges),
+				References: extractReferenceURLs(osv.References),
+			}
+			if rangesAllVersionsShape(aff.Ranges) {
+				// Mirrors Import: these ship as compact
+				// Snapshot.AllVersions entries.
+				return rec, StatusAllVersionsKept
+			}
+			// Bounded malicious ranges: still dropped (C3-B).
+			return rec, StatusRangesOnlyMalicious
 		}
 		return intel.Record{}, StatusRangesOnly
 	}
@@ -353,6 +456,39 @@ func ClassifyForEcosystem(raw []byte, targetEcosystem string) (intel.Record, Rec
 		Versions:   append([]string(nil), aff.Versions...),
 		References: extractReferenceURLs(osv.References),
 	}, StatusKept
+}
+
+// SortAndDedupeAllVersions sorts entries (ecosystem, name, ID) and
+// removes duplicates, mirroring SortRecords' reproducible-build role
+// for the all_versions section. Exported for the snapshot generator.
+func SortAndDedupeAllVersions(in []intel.AllVersionsEntry) []intel.AllVersionsEntry {
+	sort.SliceStable(in, func(i, j int) bool {
+		a, b := in[i], in[j]
+		if a.Ecosystem != b.Ecosystem {
+			return a.Ecosystem < b.Ecosystem
+		}
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		return a.ID < b.ID
+	})
+	return dedupeAllVersions(in)
+}
+
+// dedupeAllVersions removes consecutive duplicates from a sorted
+// entry slice (same ID, ecosystem, name).
+func dedupeAllVersions(in []intel.AllVersionsEntry) []intel.AllVersionsEntry {
+	if len(in) < 2 {
+		return in
+	}
+	out := in[:1]
+	for _, e := range in[1:] {
+		last := out[len(out)-1]
+		if e != last {
+			out = append(out, e)
+		}
+	}
+	return out
 }
 
 // buildEcosystemFilter returns a set keyed by the canonical

--- a/internal/intel/osvimport/osvimport_test.go
+++ b/internal/intel/osvimport/osvimport_test.go
@@ -526,6 +526,18 @@ func TestClassifyForEcosystem_FunnelStatuses(t *testing.T) {
 			}},
 		}
 		_, status := osvimport.ClassifyForEcosystem(mustMarshal(t, rec), "Go")
+		require.Equal(t, osvimport.StatusAllVersionsKept, status)
+	})
+	t.Run("bounded malicious ranges stay dropped (C3-B residual)", func(t *testing.T) {
+		rec := osvRecordFixture{
+			ID: "MAL-5",
+			Affected: []affectedFixture{{
+				Package: packageFixture{Name: "x", Ecosystem: "Go"},
+				Ranges: []rangeFixture{{Type: "SEMVER",
+					Events: []map[string]string{{"introduced": "1.0.0"}, {"fixed": "1.2.0"}}}},
+			}},
+		}
+		_, status := osvimport.ClassifyForEcosystem(mustMarshal(t, rec), "Go")
 		require.Equal(t, osvimport.StatusRangesOnlyMalicious, status)
 	})
 	t.Run("malicious with neither versions nor ranges", func(t *testing.T) {
@@ -653,3 +665,49 @@ func TestImportFromZipRejectsOversize(t *testing.T) {
 // Deterministic encoding of the embedded snapshot is covered by the
 // intel package (TestEncodeSnapshotGZIPDeterministic) now that the
 // build-time format is gzipped JSON rather than a rendered Go literal.
+
+// ---------------------------------------------------------------------------
+// All-versions entries through the production Import path (C3-A)
+
+func TestImport_AllVersionsEntries(t *testing.T) {
+	mk := func(id string, eco string, name string, ranges []rangeFixture, versions []string, summary string) []byte {
+		return mustMarshal(t, osvRecordFixture{
+			ID:      id,
+			Summary: summary,
+			Affected: []affectedFixture{{
+				Package:  packageFixture{Name: name, Ecosystem: eco},
+				Versions: versions,
+				Ranges:   ranges,
+			}},
+		})
+	}
+	allVer := []rangeFixture{{Type: "SEMVER", Events: []map[string]string{{"introduced": "0"}}}}
+	emptyEvents := []rangeFixture{{Type: "SEMVER", Events: []map[string]string{}}}
+	bounded := []rangeFixture{{Type: "SEMVER", Events: []map[string]string{{"introduced": "1.0.0"}, {"fixed": "1.2.0"}}}}
+
+	snap, err := osvimport.Import([][]byte{
+		mk("MAL-A", "npm", "evil-a", allVer, nil, ""),                           // -> entry
+		mk("MAL-B", "PyPI", "evil-b", allVer, nil, ""),                          // -> entry (pypi)
+		mk("MAL-C", "npm", "evil-c", bounded, nil, ""),                          // bounded: NOT an entry (C3-B)
+		mk("GO-1", "npm", "cve-pkg", allVer, nil, "Some generic vulnerability"), // no signal: dropped
+		mk("MAL-D", "npm", "evil-a", allVer, nil, ""),                           // distinct ID, same pkg: second entry
+		mk("MAL-A", "npm", "evil-a", allVer, nil, ""),                           // exact duplicate: deduped
+		mk("MAL-E", "npm", "kept-pkg", nil, []string{"1.0.0"}, ""),              // exact versions: normal record
+		mk("MAL-F", "npm", "no-events", emptyEvents, nil, ""),                   // empty events: asserts nothing, no entry
+	}, osvimport.Options{})
+	if err != nil {
+		t.Fatalf("Import: %v", err)
+	}
+	if len(snap.Records) != 1 || snap.Records[0].ID != "MAL-E" {
+		t.Fatalf("want 1 exact record (MAL-E), got %+v", snap.Records)
+	}
+	// Canonical ecosystem is the OSV bucket form ("PyPI"); the
+	// matcher normalizes at lookup. Sort: ecosystem, name, ID
+	// ("PyPI" < "npm" in byte order).
+	want := []intel.AllVersionsEntry{
+		{ID: "MAL-B", Ecosystem: "PyPI", Name: "evil-b"},
+		{ID: "MAL-A", Ecosystem: "npm", Name: "evil-a"},
+		{ID: "MAL-D", Ecosystem: "npm", Name: "evil-a"},
+	}
+	require.Equal(t, want, snap.AllVersions)
+}

--- a/internal/intel/snapshotmeta.go
+++ b/internal/intel/snapshotmeta.go
@@ -36,11 +36,11 @@ type SnapshotMeta struct {
 	// GzipSHA256 is the sha256 of the gzipped blob bytes (binds the blob).
 	GzipSHA256 string `json:"gzip_sha256"`
 	// JSONSHA256 is the sha256 of the decompressed JSON (defense in depth).
-	JSONSHA256 string `json:"json_sha256"`
-	GzipBytes  int    `json:"gzip_bytes"`
-	JSONBytes  int    `json:"json_bytes"`
-	RecordCount int    `json:"record_count"`
-	SourceCount int    `json:"source_count"`
+	JSONSHA256  string    `json:"json_sha256"`
+	GzipBytes   int       `json:"gzip_bytes"`
+	JSONBytes   int       `json:"json_bytes"`
+	RecordCount int       `json:"record_count"`
+	SourceCount int       `json:"source_count"`
 	Ecosystems  []string  `json:"ecosystems"`
 	GeneratedAt time.Time `json:"generated_at"`
 	// ToolVersion is the aguara version that produced the bundle. Set by

--- a/internal/intel/types.go
+++ b/internal/intel/types.go
@@ -58,12 +58,33 @@ type Snapshot struct {
 	GeneratedAt   time.Time    `json:"generated_at"`
 	Sources       []SourceMeta `json:"sources"`
 	Records       []Record     `json:"records"`
+	// AllVersions lists packages where EVERY version is marked
+	// malicious (OSV range shape: introduced 0/absent, no fixed, no
+	// last_affected). They are stored as compact entries instead of
+	// full Records because they need no version matching at all: an
+	// exact (ecosystem, name) lookup is the whole evaluation. The
+	// 2026-06-11 measurement found 99%+ of malicious range-only OSV
+	// records have this shape (197K npm, 6.4K PyPI); storing them as
+	// full Records would cost ~80 MB of heap, entries cost ~10 MB.
+	// Parallel to Records on purpose: old binaries ignore the field,
+	// new binaries accept snapshots without it (no format break).
+	AllVersions []AllVersionsEntry `json:"all_versions,omitempty"`
 	// SHA256 is optional metadata (set by the build-time generator
 	// or `aguara update`). It is NOT used to validate the snapshot
 	// during load -- the loader validates by re-parsing the JSON
 	// and enforcing size caps. The field is preserved so callers
 	// can show provenance to the user.
 	SHA256 string `json:"sha256,omitempty"`
+}
+
+// AllVersionsEntry marks every version of (Ecosystem, Name) as
+// malicious, attributed to advisory ID. Summary and reference URL are
+// synthesized at match time from the ID, so the entry stays three
+// strings.
+type AllVersionsEntry struct {
+	ID        string `json:"id"`
+	Ecosystem string `json:"ecosystem"`
+	Name      string `json:"name"`
 }
 
 // CurrentSchemaVersion is the on-disk schema version this build

--- a/internal/intel/update.go
+++ b/internal/intel/update.go
@@ -173,6 +173,7 @@ func Update(ctx context.Context, opts UpdateOptions) (*UpdateResult, error) {
 		}
 		merged.Sources = append(merged.Sources, snap.Sources...)
 		merged.Records = append(merged.Records, snap.Records...)
+		merged.AllVersions = append(merged.AllVersions, snap.AllVersions...)
 		per = append(per, EcosystemResult{
 			Ecosystem:    eco,
 			RecordsKept:  len(snap.Records),
@@ -277,6 +278,16 @@ func dedupeSources(snap *Snapshot) {
 func sortRecords(snap *Snapshot) {
 	sort.SliceStable(snap.Records, func(i, j int) bool {
 		a, b := snap.Records[i], snap.Records[j]
+		if a.Ecosystem != b.Ecosystem {
+			return a.Ecosystem < b.Ecosystem
+		}
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		return a.ID < b.ID
+	})
+	sort.SliceStable(snap.AllVersions, func(i, j int) bool {
+		a, b := snap.AllVersions[i], snap.AllVersions[j]
 		if a.Ecosystem != b.Ecosystem {
 			return a.Ecosystem < b.Ecosystem
 		}

--- a/internal/intel/update_test.go
+++ b/internal/intel/update_test.go
@@ -65,14 +65,14 @@ func TestUpdateMergesPerEcosystem(t *testing.T) {
 	perEco := map[string]intel.Snapshot{
 		intel.EcosystemNPM: {
 			SchemaVersion: intel.CurrentSchemaVersion,
-			Sources: []intel.SourceMeta{{Name: "osv.dev/npm", Kind: intel.SourceOSV}},
+			Sources:       []intel.SourceMeta{{Name: "osv.dev/npm", Kind: intel.SourceOSV}},
 			Records: []intel.Record{
 				{ID: "MAL-NPM-1", Ecosystem: intel.EcosystemNPM, Name: "evil", Versions: []string{"1.0.0"}},
 			},
 		},
 		intel.EcosystemPyPI: {
 			SchemaVersion: intel.CurrentSchemaVersion,
-			Sources: []intel.SourceMeta{{Name: "osv.dev/PyPI", Kind: intel.SourceOSV}},
+			Sources:       []intel.SourceMeta{{Name: "osv.dev/PyPI", Kind: intel.SourceOSV}},
 			Records: []intel.Record{
 				{ID: "MAL-PY-1", Ecosystem: intel.EcosystemPyPI, Name: "evil", Versions: []string{"0.1.0"}},
 			},

--- a/internal/packagecheck/packagelock_test.go
+++ b/internal/packagecheck/packagelock_test.go
@@ -372,3 +372,37 @@ func TestDiscover_PicksPackageLock(t *testing.T) {
 	require.Equal(t, "package-lock.json", targets[0].Source)
 	require.Equal(t, intel.EcosystemNPM, targets[0].Ecosystem)
 }
+
+// TestRunner_AllVersionsEntryFlagsLockfilePackage proves the C3-A
+// end-to-end: a compact all-versions entry (no Record, no version
+// list, no range evaluation) flags a lockfile package at any version
+// through the same Runner path `aguara check` uses.
+func TestRunner_AllVersionsEntryFlagsLockfilePackage(t *testing.T) {
+	snap := intel.Snapshot{
+		SchemaVersion: intel.CurrentSchemaVersion,
+		AllVersions: []intel.AllVersionsEntry{
+			{ID: "MAL-2026-7777", Ecosystem: "npm", Name: "evil-sdk"},
+		},
+	}
+	runner := &Runner{Matcher: intel.NewMatcher(snap)}
+
+	target := writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/evil-sdk": { "version": "3.1.4", "resolved": "https://registry.npmjs.org/evil-sdk/-/evil-sdk-3.1.4.tgz" },
+	    "node_modules/safe": { "version": "1.0.0", "resolved": "https://registry.npmjs.org/safe/-/safe-1.0.0.tgz" }
+	  }
+	}`)
+	res, err := runner.Run([]Target{target})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	var hits []string
+	for _, h := range res.Hits {
+		hits = append(hits, h.Ref.Name+"@"+h.Ref.Version+" -> "+h.Record.ID)
+	}
+	if len(hits) != 1 || hits[0] != "evil-sdk@3.1.4 -> MAL-2026-7777" {
+		t.Fatalf("want exactly the all-versions hit, got %v", hits)
+	}
+}

--- a/tools/measure-intel/main.go
+++ b/tools/measure-intel/main.go
@@ -295,15 +295,14 @@ type ecosystemReport struct {
 	// population range-aware matching (spec C3) would unlock per
 	// ecosystem.
 	RangesOnlyMaliciousRecords int `json:"ranges_only_malicious_records"`
-	// RangesOnlyMaliciousAllVersions: the subset of malicious
-	// ranges-only records whose every range is the "all versions"
-	// shape (introduced 0/absent, no fixed, no last_affected). These
-	// need NO version-ordering grammar to match: any installed version
-	// is affected. The C3 cost/benefit hinges on this split.
-	RangesOnlyMaliciousAllVersions int `json:"ranges_only_malicious_all_versions"`
-	SignalOrKeywordKept            int `json:"signal_or_keyword_kept_records"`
-	NeitherDroppedRecords          int `json:"neither_dropped_records"`
-	FinalKeptRecords               int `json:"final_kept_records"`
+	// KeptAllVersionsEntries: malicious records with only
+	// all-versions-shaped ranges, kept as compact
+	// Snapshot.AllVersions entries (C3-A). Counted as kept intel and
+	// included in the encoded blob below.
+	KeptAllVersionsEntries int `json:"kept_all_versions_entries"`
+	SignalOrKeywordKept    int `json:"signal_or_keyword_kept_records"`
+	NeitherDroppedRecords  int `json:"neither_dropped_records"`
+	FinalKeptRecords       int `json:"final_kept_records"`
 	// Timing
 	ParseDurationMS  int64 `json:"parse_duration_ms"`
 	RenderDurationMS int64 `json:"render_duration_ms"`
@@ -331,6 +330,7 @@ func measure(job measureJob) (ecosystemReport, error) {
 
 	parseStart := time.Now()
 	var kept []intel.Record
+	var entries []intel.AllVersionsEntry
 	for _, entry := range zr.File {
 		if !strings.HasSuffix(entry.Name, ".json") {
 			continue
@@ -359,9 +359,12 @@ func measure(job measureJob) (ecosystemReport, error) {
 			r.EcosystemMatchedRecords++
 			r.RangesOnlyDroppedRecords++
 			r.RangesOnlyMaliciousRecords++
-			if rangesAreAllVersions(data, job.ecosystem) {
-				r.RangesOnlyMaliciousAllVersions++
-			}
+		case osvimport.StatusAllVersionsKept:
+			r.EcosystemMatchedRecords++
+			r.KeptAllVersionsEntries++
+			entries = append(entries, intel.AllVersionsEntry{
+				ID: rec.ID, Ecosystem: rec.Ecosystem, Name: rec.Name,
+			})
 		case osvimport.StatusNeither:
 			r.EcosystemMatchedRecords++
 			r.NeitherDroppedRecords++
@@ -390,13 +393,15 @@ func measure(job measureJob) (ecosystemReport, error) {
 			RetrievedAt: time.Date(2026, time.May, 16, 0, 0, 0, 0, time.UTC),
 			License:     "CC-BY-4.0",
 		}},
-		Records: kept,
+		Records:     kept,
+		AllVersions: osvimport.SortAndDedupeAllVersions(entries),
 	}
 	gz, err := intel.EncodeSnapshotGZIP(snap)
 	if err != nil {
 		return r, fmt.Errorf("encode snapshot: %w", err)
 	}
 	r.GeneratedSourceBytes = int64(len(gz))
+
 	r.RenderDurationMS = time.Since(encodeStart).Milliseconds()
 
 	return r, nil
@@ -416,57 +421,9 @@ func readZipEntry(entry *zip.File) ([]byte, error) {
 	return io.ReadAll(io.LimitReader(rc, cap))
 }
 
-// rangesAreAllVersions reports whether EVERY range on the target
-// ecosystem's affected entry is the "all versions" shape: an
-// introduced event of "0" (or absent) with no fixed and no
-// last_affected. Such records affect every version of the package and
-// need no version-ordering grammar to match. Pure data inspection -
-// this does NOT mirror importer filter logic.
-func rangesAreAllVersions(raw []byte, ecosystem string) bool {
-	var rec struct {
-		Affected []struct {
-			Package struct {
-				Ecosystem string `json:"ecosystem"`
-			} `json:"package"`
-			Ranges []struct {
-				Events []map[string]string `json:"events"`
-			} `json:"ranges"`
-		} `json:"affected"`
-	}
-	if err := json.Unmarshal(raw, &rec); err != nil {
-		return false
-	}
-	eco := strings.ToLower(strings.TrimSpace(ecosystem))
-	sawRange := false
-	for _, aff := range rec.Affected {
-		if strings.ToLower(strings.TrimSpace(aff.Package.Ecosystem)) != eco {
-			continue
-		}
-		for _, rg := range aff.Ranges {
-			sawRange = true
-			for _, ev := range rg.Events {
-				// Allowlist: the only event compatible with the
-				// "all versions" shape is introduced 0/absent. Any
-				// other key (fixed, last_affected, limit, or future
-				// additions) bounds the range and requires version
-				// ordering.
-				for k, v := range ev {
-					if k != "introduced" {
-						return false
-					}
-					if v != "" && v != "0" {
-						return false
-					}
-				}
-			}
-		}
-	}
-	return sawRange
-}
-
 func renderMarkdown(w io.Writer, reports []ecosystemReport) error {
 	var buf bytes.Buffer
-	fmt.Fprintln(&buf, "| Ecosystem | Zip (MB) | Total | Matched | Withdrawn | Ranges-only | Ranges-only MALICIOUS | ...of which ALL-VERSIONS | Neither | Kept (final) | Gz blob (MB) | Parse (s) |")
+	fmt.Fprintln(&buf, "| Ecosystem | Zip (MB) | Total | Matched | Withdrawn | Ranges-only dropped | Bounded-ranges MALICIOUS (dropped) | All-versions KEPT | Neither | Kept records | Gz blob (MB) | Parse (s) |")
 	fmt.Fprintln(&buf, "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|")
 	for _, r := range reports {
 		fmt.Fprintf(&buf, "| %s | %.1f | %d | %d | %d | %d | **%d** | **%d** | %d | **%d** | %.2f | %.1f |\n",
@@ -477,7 +434,7 @@ func renderMarkdown(w io.Writer, reports []ecosystemReport) error {
 			r.WithdrawnRecords,
 			r.RangesOnlyDroppedRecords,
 			r.RangesOnlyMaliciousRecords,
-			r.RangesOnlyMaliciousAllVersions,
+			r.KeptAllVersionsEntries,
 			r.NeitherDroppedRecords,
 			r.FinalKeptRecords,
 			float64(r.GeneratedSourceBytes)/1024/1024,
@@ -487,8 +444,8 @@ func renderMarkdown(w io.Writer, reports []ecosystemReport) error {
 	fmt.Fprintln(&buf)
 	fmt.Fprintln(&buf, "Columns:")
 	fmt.Fprintln(&buf, "- **Total**: every JSON record in the zip.")
-	fmt.Fprintln(&buf, "- **Ranges-only MALICIOUS**: ranges-only records that ALSO pass the malicious signal/keyword gate - the population range-aware matching (spec C3) would unlock.")
-	fmt.Fprintln(&buf, "- **...of which ALL-VERSIONS**: malicious ranges-only records whose every range is introduced-0 with no fixed/last_affected. Matching these needs no version-ordering grammar: every version is affected.")
+	fmt.Fprintln(&buf, "- **Bounded-ranges MALICIOUS (dropped)**: malicious records whose ranges carry real version bounds; still dropped (C3-B residual).")
+	fmt.Fprintln(&buf, "- **All-versions KEPT**: malicious all-versions-shaped records kept as compact Snapshot.AllVersions entries (C3-A); included in the gz blob figure.")
 	fmt.Fprintln(&buf, "- **Matched**: records whose `affected[].package.ecosystem` matches the target.")
 	fmt.Fprintln(&buf, "- **Withdrawn**: OSV-retracted; counted in Matched, passed through as tombstones (not in Kept).")
 	fmt.Fprintln(&buf, "- **Ranges-only**: matched records dropped because the runtime matcher cannot consume version ranges yet.")

--- a/tools/update-intel/main.go
+++ b/tools/update-intel/main.go
@@ -123,9 +123,9 @@ func main() {
 		// --allow-empty exists for the one legitimate case --
 		// bootstrapping a brand-new generated file where the
 		// maintainer wants the empty stub committed.
-		if len(snap.Records) == 0 && !allowEmpty {
+		if len(snap.Records) == 0 && len(snap.AllVersions) == 0 && !allowEmpty {
 			fmt.Fprintf(os.Stderr,
-				"update-intel: %s (%s) produced 0 records. The zip may be paired with the wrong --ecosystem or have no malicious entries.\n"+
+				"update-intel: %s (%s) produced 0 records and 0 all-versions entries. The zip may be paired with the wrong --ecosystem or have no malicious entries.\n"+
 					"             Pass --allow-empty to commit an empty snapshot anyway.\n",
 				zipPath, eco)
 			os.Exit(1)
@@ -135,8 +135,10 @@ func main() {
 		}
 		merged.Sources = append(merged.Sources, snap.Sources...)
 		merged.Records = append(merged.Records, snap.Records...)
+		merged.AllVersions = append(merged.AllVersions, snap.AllVersions...)
 	}
 	osvimport.SortRecords(merged.Records)
+	merged.AllVersions = osvimport.SortAndDedupeAllVersions(merged.AllVersions)
 
 	jsonBytes, err := intel.MarshalSnapshotJSON(merged)
 	if err != nil {


### PR DESCRIPTION
The measurement in #216 showed that 99%+ of the malicious advisories Aguara dropped for carrying no exact versions share one shape: every version of the package is malicious. Matching that needs no version comparison at all - knowing the package name is the whole evaluation.

This adds a compact representation for exactly that, end to end:

- The snapshot gains a parallel `all_versions` section of three-string entries (advisory ID, ecosystem, name). Stored as full records these advisories would cost ~80 MB of memory; as entries they cost ~10 MB. No format break: old binaries ignore the field, new binaries accept old snapshots.
- The importer keeps malicious all-versions records as entries. Bounded malicious ranges (npm: 1,095; PyPI: 4) remain a follow-up.
- The matcher flags any installed version of a listed package. The user-facing finding is synthesized from the advisory ID (summary plus osv.dev reference), manual advisories keep display priority, withdrawn advisories retract entries, and one advisory never produces two findings.

**What it unlocks at the next snapshot regeneration**

| Ecosystem | Detections today | New all-versions entries | Blob |
|---|---:|---:|---|
| npm | 16,941 | **+196,191** | 0.61 -> 2.41 MB gz |
| PyPI | 4,978 | **+6,373** | 0.16 -> 0.20 MB gz |

Measured against the live OSV buckets. An end-to-end test proves a lockfile package flags at any version through the same path `aguara check` uses.

C3-A of the range-matching work. The bounded-range residual (C3-B) follows separately.
