### PR TITLE
Report test coverage to Codecov

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,37 @@
+name: coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverage-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  coverage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Test with coverage
+        run: go test -race -count=1 -coverprofile=coverage.out ./...
+
+      - name: Upload to Codecov
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        with:
+          files: coverage.out
+          token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Aguara v0.27.0 (2026-06-12; aggregates the terminal UX round #220 TTY detection 
 
 Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, multi-arch `linux/amd64+arm64`, runs as non-root UID 10001, base images digest-pinned, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
-GitHub: 48 stars, 6 forks. 0 open PRs, 0 open issues. 7 awesome-list PRs pending review in external repos. 7 forks on garagon account (pending cleanup after awesome-list PRs resolve).
+GitHub: 84 stars, 15 forks. 3 awesome-list PRs pending review in external repos (sbilly/awesome-security, Puliczek/awesome-mcp-security, ottosulin/awesome-ai-security; 3 others merged, forks deleted 2026-07-01). Issue #230: external contributor building an out-of-tree ATR rule pack for `--rules` (welcomed; link from README when it ships).
 
 Pattern matcher already uses an Aho-Corasick keyword prefilter (active in production since v0.14.0). Real perf is ~210ms/op on the synthetic bench (was ~770ms without AC), so do not treat "pattern matcher perf" as an open backlog item unless pprof shows a concrete regression. Pending improvements: WASM build (cmd/wasm/ incomplete), adoption/marketing.
 
@@ -189,7 +189,7 @@ Content must pass ALL four stages before being marked `status: ready`.
 - **wong2/awesome-mcp-servers** does NOT accept PRs - must use mcpservers.org/submit web form.
 - **GitHub topics**: 15 keywords max useful for SEO.
 - **OpenAlternative.co / OpenSourceAlternative.to**: Don't accept CLIs. Descartados.
-- **awesome-go**: Blocked until July 2026 (requires 5-month repo age). Also needs Codecov badge integration.
+- **awesome-go**: Eligible 2026-07-17 (repo created 2026-02-17; requires 5-month age). Codecov badge shipped via coverage workflow; entry draft in the vault's awesome-lists channel.
 - **Official MCP Registry**: Only accepts npm/TypeScript packages. Not applicable for Go.
 - Distribution channels with submission tracking: `DOCS/Aguara/distribution/`.
 - Demo video: Remotion project at `/Users/dev/Dev/videos/aguara-demo/`. Terminal segments recorded with VHS (charmbracelet/vhs), slides as React components, rendered with `npx remotion render AguaraDemo output.mp4`.

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 <p align="center">
   <a href="https://github.com/garagon/aguara/actions/workflows/ci.yml"><img src="https://github.com/garagon/aguara/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <a href="https://codecov.io/gh/garagon/aguara"><img src="https://codecov.io/gh/garagon/aguara/branch/main/graph/badge.svg" alt="Coverage"></a>
   <a href="https://goreportcard.com/report/github.com/garagon/aguara"><img src="https://goreportcard.com/badge/github.com/garagon/aguara" alt="Go Report Card"></a>
   <a href="https://pkg.go.dev/github.com/garagon/aguara"><img src="https://pkg.go.dev/badge/github.com/garagon/aguara.svg" alt="Go Reference"></a>
   <a href="https://github.com/garagon/aguara/releases"><img src="https://img.shields.io/github/v/release/garagon/aguara" alt="GitHub Release"></a>

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,12 @@
+# Coverage reporting is informational only: it never turns a PR red.
+# CI correctness gates live in .github/workflows/ci.yml.
+coverage:
+  status:
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
+
+comment: false


### PR DESCRIPTION
Publishes the project's test coverage so anyone evaluating aguara can see how well the codebase is exercised, and adds the coverage badge to the README next to CI and Go Report Card.

## What changed

- New `coverage` workflow: runs the race-enabled test suite with a coverage profile on pushes to main and on PRs, and uploads the report to Codecov.
- `codecov.yml`: coverage statuses are informational only, so a coverage dip never turns a PR red. Correctness gates stay in the CI workflow.
- README: coverage badge linking to the Codecov dashboard.

Local run of the same command reports 80.2% total statement coverage. The badge populates after the first upload from main.

## Notes

- The Codecov action is pinned by commit SHA (v7.0.0), matching how other third-party actions are pinned here.
- The upload requires a `CODECOV_TOKEN` repo secret (Codecov rejects tokenless uploads for this repo because the branch is protected). Until the secret is set, the workflow still passes and simply skips reporting.
