### PR TITLE
Add agent handoff guidance to audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
   next steps for humans, CI dashboards, and agent workflows. The
   existing `verdict.status`, `threshold_exceeded`, and exit-code
   behavior are unchanged.
+- `aguara audit` now also emits agent handoff guidance derived from
+  triage, with explicit `allowed`, `review_only`, or `blocked` status
+  plus allowed and blocked actions for agent workflows. This gives AI
+  coding tools a safer pre-execution contract without changing scan
+  findings, gates, or exit codes.
 - README positioning now leads with when to run Aguara - before
   install, before CI, or before handing a repo to an AI coding agent -
   and adds a short "When to Use Aguara" section mapping real trust

--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -78,6 +78,7 @@ type AuditResult struct {
 	Scan    *scanner.ScanResult   `json:"scan"`
 	Verdict AuditVerdict          `json:"verdict"`
 	Triage  AuditTriage           `json:"triage"`
+	Handoff AuditAgentHandoff     `json:"agent_handoff"`
 	Intel   incident.IntelSummary `json:"intel"`
 }
 
@@ -111,6 +112,16 @@ type AuditTriageReason struct {
 	Kind     string `json:"kind"`
 	Severity string `json:"severity"`
 	Message  string `json:"message"`
+}
+
+// AuditAgentHandoff translates the triage decision into guidance for AI coding
+// agents and other automation that might otherwise install, test, build, or run
+// project-defined commands immediately after cloning a repository.
+type AuditAgentHandoff struct {
+	Status         string   `json:"status"` // "allowed" | "review_only" | "blocked"
+	Summary        string   `json:"summary"`
+	AllowedActions []string `json:"allowed_actions"`
+	BlockedActions []string `json:"blocked_actions"`
 }
 
 func runAudit(cmd *cobra.Command, args []string) error {
@@ -217,6 +228,7 @@ func runAudit(cmd *cobra.Command, args []string) error {
 	}
 	result.Verdict = verdict
 	result.Triage = computeAuditTriage(result)
+	result.Handoff = computeAuditAgentHandoff(result.Triage)
 
 	// 4. Emit.
 	if flagFormat == "json" {
@@ -474,6 +486,48 @@ func hasAnyFindings(result *AuditResult) bool {
 	return len(result.Check.Findings) > 0 || len(result.Scan.Findings) > 0
 }
 
+func computeAuditAgentHandoff(triage AuditTriage) AuditAgentHandoff {
+	switch triage.Decision {
+	case "stop":
+		return AuditAgentHandoff{
+			Status:  "blocked",
+			Summary: "Do not hand this repository to an agent for execution yet.",
+			AllowedActions: []string{
+				"Inspect files and lockfiles.",
+				"Explain Aguara findings.",
+				"Propose remediation patches.",
+			},
+			BlockedActions: []string{
+				"Do not run package install scripts.",
+				"Do not run build, test, CI, or project automation.",
+				"Do not execute project-defined agent hooks or tools.",
+			},
+		}
+	case "review":
+		return AuditAgentHandoff{
+			Status:  "review_only",
+			Summary: "Limit agent work to inspection and remediation until findings are reviewed.",
+			AllowedActions: []string{
+				"Inspect source, lockfiles, configs, and findings.",
+				"Explain risk and propose patches.",
+				"Edit files only when a reviewer approves the trust decision.",
+			},
+			BlockedActions: []string{
+				"Do not run install, build, test, or project automation until review is complete.",
+				"Do not accept agent or MCP configuration from this repository as trusted yet.",
+			},
+		}
+	default:
+		return AuditAgentHandoff{
+			Status:  "allowed",
+			Summary: "No audit finding requires limiting agent handoff.",
+			AllowedActions: []string{
+				"Proceed with normal agent workflow under the repository owner's policy.",
+			},
+		}
+	}
+}
+
 func writeAuditJSON(result *AuditResult) error {
 	w := os.Stdout
 	if flagOutput != "" {
@@ -583,6 +637,28 @@ func writeAuditTerminal(result *AuditResult) error {
 		}
 		if len(result.Triage.RecommendedNextSteps) > 0 {
 			fmt.Printf("  %s\n", st.Dim("Next: "+result.Triage.RecommendedNextSteps[0]))
+		}
+	}
+
+	if result.Handoff.Status != "" {
+		var handoffLine string
+		switch result.Handoff.Status {
+		case "blocked":
+			handoffLine = st.SeverityIcon("CRITICAL") + " " + st.RedBold("Agent handoff: BLOCKED")
+		case "review_only":
+			handoffLine = st.SeverityIcon("MEDIUM") + " " + st.Yellow(st.Bold("Agent handoff: REVIEW ONLY"))
+		default:
+			handoffLine = st.Green(st.Bold("✔ Agent handoff: ALLOWED"))
+		}
+		fmt.Printf("  %s\n", handoffLine)
+		if result.Handoff.Summary != "" {
+			fmt.Printf("  %s\n", st.Dim(result.Handoff.Summary))
+		}
+		if len(result.Handoff.AllowedActions) > 0 {
+			fmt.Printf("  %s\n", st.Dim("Allowed: "+result.Handoff.AllowedActions[0]))
+		}
+		if len(result.Handoff.BlockedActions) > 0 {
+			fmt.Printf("  %s\n", st.Dim("Blocked: "+result.Handoff.BlockedActions[0]))
 		}
 	}
 

--- a/cmd/aguara/commands/audit_test.go
+++ b/cmd/aguara/commands/audit_test.go
@@ -58,6 +58,7 @@ func TestAuditCleanProject(t *testing.T) {
 	require.Equal(t, "pass", result.Verdict.Status)
 	require.False(t, result.Verdict.ThresholdExceeded)
 	require.Equal(t, "proceed", result.Triage.Decision)
+	require.Equal(t, "allowed", result.Handoff.Status)
 	require.Empty(t, result.Check.Findings)
 }
 
@@ -91,6 +92,8 @@ func TestAuditDetectsCompromisedNPMPackage(t *testing.T) {
 	require.Equal(t, "stop", result.Triage.Decision,
 		"triage answers whether to trust this repo now, independently from default audit exit policy")
 	requireTriageReason(t, result.Triage, "known_malicious_package")
+	require.Equal(t, "blocked", result.Handoff.Status)
+	require.NotEmpty(t, result.Handoff.BlockedActions)
 }
 
 func TestAuditCIFailsOnCritical(t *testing.T) {
@@ -350,6 +353,57 @@ func TestAuditTriageDocumentsBaselineVisibility(t *testing.T) {
 	got := computeAuditTriage(result)
 	require.Equal(t, "review", got.Decision)
 	requireTriageReason(t, got, "baseline_existing_findings")
+}
+
+func TestAuditAgentHandoffTable(t *testing.T) {
+	cases := []struct {
+		name          string
+		decision      string
+		wantStatus    string
+		wantAllowed   bool
+		wantBlocked   bool
+		summaryNeedle string
+	}{
+		{
+			name:          "proceed allows normal handoff",
+			decision:      "proceed",
+			wantStatus:    "allowed",
+			wantAllowed:   true,
+			summaryNeedle: "No audit finding",
+		},
+		{
+			name:          "review limits handoff to review only",
+			decision:      "review",
+			wantStatus:    "review_only",
+			wantAllowed:   true,
+			wantBlocked:   true,
+			summaryNeedle: "Limit agent work",
+		},
+		{
+			name:          "stop blocks execution handoff",
+			decision:      "stop",
+			wantStatus:    "blocked",
+			wantAllowed:   true,
+			wantBlocked:   true,
+			summaryNeedle: "Do not hand",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeAuditAgentHandoff(AuditTriage{Decision: tc.decision})
+			require.Equal(t, tc.wantStatus, got.Status)
+			require.Contains(t, got.Summary, tc.summaryNeedle)
+			if tc.wantAllowed {
+				require.NotEmpty(t, got.AllowedActions)
+			}
+			if tc.wantBlocked {
+				require.NotEmpty(t, got.BlockedActions)
+			} else {
+				require.Empty(t, got.BlockedActions)
+			}
+		})
+	}
 }
 
 // stubAuditResult builds a minimal AuditResult with the requested

--- a/cmd/aguara/commands/terminal_writers_test.go
+++ b/cmd/aguara/commands/terminal_writers_test.go
@@ -165,6 +165,7 @@ func TestWriteAuditTerminal(t *testing.T) {
 	require.NoError(t, err)
 	clean.Verdict = v
 	clean.Triage = computeAuditTriage(clean)
+	clean.Handoff = computeAuditAgentHandoff(clean.Triage)
 
 	fetch, restore := captureStdout(t)
 	require.NoError(t, writeAuditTerminal(clean))
@@ -176,6 +177,7 @@ func TestWriteAuditTerminal(t *testing.T) {
 	require.Contains(t, out, "No content findings")
 	require.Contains(t, out, "Verdict: PASS")
 	require.Contains(t, out, "Triage: PROCEED")
+	require.Contains(t, out, "Agent handoff: ALLOWED")
 	require.NotContains(t, out, "Next: aguara explain")
 
 	// Findings on both sides + threshold exceeded: red verdict path,
@@ -192,6 +194,7 @@ func TestWriteAuditTerminal(t *testing.T) {
 	require.NoError(t, err)
 	bad.Verdict = v
 	bad.Triage = computeAuditTriage(bad)
+	bad.Handoff = computeAuditAgentHandoff(bad.Triage)
 
 	fetch, restore = captureStdout(t)
 	require.NoError(t, writeAuditTerminal(bad))
@@ -201,6 +204,7 @@ func TestWriteAuditTerminal(t *testing.T) {
 	require.Contains(t, out, "SUPPLY_003")
 	require.Contains(t, out, "Verdict: FAIL")
 	require.Contains(t, out, "Triage: STOP")
+	require.Contains(t, out, "Agent handoff: BLOCKED")
 	require.Contains(t, out, "Next: aguara explain SUPPLY_003")
 
 	resetFlags()


### PR DESCRIPTION
What

Adds explicit agent handoff guidance to `aguara audit`.

The previous triage work answers the trust question: proceed, review, or stop. This PR turns that decision into instructions an AI coding agent, CI assistant, or automation layer can actually follow before it runs anything from a cloned repository.

Why

Aguara is used at the point where risk becomes operational: before install scripts run, before CI executes project automation, and before an agent inherits repo instructions, hooks, MCP config, or package-manager policy.

A human can read findings and decide what to do. An agent needs a narrower contract:

- can I inspect this repository?
- can I propose patches?
- can I run install/build/test?
- should I trust repo-shipped agent or MCP configuration?

This PR makes that contract explicit without changing the scanner's detection behavior.

What changed

`aguara audit` JSON now includes an additive `agent_handoff` block derived from triage:

- `allowed` when audit found no reason to limit the agent workflow
- `review_only` when the agent should inspect and propose remediation, but avoid execution until a reviewer understands the findings
- `blocked` when the agent should not execute repo-controlled commands because the audit found known-malicious packages, critical findings, or a failed gate

Terminal output also prints the handoff status below triage:

- `Agent handoff: ALLOWED`
- `Agent handoff: REVIEW ONLY`
- `Agent handoff: BLOCKED`

Each JSON result includes allowed and blocked actions so downstream tools do not need to invent their own policy from raw findings.

What did not change

- no new detection rules
- no severity changes
- no exit-code changes
- no `verdict.status` changes
- no change to check, scan, or SARIF contracts

Validation

- `go test ./cmd/aguara/commands`
- `go test -race ./cmd/aguara/commands`
- `go test ./...`
- `go build ./cmd/aguara`
- `make lint`
- manual JSON smoke with `event-stream@3.3.6`: `triage=stop`, `agent_handoff=blocked`
