### PR TITLE
Scope the coverage badge to shipped scanner code

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,13 @@
 # Coverage reporting is informational only: it never turns a PR red.
 # CI correctness gates live in .github/workflows/ci.yml.
+
+# The badge measures the shipped scanner. Dev-side utilities (intel
+# data-pipeline scripts, benchmark harness) are excluded: they are not
+# part of the product users install and have no test suite by design.
+ignore:
+  - "tools/**"
+  - "benchmarks/**"
+
 coverage:
   status:
     project:


### PR DESCRIPTION
The first Codecov report came in at 76.36% while the scanner's real coverage is 80.1% (verified on a clean clone, CI conditions). The gap: the coverage profile includes dev-side utilities (`tools/` intel data-pipeline scripts, `benchmarks/` harness) that never ship in the binary and have no test suite by design, all counting as 0%.

This excludes those paths in `codecov.yml` so the badge reflects the product users install. No workflow changes; statuses remain informational-only.