### PR TITLE
Render WASM scan results as text

### DIFF
--- a/.github/workflows/wasm-ui.yml
+++ b/.github/workflows/wasm-ui.yml
@@ -1,0 +1,41 @@
+name: WASM UI
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "cmd/wasm/**"
+      - ".github/workflows/wasm-ui.yml"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: wasm-ui-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  browser:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    env:
+      GOMAXPROCS: "2"
+      GOMEMLIMIT: "768MiB"
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version: "1.25"
+      - uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+      - name: Install browser test dependencies
+        working-directory: cmd/wasm
+        run: |
+          npm ci --ignore-scripts --no-audit --no-fund
+          npx --no-install playwright install --with-deps chromium
+      - name: Build WASM
+        run: GOOS=js GOARCH=wasm go build -p 1 -trimpath -o "$RUNNER_TEMP/aguara.wasm" ./cmd/wasm
+      - name: Check rendering in Chromium
+        working-directory: cmd/wasm
+        run: AGUARA_WASM="$RUNNER_TEMP/aguara.wasm" AGUARA_WASM_EXEC="$(go env GOROOT)/lib/wasm/wasm_exec.js" npm test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- The bundled WebAssembly page now renders finding fields, summaries, and
+  errors as text instead of HTML. Match previews retain their 120-character
+  limit without shortening or splitting HTML entities during rendering.
 - Scans now return an error if a selected file cannot be read, an analyzer
   reports a failure, or directory discovery cannot complete. Partial findings
   are not presented as a successful report, including in `scan --auto`.

--- a/cmd/wasm/.gitignore
+++ b/cmd/wasm/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/cmd/wasm/README.md
+++ b/cmd/wasm/README.md
@@ -1,0 +1,34 @@
+# Browser rendering tests
+
+This directory contains the bundled WASM example and its browser tests. Node
+and Playwright are test dependencies only; the example has no new runtime
+dependency.
+
+From this directory, install the pinned test dependencies and Chromium:
+
+```sh
+npm ci --ignore-scripts --no-audit --no-fund
+npx --no-install playwright install chromium
+npm test
+```
+
+The renderer tests supply controlled JSON at the WASM boundary and verify text
+display, severity styles, scan options, errors, and tabs in Chromium. They block
+unexpected requests and check that hostile result fields create no HTML nodes
+or executable event handlers. Numeric-field cases are defensive rendering
+checks, not claims that Go emits those fields as strings.
+
+To include the real-engine integration test, build WASM from the repository
+root and provide the matching Go runtime script:
+
+```sh
+GOMAXPROCS=2 GOMEMLIMIT=768MiB GOOS=js GOARCH=wasm \
+  go build -p 1 -trimpath -o /tmp/aguara-ui-test.wasm ./cmd/wasm
+cd cmd/wasm
+AGUARA_WASM=/tmp/aguara-ui-test.wasm \
+  AGUARA_WASM_EXEC="$(go env GOROOT)/lib/wasm/wasm_exec.js" npm test
+```
+
+Without `AGUARA_WASM`, the integration test is explicitly skipped. The WASM UI
+workflow builds the binary and runs both test paths. Tests use one Chromium
+instance and run sequentially; they are not fuzzing, load tests, or benchmarks.

--- a/cmd/wasm/index.html
+++ b/cmd/wasm/index.html
@@ -95,15 +95,22 @@
     <script src="wasm_exec.js"></script>
     <script>
         const go = new Go();
-        const sevOrder = { critical: 4, high: 3, medium: 2, low: 1, info: 0 };
         const sevNames = ['info', 'low', 'medium', 'high', 'critical'];
+
+        // Scan results are data, including names and errors. Never parse them as HTML.
+        function textElement(tag, className, text) {
+            const element = document.createElement(tag);
+            element.className = className;
+            element.textContent = text;
+            return element;
+        }
 
         WebAssembly.instantiateStreaming(fetch("aguara.wasm"), go.importObject).then((result) => {
             go.run(result.instance);
             document.getElementById("scan").disabled = false;
             document.getElementById("scan").textContent = "Scan";
             document.getElementById("explain-btn").disabled = false;
-            document.getElementById("results").innerHTML = '<p class="loading">Ready. Paste content and click Scan.</p>';
+            document.getElementById("results").replaceChildren(textElement('p', 'loading', 'Ready. Paste content and click Scan.'));
             loadRuleList();
         });
 
@@ -126,7 +133,7 @@
             const severity = document.getElementById("severity").value;
             const profile = document.getElementById("profile").value;
 
-            resultsDiv.innerHTML = '<p class="loading">Scanning...</p>';
+            resultsDiv.replaceChildren(textElement('p', 'loading', 'Scanning...'));
 
             const opts = {};
             if (severity) opts.minSeverity = severity;
@@ -139,24 +146,31 @@
                 const parsed = JSON.parse(json);
 
                 if (parsed.findings && parsed.findings.length > 0) {
-                    const stats = `<div class="stats">${parsed.findings.length} finding${parsed.findings.length > 1 ? 's' : ''} - ${parsed.rules_loaded} rules - ${elapsed}s</div>`;
-                    const findings = parsed.findings
+                    const stats = textElement('div', 'stats', `${parsed.findings.length} finding${parsed.findings.length > 1 ? 's' : ''} - ${parsed.rules_loaded} rules - ${elapsed}s`);
+                    const findings = document.createDocumentFragment();
+                    findings.append(stats);
+                    parsed.findings
                         .sort((a, b) => (b.severity || 0) - (a.severity || 0))
-                        .map(f => {
-                            const sev = sevNames[f.severity] || 'info';
-                            return `<div class="finding ${sev}">
-                                <div class="finding-header">${f.rule_id}: ${f.rule_name}</div>
-                                <div class="finding-meta">${sev.toUpperCase()} - Line ${f.line} - ${f.category}</div>
-                                <div class="finding-meta">Match: <code>${escapeHtml(f.matched_text || '').substring(0, 120)}</code></div>
-                                ${f.remediation ? `<div class="finding-remediation">${escapeHtml(f.remediation)}</div>` : ''}
-                            </div>`;
-                        }).join('');
-                    resultsDiv.innerHTML = stats + findings;
+                        .forEach(f => {
+                            const sev = Number.isInteger(f.severity) && f.severity >= 0 && f.severity < sevNames.length
+                                ? sevNames[f.severity] : 'info';
+                            const finding = textElement('div', `finding ${sev}`, '');
+                            const match = textElement('div', 'finding-meta', 'Match: ');
+                            match.append(textElement('code', '', String(f.matched_text || '').substring(0, 120)));
+                            finding.append(
+                                textElement('div', 'finding-header', `${f.rule_id}: ${f.rule_name}`),
+                                textElement('div', 'finding-meta', `${sev.toUpperCase()} - Line ${f.line} - ${f.category}`),
+                                match
+                            );
+                            if (f.remediation) finding.append(textElement('div', 'finding-remediation', f.remediation));
+                            findings.append(finding);
+                        });
+                    resultsDiv.replaceChildren(findings);
                 } else {
-                    resultsDiv.innerHTML = `<div class="clean">No security issues found. (${parsed.rules_loaded} rules, ${elapsed}s)</div>`;
+                    resultsDiv.replaceChildren(textElement('div', 'clean', `No security issues found. (${parsed.rules_loaded} rules, ${elapsed}s)`));
                 }
             } catch (e) {
-                resultsDiv.innerHTML = `<p class="error">Error: ${escapeHtml(e.message)}</p>`;
+                resultsDiv.replaceChildren(textElement('p', 'error', `Error: ${e.message}`));
             }
         });
 
@@ -165,9 +179,9 @@
             try {
                 const rules = JSON.parse(aguaraListRules());
                 const listDiv = document.getElementById("rule-list");
-                listDiv.innerHTML = `<p class="stats">${rules.length} rules loaded</p>`;
+                listDiv.replaceChildren(textElement('p', 'stats', `${rules.length} rules loaded`));
             } catch (e) {
-                document.getElementById("rule-list").innerHTML = `<p class="error">${e.message}</p>`;
+                document.getElementById("rule-list").replaceChildren(textElement('p', 'error', e.message));
             }
         }
 
@@ -185,12 +199,6 @@
         document.getElementById("rule-id").addEventListener("keydown", (e) => {
             if (e.key === "Enter") document.getElementById("explain-btn").click();
         });
-
-        function escapeHtml(s) {
-            const div = document.createElement('div');
-            div.textContent = s;
-            return div.innerHTML;
-        }
     </script>
 </body>
 </html>

--- a/cmd/wasm/package-lock.json
+++ b/cmd/wasm/package-lock.json
@@ -1,0 +1,60 @@
+{
+  "name": "aguara-wasm-ui-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "aguara-wasm-ui-tests",
+      "devDependencies": {
+        "playwright": "1.62.1"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    }
+  }
+}

--- a/cmd/wasm/package.json
+++ b/cmd/wasm/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "aguara-wasm-ui-tests",
+  "private": true,
+  "scripts": {
+    "test": "node --test --test-concurrency=1 render.test.cjs"
+  },
+  "devDependencies": {
+    "playwright": "1.62.1"
+  }
+}

--- a/cmd/wasm/render.test.cjs
+++ b/cmd/wasm/render.test.cjs
@@ -1,0 +1,198 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const {before, after, test} = require('node:test');
+const {chromium} = require('playwright');
+
+const html = fs.readFileSync(path.join(__dirname, 'index.html'), 'utf8');
+const payload = '<img src="https://invalid.example/probe" onerror="window.executed=true"><svg onload="window.executed=true"></svg>';
+let browser;
+
+before(async () => { browser = await chromium.launch({headless: true}); });
+after(async () => { await browser?.close(); });
+
+async function withPage(run) {
+    const page = await browser.newPage();
+    const requests = [];
+    try {
+        // Exercise the shipped page at its JSON boundary; no engine mock changes
+        // the renderer. Network is intercepted to make injected requests observable.
+        await page.route('**/*', route => {
+            const url = new URL(route.request().url());
+            if (url.href === 'http://aguara.test/') {
+                return route.fulfill({contentType: 'text/html', body: html});
+            }
+            if (url.href === 'http://aguara.test/wasm_exec.js') {
+                return route.fulfill({contentType: 'application/javascript', body: 'window.Go = class { importObject = {}; run() {} };'});
+            }
+            requests.push(url.href);
+            return route.abort();
+        });
+        await page.addInitScript(() => {
+            WebAssembly.instantiateStreaming = async () => ({instance: {}});
+            window.fetch = async () => ({});
+            window.aguaraListRules = () => '[]';
+            window.aguaraExplainRule = () => JSON.stringify({id: 'TEST_001'});
+            window.aguaraScanContent = async (...args) => {
+                window.scanArgs = args;
+                if (window.scanError) throw new Error(window.scanError);
+                return JSON.stringify(window.scanResult || {findings: [], rules_loaded: 3});
+            };
+        });
+        await page.goto('http://aguara.test/');
+        await page.waitForFunction(() => !document.getElementById('scan').disabled);
+        await run(page);
+        assert.equal(await page.evaluate(() => window.executed === true), false);
+        assert.equal(await page.locator('#results img, #results svg, #rule-list img, #rule-list svg').count(), 0);
+        assert.deepEqual(requests, []);
+    } finally {
+        await page.close();
+    }
+}
+
+async function scan(page, result) {
+    await page.evaluate(value => { window.scanResult = value; }, result);
+    await page.locator('#content').fill('Sample content');
+    await page.locator('#scan').click();
+    await page.waitForFunction(() => !document.getElementById('results').textContent.includes('Scanning...'));
+}
+
+function finding(overrides = {}) {
+    return {rule_id: 'TEST_001', rule_name: 'Test finding', severity: 3, line: 7,
+        category: 'prompt-injection', matched_text: 'sample', ...overrides};
+}
+
+for (const field of ['rule_id', 'rule_name', 'category', 'line', 'matched_text', 'remediation']) {
+    test(`${field} is rendered as literal text`, async () => {
+        await withPage(async page => {
+            await scan(page, {findings: [finding({[field]: payload})], rules_loaded: 3});
+            const expected = field === 'matched_text' ? payload.slice(0, 120) : payload;
+            assert.ok((await page.locator('#results').innerText()).includes(expected));
+        });
+    });
+}
+
+test('rule totals are text in both findings and clean output', async () => {
+    await withPage(async page => {
+        for (const findings of [[finding()], []]) {
+            await scan(page, {findings, rules_loaded: payload});
+            assert.ok((await page.locator('#results').innerText()).includes(payload));
+        }
+    });
+});
+
+test('scan and catalog errors cannot insert markup', async () => {
+    await withPage(async page => {
+        await page.evaluate(value => { window.scanError = value; }, payload);
+        await scan(page, {});
+        assert.equal(await page.locator('#results .error').textContent(), 'Error: ' + payload);
+        await page.evaluate(value => {
+            window.aguaraListRules = () => { throw new Error(value); };
+            loadRuleList();
+        }, payload);
+        assert.equal(await page.locator('#rule-list .error').textContent(), payload);
+    });
+});
+
+test('ordinary findings keep severity order, metadata, remediation and preview', async () => {
+    await withPage(async page => {
+        const match = '&<>"'.repeat(50);
+        await scan(page, {findings: [finding({severity: 1}), finding({severity: 4, matched_text: match, remediation: 'Review permissions.'})], rules_loaded: 3});
+        assert.deepEqual(await page.locator('.finding').evaluateAll(nodes => nodes.map(n => n.className)), ['finding critical', 'finding low']);
+        assert.equal(await page.locator('.finding').first().locator('.finding-meta').first().textContent(), 'CRITICAL - Line 7 - prompt-injection');
+        assert.equal(await page.locator('.finding-remediation').textContent(), 'Review permissions.');
+        assert.equal(await page.locator('code').first().textContent(), match.slice(0, 120));
+        assert.match(await page.locator('.stats').first().textContent(), /^2 findings - 3 rules - /);
+    });
+});
+
+test('unknown severity falls back to info without creating attributes', async () => {
+    await withPage(async page => {
+        await scan(page, {findings: [finding({severity: payload})], rules_loaded: 3});
+        assert.equal(await page.locator('.finding').getAttribute('class'), 'finding info');
+    });
+});
+
+test('all severity styles and absent optional values are preserved', async () => {
+    await withPage(async page => {
+        await scan(page, {findings: [0, 1, 2, 3, 4].map(severity => finding({severity, matched_text: null})), rules_loaded: 3});
+        assert.deepEqual(await page.locator('.finding').evaluateAll(nodes => nodes.map(n => n.className)),
+            ['finding critical', 'finding high', 'finding medium', 'finding low', 'finding info']);
+        assert.equal(await page.locator('.finding-remediation').count(), 0);
+        assert.deepEqual(await page.locator('code').allTextContents(), ['', '', '', '', '']);
+    });
+});
+
+test('clean output, options, tab switching and explain still work', async () => {
+    await withPage(async page => {
+        await page.locator('#filename').fill('config.json');
+        await page.locator('#severity').selectOption('high');
+        await page.locator('#profile').selectOption('minimal');
+        await scan(page, {findings: [], rules_loaded: 3});
+        assert.match(await page.locator('.clean').textContent(), /^No security issues found\. \(3 rules, /);
+        assert.deepEqual(await page.evaluate(() => window.scanArgs), ['Sample content', 'config.json', {minSeverity: 'high', profile: 'minimal'}]);
+        await page.locator('[data-tab="rules"]').click();
+        assert.ok(await page.locator('#tab-rules').isVisible());
+        await page.evaluate(value => {
+            window.aguaraExplainRule = () => JSON.stringify({name: value});
+        }, payload);
+        await page.locator('#rule-id').fill('TEST_001');
+        await page.locator('#rule-id').press('Enter');
+        assert.deepEqual(JSON.parse(await page.locator('#rule-detail').textContent()), {name: payload});
+        await page.evaluate(value => {
+            window.aguaraExplainRule = () => { throw new Error(value); };
+        }, payload);
+        await page.locator('#explain-btn').click();
+        assert.equal(await page.locator('#rule-detail').textContent(), 'Error: ' + payload);
+    });
+});
+
+test('real WASM scans and explains results without interpreting document HTML', {
+    skip: !process.env.AGUARA_WASM,
+    timeout: 60000,
+}, async () => {
+    assert.ok(process.env.AGUARA_WASM_EXEC, 'AGUARA_WASM_EXEC must match the WASM Go toolchain');
+    const page = await browser.newPage();
+    const requests = [];
+    const errors = [];
+    try {
+        page.on('pageerror', error => errors.push(error.message));
+        const assets = new Map([
+            ['http://localhost/', ['text/html', html]],
+            ['http://localhost/wasm_exec.js', ['application/javascript', fs.readFileSync(process.env.AGUARA_WASM_EXEC)]],
+            ['http://localhost/aguara.wasm', ['application/wasm', fs.readFileSync(process.env.AGUARA_WASM)]],
+        ]);
+        await page.route('**/*', route => {
+            const asset = assets.get(route.request().url());
+            if (asset) return route.fulfill({contentType: asset[0], body: asset[1]});
+            requests.push(route.request().url());
+            return route.abort();
+        });
+        await page.goto('http://localhost/');
+        await page.waitForFunction(() => !document.getElementById('scan').disabled);
+        const source = '# `<img src=x onerror=window.x=1>`\n\nwrite file overwrite modify file append to create file save to disk\n';
+        const result = await page.evaluate(async content => JSON.parse(await aguaraScanContent(content, 'skill.md')), source);
+        assert.ok(result.findings.some(f => f.rule_id === 'NLP_HEADING_MISMATCH'), JSON.stringify(result.findings.map(f => ({id: f.rule_id, name: f.rule_name}))));
+        // The previous heading-to-name route was removed by the redaction fix.
+        // Keep this integration control separate from hostile JSON renderer tests.
+        assert.ok(result.findings.every(f => !f.rule_name.includes('<img')));
+        await page.locator('#content').fill(source);
+        await page.locator('#scan').click();
+        await page.waitForFunction(() => document.querySelectorAll('.finding').length > 0);
+        assert.equal(await page.locator('.finding').count(), result.findings.length);
+        assert.equal(await page.locator('#results img, #results svg').count(), 0);
+        assert.equal(await page.evaluate(() => window.x === 1), false);
+        await page.locator('#content').fill('A short paragraph about ordinary documentation.');
+        await page.locator('#scan').click();
+        await page.waitForFunction(() => document.querySelector('.clean') !== null);
+        assert.equal(await page.locator('.finding').count(), 0);
+        await page.locator('[data-tab="rules"]').click();
+        await page.locator('#rule-id').fill('PROMPT_INJECTION_001');
+        await page.locator('#explain-btn').click();
+        assert.equal(JSON.parse(await page.locator('#rule-detail').textContent()).id, 'PROMPT_INJECTION_001');
+        assert.deepEqual(requests, []);
+        assert.deepEqual(errors, []);
+    } finally {
+        await page.close();
+    }
+});


### PR DESCRIPTION
The bundled browser page should display what Aguara found without interpreting
that content as HTML. This change builds the result view with DOM elements and
text nodes, covering finding names, IDs, categories, match previews, remediation,
summaries, and error messages.

Severity styling, sorting, scan options, and rule explanations are preserved.
Match previews now truncate the original text at 120 characters instead of
truncating an HTML-escaped string, so characters such as `<` and `&` display
correctly without consuming the preview budget as entities.

The change is limited to the bundled WASM example. It does not change detection
rules, the Go or WASM API, JSON output, or downstream applications.

Thirteen Chromium tests cover hostile result fields, errors, ordinary controls,
and a real WASM scan and rule explanation. The controlled-JSON tests exercise
the rendering boundary directly; the real-engine test verifies current scan
behavior separately. A dedicated CI workflow runs both. Playwright is a pinned,
test-only dependency; the page has no new runtime dependency.

Local validation: all 13 browser tests passed, WASM compiled, and JavaScript
syntax, workflow YAML, and diff checks passed. Tests run sequentially in one
Chromium instance. No local fuzzing, stress tests, or benchmarks were run.