### PR TITLE
Release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,55 @@
 All notable changes to Aguara are documented in this file.
 Format based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.27.0] - 2026-06-12
+
+The terminal experience grows up. Every Aguara command now speaks the
+same visual language, adapts to where its output is going, and the
+parsers that read attacker-controlled files gain a native fuzz harness
+that runs nightly. JSON, SARIF, and markdown outputs are unchanged.
+
+### Added
+
+- **Shared terminal style layer** (#221): one palette, severity icons,
+  section headers, and separators across `scan`, `check`, `audit`,
+  `explain`, and `clean` - commands no longer hand-roll their own ANSI
+  codes. `aguara audit` opens with a framed header, lists findings in
+  aligned columns under `PACKAGE CHECK` and `CONTENT SCAN` sections,
+  and closes with a framed verdict (green PASS, yellow FINDINGS, red
+  FAIL). New `--verbose` flag on `audit` lists every content finding
+  instead of capping at 10. `aguara --help` groups commands by
+  workflow and shows copy-paste examples; `scan` and `audit` close
+  with a `Next: aguara explain <rule>` hint for the most severe
+  finding.
+- **Native fuzz harness** (#223): 22 Go fuzz targets covering every
+  parser that touches untrusted input - the ten lockfile parsers
+  behind `aguara check`, the pattern engine with its NFKC
+  normalization and 8-decoder rescan, the markdown/JSON/YAML NLP
+  extractor, the JS/Python/Rust scanners, the policy analyzers, and
+  the custom-rule loader. Each target asserts the parser never panics
+  and never emits a finding without a rule ID. Seed corpora run inside
+  `make test`; a nightly workflow fuzzes each target for 60 seconds
+  and uploads any crasher as a reproducible artifact. `make fuzz` runs
+  the same loop locally. Initial shakeout: ~37M executions, zero
+  crashes.
+
+### Fixed
+
+- **Terminal detection** (#220): color and the progress spinner now
+  turn themselves off when stdout is not an interactive terminal -
+  piped output, file redirection, and CI logs no longer collect ANSI
+  escape codes or spinner frames. `NO_COLOR` now covers every command,
+  including `explain` and `clean`, which previously ignored it.
+  Separators and the spinner size themselves to the real terminal
+  width. `aguara audit` renders the FINDINGS verdict in yellow instead
+  of green: exit code 0 with unresolved findings is not a clean pass.
+
+### Changed
+
+- Dependency updates: Go modules minor/patch group (#222);
+  `actions/checkout` v6, `github/codeql-action` v4,
+  `goreleaser-action` 7.2.2 (#186, #187, #188).
+
 ## [0.26.0] - 2026-06-11
 
 Threat-intel coverage grows by an order of magnitude. Until now the

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.26.0
+INSTALL_SH_TEST_VERSION ?= v0.27.0
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ brew install garagon/tap/aguara
 ### Docker
 
 ```bash
-docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.26.0 check /repo
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.27.0 check /repo
 ```
 
 Multi-arch (`linux/amd64` + `linux/arm64`), runs as non-root UID 10001, base images digest-pinned, and signed at the digest with Cosign plus SPDX SBOM and SLSA provenance attestations. Pin a specific release tag for reproducibility.
@@ -234,7 +234,7 @@ Multi-arch (`linux/amd64` + `linux/arm64`), runs as non-root UID 10001, base ima
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
-  | VERSION=v0.26.0 sh
+  | VERSION=v0.27.0 sh
 ```
 
 `install.sh` downloads `checksums.txt` and verifies the archive's SHA256 against it, aborting if neither `sha256sum` nor `shasum` is available. This catches a tampered archive at the registry layer but does not verify the Cosign signature on `checksums.txt` itself; for full keyless-signature verification on the curl-pipe path, follow the Cosign step in [Verifying signed releases](#verifying-signed-releases). Default install location is `~/.local/bin`; override with `INSTALL_DIR` for CI or containers.
@@ -242,11 +242,11 @@ curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh \
 ### GitHub Action
 
 ```yaml
-- uses: garagon/aguara@v0.26.0
+- uses: garagon/aguara@v0.27.0
   with:
     path: .
     fail-on: high
-    version: v0.26.0
+    version: v0.27.0
 ```
 
 Both pins are required: the action ref pins the composite action and its install script, and `version:` pins the Aguara binary it installs. Setting both keeps the workflow reproducible and dependabot-friendly. See [`action.yml`](action.yml) for all inputs.
@@ -284,15 +284,15 @@ GitHub Code Scanning, GitLab SAST, and plain Docker-in-CI examples are below.
 
 ```yaml
 # GitHub Action with SARIF upload (needs security-events: write)
-- uses: garagon/aguara@v0.26.0
-  with: { path: ., severity: medium, fail-on: high, version: v0.26.0 }
+- uses: garagon/aguara@v0.27.0
+  with: { path: ., severity: medium, fail-on: high, version: v0.27.0 }
 ```
 
 ```yaml
 # GitLab CI
 security-scan:
   script:
-    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.26.0 sh
+    - curl -fsSL https://raw.githubusercontent.com/garagon/aguara/main/install.sh | VERSION=v0.27.0 sh
     - aguara scan . --format sarif -o gl-sast-report.sarif --fail-on high
   artifacts:
     reports:
@@ -349,7 +349,7 @@ A separate `aguara check` / `aguara audit` path inspects installed package trees
 Every release is signed with [Cosign](https://github.com/sigstore/cosign) keyless, ships an SPDX SBOM per archive, and is built with `-trimpath` for reproducibility. The container image is signed at the digest with SBOM + SLSA provenance attestations.
 
 ```bash
-VERSION=v0.26.0
+VERSION=v0.27.0
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}
@@ -397,7 +397,7 @@ Suppress individual findings inline with `# aguara-ignore RULE_ID` (also `-next-
 
 ## Aguara Watch
 
-Aguara Watch is being reworked. The previous public observatory is stale and is not a supported surface for v0.26.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
+Aguara Watch is being reworked. The previous public observatory is stale and is not a supported surface for v0.27.0. The supported surfaces are the CLI, GitHub Action, Docker image, signed releases, and Go library.
 
 ## Contributing
 

--- a/action.yml
+++ b/action.yml
@@ -88,7 +88,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.26.0"
+        DEFAULT_REF="v0.27.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -203,7 +203,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.26.0 tag rather than `@v1`
+// The action ref is pinned to the v0.27.0 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -232,7 +232,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.26.0
+        uses: garagon/aguara@v0.27.0
         with:
           path: .
           fail-on: high
@@ -241,7 +241,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.26.0
+          version: v0.27.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
Prepares the v0.27.0 release, aggregating the terminal UX round and the fuzz harness.

**What ships in v0.27.0:**

- **Unified terminal output** (#220, #221): every command shares one style layer - palette, severity icons, framed verdicts. Color and the spinner turn themselves off on pipes, file output, and CI; `NO_COLOR` now covers every command. `audit` gains `--verbose` and aligned finding sections; `--help` groups commands by workflow with copy-paste examples.
- **Native fuzz harness** (#223): 22 Go fuzz targets over every parser that reads untrusted input, with seed corpora in `make test`, a nightly fuzz workflow, and `make fuzz` for local runs.
- Dependency updates (#222, #186-#188).

JSON, SARIF, and markdown outputs are unchanged.

**This PR:** CHANGELOG entry for 0.27.0 plus the version-pin bump (README, Makefile, action.yml, `aguara init` template) - `check-version-pins.sh` passes on v0.27.0. No code changes.

After merge: tag v0.27.0, GoReleaser publishes binaries, Homebrew tap, and the Docker image.