### PR TITLE
Add machine-readable audit action plan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
   plus allowed and blocked actions for agent workflows. This gives AI
   coding tools a safer pre-execution contract without changing scan
   findings, gates, or exit codes.
+- `aguara audit` JSON now includes an additive `action_plan` block with
+  machine-readable permissions for install, execution, CI, repo agent
+  config, editing, and finding explanation. It is derived from triage
+  and agent handoff so wrappers and MCP clients can apply the same
+  trust decision without parsing prose.
 - README positioning now leads with when to run Aguara - before
   install, before CI, or before handing a repo to an AI coding agent -
   and adds a short "When to Use Aguara" section mapping real trust

--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -79,6 +79,7 @@ type AuditResult struct {
 	Verdict AuditVerdict          `json:"verdict"`
 	Triage  AuditTriage           `json:"triage"`
 	Handoff AuditAgentHandoff     `json:"agent_handoff"`
+	Plan    AuditActionPlan       `json:"action_plan"`
 	Intel   incident.IntelSummary `json:"intel"`
 }
 
@@ -122,6 +123,21 @@ type AuditAgentHandoff struct {
 	Summary        string   `json:"summary"`
 	AllowedActions []string `json:"allowed_actions"`
 	BlockedActions []string `json:"blocked_actions"`
+}
+
+// AuditActionPlan is a compact machine-readable contract for agents and
+// wrappers that need booleans instead of prose before they decide whether to
+// install dependencies, run tests, execute CI, or only inspect the repository.
+type AuditActionPlan struct {
+	TrustState             string   `json:"trust_state"` // "allowed" | "review_only" | "blocked"
+	CanInstallDependencies bool     `json:"can_install_dependencies"`
+	CanExecuteProjectCode  bool     `json:"can_execute_project_code"`
+	CanRunCI               bool     `json:"can_run_ci"`
+	CanUseRepoAgentConfig  bool     `json:"can_use_repo_agent_config"`
+	CanEditFiles           bool     `json:"can_edit_files"`
+	CanExplainFindings     bool     `json:"can_explain_findings"`
+	Priority               []string `json:"priority"`
+	NextCommands           []string `json:"next_commands"`
 }
 
 func runAudit(cmd *cobra.Command, args []string) error {
@@ -229,6 +245,7 @@ func runAudit(cmd *cobra.Command, args []string) error {
 	result.Verdict = verdict
 	result.Triage = computeAuditTriage(result)
 	result.Handoff = computeAuditAgentHandoff(result.Triage)
+	result.Plan = computeAuditActionPlan(result)
 
 	// 4. Emit.
 	if flagFormat == "json" {
@@ -528,6 +545,65 @@ func computeAuditAgentHandoff(triage AuditTriage) AuditAgentHandoff {
 	}
 }
 
+func computeAuditActionPlan(result *AuditResult) AuditActionPlan {
+	plan := AuditActionPlan{
+		TrustState:             "allowed",
+		CanInstallDependencies: true,
+		CanExecuteProjectCode:  true,
+		CanRunCI:               true,
+		CanUseRepoAgentConfig:  true,
+		CanEditFiles:           true,
+		CanExplainFindings:     true,
+	}
+	if result == nil {
+		return plan
+	}
+
+	switch result.Handoff.Status {
+	case "blocked":
+		plan.TrustState = "blocked"
+		plan.CanInstallDependencies = false
+		plan.CanExecuteProjectCode = false
+		plan.CanRunCI = false
+		plan.CanUseRepoAgentConfig = false
+	case "review_only":
+		plan.TrustState = "review_only"
+		plan.CanInstallDependencies = false
+		plan.CanExecuteProjectCode = false
+		plan.CanRunCI = false
+		plan.CanUseRepoAgentConfig = false
+	default:
+		plan.TrustState = "allowed"
+	}
+
+	plan.Priority = auditActionPriority(result.Triage)
+	plan.NextCommands = auditActionNextCommands(result)
+	return plan
+}
+
+func auditActionPriority(triage AuditTriage) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, r := range triage.Reasons {
+		if seen[r.Kind] {
+			continue
+		}
+		seen[r.Kind] = true
+		out = append(out, r.Kind)
+	}
+	return out
+}
+
+func auditActionNextCommands(result *AuditResult) []string {
+	if result == nil || result.Scan == nil {
+		return nil
+	}
+	if rule := topScanRule(result.Scan.Findings); rule != "" {
+		return []string{"aguara explain " + rule}
+	}
+	return nil
+}
+
 func writeAuditJSON(result *AuditResult) error {
 	w := os.Stdout
 	if flagOutput != "" {
@@ -660,6 +736,19 @@ func writeAuditTerminal(result *AuditResult) error {
 		if len(result.Handoff.BlockedActions) > 0 {
 			fmt.Printf("  %s\n", st.Dim("Blocked: "+result.Handoff.BlockedActions[0]))
 		}
+	}
+
+	if result.Plan.TrustState != "" {
+		execStatus := "yes"
+		installStatus := "yes"
+		if !result.Plan.CanExecuteProjectCode {
+			execStatus = "no"
+		}
+		if !result.Plan.CanInstallDependencies {
+			installStatus = "no"
+		}
+		fmt.Printf("  %s\n", st.Dim(fmt.Sprintf("Action plan: install=%s execute=%s trust_state=%s",
+			installStatus, execStatus, result.Plan.TrustState)))
 	}
 
 	if rule := topScanRule(result.Scan.Findings); rule != "" {

--- a/cmd/aguara/commands/audit_test.go
+++ b/cmd/aguara/commands/audit_test.go
@@ -59,6 +59,9 @@ func TestAuditCleanProject(t *testing.T) {
 	require.False(t, result.Verdict.ThresholdExceeded)
 	require.Equal(t, "proceed", result.Triage.Decision)
 	require.Equal(t, "allowed", result.Handoff.Status)
+	require.Equal(t, "allowed", result.Plan.TrustState)
+	require.True(t, result.Plan.CanInstallDependencies)
+	require.True(t, result.Plan.CanExecuteProjectCode)
 	require.Empty(t, result.Check.Findings)
 }
 
@@ -94,6 +97,11 @@ func TestAuditDetectsCompromisedNPMPackage(t *testing.T) {
 	requireTriageReason(t, result.Triage, "known_malicious_package")
 	require.Equal(t, "blocked", result.Handoff.Status)
 	require.NotEmpty(t, result.Handoff.BlockedActions)
+	require.Equal(t, "blocked", result.Plan.TrustState)
+	require.False(t, result.Plan.CanInstallDependencies)
+	require.False(t, result.Plan.CanExecuteProjectCode)
+	require.False(t, result.Plan.CanUseRepoAgentConfig)
+	require.Contains(t, result.Plan.Priority, "known_malicious_package")
 }
 
 func TestAuditCIFailsOnCritical(t *testing.T) {
@@ -401,6 +409,84 @@ func TestAuditAgentHandoffTable(t *testing.T) {
 				require.NotEmpty(t, got.BlockedActions)
 			} else {
 				require.Empty(t, got.BlockedActions)
+			}
+		})
+	}
+}
+
+func TestAuditActionPlanTable(t *testing.T) {
+	cases := []struct {
+		name        string
+		result      *AuditResult
+		decision    string
+		handoff     string
+		wantTrust   string
+		wantInstall bool
+		wantExec    bool
+		wantConfig  bool
+		wantExplain bool
+		ruleID      string
+		wantCommand string
+	}{
+		{
+			name:        "allowed can execute",
+			result:      stubAuditResult(t, 0, 0, 0, 0, 0, 0),
+			decision:    "proceed",
+			handoff:     "allowed",
+			wantTrust:   "allowed",
+			wantInstall: true,
+			wantExec:    true,
+			wantConfig:  true,
+			wantExplain: true,
+		},
+		{
+			name:        "review only blocks execution but allows explanation",
+			result:      stubAuditResult(t, 0, 1, 0, 1, 0, 0),
+			decision:    "review",
+			handoff:     "review_only",
+			wantTrust:   "review_only",
+			wantInstall: false,
+			wantExec:    false,
+			wantConfig:  false,
+			wantExplain: true,
+			ruleID:      "HIGH_RULE",
+			wantCommand: "aguara explain HIGH_RULE",
+		},
+		{
+			name:        "blocked prevents project execution",
+			result:      stubAuditResult(t, 1, 0, 1, 0, 0, 0),
+			decision:    "stop",
+			handoff:     "blocked",
+			wantTrust:   "blocked",
+			wantInstall: false,
+			wantExec:    false,
+			wantConfig:  false,
+			wantExplain: true,
+			ruleID:      "CRITICAL_RULE",
+			wantCommand: "aguara explain CRITICAL_RULE",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tc.result.Triage = AuditTriage{
+				Decision: tc.decision,
+				Reasons:  []AuditTriageReason{{Kind: "test_reason", Severity: "warning"}},
+			}
+			tc.result.Handoff = AuditAgentHandoff{Status: tc.handoff}
+			if len(tc.result.Scan.Findings) > 0 && tc.ruleID != "" {
+				tc.result.Scan.Findings[0].RuleID = tc.ruleID
+			}
+
+			got := computeAuditActionPlan(tc.result)
+			require.Equal(t, tc.wantTrust, got.TrustState)
+			require.Equal(t, tc.wantInstall, got.CanInstallDependencies)
+			require.Equal(t, tc.wantExec, got.CanExecuteProjectCode)
+			require.Equal(t, tc.wantConfig, got.CanUseRepoAgentConfig)
+			require.Equal(t, tc.wantExplain, got.CanExplainFindings)
+			require.Contains(t, got.Priority, "test_reason")
+			if tc.wantCommand != "" {
+				require.Contains(t, got.NextCommands, tc.wantCommand)
 			}
 		})
 	}

--- a/cmd/aguara/commands/terminal_writers_test.go
+++ b/cmd/aguara/commands/terminal_writers_test.go
@@ -166,6 +166,7 @@ func TestWriteAuditTerminal(t *testing.T) {
 	clean.Verdict = v
 	clean.Triage = computeAuditTriage(clean)
 	clean.Handoff = computeAuditAgentHandoff(clean.Triage)
+	clean.Plan = computeAuditActionPlan(clean)
 
 	fetch, restore := captureStdout(t)
 	require.NoError(t, writeAuditTerminal(clean))
@@ -178,6 +179,7 @@ func TestWriteAuditTerminal(t *testing.T) {
 	require.Contains(t, out, "Verdict: PASS")
 	require.Contains(t, out, "Triage: PROCEED")
 	require.Contains(t, out, "Agent handoff: ALLOWED")
+	require.Contains(t, out, "Action plan: install=yes execute=yes trust_state=allowed")
 	require.NotContains(t, out, "Next: aguara explain")
 
 	// Findings on both sides + threshold exceeded: red verdict path,
@@ -195,6 +197,7 @@ func TestWriteAuditTerminal(t *testing.T) {
 	bad.Verdict = v
 	bad.Triage = computeAuditTriage(bad)
 	bad.Handoff = computeAuditAgentHandoff(bad.Triage)
+	bad.Plan = computeAuditActionPlan(bad)
 
 	fetch, restore = captureStdout(t)
 	require.NoError(t, writeAuditTerminal(bad))
@@ -205,6 +208,7 @@ func TestWriteAuditTerminal(t *testing.T) {
 	require.Contains(t, out, "Verdict: FAIL")
 	require.Contains(t, out, "Triage: STOP")
 	require.Contains(t, out, "Agent handoff: BLOCKED")
+	require.Contains(t, out, "Action plan: install=no execute=no trust_state=blocked")
 	require.Contains(t, out, "Next: aguara explain SUPPLY_003")
 
 	resetFlags()


### PR DESCRIPTION
What

Adds a machine-readable `action_plan` block to `aguara audit`.

The last two PRs made audit easier for people to act on:

- `triage` answers whether the repository is `proceed`, `review`, or `stop`
- `agent_handoff` explains what an AI coding agent should or should not do

This PR turns that same decision into explicit booleans that wrappers, MCP clients, GitHub Actions, dashboards, and agent runtimes can consume without parsing prose.

Why

Aguara runs before trust is delegated: before install, before CI, and before an agent executes repo-controlled commands or accepts repo-shipped agent configuration.

At that point an integration needs a simple contract:

- can dependencies be installed?
- can project code run?
- can CI or tests run?
- can repo agent config be trusted?
- can the agent still inspect, explain, and propose patches?

`action_plan` answers those questions directly while keeping the existing audit contracts unchanged.

What changed

`aguara audit --format json` now includes:

- `action_plan.trust_state`
- `can_install_dependencies`
- `can_execute_project_code`
- `can_run_ci`
- `can_use_repo_agent_config`
- `can_edit_files`
- `can_explain_findings`
- `priority`
- `next_commands`

The terminal output also prints a compact action-plan line, for example:

`Action plan: install=no execute=no trust_state=blocked`

Behavior

- clean audit: install/execute/CI/config are allowed
- review-only audit: install/execute/CI/config are blocked, but edit/explain remain allowed
- blocked audit: install/execute/CI/config are blocked and priority reasons are exposed

What did not change

- no new detection rules
- no severity changes
- no exit-code changes
- no `verdict.status` changes
- no SARIF, check, or scan contract changes

Validation

- `go test ./cmd/aguara/commands`
- `go test -race ./cmd/aguara/commands`
- `go test ./...`
- `go build ./cmd/aguara`
- `make lint`
- manual JSON smokes for clean, review-only, and blocked repos
