### PR TITLE
Keep local scans offline by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+### Fixed
+
+- `aguara scan` no longer contacts GitHub Releases in the background to
+  check for a newer binary. Local scans now honor Aguara's offline-by-default
+  contract without requiring `--no-update-check`; threat-intel refresh remains
+  an explicit `aguara update` or `--fresh` operation.
+
 ### Changed
 
 - `aguara audit` JSON now includes an additive `triage` block with a

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -22,7 +22,6 @@ import (
 	"github.com/garagon/aguara/internal/scanner"
 	"github.com/garagon/aguara/internal/state"
 	"github.com/garagon/aguara/internal/types"
-	"github.com/garagon/aguara/internal/update"
 )
 
 var (
@@ -92,24 +91,6 @@ func runScan(cmd *cobra.Command, args []string) error {
 	}
 	if flagAuto {
 		return runAutoScan(cmd)
-	}
-
-	// Background update check
-	var updateMsg string
-	if !flagNoUpdateCheck {
-		done := make(chan struct{})
-		go func() {
-			defer close(done)
-			if r := update.CheckLatest(Version, "garagon/aguara"); r != nil && r.NeedsUpdate() {
-				updateMsg = fmt.Sprintf("\nUpdate available: %s → %s\n", r.Latest, r.UpdateURL)
-			}
-		}()
-		defer func() {
-			<-done
-			if updateMsg != "" {
-				fmt.Fprint(os.Stderr, updateMsg)
-			}
-		}()
 	}
 
 	targetPath := args[0]

--- a/cmd/aguara/commands/scan_test.go
+++ b/cmd/aguara/commands/scan_test.go
@@ -4,14 +4,25 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sync/atomic"
 	"testing"
 
 	"github.com/garagon/aguara/internal/intel"
 	"github.com/stretchr/testify/require"
 )
+
+type countingTransport struct {
+	calls atomic.Int32
+}
+
+func (t *countingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	t.calls.Add(1)
+	return nil, errors.New("unexpected network request")
+}
 
 // resetFlags resets all global flags to defaults between test runs.
 func resetFlags() {
@@ -82,6 +93,34 @@ func scanToFile(t *testing.T, args ...string) []byte {
 	data, err := os.ReadFile(outFile)
 	require.NoError(t, err)
 	return data
+}
+
+func TestScanDoesNotCheckForUpdatesOverNetwork(t *testing.T) {
+	resetFlags()
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "README.md"), []byte("# safe\n"), 0o600))
+	outFile := filepath.Join(t.TempDir(), "out.json")
+
+	transport := &countingTransport{}
+	previousTransport := http.DefaultTransport
+	previousVersion := Version
+	http.DefaultTransport = transport
+	Version = "0.27.0"
+
+	rootCmd.SetOut(new(bytes.Buffer))
+	rootCmd.SetErr(new(bytes.Buffer))
+	rootCmd.SetArgs([]string{"scan", dir, "--format", "json", "-o", outFile})
+	t.Cleanup(func() {
+		http.DefaultTransport = previousTransport
+		Version = previousVersion
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		resetFlags()
+	})
+
+	require.NoError(t, rootCmd.Execute())
+	require.Zero(t, transport.calls.Load(), "scan must not contact a release API")
 }
 
 func TestScanChangedFilesRejectsSymlink(t *testing.T) {


### PR DESCRIPTION
Aguara is designed to inspect an untrusted repository without sending its contents away or depending on a network service. `aguara scan` still made one background request to GitHub Releases to check whether a newer binary existed. It was not telemetry and did not include scan data, but it was hidden network egress during a command we describe as offline by default.

This change removes that release check from the scan path.

What changes:

- `aguara scan` performs no release lookup, even for a published binary running outside CI.
- Threat-intel network access remains explicit through `aguara update` or `--fresh`.
- Release discovery remains available when someone deliberately runs `aguara version`; the existing `--no-update-check` compatibility flag is unchanged.
- A transport-level regression test runs `scan` as a release build without `--no-update-check` and fails if any HTTP request is attempted.

Detection, threat-intel matching, output schemas, findings, and exit codes are unchanged. The practical result is simpler: cloning a repository and scanning it does not create an outbound request or wait on a release API.

Validation:

- `go test -race -count=1 ./...`
- `make build`
- `make vet`
- `make lint` (0 issues)
