### PR TITLE
Auto-disable color and spinner when output is not a terminal

### DIFF
--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -447,9 +447,14 @@ func writeAuditTerminal(result *AuditResult) error {
 	}
 	printIntelFreshness(result.Intel, flagAuditCI)
 
+	// Green is reserved for a clean pass: FINDINGS exits 0 but still
+	// means unresolved findings exist, so it renders yellow.
 	verdictColor := green
-	if result.Verdict.ThresholdExceeded {
+	switch {
+	case result.Verdict.ThresholdExceeded:
 		verdictColor = red
+	case result.Verdict.Status == "findings":
+		verdictColor = yellow
 	}
 	fmt.Printf("\n%s%sVerdict: %s%s (check: %d critical / %d warning, scan: %d critical / %d high)\n",
 		verdictColor, bold, strings.ToUpper(result.Verdict.Status), reset,

--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -28,8 +28,13 @@ var (
 )
 
 var auditCmd = &cobra.Command{
-	Use:   "audit [path]",
-	Short: "Run scan + check together and produce a single verdict",
+	Use:     "audit [path]",
+	GroupID: groupScan,
+	Short:   "Run scan + check together and produce a single verdict",
+	Example: `  aguara audit .               Package check + content scan, one verdict
+  aguara audit . --ci          CI gate: exit 1 on critical, no color
+  aguara audit . --verbose     List every content finding (no cap)
+  aguara audit . --fresh       Refresh threat intel first (network opt-in)`,
 	Long: `Audit a project: run the supply-chain check (compromised packages /
 persistence artifacts) and the content scan (rule-based detection of
 prompt injection, credential leaks, etc.) together, and report a
@@ -398,9 +403,9 @@ func writeAuditTerminal(result *AuditResult) error {
 	fmt.Printf("  Target: %s\n", result.Target)
 	fmt.Printf("%s\n", sep)
 
-	fmt.Printf("\n%s\n", st.SectionHeader("SUPPLY CHAIN", width))
+	fmt.Printf("\n%s\n", st.SectionHeader("PACKAGE CHECK", width))
 	if len(result.Check.Findings) == 0 {
-		fmt.Printf("\n  %s\n", st.OK("No compromised packages or artifacts found."))
+		fmt.Printf("\n  %s\n", st.OK("No known-compromised packages or persistence artifacts found."))
 	} else {
 		for _, f := range result.Check.Findings {
 			label := string(f.Severity)
@@ -434,7 +439,7 @@ func writeAuditTerminal(result *AuditResult) error {
 			shown++
 		}
 		if !flagAuditVerbose && len(result.Scan.Findings) > maxList {
-			fmt.Printf("  %s\n", st.Dim(fmt.Sprintf("... +%d more (rerun with --verbose, or --format json)",
+			fmt.Printf("  %s\n", st.Dim(fmt.Sprintf("... +%d more (rerun with --verbose or use --format json)",
 				len(result.Scan.Findings)-maxList)))
 		}
 	}
@@ -465,5 +470,23 @@ func writeAuditTerminal(result *AuditResult) error {
 	}
 
 	fmt.Printf("\n%s\n  %s\n%s\n", sep, line, sep)
+
+	if rule := topScanRule(result.Scan.Findings); rule != "" {
+		fmt.Printf("  %s\n", st.Dim("Next: aguara explain "+rule))
+	}
 	return nil
+}
+
+// topScanRule returns the rule behind the most severe content finding,
+// for the Next hint after the verdict.
+func topScanRule(findings []scanner.Finding) string {
+	best := -1
+	rule := ""
+	for _, f := range findings {
+		if int(f.Severity) > best {
+			best = int(f.Severity)
+			rule = f.RuleID
+		}
+	}
+	return rule
 }

--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/garagon/aguara/internal/baseline"
 	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/output"
 	"github.com/garagon/aguara/internal/scanner"
 	"github.com/garagon/aguara/internal/types"
 	"github.com/spf13/cobra"
@@ -23,6 +24,7 @@ var (
 	flagAuditBaseline      string
 	flagAuditWriteBaseline string
 	flagAuditInsecure      bool
+	flagAuditVerbose       bool
 )
 
 var auditCmd = &cobra.Command{
@@ -50,6 +52,7 @@ func init() {
 	auditCmd.Flags().BoolVar(&flagAuditAllowStale, "allow-stale", false, "If --fresh fails, fall back to previously verified local intel (errors if none is cached)")
 	auditCmd.Flags().StringVar(&flagAuditBaseline, "baseline", "", "Gate scan findings only on those NOT in this baseline file (package findings always gate; fails closed if missing/malformed)")
 	auditCmd.Flags().StringVar(&flagAuditWriteBaseline, "write-baseline", "", "Write the scan findings as a baseline to this file (skips sensitive findings); package findings still gate")
+	auditCmd.Flags().BoolVar(&flagAuditVerbose, "verbose", false, "List every content finding instead of capping at 10")
 	// Runtime errors (ErrThresholdExceeded after the verdict
 	// computes "fail", --fresh network failures) should not
 	// trigger Cobra's flag-usage block. The verdict line plus the
@@ -386,56 +389,53 @@ func writeAuditJSON(result *AuditResult) error {
 }
 
 func writeAuditTerminal(result *AuditResult) error {
-	bold := "\033[1m"
-	dim := "\033[2m"
-	red := "\033[31m"
-	green := "\033[32m"
-	yellow := "\033[33m"
-	reset := "\033[0m"
-	if flagNoColor {
-		bold, dim, red, green, yellow, reset = "", "", "", "", "", ""
-	}
+	st := output.NewStyle(flagNoColor)
+	width := output.DetectWidth(os.Stdout)
+	sep := st.Separator(width)
 
-	fmt.Printf("\n%sAguara audit: %s%s\n\n", bold, result.Target, reset)
+	fmt.Printf("\n%s\n", sep)
+	fmt.Printf("  %s\n", st.Bold("AGUARA AUDIT"))
+	fmt.Printf("  Target: %s\n", result.Target)
+	fmt.Printf("%s\n", sep)
 
-	fmt.Printf("%sSupply chain%s\n", bold, reset)
+	fmt.Printf("\n%s\n", st.SectionHeader("SUPPLY CHAIN", width))
 	if len(result.Check.Findings) == 0 {
-		fmt.Printf("  %s✔ No compromised packages or artifacts found.%s\n", green, reset)
+		fmt.Printf("\n  %s\n", st.OK("No compromised packages or artifacts found."))
 	} else {
 		for _, f := range result.Check.Findings {
-			sev := red
-			if f.Severity == incident.SevWarning {
-				sev = yellow
-			}
-			fmt.Printf("  %s%-10s%s %s\n", sev, f.Severity, reset, f.Title)
+			label := string(f.Severity)
+			fmt.Printf("\n  %s %s %s\n", st.SeverityIcon(label), st.SeverityLabel(fmt.Sprintf("%-8s", label)), f.Title)
 			if f.Path != "" {
-				fmt.Printf("           %sPath: %s%s\n", dim, f.Path, reset)
+				fmt.Printf("             %s\n", st.Dim(f.Path))
 			}
 		}
 	}
 
-	fmt.Printf("\n%sContent scan%s\n", bold, reset)
+	fmt.Printf("\n%s\n", st.SectionHeader("CONTENT SCAN", width))
 	if len(result.Scan.Findings) == 0 {
-		fmt.Printf("  %s✔ No content findings.%s\n", green, reset)
+		fmt.Printf("\n  %s\n", st.OK("No content findings."))
 	} else {
-		// Cap the verbose listing -- a noisy repo can dump
-		// hundreds of low-severity findings into the audit
-		// output. Showing all of them buries the verdict.
+		// Cap the listing unless --verbose -- a noisy repo can dump
+		// hundreds of low-severity findings into the audit output,
+		// and showing all of them buries the verdict.
 		const maxList = 10
 		shown := 0
+		fmt.Println()
 		for _, f := range result.Scan.Findings {
-			if shown >= maxList {
+			if !flagAuditVerbose && shown >= maxList {
 				break
 			}
-			fmt.Printf("  %s%-9s%s %s (%s)\n", red, f.Severity.String(), reset, f.RuleName, f.RuleID)
-			if f.FilePath != "" {
-				fmt.Printf("           %s%s:%d%s\n", dim, f.FilePath, f.Line, reset)
-			}
+			label := f.Severity.String()
+			fmt.Printf("  %s %s %s %s\n",
+				st.SeverityIcon(label),
+				st.Bold(st.Cell(f.RuleID, 24)),
+				st.Cell(f.RuleName, 36),
+				st.Cyan(fmt.Sprintf("%s:%d", f.FilePath, f.Line)))
 			shown++
 		}
-		if len(result.Scan.Findings) > maxList {
-			fmt.Printf("  %s... +%d more (full list in --format json)%s\n",
-				dim, len(result.Scan.Findings)-maxList, reset)
+		if !flagAuditVerbose && len(result.Scan.Findings) > maxList {
+			fmt.Printf("  %s\n", st.Dim(fmt.Sprintf("... +%d more (rerun with --verbose, or --format json)",
+				len(result.Scan.Findings)-maxList)))
 		}
 	}
 
@@ -448,17 +448,22 @@ func writeAuditTerminal(result *AuditResult) error {
 	printIntelFreshness(result.Intel, flagAuditCI)
 
 	// Green is reserved for a clean pass: FINDINGS exits 0 but still
-	// means unresolved findings exist, so it renders yellow.
-	verdictColor := green
-	switch {
-	case result.Verdict.ThresholdExceeded:
-		verdictColor = red
-	case result.Verdict.Status == "findings":
-		verdictColor = yellow
-	}
-	fmt.Printf("\n%s%sVerdict: %s%s (check: %d critical / %d warning, scan: %d critical / %d high)\n",
-		verdictColor, bold, strings.ToUpper(result.Verdict.Status), reset,
+	// means unresolved findings exist, so it renders yellow with the
+	// medium-tier icon; FAIL is red with the critical icon.
+	verdict := fmt.Sprintf("Verdict: %s", strings.ToUpper(result.Verdict.Status))
+	counts := fmt.Sprintf("(check: %d critical / %d warning, scan: %d critical / %d high)",
 		result.Verdict.CheckCriticals, result.Verdict.CheckWarnings,
 		result.Verdict.ScanCriticals, result.Verdict.ScanHighs)
+	var line string
+	switch {
+	case result.Verdict.ThresholdExceeded:
+		line = st.SeverityIcon("CRITICAL") + " " + st.RedBold(verdict) + " " + counts
+	case result.Verdict.Status == "findings":
+		line = st.SeverityIcon("MEDIUM") + " " + st.Yellow(st.Bold(verdict)) + " " + counts
+	default:
+		line = st.Green(st.Bold("✔ "+verdict)) + " " + counts
+	}
+
+	fmt.Printf("\n%s\n  %s\n%s\n", sep, line, sep)
 	return nil
 }

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/garagon/aguara/internal/incident"
 	"github.com/garagon/aguara/internal/intel"
+	"github.com/garagon/aguara/internal/output"
 	"github.com/garagon/aguara/internal/packagecheck"
 	"github.com/spf13/cobra"
 )
@@ -958,23 +959,32 @@ func writeCheckJSON(result *incident.CheckResult) error {
 }
 
 func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
+	st := output.NewStyle(flagNoColor)
+	width := output.DetectWidth(os.Stdout)
+	sep := st.Separator(width)
+
 	ecosystem := plan.singleEcoToken()
 	envLabel := singleEcoEnvLabel(ecosystem)
 	if envLabel == "" {
 		envLabel = "project dependencies"
 	}
-	fmt.Printf("\nScanning %s: %s\n", envLabel, result.Environment)
+
+	fmt.Printf("\n%s\n", sep)
+	fmt.Printf("  %s\n", st.Bold("AGUARA CHECK"))
+	var meta string
 	switch {
 	case plan.isMulti():
-		fmt.Printf("Packages read: %d  |  Targets found: %d\n\n", result.PackagesRead, len(result.Ecosystems))
+		meta = fmt.Sprintf("%d packages · %d targets", result.PackagesRead, len(result.Ecosystems))
 	case ecosystem == ecoNPM:
-		fmt.Printf("Packages read: %d\n\n", result.PackagesRead)
+		meta = fmt.Sprintf("%d packages", result.PackagesRead)
 	case ecosystem == ecoGo, ecosystem == ecoCargo, ecosystem == ecoComposer,
 		ecosystem == ecoRuby, ecosystem == ecoMaven, ecosystem == ecoNuGet:
-		fmt.Printf("Packages read: %d  |  Lockfiles found: %d\n\n", result.PackagesRead, len(result.Ecosystems))
+		meta = fmt.Sprintf("%d packages · %d lockfiles", result.PackagesRead, len(result.Ecosystems))
 	default:
-		fmt.Printf("Packages read: %d  |  .pth files scanned: %d\n\n", result.PackagesRead, result.PthScanned)
+		meta = fmt.Sprintf("%d packages · %d .pth files", result.PackagesRead, result.PthScanned)
 	}
+	fmt.Printf("  Scanning %s: %s  ·  %s\n", envLabel, result.Environment, meta)
+	fmt.Printf("%s\n\n", sep)
 
 	// Provenance line: which intel answered this scan, and how old it is.
 	// Suppressed under --ci to keep stdout to findings (a stale local
@@ -982,47 +992,18 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 	printIntelFreshness(result.Intel, flagCheckCI)
 
 	if len(result.Findings) == 0 {
-		green := "\033[32m"
-		reset := "\033[0m"
-		if flagNoColor {
-			green = ""
-			reset = ""
-		}
-		fmt.Printf("  %s✔ No compromised packages or artifacts found.%s\n\n", green, reset)
+		fmt.Printf("  %s\n\n", st.OK("No compromised packages or artifacts found."))
 		return nil
 	}
 
-	red := "\033[31m"
-	yellow := "\033[33m"
-	bold := "\033[1m"
-	dim := "\033[2m"
-	reset := "\033[0m"
-	cyan := "\033[36m"
-	if flagNoColor {
-		red = ""
-		yellow = ""
-		bold = ""
-		dim = ""
-		reset = ""
-		cyan = ""
-	}
-
 	for _, f := range result.Findings {
-		var sevColor string
-		switch f.Severity {
-		case incident.SevCritical:
-			sevColor = red + bold
-		case incident.SevWarning:
-			sevColor = yellow
-		default:
-			sevColor = cyan
-		}
-		fmt.Printf("%s%-10s%s %s\n", sevColor, f.Severity, reset, f.Title)
+		label := string(f.Severity)
+		fmt.Printf("  %s %s %s\n", st.SeverityIcon(label), st.SeverityLabel(fmt.Sprintf("%-8s", label)), f.Title)
 		if f.Path != "" {
-			fmt.Printf("           %sPath: %s%s\n", dim, f.Path, reset)
+			fmt.Printf("             %s\n", st.Dim("Path: "+f.Path))
 		}
 		if f.Detail != "" {
-			fmt.Printf("           %s%s%s\n", dim, f.Detail, reset)
+			fmt.Printf("             %s\n", st.Dim(f.Detail))
 		}
 		fmt.Println()
 	}
@@ -1035,10 +1016,10 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 		}
 	}
 	if atRisk > 0 {
-		fmt.Printf("%sCredentials at risk:%s\n", bold, reset)
+		fmt.Printf("%s\n\n", st.SectionHeader("CREDENTIALS AT RISK", width))
 		for _, c := range result.Credentials {
 			if c.Exists {
-				fmt.Printf("  %-30s %sEXISTS%s  %s%s%s\n", c.Path, red, reset, dim, c.Guidance, reset)
+				fmt.Printf("  %-30s %s  %s\n", c.Path, st.Red("EXISTS"), st.Dim(c.Guidance))
 			}
 		}
 		fmt.Println()
@@ -1051,7 +1032,7 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 	// credentials" guidance; the Python path keeps the
 	// `aguara clean` recommendation since it owns the
 	// persistence-artifact cleanup.
-	fmt.Printf("%sAction required:%s\n", bold, reset)
+	fmt.Printf("%s\n\n", st.SectionHeader("ACTION REQUIRED", width))
 	switch ecosystem {
 	case ecoPython:
 		fmt.Println("  1. Run 'aguara clean' to remove malicious files and persistence artifacts")
@@ -1080,12 +1061,12 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 	}
 	var parts []string
 	if critCount > 0 {
-		parts = append(parts, fmt.Sprintf("%s%d critical%s", red, critCount, reset))
+		parts = append(parts, st.RedBold(fmt.Sprintf("%d critical", critCount)))
 	}
 	if warnCount > 0 {
-		parts = append(parts, fmt.Sprintf("%s%d warning%s", yellow, warnCount, reset))
+		parts = append(parts, st.Yellow(fmt.Sprintf("%d warning", warnCount)))
 	}
-	fmt.Printf("\n%s\n", strings.Join(parts, " · "))
+	fmt.Printf("\n%s\n  %s\n%s\n", sep, strings.Join(parts, " · "), sep)
 
 	return nil
 }

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -67,8 +67,13 @@ var osvIDToEcoToken = func() map[string]string {
 }()
 
 var checkCmd = &cobra.Command{
-	Use:   "check [path]",
-	Short: "Check for compromised packages and persistence artifacts",
+	Use:     "check [path]",
+	GroupID: groupScan,
+	Short:   "Check for compromised packages and persistence artifacts",
+	Example: `  aguara check                       Auto-detect lockfiles in the current dir
+  aguara check --path . --ecosystem npm   Check npm dependencies only
+  aguara check --fresh               Refresh threat intel first (network opt-in)
+  aguara check --ci                  CI gate: exit 1 on critical findings`,
 	Long: `Run from a project root. Aguara discovers installed npm /
 Python environments at the path AND lockfiles for Go, Rust,
 PHP/Composer, Ruby/Bundler, Java/Maven/Gradle, and .NET/NuGet
@@ -983,7 +988,7 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 	default:
 		meta = fmt.Sprintf("%d packages · %d .pth files", result.PackagesRead, result.PthScanned)
 	}
-	fmt.Printf("  Scanning %s: %s  ·  %s\n", envLabel, result.Environment, meta)
+	fmt.Printf("  Target: %s  ·  %s  ·  %s\n", result.Environment, envLabel, meta)
 	fmt.Printf("%s\n\n", sep)
 
 	// Provenance line: which intel answered this scan, and how old it is.
@@ -992,7 +997,7 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 	printIntelFreshness(result.Intel, flagCheckCI)
 
 	if len(result.Findings) == 0 {
-		fmt.Printf("  %s\n\n", st.OK("No compromised packages or artifacts found."))
+		fmt.Printf("  %s\n\n", st.OK("No known-compromised packages or persistence artifacts found."))
 		return nil
 	}
 

--- a/cmd/aguara/commands/clean.go
+++ b/cmd/aguara/commands/clean.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/output"
 	"github.com/spf13/cobra"
 )
 
@@ -109,40 +110,29 @@ func writeCleanJSON(result *incident.CleanResult) error {
 }
 
 func writeCleanTerminal(result *incident.CleanResult) error {
-	red := "\033[31m"
-	green := "\033[32m"
-	bold := "\033[1m"
-	dim := "\033[2m"
-	reset := "\033[0m"
-	if flagNoColor {
-		red = ""
-		green = ""
-		bold = ""
-		dim = ""
-		reset = ""
-	}
+	st := output.NewStyle(flagNoColor)
 
 	done := 0
 	for i, a := range result.Actions {
-		status := green + "\u2714" + reset
+		status := st.Green("\u2714")
 		if a.Error != "" {
-			status = red + "\u2716" + reset
+			status = st.Red("\u2716")
 		}
 		if !a.Done && a.Error == "" {
-			status = dim + "-" + reset
+			status = st.Dim("-")
 		}
 		fmt.Printf("\n[%d/%d] %s %s %s\n", i+1, len(result.Actions), status, a.Type, a.Target)
 		if a.Error != "" {
-			fmt.Printf("       %s%s%s\n", red, a.Error, reset)
+			fmt.Printf("       %s\n", st.Red(a.Error))
 		}
 		if a.Done {
 			done++
 		}
 	}
 
-	fmt.Printf("\n%sCleaned %d/%d issues.%s", bold, done, len(result.Actions), reset)
+	fmt.Printf("\n%s", st.Bold(fmt.Sprintf("Cleaned %d/%d issues.", done, len(result.Actions))))
 	if result.QuarantineDir != "" {
-		fmt.Printf(" Quarantine: %s%s%s", dim, result.QuarantineDir, reset)
+		fmt.Printf(" Quarantine: %s", st.Dim(result.QuarantineDir))
 	}
 	fmt.Println()
 
@@ -154,10 +144,10 @@ func writeCleanTerminal(result *incident.CleanResult) error {
 		}
 	}
 	if atRisk > 0 {
-		fmt.Printf("\n%sIMPORTANT: Rotate these credentials NOW:%s\n", bold+red, reset)
+		fmt.Printf("\n%s\n", st.RedBold("IMPORTANT: Rotate these credentials NOW:"))
 		for _, c := range result.Credentials {
 			if c.Exists {
-				fmt.Printf("  %s%-30s%s %s\n", bold, c.Path, reset, c.Guidance)
+				fmt.Printf("  %s %s\n", st.Bold(fmt.Sprintf("%-30s", c.Path)), c.Guidance)
 			}
 		}
 		fmt.Println()

--- a/cmd/aguara/commands/clean.go
+++ b/cmd/aguara/commands/clean.go
@@ -19,8 +19,9 @@ var (
 )
 
 var cleanCmd = &cobra.Command{
-	Use:   "clean",
-	Short: "Remove compromised packages, malicious files, and persistence artifacts",
+	Use:     "clean",
+	GroupID: groupScan,
+	Short:   "Remove compromised packages, malicious files, and persistence artifacts",
 	Long: `Detects and removes compromised Python packages, quarantines malicious .pth files,
 and disables persistence backdoors. Use --dry-run to preview without changes.`,
 	RunE: runClean,

--- a/cmd/aguara/commands/discover.go
+++ b/cmd/aguara/commands/discover.go
@@ -11,11 +11,12 @@ import (
 )
 
 var discoverCmd = &cobra.Command{
-	Use:   "discover",
-	Short: "Discover MCP client configurations on this machine",
-	Long:  `Scans well-known paths for 17 MCP client applications and lists their configured servers.`,
-	Args:  cobra.NoArgs,
-	RunE:  runDiscover,
+	Use:     "discover",
+	GroupID: groupScan,
+	Short:   "Discover MCP client configurations on this machine",
+	Long:    `Scans well-known paths for 17 MCP client applications and lists their configured servers.`,
+	Args:    cobra.NoArgs,
+	RunE:    runDiscover,
 }
 
 func init() {

--- a/cmd/aguara/commands/explain.go
+++ b/cmd/aguara/commands/explain.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/garagon/aguara/internal/output"
 	"github.com/garagon/aguara/internal/rulecatalog"
 	"github.com/garagon/aguara/internal/rulemeta"
 )
@@ -66,64 +67,40 @@ func writeExplainJSON(w io.Writer, r *rulemeta.Rule) error {
 }
 
 func writeExplainTerminal(w io.Writer, found *rulemeta.Rule) error {
-	color := func(code, text string) string {
-		if flagNoColor {
-			return text
-		}
-		return code + text + "\033[0m"
-	}
+	st := output.NewStyle(flagNoColor)
 
-	bold := "\033[1m"
-	dim := "\033[2m"
-	yellow := "\033[33m"
-	cyan := "\033[36m"
-	red := "\033[31m"
-	green := "\033[32m"
-
-	sevColor := cyan
-	switch found.Severity {
-	case "CRITICAL":
-		sevColor = red + bold
-	case "HIGH":
-		sevColor = red
-	case "MEDIUM":
-		sevColor = yellow
-	}
-
-	fmt.Fprintf(w, "\n%s %s\n", color(dim, "Rule:"), color(bold, found.ID))
-	fmt.Fprintf(w, "%s %s\n", color(dim, "Name:"), found.Name)
-	fmt.Fprintf(w, "%s %s\n", color(dim, "Severity:"), color(sevColor, found.Severity))
-	fmt.Fprintf(w, "%s %s\n", color(dim, "Category:"), found.Category)
+	fmt.Fprintf(w, "\n%s %s %s %s\n", st.SeverityIcon(found.Severity), st.Bold(found.ID), found.Name, st.SeverityLabel(found.Severity))
+	fmt.Fprintf(w, "%s %s\n", st.Dim("Category:"), found.Category)
 	if found.Analyzer != "" {
-		fmt.Fprintf(w, "%s %s\n", color(dim, "Analyzer:"), found.Analyzer)
+		fmt.Fprintf(w, "%s %s\n", st.Dim("Analyzer:"), found.Analyzer)
 	}
 
 	if found.Description != "" {
-		fmt.Fprintf(w, "\n%s\n%s\n", color(bold, "Description:"), found.Description)
+		fmt.Fprintf(w, "\n%s\n%s\n", st.Bold("Description:"), found.Description)
 	}
 
 	if found.Remediation != "" {
-		fmt.Fprintf(w, "\n%s\n%s\n", color(bold, "Remediation:"), color(green, found.Remediation))
+		fmt.Fprintf(w, "\n%s\n%s\n", st.Bold("Remediation:"), st.Green(found.Remediation))
 	}
 
 	if len(found.Patterns) > 0 {
-		fmt.Fprintf(w, "\n%s\n", color(bold, "Patterns:"))
+		fmt.Fprintf(w, "\n%s\n", st.Bold("Patterns:"))
 		for i, p := range found.Patterns {
-			fmt.Fprintf(w, "  %d. %s\n", i+1, color(dim, p))
+			fmt.Fprintf(w, "  %d. %s\n", i+1, st.Dim(p))
 		}
 	}
 
 	if len(found.TruePositives) > 0 {
-		fmt.Fprintf(w, "\n%s\n", color(bold, "True Positives:"))
+		fmt.Fprintf(w, "\n%s\n", st.Bold("True Positives:"))
 		for _, ex := range found.TruePositives {
-			fmt.Fprintf(w, "  %s %s\n", color(red, "✖"), ex)
+			fmt.Fprintf(w, "  %s %s\n", st.Red("✖"), ex)
 		}
 	}
 
 	if len(found.FalsePositives) > 0 {
-		fmt.Fprintf(w, "\n%s\n", color(bold, "False Positives:"))
+		fmt.Fprintf(w, "\n%s\n", st.Bold("False Positives:"))
 		for _, ex := range found.FalsePositives {
-			fmt.Fprintf(w, "  %s %s\n", color(green, "✔"), ex)
+			fmt.Fprintf(w, "  %s %s\n", st.Green("✔"), ex)
 		}
 	}
 

--- a/cmd/aguara/commands/explain.go
+++ b/cmd/aguara/commands/explain.go
@@ -15,10 +15,11 @@ import (
 )
 
 var explainCmd = &cobra.Command{
-	Use:   "explain <RULE_ID>",
-	Short: "Show detailed information about a detection rule",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runExplain,
+	Use:     "explain <RULE_ID>",
+	GroupID: groupRules,
+	Short:   "Show detailed information about a detection rule",
+	Args:    cobra.ExactArgs(1),
+	RunE:    runExplain,
 }
 
 func init() {

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -14,11 +14,12 @@ var (
 )
 
 var initCmd = &cobra.Command{
-	Use:   "init [path]",
-	Short: "Initialize Aguara configuration files",
-	Long:  `Scaffolds .aguara.yml, .aguaraignore, and a GitHub Actions workflow for Aguara scanning.`,
-	Args:  cobra.MaximumNArgs(1),
-	RunE:  runInit,
+	Use:     "init [path]",
+	GroupID: groupSetup,
+	Short:   "Initialize Aguara configuration files",
+	Long:    `Scaffolds .aguara.yml, .aguaraignore, and a GitHub Actions workflow for Aguara scanning.`,
+	Args:    cobra.MaximumNArgs(1),
+	RunE:    runInit,
 }
 
 func init() {

--- a/cmd/aguara/commands/list_rules.go
+++ b/cmd/aguara/commands/list_rules.go
@@ -14,9 +14,10 @@ import (
 var flagCategory string
 
 var listRulesCmd = &cobra.Command{
-	Use:   "list-rules",
-	Short: "List all available detection rules",
-	RunE:  runListRules,
+	Use:     "list-rules",
+	GroupID: groupRules,
+	Short:   "List all available detection rules",
+	RunE:    runListRules,
 }
 
 func init() {

--- a/cmd/aguara/commands/root.go
+++ b/cmd/aguara/commands/root.go
@@ -21,10 +21,26 @@ var (
 	flagNoUpdateCheck bool
 )
 
+// Help groups: every command declares one of these as its GroupID so
+// `aguara --help` reads as workflows instead of an alphabetical list.
+const (
+	groupScan  = "scan"
+	groupRules = "rules"
+	groupSetup = "setup"
+)
+
 var rootCmd = &cobra.Command{
 	Use:   "aguara",
-	Short: "Security scanner for AI agent skills and MCP servers",
-	Long:  `Aguara is a security scanner that detects prompt injection, data exfiltration, and credential leaks in AI agent skill definitions and MCP server configurations.`,
+	Short: "Security engine for AI agent and supply-chain trust",
+	Long: `Aguara is an open source security engine for AI agent and supply-chain
+trust. It detects prompt injection, data exfiltration, credential leaks,
+and known-compromised packages across AI agent skills, MCP servers, CI
+workflows, and dependency lockfiles. No SaaS account, no telemetry, no
+LLM calls; default runs stay offline.`,
+	Example: `  aguara scan ./my-skill     Scan a skill or MCP server directory
+  aguara audit . --ci        Package check + content scan, one verdict, gate CI
+  aguara check               Check dependencies for known-compromised packages
+  aguara explain CRED_001    Show what a rule detects and how to fix it`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		resolveColorMode()
 	},
@@ -50,6 +66,13 @@ func resolveColorMode() {
 
 func init() {
 	rootCmd.Version = Version
+	rootCmd.AddGroup(
+		&cobra.Group{ID: groupScan, Title: "Scan & audit:"},
+		&cobra.Group{ID: groupRules, Title: "Rules & threat intel:"},
+		&cobra.Group{ID: groupSetup, Title: "Setup:"},
+	)
+	rootCmd.SetHelpCommandGroupID(groupSetup)
+	rootCmd.SetCompletionCommandGroupID(groupSetup)
 	rootCmd.PersistentFlags().StringVar(&flagSeverity, "severity", "info", "Minimum severity to report (critical, high, medium, low, info)")
 	rootCmd.PersistentFlags().StringVar(&flagFormat, "format", "terminal", "Output format (terminal, json, sarif, markdown)")
 	rootCmd.PersistentFlags().StringVarP(&flagOutput, "output", "o", "", "Output file path (default: stdout)")

--- a/cmd/aguara/commands/root.go
+++ b/cmd/aguara/commands/root.go
@@ -6,6 +6,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/garagon/aguara/internal/output"
 )
 
 var (
@@ -23,9 +25,27 @@ var rootCmd = &cobra.Command{
 	Use:   "aguara",
 	Short: "Security scanner for AI agent skills and MCP servers",
 	Long:  `Aguara is a security scanner that detects prompt injection, data exfiltration, and credential leaks in AI agent skill definitions and MCP server configurations.`,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		resolveColorMode()
+	},
 	PersistentPostRun: func(cmd *cobra.Command, args []string) {
 		checkPathHint()
 	},
+}
+
+// resolveColorMode disables color before any command runs when the
+// destination cannot render it: NO_COLOR set (https://no-color.org),
+// --output redirecting to a file, or stdout not attached to an
+// interactive terminal (pipes, CI logs, shell redirection). --no-color
+// stays the explicit override; per-command --ci handling may still
+// disable color afterwards.
+func resolveColorMode() {
+	if flagNoColor {
+		return
+	}
+	if os.Getenv("NO_COLOR") != "" || flagOutput != "" || !output.IsTerminal(os.Stdout) {
+		flagNoColor = true
+	}
 }
 
 func init() {

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -525,6 +525,16 @@ func scanChangedFiles(ctx context.Context, s *scanner.Scanner, targetPath string
 func writeOutput(result *scanner.ScanResult) error {
 	output.ToolVersion = Version
 
+	w := os.Stdout
+	if flagOutput != "" {
+		f, err := os.Create(flagOutput)
+		if err != nil {
+			return fmt.Errorf("creating output file: %w", err)
+		}
+		defer func() { _ = f.Close() }()
+		w = f
+	}
+
 	var formatter output.Formatter
 	switch strings.ToLower(flagFormat) {
 	case "json":
@@ -534,17 +544,11 @@ func writeOutput(result *scanner.ScanResult) error {
 	case "markdown", "md":
 		formatter = &output.MarkdownFormatter{}
 	default:
-		formatter = &output.TerminalFormatter{NoColor: flagNoColor, Verbose: flagVerbose}
-	}
-
-	w := os.Stdout
-	if flagOutput != "" {
-		f, err := os.Create(flagOutput)
-		if err != nil {
-			return fmt.Errorf("creating output file: %w", err)
+		formatter = &output.TerminalFormatter{
+			NoColor: flagNoColor,
+			Verbose: flagVerbose,
+			Width:   output.DetectWidth(w),
 		}
-		defer func() { _ = f.Close() }()
-		w = f
 	}
 
 	return formatter.Format(w, result)
@@ -556,7 +560,9 @@ func isTerminalFormat() bool {
 }
 
 func startSpinnerIfTerminal(s *scanner.Scanner, message string) *output.Spinner {
-	if !isTerminalFormat() {
+	// Animate only when stderr is an interactive terminal; piped or
+	// CI stderr would collect raw \r frames as log noise.
+	if !isTerminalFormat() || !output.IsTerminal(os.Stderr) {
 		return nil
 	}
 	sp := output.NewSpinner(os.Stderr)

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -42,8 +42,13 @@ var (
 )
 
 var scanCmd = &cobra.Command{
-	Use:   "scan [path]",
-	Short: "Scan a directory for security issues",
+	Use:     "scan [path]",
+	GroupID: groupScan,
+	Short:   "Scan a directory for security issues",
+	Example: `  aguara scan ./skill                Scan a skill or MCP server directory
+  aguara scan . --severity high      Report only HIGH and CRITICAL findings
+  aguara scan . --fail-on high       Exit 1 when HIGH+ findings exist (CI gate)
+  aguara scan . --format sarif -o scan.sarif   For GitHub code scanning`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		if flagAuto {
 			if len(args) > 0 {

--- a/cmd/aguara/commands/scan_test.go
+++ b/cmd/aguara/commands/scan_test.go
@@ -55,6 +55,7 @@ func resetFlags() {
 	flagAuditBaseline = ""
 	flagAuditWriteBaseline = ""
 	flagAuditInsecure = false
+	flagAuditVerbose = false
 }
 
 // scanToFile runs aguara scan and writes output to a temp file, returning the content.

--- a/cmd/aguara/commands/status.go
+++ b/cmd/aguara/commands/status.go
@@ -11,8 +11,9 @@ import (
 )
 
 var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Show Aguara version and threat-intel freshness",
+	Use:     "status",
+	GroupID: groupRules,
+	Short:   "Show Aguara version and threat-intel freshness",
 	Long: `Print the binary version, embedded threat-intel snapshot age, and
 local cached snapshot status (if any).
 

--- a/cmd/aguara/commands/update.go
+++ b/cmd/aguara/commands/update.go
@@ -33,8 +33,9 @@ const defaultIntelBundleBaseURL = "https://github.com/garagon/aguara/releases/do
 var intelBundleBaseURL = defaultIntelBundleBaseURL
 
 var updateCmd = &cobra.Command{
-	Use:   "update",
-	Short: "Refresh the local threat-intel snapshot from Aguara's signed bundle",
+	Use:     "update",
+	GroupID: groupRules,
+	Short:   "Refresh the local threat-intel snapshot from Aguara's signed bundle",
 	Long: `Refresh Aguara's local threat-intel snapshot. Downloads the latest
 Aguara-signed advisory bundle, verifies its Sigstore signature against
 the expected publisher identity and the manifest against the blob, and

--- a/cmd/aguara/commands/version.go
+++ b/cmd/aguara/commands/version.go
@@ -16,8 +16,9 @@ var (
 )
 
 var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version",
+	Use:     "version",
+	GroupID: groupSetup,
+	Short:   "Print the version",
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("aguara %s (commit: %s)\n", Version, Commit)
 		if flagNoUpdateCheck {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/yuin/goldmark v1.8.2
+	golang.org/x/term v0.42.0
 	golang.org/x/text v0.36.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -77,7 +78,6 @@ require (
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
-	golang.org/x/term v0.42.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260316180232-0b37fe3546d5 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260316180232-0b37fe3546d5 // indirect
 	google.golang.org/grpc v1.79.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -220,6 +220,7 @@ github.com/jedisct1/go-minisign v0.0.0-20211028175153-1c139d1cc84b/go.mod h1:hQm
 github.com/jellydator/ttlcache/v3 v3.4.0 h1:YS4P125qQS0tNhtL6aeYkheEaB/m8HCqdMMP4mnWdTY=
 github.com/jellydator/ttlcache/v3 v3.4.0/go.mod h1:Hw9EgjymziQD3yGsQdf1FqFdpp7YjFMd4Srg5EJlgD4=
 github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 h1:liMMTbpW34dhU4az1GN0pTPADwNmvoRSeoZ6PItiqnY=
+github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
 github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -360,6 +361,7 @@ golang.org/x/text v0.36.0/go.mod h1:NIdBknypM8iqVmPiuco0Dh6P5Jcdk8lJL0CUebqK164=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
 gonum.org/v1/gonum v0.16.0 h1:5+ul4Swaf3ESvrOnidPp4GZbzf0mxVQpDCYUQE7OJfk=
+gonum.org/v1/gonum v0.16.0/go.mod h1:fef3am4MQ93R2HHpKnLk4/Tbh/s0+wqD5nfa6Pnwy4E=
 google.golang.org/api v0.272.0 h1:eLUQZGnAS3OHn31URRf9sAmRk3w2JjMx37d2k8AjJmA=
 google.golang.org/api v0.272.0/go.mod h1:wKjowi5LNJc5qarNvDCvNQBn3rVK8nSy6jg2SwRwzIA=
 google.golang.org/genproto v0.0.0-20260316180232-0b37fe3546d5 h1:JNfk58HZ8lfmXbYK2vx/UvsqIL59TzByCxPIX4TDmsE=

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -23,7 +23,7 @@ func TestTerminalFormatterNoFindings(t *testing.T) {
 	require.NoError(t, f.Format(&buf, result))
 	out := buf.String()
 	require.Contains(t, out, "No security issues found")
-	require.Contains(t, out, "SCAN RESULTS")
+	require.Contains(t, out, "AGUARA SCAN")
 	require.Contains(t, out, "5 files scanned")
 	require.Contains(t, out, "0 findings")
 	require.Contains(t, out, "Target: testdata/benign")
@@ -57,7 +57,7 @@ func TestTerminalFormatterWithFindings(t *testing.T) {
 	require.Contains(t, out, "TEST_001")
 	require.Contains(t, out, "CRITICAL")
 	require.Contains(t, out, "test.md")
-	require.Contains(t, out, "SCAN RESULTS")
+	require.Contains(t, out, "AGUARA SCAN")
 	require.Contains(t, out, "1 files scanned")
 	// Critical finding should show matched text preview
 	require.Contains(t, out, "bad stuff")

--- a/internal/output/spinner.go
+++ b/internal/output/spinner.go
@@ -15,14 +15,21 @@ var spinnerFrames = []rune("⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏")
 type Spinner struct {
 	mu      sync.Mutex
 	w       io.Writer
+	width   int
 	message string
 	done    chan struct{}
 	stopped bool
 }
 
-// NewSpinner creates a spinner that writes to w.
+// NewSpinner creates a spinner that writes to w. Frames are padded to
+// the terminal width (capped at 80 columns) so a narrower terminal
+// does not wrap the spinner line into a new row on every tick.
 func NewSpinner(w io.Writer) *Spinner {
-	return &Spinner{w: w}
+	width := 80
+	if detected := DetectWidth(w); detected > 0 && detected < width {
+		width = detected
+	}
+	return &Spinner{w: w, width: width}
 }
 
 // Start begins the spinner animation with the given message.
@@ -55,9 +62,10 @@ func (s *Spinner) Stop() {
 
 	close(s.done)
 
-	// Clear the spinner line
+	// Clear the spinner line. Frames pad to s.width, so clearing the
+	// full width covers any message length.
 	s.mu.Lock()
-	fmt.Fprintf(s.w, "\r%s\r", strings.Repeat(" ", len(s.message)+4))
+	fmt.Fprintf(s.w, "\r%s\r", strings.Repeat(" ", s.width-1))
 	s.mu.Unlock()
 }
 
@@ -74,14 +82,23 @@ func (s *Spinner) loop() {
 			s.mu.Lock()
 			frame := spinnerFrames[i%len(spinnerFrames)]
 			msg := s.message
+			width := s.width
 			s.mu.Unlock()
 
-			// Pad with spaces to overwrite any leftover chars from a longer previous message
-			line := fmt.Sprintf("\r%c %s", frame, msg)
-			padded := fmt.Sprintf("%-80s", line)
+			// Truncate to the terminal width, then pad with spaces to
+			// overwrite any leftover chars from a longer previous message.
+			visible := fmt.Sprintf("%c %s", frame, msg)
+			if runes := []rune(visible); len(runes) > width-1 {
+				visible = string(runes[:width-1])
+			}
+			padded := fmt.Sprintf("\r%-*s", width-1, visible)
 
 			s.mu.Lock()
-			fmt.Fprint(s.w, padded)
+			// A Stop racing this tick may have already cleared the
+			// line; writing one more frame would leave it on screen.
+			if !s.stopped {
+				fmt.Fprint(s.w, padded)
+			}
 			s.mu.Unlock()
 
 			i++

--- a/internal/output/style.go
+++ b/internal/output/style.go
@@ -1,0 +1,111 @@
+package output
+
+import (
+	"fmt"
+	"strings"
+	"unicode/utf8"
+)
+
+// Style renders Aguara's shared terminal vocabulary: one palette, one
+// set of severity icons, one section-header shape across every command
+// (scan, check, audit, explain, clean). NoColor strips ANSI codes but
+// keeps the unicode layout intact.
+type Style struct {
+	NoColor bool
+}
+
+// NewStyle returns a Style honoring the resolved no-color mode.
+func NewStyle(noColor bool) Style {
+	return Style{NoColor: noColor}
+}
+
+func (s Style) paint(code, text string) string {
+	if s.NoColor || text == "" {
+		return text
+	}
+	return code + text + reset
+}
+
+func (s Style) Bold(t string) string      { return s.paint(bold, t) }
+func (s Style) Dim(t string) string       { return s.paint(dim, t) }
+func (s Style) Red(t string) string       { return s.paint(red, t) }
+func (s Style) RedBold(t string) string   { return s.paint(red+bold, t) }
+func (s Style) Green(t string) string     { return s.paint(green, t) }
+func (s Style) Yellow(t string) string    { return s.paint(yellow, t) }
+func (s Style) Blue(t string) string      { return s.paint(blue, t) }
+func (s Style) Cyan(t string) string      { return s.paint(cyan, t) }
+func (s Style) Underline(t string) string { return s.paint(bold+underline, t) }
+
+// OK renders the shared clean-state line: a green check plus message.
+func (s Style) OK(text string) string {
+	return s.paint(green, "✔ "+text)
+}
+
+// SeverityIcon returns the icon scan introduced for each severity,
+// keyed by canonical label so check/audit (string severities) and
+// scan (typed severities) share one mapping. Check's WARNING maps to
+// the MEDIUM tier.
+func (s Style) SeverityIcon(label string) string {
+	switch strings.ToUpper(label) {
+	case "CRITICAL":
+		return s.paint(red+bold, "✖")
+	case "HIGH":
+		return s.paint(red, "▲")
+	case "MEDIUM", "WARNING":
+		return s.paint(yellow, "■")
+	case "LOW":
+		return s.paint(blue, "●")
+	case "INFO":
+		return s.paint(cyan, "○")
+	default:
+		return "?"
+	}
+}
+
+// SeverityLabel returns the label painted in its severity color.
+func (s Style) SeverityLabel(label string) string {
+	return s.paint(severityCode(label), label)
+}
+
+func severityCode(label string) string {
+	switch strings.ToUpper(label) {
+	case "CRITICAL":
+		return red + bold
+	case "HIGH":
+		return red
+	case "MEDIUM", "WARNING":
+		return yellow
+	case "LOW":
+		return blue
+	case "INFO":
+		return cyan
+	default:
+		return ""
+	}
+}
+
+// Cell pads or truncates text to exactly w columns -- the shape scan
+// uses for aligned finding columns.
+func (s Style) Cell(text string, w int) string {
+	return fmt.Sprintf("%-*s", w, truncate(text, w))
+}
+
+// Separator renders a full-width dim rule line. Zero width falls back
+// to the 72-column default.
+func (s Style) Separator(width int) string {
+	if width <= 0 {
+		width = lineWidth
+	}
+	return s.paint(dim, strings.Repeat("─", width))
+}
+
+// SectionHeader renders the shared "── TITLE ────" shape padded to
+// width (zero → 72), bold like scan's severity sections.
+func (s Style) SectionHeader(title string, width int) string {
+	if width <= 0 {
+		width = lineWidth
+	}
+	prefix := "── " + title + " "
+	remaining := max(width-utf8.RuneCountInString(prefix), 0)
+	return s.paint(bold, prefix+strings.Repeat("─", remaining))
+}

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -108,7 +108,7 @@ func (f *TerminalFormatter) sectionHeader(title string) string {
 func (f *TerminalFormatter) printHeader(w io.Writer, result *scanner.ScanResult) {
 	sep := f.separator()
 	fmt.Fprintf(w, "\n%s\n", f.color(dim, sep))
-	fmt.Fprintf(w, "  %s\n", f.color(bold, "AGUARA SCAN RESULTS"))
+	fmt.Fprintf(w, "  %s\n", f.color(bold, "AGUARA SCAN"))
 
 	parts := []string{}
 	if result.Target != "" {
@@ -297,6 +297,24 @@ func (f *TerminalFormatter) printFooter(w io.Writer, result *scanner.ScanResult)
 		fmt.Fprintf(w, "  %s\n", f.color(dim, line))
 	}
 	fmt.Fprintf(w, "%s\n", f.color(dim, sep))
+
+	if rule := topRuleID(result.Findings); rule != "" {
+		fmt.Fprintf(w, "  %s\n", f.color(dim, "Next: aguara explain "+rule))
+	}
+}
+
+// topRuleID returns the rule behind the most severe finding -- the one
+// the Next hint points `aguara explain` at.
+func topRuleID(findings []scanner.Finding) string {
+	best := -1
+	rule := ""
+	for _, f := range findings {
+		if int(f.Severity) > best {
+			best = int(f.Severity)
+			rule = f.RuleID
+		}
+	}
+	return rule
 }
 
 func (f *TerminalFormatter) severityIcon(sev scanner.Severity) string {

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -18,6 +18,7 @@ const (
 	dim       = "\033[2m"
 	underline = "\033[4m"
 	red       = "\033[31m"
+	green     = "\033[32m"
 	yellow    = "\033[33m"
 	blue      = "\033[34m"
 	magenta   = "\033[35m"
@@ -67,7 +68,7 @@ func (f *TerminalFormatter) Format(w io.Writer, result *scanner.ScanResult) erro
 	f.printHeader(w, result)
 
 	if len(result.Findings) == 0 {
-		fmt.Fprintf(w, "\n  %s No security issues found.\n", f.color(cyan, "\u2714"))
+		fmt.Fprintf(w, "\n  %s\n", NewStyle(f.NoColor).OK("No security issues found."))
 	} else {
 		counts := f.countBySeverity(result.Findings)
 		f.printDashboard(w, counts)
@@ -299,37 +300,11 @@ func (f *TerminalFormatter) printFooter(w io.Writer, result *scanner.ScanResult)
 }
 
 func (f *TerminalFormatter) severityIcon(sev scanner.Severity) string {
-	switch sev {
-	case scanner.SeverityCritical:
-		return f.color(red+bold, "\u2716")
-	case scanner.SeverityHigh:
-		return f.color(red, "\u25b2")
-	case scanner.SeverityMedium:
-		return f.color(yellow, "\u25a0")
-	case scanner.SeverityLow:
-		return f.color(blue, "\u25cf")
-	case scanner.SeverityInfo:
-		return f.color(cyan, "\u25cb")
-	default:
-		return "?"
-	}
+	return NewStyle(f.NoColor).SeverityIcon(sev.String())
 }
 
 func (f *TerminalFormatter) severityColor(sev scanner.Severity) string {
-	switch sev {
-	case scanner.SeverityCritical:
-		return red + bold
-	case scanner.SeverityHigh:
-		return red
-	case scanner.SeverityMedium:
-		return yellow
-	case scanner.SeverityLow:
-		return blue
-	case scanner.SeverityInfo:
-		return cyan
-	default:
-		return ""
-	}
+	return severityCode(sev.String())
 }
 
 func (f *TerminalFormatter) renderBar(count, max, width int, sev scanner.Severity) string {

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -40,6 +40,16 @@ const (
 type TerminalFormatter struct {
 	NoColor bool
 	Verbose bool
+	// Width is the rendering width for separators and section headers.
+	// Zero falls back to the 72-column default.
+	Width int
+}
+
+func (f *TerminalFormatter) width() int {
+	if f.Width > 0 {
+		return f.Width
+	}
+	return lineWidth
 }
 
 func (f *TerminalFormatter) color(code, text string) string {
@@ -50,10 +60,8 @@ func (f *TerminalFormatter) color(code, text string) string {
 }
 
 func (f *TerminalFormatter) Format(w io.Writer, result *scanner.ScanResult) error {
-	if f.NoColor {
-		if os.Getenv("NO_COLOR") != "" {
-			f.NoColor = true
-		}
+	if !f.NoColor && os.Getenv("NO_COLOR") != "" {
+		f.NoColor = true
 	}
 
 	f.printHeader(w, result)
@@ -86,13 +94,13 @@ func (f *TerminalFormatter) Format(w io.Writer, result *scanner.ScanResult) erro
 }
 
 func (f *TerminalFormatter) separator() string {
-	return strings.Repeat("\u2500", lineWidth)
+	return strings.Repeat("\u2500", f.width())
 }
 
 func (f *TerminalFormatter) sectionHeader(title string) string {
 	prefix := "\u2500\u2500 " + title + " "
 	displayLen := utf8.RuneCountInString(prefix)
-	remaining := max(lineWidth-displayLen, 0)
+	remaining := max(f.width()-displayLen, 0)
 	return prefix + strings.Repeat("\u2500", remaining)
 }
 

--- a/internal/output/tty.go
+++ b/internal/output/tty.go
@@ -1,0 +1,36 @@
+package output
+
+import (
+	"io"
+	"os"
+
+	"golang.org/x/term"
+)
+
+// IsTerminal reports whether w is attached to an interactive terminal.
+// Non-file writers (buffers, pipes wrapped in io.Writer) are never
+// terminals.
+func IsTerminal(w io.Writer) bool {
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd()))
+}
+
+// DetectWidth returns the rendering width for w when it is an
+// interactive terminal, clamped to [40, 100] so narrow terminals keep
+// separators on one line and wide ones do not stretch section rules
+// across the whole screen. Returns 0 (use the caller's default) when
+// w is not a terminal or its size cannot be read.
+func DetectWidth(w io.Writer) int {
+	f, ok := w.(*os.File)
+	if !ok || !term.IsTerminal(int(f.Fd())) {
+		return 0
+	}
+	cols, _, err := term.GetSize(int(f.Fd()))
+	if err != nil || cols <= 0 {
+		return 0
+	}
+	return min(max(cols, 40), 100)
+}

--- a/internal/output/tty_test.go
+++ b/internal/output/tty_test.go
@@ -1,0 +1,67 @@
+package output
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestIsTerminalNonFileWriter(t *testing.T) {
+	if IsTerminal(&bytes.Buffer{}) {
+		t.Error("expected IsTerminal to be false for a non-file writer")
+	}
+}
+
+func TestIsTerminalRegularFile(t *testing.T) {
+	f, err := os.Create(filepath.Join(t.TempDir(), "out.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if IsTerminal(f) {
+		t.Error("expected IsTerminal to be false for a regular file")
+	}
+}
+
+func TestDetectWidthNonTerminal(t *testing.T) {
+	if w := DetectWidth(&bytes.Buffer{}); w != 0 {
+		t.Errorf("expected width 0 for a non-file writer, got %d", w)
+	}
+
+	f, err := os.Create(filepath.Join(t.TempDir(), "out.txt"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = f.Close() }()
+
+	if w := DetectWidth(f); w != 0 {
+		t.Errorf("expected width 0 for a regular file, got %d", w)
+	}
+}
+
+func TestTerminalFormatterWidth(t *testing.T) {
+	cases := []struct {
+		name  string
+		width int
+		want  int
+	}{
+		{"default", 0, lineWidth},
+		{"narrow", 50, 50},
+		{"wide", 100, 100},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			f := &TerminalFormatter{Width: tc.width}
+			if got := utf8.RuneCountInString(f.separator()); got != tc.want {
+				t.Errorf("separator length = %d, want %d", got, tc.want)
+			}
+			header := f.sectionHeader("CRITICAL (5)")
+			if got := utf8.RuneCountInString(header); got != tc.want {
+				t.Errorf("sectionHeader length = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Aguara now detects where its output is going and adapts automatically:

- Piping or redirecting any command (`aguara scan . | less`, `> report.txt`, CI logs) no longer emits raw ANSI escape codes - color turns itself off when stdout is not an interactive terminal, when `--output` writes to a file, or when `NO_COLOR` is set. `--no-color` keeps working as the explicit override. This now covers every command, including `explain` and `clean`, which previously ignored `NO_COLOR`.
- The progress spinner only animates on an interactive terminal, so piped and CI runs no longer collect carriage-return frames as log noise, and error messages are no longer indented by leftover spinner padding.
- `aguara audit` renders the FINDINGS verdict in yellow instead of green: exit code 0 with unresolved findings is not a clean pass, and the color now says so.
- Scan separators and the spinner size themselves to the real terminal width instead of assuming 72/80 columns.

No flag changes, no output-format changes for JSON/SARIF/markdown. Verified end to end on macOS PTY, pipes, file output, and the Docker image (non-TTY and `-t`).