### PR TITLE
Keep npm bounded-range malicious advisories (C3-B)

### DIFF
--- a/internal/intel/matcher_test.go
+++ b/internal/intel/matcher_test.go
@@ -579,3 +579,40 @@ func TestSnapshot_AllVersionsRoundTrip(t *testing.T) {
 		t.Fatalf("round trip lost entries: %+v", back.AllVersions)
 	}
 }
+
+func TestMatcher_NPMBoundedRanges_RealOSVShapes(t *testing.T) {
+	// Real npm OSV bounded shapes (extracted 2026-06-11 from the live
+	// bucket): an open-ended introduced range and an introduced-0 +
+	// fixed range. OSV semantics: introduced inclusive, fixed exclusive.
+	snap := intel.Snapshot{Records: []intel.Record{
+		{ // MAL-2022-219 shape: {introduced: 1.2.2}
+			ID: "MAL-2022-219", Ecosystem: intel.EcosystemNPM, Name: "perp",
+			Kind:   intel.KindMalicious,
+			Ranges: []intel.VersionRange{{Type: "SEMVER", Introduced: "1.2.2"}},
+		},
+		{ // MAL-2022-455 shape: {introduced: 0, fixed: 6.72.11}
+			ID: "MAL-2022-455", Ecosystem: intel.EcosystemNPM, Name: "apollo",
+			Kind:   intel.KindMalicious,
+			Ranges: []intel.VersionRange{{Type: "SEMVER", Introduced: "0", Fixed: "6.72.11"}},
+		},
+	}}
+	m := intel.NewMatcher(snap)
+	cases := []struct {
+		name, version string
+		want          bool
+	}{
+		{"perp", "1.2.1", false},  // below introduced
+		{"perp", "1.2.2", true},   // introduced inclusive
+		{"perp", "9.9.9", true},   // open-ended
+		{"apollo", "0.0.1", true}, // from 0
+		{"apollo", "6.72.10", true},
+		{"apollo", "6.72.11", false}, // fixed exclusive
+		{"apollo", "7.0.0", false},
+	}
+	for _, c := range cases {
+		got := m.MatchPackage(intel.MatchInput{Ecosystem: "npm", Name: c.name, Version: c.version})
+		if (len(got) > 0) != c.want {
+			t.Errorf("%s@%s: want match=%v, got %d matches", c.name, c.version, c.want, len(got))
+		}
+	}
+}

--- a/internal/intel/osvimport/osvimport.go
+++ b/internal/intel/osvimport/osvimport.go
@@ -143,6 +143,19 @@ func convertRanges(in []osvRange) []intel.VersionRange {
 			if v, ok := ev["last_affected"]; ok {
 				cur.LastAffected = v
 			}
+			if v, ok := ev["limit"]; ok && v != "" {
+				// OSV `limit` caps the range's domain (exclusive):
+				// versions below it follow the events as stated,
+				// versions at/above it are outside the range. Closing
+				// the open segment at the limit is therefore
+				// conservative-correct (never flags above the limit),
+				// and events past the limit are outside the domain,
+				// so processing stops for this range.
+				if open && cur.Fixed == "" && cur.LastAffected == "" {
+					cur.Fixed = v
+				}
+				break
+			}
 		}
 		if open {
 			out = append(out, cur)
@@ -307,6 +320,31 @@ func convertOSVRecord(raw []byte, ecoFilter map[string]struct{}) ([]intel.Record
 						Ecosystem: eco,
 						Name:      aff.Package.Name,
 					})
+					continue
+				}
+				// Bounded malicious ranges (real version bounds) ship
+				// as full Records WITH Ranges - npm only (C3-B): the
+				// matcher's range evaluation is gated to npm's semver
+				// grammar (ecosystemSupportsRanges), so importing
+				// bounded ranges for any other ecosystem would embed
+				// dead data. Measured residual: npm 1,095 / PyPI 4.
+				if (signal || keywordHit) && eco == "npm" {
+					// A range whose events never open (no introduced)
+					// converts to nothing, and a range type the
+					// matcher cannot evaluate (e.g. GIT) would import
+					// as dead data; both are dropped.
+					if rngs := evaluableRanges(convertRanges(aff.Ranges)); len(rngs) > 0 {
+						out = append(out, intel.Record{
+							ID:         osv.ID,
+							Aliases:    append([]string(nil), osv.Aliases...),
+							Ecosystem:  eco,
+							Name:       aff.Package.Name,
+							Kind:       intel.KindMalicious,
+							Summary:    pickSummary(osv),
+							Ranges:     rngs,
+							References: extractReferenceURLs(osv.References),
+						})
+					}
 				}
 				continue
 			}
@@ -438,7 +476,20 @@ func ClassifyForEcosystem(raw []byte, targetEcosystem string) (intel.Record, Rec
 				// Snapshot.AllVersions entries.
 				return rec, StatusAllVersionsKept
 			}
-			// Bounded malicious ranges: still dropped (C3-B).
+			rec.Ranges = evaluableRanges(rec.Ranges)
+			if len(rec.Ranges) == 0 {
+				// Every range converted to nothing (empty events,
+				// limit-only): the record asserts nothing usable and
+				// Import drops it.
+				return intel.Record{}, StatusRangesOnly
+			}
+			if canon == "npm" {
+				// npm bounded ranges ship as full Records (C3-B):
+				// the matcher's semver range evaluation covers them.
+				return rec, StatusKept
+			}
+			// Bounded malicious ranges outside npm: still dropped
+			// (the range gate is npm-only).
 			return rec, StatusRangesOnlyMalicious
 		}
 		return intel.Record{}, StatusRangesOnly
@@ -473,6 +524,20 @@ func SortAndDedupeAllVersions(in []intel.AllVersionsEntry) []intel.AllVersionsEn
 		return a.ID < b.ID
 	})
 	return dedupeAllVersions(in)
+}
+
+// evaluableRanges keeps only ranges whose Type the matcher's semver
+// engine can evaluate (SEMVER / ECOSYSTEM); a GIT or unknown-typed
+// range would import as dead data the matcher silently skips.
+func evaluableRanges(in []intel.VersionRange) []intel.VersionRange {
+	var out []intel.VersionRange
+	for _, r := range in {
+		switch strings.ToUpper(strings.TrimSpace(r.Type)) {
+		case "SEMVER", "ECOSYSTEM":
+			out = append(out, r)
+		}
+	}
+	return out
 }
 
 // dedupeAllVersions removes consecutive duplicates from a sorted

--- a/internal/intel/osvimport/osvimport_test.go
+++ b/internal/intel/osvimport/osvimport_test.go
@@ -528,6 +528,54 @@ func TestClassifyForEcosystem_FunnelStatuses(t *testing.T) {
 		_, status := osvimport.ClassifyForEcosystem(mustMarshal(t, rec), "Go")
 		require.Equal(t, osvimport.StatusAllVersionsKept, status)
 	})
+	t.Run("limit closes the open segment conservatively", func(t *testing.T) {
+		// OSV `limit` caps the range domain (exclusive). The open
+		// segment closes at the limit - versions below stay covered,
+		// versions at/above never match - and closed pairs before the
+		// limit are preserved.
+		rec := osvRecordFixture{
+			ID: "MAL-7",
+			Affected: []affectedFixture{{
+				Package: packageFixture{Name: "x", Ecosystem: "npm"},
+				Ranges: []rangeFixture{{Type: "SEMVER",
+					Events: []map[string]string{{"introduced": "1.0.0"}, {"limit": "2.0.0"}}}},
+			}},
+		}
+		got, status := osvimport.ClassifyForEcosystem(mustMarshal(t, rec), "npm")
+		require.Equal(t, osvimport.StatusKept, status)
+		require.Equal(t, []intel.VersionRange{{Type: "SEMVER", Introduced: "1.0.0", Fixed: "2.0.0"}}, got.Ranges)
+
+		// Closed pair before a later limited segment survives.
+		rec2 := osvRecordFixture{
+			ID: "MAL-8",
+			Affected: []affectedFixture{{
+				Package: packageFixture{Name: "y", Ecosystem: "npm"},
+				Ranges: []rangeFixture{{Type: "SEMVER",
+					Events: []map[string]string{
+						{"introduced": "1.0.0"}, {"fixed": "1.2.0"},
+						{"introduced": "3.0.0"}, {"limit": "4.0.0"},
+					}}},
+			}},
+		}
+		got2, status2 := osvimport.ClassifyForEcosystem(mustMarshal(t, rec2), "npm")
+		require.Equal(t, osvimport.StatusKept, status2)
+		require.Equal(t, []intel.VersionRange{
+			{Type: "SEMVER", Introduced: "1.0.0", Fixed: "1.2.0"},
+			{Type: "SEMVER", Introduced: "3.0.0", Fixed: "4.0.0"},
+		}, got2.Ranges)
+	})
+	t.Run("git-typed npm ranges import as nothing", func(t *testing.T) {
+		rec := osvRecordFixture{
+			ID: "MAL-9",
+			Affected: []affectedFixture{{
+				Package: packageFixture{Name: "z", Ecosystem: "npm"},
+				Ranges: []rangeFixture{{Type: "GIT",
+					Events: []map[string]string{{"introduced": "abc123"}}}},
+			}},
+		}
+		_, status := osvimport.ClassifyForEcosystem(mustMarshal(t, rec), "npm")
+		require.Equal(t, osvimport.StatusRangesOnly, status)
+	})
 	t.Run("bounded malicious ranges stay dropped (C3-B residual)", func(t *testing.T) {
 		rec := osvRecordFixture{
 			ID: "MAL-5",
@@ -698,8 +746,17 @@ func TestImport_AllVersionsEntries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Import: %v", err)
 	}
-	if len(snap.Records) != 1 || snap.Records[0].ID != "MAL-E" {
-		t.Fatalf("want 1 exact record (MAL-E), got %+v", snap.Records)
+	// MAL-C (npm bounded ranges) now ships as a Record WITH Ranges
+	// (C3-B); MAL-E keeps its exact versions; MAL-F (empty events)
+	// converts to nothing and is dropped as dead data.
+	if len(snap.Records) != 2 {
+		t.Fatalf("want 2 records (MAL-C bounded + MAL-E exact), got %+v", snap.Records)
+	}
+	if snap.Records[0].ID != "MAL-C" || len(snap.Records[0].Ranges) != 1 || len(snap.Records[0].Versions) != 0 {
+		t.Fatalf("MAL-C should be a ranges-only record: %+v", snap.Records[0])
+	}
+	if snap.Records[1].ID != "MAL-E" {
+		t.Fatalf("want MAL-E second, got %+v", snap.Records[1])
 	}
 	// Canonical ecosystem is the OSV bucket form ("PyPI"); the
 	// matcher normalizes at lookup. Sort: ecosystem, name, ID

--- a/internal/packagecheck/packagelock_test.go
+++ b/internal/packagecheck/packagelock_test.go
@@ -406,3 +406,43 @@ func TestRunner_AllVersionsEntryFlagsLockfilePackage(t *testing.T) {
 		t.Fatalf("want exactly the all-versions hit, got %v", hits)
 	}
 }
+
+// TestRunner_NPMBoundedRangeFlagsInRangeOnly proves C3-B end to end:
+// a ranges-only npm record (no exact versions) flags a lockfile
+// package inside the range and stays silent outside it.
+func TestRunner_NPMBoundedRangeFlagsInRangeOnly(t *testing.T) {
+	snap := intel.Snapshot{Records: []intel.Record{{
+		ID: "MAL-2026-RANGE", Ecosystem: "npm", Name: "evil-range",
+		Kind:   intel.KindMalicious,
+		Ranges: []intel.VersionRange{{Type: "SEMVER", Introduced: "1.0.0", Fixed: "2.0.0"}},
+	}}}
+	runner := &Runner{Matcher: intel.NewMatcher(snap)}
+	target := writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/evil-range": { "version": "1.5.0", "resolved": "https://registry.npmjs.org/evil-range/-/evil-range-1.5.0.tgz" }
+	  }
+	}`)
+	res, err := runner.Run([]Target{target})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Hits) != 1 || res.Hits[0].Record.ID != "MAL-2026-RANGE" {
+		t.Fatalf("in-range version should flag, got %+v", res.Hits)
+	}
+	target2 := writeLock(t, `{
+	  "lockfileVersion": 3,
+	  "packages": {
+	    "": { "name": "myapp", "version": "1.0.0" },
+	    "node_modules/evil-range": { "version": "2.0.0", "resolved": "https://registry.npmjs.org/evil-range/-/evil-range-2.0.0.tgz" }
+	  }
+	}`)
+	res2, err := runner.Run([]Target{target2})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res2.Hits) != 0 {
+		t.Fatalf("fixed version (exclusive) must not flag, got %+v", res2.Hits)
+	}
+}


### PR DESCRIPTION
The all-versions work (#217) left one measured residual: 1,095 npm malicious advisories whose ranges carry real version bounds. The matcher's semver range evaluation has handled exactly this shape since the manual emergency records - the gap was purely at import.

The importer now keeps npm ranges-only malicious records as full records with their ranges. Strictly npm: range evaluation is gated to npm's semver grammar, so importing bounded ranges for any other ecosystem would embed dead data (residual outside npm: PyPI 4, others 0 - documented and deliberately dropped).

No new version grammar was written. Matching is verified against real shapes from the live OSV bucket, locking the semantics: introduced inclusive, fixed exclusive. OSV `limit` events close the open segment conservatively - versions below the limit stay covered, versions at or above it never match. Ranges the matcher cannot evaluate (GIT-typed, empty events) are dropped rather than imported dead.

Measured against the live npm bucket: kept records 16,941 -> 18,036 (exactly the residual), blob 2.41 -> 2.45 MB gz. An end-to-end test proves a lockfile package flags inside the range and stays silent at the fixed version.

This completes the range-matching work: #216 measured it, #217 shipped the all-versions bulk, this ships the bounded residual.