### PR TITLE
Cover the CLI writers, clean helpers, and discover redaction

### DIFF
--- a/cmd/aguara/commands/terminal_writers_test.go
+++ b/cmd/aguara/commands/terminal_writers_test.go
@@ -1,0 +1,350 @@
+package commands
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/garagon/aguara/internal/packagecheck"
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/garagon/aguara/internal/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests cover the terminal writers and pure CLI helpers that
+// scanToFile-style tests cannot reach: the writers print via fmt to
+// os.Stdout (not cobra's SetOut), so they use captureStdout from
+// status_test.go. All of them call resetFlags() first because the
+// writers read package-level flag vars.
+
+func TestCheckFailOnThresholdFindings(t *testing.T) {
+	resetFlags()
+
+	// No --fail-on set: never gates.
+	flagFailOn = ""
+	require.NoError(t, checkFailOnThresholdFindings([]scanner.Finding{{Severity: scanner.SeverityCritical}}))
+
+	// Invalid threshold: explicit error, never a silent pass.
+	flagFailOn = "critcal" // intentional typo
+	err := checkFailOnThresholdFindings(nil)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "invalid --fail-on")
+
+	// Below the gate.
+	flagFailOn = "critical"
+	require.NoError(t, checkFailOnThresholdFindings([]scanner.Finding{{Severity: scanner.SeverityHigh}}))
+
+	// At the gate: trips with ErrThresholdExceeded.
+	err = checkFailOnThresholdFindings([]scanner.Finding{{Severity: scanner.SeverityCritical}})
+	require.ErrorIs(t, err, ErrThresholdExceeded)
+
+	// The ScanResult wrapper delegates to the findings gate.
+	err = checkFailOnThreshold(&scanner.ScanResult{Findings: []types.Finding{{Severity: scanner.SeverityCritical}}})
+	require.ErrorIs(t, err, ErrThresholdExceeded)
+
+	resetFlags()
+}
+
+func TestTopScanRule(t *testing.T) {
+	assert.Equal(t, "", topScanRule(nil))
+	assert.Equal(t, "HIGH_RULE", topScanRule([]scanner.Finding{
+		{RuleID: "LOW_RULE", Severity: scanner.SeverityLow},
+		{RuleID: "HIGH_RULE", Severity: scanner.SeverityHigh},
+		{RuleID: "MED_RULE", Severity: scanner.SeverityMedium},
+	}))
+}
+
+func TestSingleEcoEnvLabel(t *testing.T) {
+	cases := map[string]string{
+		ecoPython:   "Python environment",
+		ecoNPM:      "npm dependencies",
+		"":          "",
+		"multi-eco": "",
+	}
+	for token, want := range cases {
+		got := singleEcoEnvLabel(token)
+		if want == "" {
+			assert.Equal(t, "", got, "token %q", token)
+		} else {
+			assert.Equal(t, want, got, "token %q", token)
+		}
+	}
+	// Every packagecheck ecosystem must produce a non-empty label so
+	// the terminal header never renders an empty slot.
+	for _, token := range []string{ecoGo, ecoCargo, ecoComposer, ecoRuby, ecoMaven, ecoNuGet} {
+		assert.NotEmpty(t, singleEcoEnvLabel(token), "token %q", token)
+	}
+}
+
+func TestEcosystemFindingText(t *testing.T) {
+	hit := packagecheck.Hit{
+		Ref:    packagecheck.PackageRef{Name: "evil-pkg", Version: "1.2.3"},
+		Record: intel.Record{ID: "MAL-2026-0001"},
+	}
+	// Every ecosystem token must yield a title naming the package and
+	// a remediation the user can act on; no token may fall through to
+	// an empty pair.
+	for _, token := range []string{ecoGo, ecoCargo, ecoComposer, ecoRuby, ecoMaven, ecoNuGet, ecoNPM, ecoPython} {
+		title, remediation := ecosystemFindingText(token, hit)
+		assert.Contains(t, title, "evil-pkg", "token %q", token)
+		assert.Contains(t, title, "MAL-2026-0001", "token %q", token)
+		assert.NotEmpty(t, remediation, "token %q", token)
+	}
+}
+
+func TestIntelSourceLabel(t *testing.T) {
+	cases := map[string]string{
+		"embedded":       "embedded",
+		"local":          "local",
+		"local-verified": "local verified",
+		"remote-fresh":   "remote (fresh)",
+		"":               "embedded",
+		"future-mode":    "future-mode",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, intelSourceLabel(in), "snapshot %q", in)
+	}
+}
+
+func TestPrintIntelFreshnessWritesStdout(t *testing.T) {
+	resetFlags()
+	fetch, restore := captureStdout(t)
+	defer restore()
+
+	printIntelFreshness(incident.IntelSummary{
+		Snapshot:    "embedded",
+		GeneratedAt: time.Now().Add(-48 * time.Hour),
+		AgeDays:     2,
+	}, false)
+
+	out := fetch()
+	require.Contains(t, out, "embedded", "non-CI mode must print the provenance line to stdout")
+}
+
+func TestApplyAuditCIDefaults(t *testing.T) {
+	resetFlags()
+	t.Setenv("NO_COLOR", "")
+
+	// --ci implies --fail-on critical and no color.
+	flagAuditCI = true
+	applyAuditCIDefaults()
+	assert.Equal(t, "critical", flagAuditFailOn)
+	assert.True(t, flagNoColor)
+
+	// An explicit --fail-on wins over the CI default.
+	resetFlags()
+	flagAuditCI = true
+	flagAuditFailOn = "warning"
+	applyAuditCIDefaults()
+	assert.Equal(t, "warning", flagAuditFailOn)
+
+	// NO_COLOR alone disables color without touching the gate.
+	resetFlags()
+	t.Setenv("NO_COLOR", "1")
+	applyAuditCIDefaults()
+	assert.True(t, flagNoColor)
+	assert.Empty(t, flagAuditFailOn)
+
+	resetFlags()
+}
+
+func TestWriteAuditTerminal(t *testing.T) {
+	resetFlags()
+	flagNoColor = true
+
+	// Clean pass: OK lines plus a green verdict, no Next hint.
+	clean := stubAuditResult(t, 0, 0, 0, 0, 0, 0)
+	clean.Target = "/tmp/clean"
+	v, err := computeAuditVerdict(clean, "critical")
+	require.NoError(t, err)
+	clean.Verdict = v
+
+	fetch, restore := captureStdout(t)
+	require.NoError(t, writeAuditTerminal(clean))
+	restore()
+	out := fetch()
+	require.Contains(t, out, "AGUARA AUDIT")
+	require.Contains(t, out, "Target: /tmp/clean")
+	require.Contains(t, out, "No known-compromised packages")
+	require.Contains(t, out, "No content findings")
+	require.Contains(t, out, "Verdict: PASS")
+	require.NotContains(t, out, "Next: aguara explain")
+
+	// Findings on both sides + threshold exceeded: red verdict path,
+	// capped scan listing, Next hint from the top rule.
+	resetFlags()
+	flagNoColor = true
+	bad := stubAuditResult(t, 1, 1, 1, 0, 0, 0)
+	bad.Target = "/tmp/bad"
+	bad.Check.Findings[0].Title = "evil-pkg 1.0.0 is a known compromised package"
+	bad.Check.Findings[0].Path = "/tmp/bad/node_modules/evil-pkg"
+	bad.Scan.Findings[0].RuleID = "SUPPLY_003"
+	bad.Scan.Findings[0].RuleName = "Download-and-execute"
+	v, err = computeAuditVerdict(bad, "critical")
+	require.NoError(t, err)
+	bad.Verdict = v
+
+	fetch, restore = captureStdout(t)
+	require.NoError(t, writeAuditTerminal(bad))
+	restore()
+	out = fetch()
+	require.Contains(t, out, "evil-pkg 1.0.0")
+	require.Contains(t, out, "SUPPLY_003")
+	require.Contains(t, out, "Verdict: FAIL")
+	require.Contains(t, out, "Next: aguara explain SUPPLY_003")
+
+	resetFlags()
+}
+
+func TestWriteAuditTerminalCapsScanListing(t *testing.T) {
+	resetFlags()
+	flagNoColor = true
+
+	res := stubAuditResult(t, 0, 0, 0, 0, 0, 0)
+	res.Target = "/tmp/noisy"
+	for i := 0; i < 15; i++ {
+		res.Scan.Findings = append(res.Scan.Findings,
+			types.Finding{RuleID: "LOW_RULE", Severity: scanner.SeverityLow})
+	}
+	v, err := computeAuditVerdict(res, "critical")
+	require.NoError(t, err)
+	res.Verdict = v
+
+	fetch, restore := captureStdout(t)
+	require.NoError(t, writeAuditTerminal(res))
+	restore()
+	out := fetch()
+	require.Contains(t, out, "+5 more", "listing must cap at 10 without --verbose")
+
+	// --verbose lifts the cap.
+	resetFlags()
+	flagNoColor = true
+	flagAuditVerbose = true
+	fetch, restore = captureStdout(t)
+	require.NoError(t, writeAuditTerminal(res))
+	restore()
+	require.NotContains(t, fetch(), "+5 more")
+
+	resetFlags()
+}
+
+func TestWriteCheckTerminal(t *testing.T) {
+	resetFlags()
+	flagNoColor = true
+
+	// Empty result: OK line, no findings sections.
+	fetch, restore := captureStdout(t)
+	require.NoError(t, writeCheckTerminal(&incident.CheckResult{}, checkPlan{}))
+	restore()
+	out := fetch()
+	require.Contains(t, out, "AGUARA CHECK")
+	require.Contains(t, out, "No known-compromised packages")
+
+	// Findings + at-risk credentials: full sections render.
+	res := &incident.CheckResult{
+		Environment:  "test-env",
+		PackagesRead: 3,
+		Findings: []incident.Finding{{
+			Severity: incident.SevCritical,
+			Title:    "evil-pkg 1.0.0 is a known compromised package",
+			Path:     "/tmp/x/node_modules/evil-pkg",
+			Detail:   "matched intel record MAL-2026-0001",
+		}},
+		Credentials: []incident.CredentialFile{{
+			Path: "~/.npmrc", Exists: true, Guidance: "rotate npm tokens",
+		}},
+	}
+	fetch, restore = captureStdout(t)
+	require.NoError(t, writeCheckTerminal(res, checkPlan{}))
+	restore()
+	out = fetch()
+	require.Contains(t, out, "evil-pkg 1.0.0")
+	require.Contains(t, out, "CREDENTIALS AT RISK")
+	require.Contains(t, out, "ACTION REQUIRED")
+
+	resetFlags()
+}
+
+func TestWriteCleanJSONToFile(t *testing.T) {
+	resetFlags()
+	out := filepath.Join(t.TempDir(), "clean.json")
+	flagOutput = out
+
+	res := &incident.CleanResult{
+		QuarantineDir: "/tmp/q",
+		DryRun:        true,
+		Actions: []incident.CleanAction{
+			{Type: "delete", Target: "/tmp/x/evil.pth", Done: true},
+		},
+	}
+	require.NoError(t, writeCleanJSON(res))
+
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	var decoded incident.CleanResult
+	require.NoError(t, json.Unmarshal(data, &decoded))
+	assert.True(t, decoded.DryRun)
+	require.Len(t, decoded.Actions, 1)
+	assert.Equal(t, "delete", decoded.Actions[0].Type)
+
+	resetFlags()
+}
+
+func TestWriteCleanTerminal(t *testing.T) {
+	resetFlags()
+	flagNoColor = true
+
+	res := &incident.CleanResult{
+		QuarantineDir: "/tmp/q",
+		Actions: []incident.CleanAction{
+			{Type: "delete", Target: "/tmp/x/evil.pth", Done: true},
+			{Type: "uninstall", Target: "evil-pkg", Error: "pip not found"},
+			{Type: "disable", Target: "evil.service", Done: false},
+		},
+	}
+	fetch, restore := captureStdout(t)
+	require.NoError(t, writeCleanTerminal(res))
+	restore()
+	out := fetch()
+	require.Contains(t, out, "Cleaned 1/3 issues")
+	require.Contains(t, out, "pip not found")
+
+	resetFlags()
+}
+
+func TestRunCleanNoFindings(t *testing.T) {
+	resetFlags()
+	flagCheckPath = t.TempDir() // empty dir: nothing to clean
+
+	fetch, restore := captureStdout(t)
+	err := runClean(cleanCmd, nil)
+	restore()
+	require.NoError(t, err)
+	require.Contains(t, fetch(), "No compromised packages")
+
+	resetFlags()
+}
+
+func TestWriteAuditTerminalStrings(t *testing.T) {
+	// Sanity: the writers must never emit the raw placeholder used by
+	// redaction as a formatting artifact.
+	resetFlags()
+	flagNoColor = true
+	res := stubAuditResult(t, 0, 0, 0, 0, 0, 0)
+	v, err := computeAuditVerdict(res, "critical")
+	require.NoError(t, err)
+	res.Verdict = v
+
+	fetch, restore := captureStdout(t)
+	require.NoError(t, writeAuditTerminal(res))
+	restore()
+	assert.False(t, strings.Contains(fetch(), "%!"), "no fmt formatting artifacts")
+
+	resetFlags()
+}

--- a/discover/discover_test.go
+++ b/discover/discover_test.go
@@ -669,3 +669,113 @@ func TestClientDisplayName_AllClients(t *testing.T) {
 		}
 	}
 }
+
+func TestRedactEnvMasksSensitiveKeys(t *testing.T) {
+	in := map[string]string{
+		"API_KEY":       "sk-123",
+		"GITHUB_TOKEN":  "ghp_x",
+		"DB_PASSWORD":   "hunter2",
+		"MY_SECRET_URL": "https://internal",
+		"AUTH_HEADER":   "Bearer x",
+		"PRIVATE_KEY":   "-----BEGIN",
+		"MY_CREDENTIAL": "x",
+		"PLAIN_SETTING": "visible",
+		"TIMEOUT_MS":    "3000",
+		"lowercase_key": "also-masked",
+	}
+	out := redactEnv(in)
+	for k, v := range out {
+		switch k {
+		case "PLAIN_SETTING", "TIMEOUT_MS":
+			if v == "***REDACTED***" {
+				t.Errorf("%s must stay visible, got redacted", k)
+			}
+		default:
+			if v != "***REDACTED***" {
+				t.Errorf("%s must be redacted, got %q", k, v)
+			}
+		}
+	}
+	if len(out) != len(in) {
+		t.Errorf("redactEnv changed map size: %d != %d", len(out), len(in))
+	}
+	// Original map must be untouched.
+	if in["API_KEY"] != "sk-123" {
+		t.Error("redactEnv mutated its input")
+	}
+	// Empty map short-circuits.
+	if got := redactEnv(nil); got != nil {
+		t.Errorf("redactEnv(nil) = %v, want nil", got)
+	}
+}
+
+func TestResultRedacted(t *testing.T) {
+	r := &Result{Clients: []ClientResult{{
+		Client: "cursor",
+		Path:   "/tmp/mcp.json",
+		Servers: []MCPServer{{
+			Name:    "srv",
+			Command: "npx",
+			Env:     map[string]string{"API_KEY": "sk-123", "MODE": "prod"},
+		}},
+	}}}
+
+	red := r.Redacted()
+	if got := red.Clients[0].Servers[0].Env["API_KEY"]; got != "***REDACTED***" {
+		t.Errorf("API_KEY = %q, want redacted", got)
+	}
+	if got := red.Clients[0].Servers[0].Env["MODE"]; got != "prod" {
+		t.Errorf("MODE = %q, want prod", got)
+	}
+	// The source result keeps the secret (redaction is copy-on-write).
+	if got := r.Clients[0].Servers[0].Env["API_KEY"]; got != "sk-123" {
+		t.Errorf("Redacted mutated the source: %q", got)
+	}
+}
+
+func TestScanWithTempHome(t *testing.T) {
+	// Point HOME at a temp dir with a single cursor config so Scan
+	// exercises the real KnownClients walk without touching the
+	// machine's actual configs. Only asserts on the cursor entry:
+	// other clients simply find nothing under the temp HOME.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, ".config"))
+
+	cursorDir := filepath.Join(home, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeTestConfig(t, cursorDir, "mcp.json", map[string]mcpServerJSON{
+		"scanner": {Command: "npx", Args: []string{"-y", "some-mcp"}, Env: map[string]string{"API_KEY": "sk-1"}},
+	})
+
+	result, err := Scan()
+	if err != nil {
+		t.Fatalf("Scan failed: %v", err)
+	}
+	var cursor *ClientResult
+	for i := range result.Clients {
+		if result.Clients[i].Client == "cursor" {
+			cursor = &result.Clients[i]
+		}
+	}
+	if cursor == nil {
+		t.Fatalf("cursor config not discovered; clients: %+v", result.Clients)
+	}
+	if len(cursor.Servers) != 1 || cursor.Servers[0].Name != "scanner" {
+		t.Fatalf("unexpected servers: %+v", cursor.Servers)
+	}
+
+	// AllServers flattens with the client name attached.
+	all := result.AllServers()
+	found := false
+	for _, s := range all {
+		if s.Client == "cursor" && s.Server.Name == "scanner" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("AllServers missing the cursor/scanner entry")
+	}
+}

--- a/internal/incident/cleaner_test.go
+++ b/internal/incident/cleaner_test.go
@@ -100,3 +100,85 @@ func TestCleanActionTypes(t *testing.T) {
 	assert.True(t, types["uninstall"], "should have uninstall action for compromised package")
 	assert.True(t, types["delete"], "should have delete action for malicious .pth")
 }
+
+func TestQuarantineFileMovesIntoQuarantine(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "evil.pth")
+	require.NoError(t, os.WriteFile(src, []byte("payload"), 0644))
+	q := filepath.Join(dir, "quarantine")
+
+	ok, errMsg := quarantineFile(src, q)
+	require.True(t, ok, errMsg)
+
+	_, err := os.Stat(src)
+	assert.True(t, os.IsNotExist(err), "source must be gone after quarantine")
+	data, err := os.ReadFile(filepath.Join(q, "evil.pth"))
+	require.NoError(t, err)
+	assert.Equal(t, "payload", string(data))
+}
+
+func TestQuarantineFileMissingSource(t *testing.T) {
+	dir := t.TempDir()
+	ok, errMsg := quarantineFile(filepath.Join(dir, "does-not-exist.pth"), filepath.Join(dir, "q"))
+	assert.False(t, ok)
+	assert.NotEmpty(t, errMsg)
+}
+
+func TestQuarantineDirMovesDirectory(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "evil-pkg")
+	require.NoError(t, os.MkdirAll(src, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(src, "index.js"), []byte("x"), 0644))
+	q := filepath.Join(dir, "quarantine")
+
+	ok, errMsg := quarantineDir(src, q)
+	require.True(t, ok, errMsg)
+
+	_, err := os.Stat(src)
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(q, "evil-pkg", "index.js"))
+	assert.NoError(t, err)
+}
+
+func TestQuarantineDirMissingSource(t *testing.T) {
+	dir := t.TempDir()
+	ok, errMsg := quarantineDir(filepath.Join(dir, "nope"), filepath.Join(dir, "q"))
+	assert.False(t, ok)
+	assert.NotEmpty(t, errMsg)
+}
+
+func TestRemoveFileHelper(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "victim.txt")
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0644))
+
+	ok, errMsg := removeFile(path)
+	require.True(t, ok, errMsg)
+	_, err := os.Stat(path)
+	assert.True(t, os.IsNotExist(err))
+
+	ok, errMsg = removeFile(path)
+	assert.False(t, ok, "second removal must report the miss")
+	assert.NotEmpty(t, errMsg)
+}
+
+func TestUninstallPackageWithoutTools(t *testing.T) {
+	// With an empty PATH neither uv nor pip resolve, so the helper
+	// must fail with the documented message instead of hanging or
+	// executing anything.
+	t.Setenv("PATH", t.TempDir())
+	ok, errMsg := uninstallPackage("evil-pkg")
+	assert.False(t, ok)
+	assert.Contains(t, errMsg, "neither pip nor uv found")
+}
+
+func TestDisableServiceWithoutSystemctl(t *testing.T) {
+	// systemctl is absent from an empty PATH (and from macOS hosts);
+	// the helper must report failure, not panic. Note the message is
+	// empty in this path: CombinedOutput fails before producing any
+	// output and the helper only relays command output, not the exec
+	// error itself.
+	t.Setenv("PATH", t.TempDir())
+	ok, _ := disableService("evil.service")
+	assert.False(t, ok)
+}


### PR DESCRIPTION
Closes the real coverage gap behind the badge work: the packages users touch most (CLI commands, incident cleanup, MCP discovery) had the lowest test coverage in the repo.

## What's covered now

- **Terminal writers** (`check`, `audit`, `clean`): rendered output asserted via stdout capture - verdict lines, severity sections, the 10-finding listing cap and its `--verbose` lift, credentials-at-risk and action-required sections.
- **Gates and defaults**: the `--fail-on` threshold gate (including the invalid-value error path that must never silently pass) and `--ci` implying `--fail-on critical` + `NO_COLOR`.
- **Pure helpers**: per-ecosystem finding text (all 8 ecosystems must name the package, the advisory ID, and an actionable remediation), intel freshness labels, top-rule hint.
- **Incident clean helpers**: quarantine file/dir moves and their missing-source error paths in temp dirs; `uninstallPackage`/`disableService` exercised with an isolated PATH so no real package manager is ever invoked.
- **Discover**: env redaction (sensitive keys masked, copy-on-write, size preserved), `Redacted()`, and a real `Scan()` walk against a temp `HOME` with a cursor config.

## Coverage impact

| Package | Before | After |
|---|---|---|
| `cmd/aguara/commands` | 66.3% | 78.3% |
| `internal/incident` | 72.7% | 77.2% |
| `discover` | 73.8% | 89.4% |
| **Total** | **80.2%** | **82.4%** |

Full suite green with `-race`, lint clean. Test-only change: no production code touched.