### PR TITLE
Stop WASM callbacks from retaining completed scans

### DIFF
--- a/.github/workflows/wasm-ui.yml
+++ b/.github/workflows/wasm-ui.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: "24"
+      - name: Test WASM callback lifetime
+        run: GOMAXPROCS=1 GOOS=js GOARCH=wasm go test -p 1 -parallel 1 -count=1 -timeout=30s -exec "$(go env GOROOT)/lib/wasm/go_js_wasm_exec" ./cmd/wasm
       - name: Install browser test dependencies
         working-directory: cmd/wasm
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- WASM scans now release their per-call Promise executor callbacks. Completed
+  scans no longer remain referenced by those callback registrations in a
+  long-lived browser session; asynchronous results and errors are unchanged.
 - The bundled WebAssembly page now renders finding fields, summaries, and
   errors as text instead of HTML. Match previews retain their 120-character
   limit without shortening or splitting HTML entities during rendering.

--- a/cmd/wasm/README.md
+++ b/cmd/wasm/README.md
@@ -32,3 +32,21 @@ AGUARA_WASM=/tmp/aguara-ui-test.wasm \
 Without `AGUARA_WASM`, the integration test is explicitly skipped. The WASM UI
 workflow builds the binary and runs both test paths. Tests use one Chromium
 instance and run sequentially; they are not fuzzing, load tests, or benchmarks.
+
+## Promise lifecycle tests
+
+The Go tests in this directory run as WASM under Node, not as native Go tests.
+From the repository root:
+
+```sh
+GOMAXPROCS=1 GOMEMLIMIT=768MiB GOOS=js GOARCH=wasm \
+  go test -p 1 -parallel 1 -run '^Test' -count=1 -timeout=30s \
+  -exec "$(go env GOROOT)/lib/wasm/go_js_wasm_exec" ./cmd/wasm
+```
+
+They check Promise success, rejection, delayed completion, constructor failure,
+and both scan entry points. A small captured object with a finalizer checks
+that completed work is no longer held by the executor callback. Collection
+checks are bounded; they do not measure heap growth or scan throughput. The
+WASM UI workflow also runs these tests. `GOMAXPROCS=1` is required for Go's
+single-threaded JS/WASM runtime; the race detector does not support this target.

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -138,6 +138,9 @@ func newPromise(fn func() (any, error)) js.Value {
 
 		return nil
 	})
+	// Promise invokes its executor synchronously. The goroutine keeps the work
+	// alive until it settles; the executor registration is no longer needed.
+	defer handler.Release()
 
 	return js.Global().Get("Promise").New(handler)
 }

--- a/cmd/wasm/main_test.go
+++ b/cmd/wasm/main_test.go
@@ -1,0 +1,166 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"runtime"
+	"strings"
+	"syscall/js"
+	"testing"
+	"time"
+)
+
+type promiseResult struct {
+	value    js.Value
+	rejected bool
+}
+
+func awaitPromise(t *testing.T, promise js.Value) promiseResult {
+	t.Helper()
+	done := make(chan promiseResult, 1)
+	resolve := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		done <- promiseResult{value: args[0]}
+		return nil
+	})
+	defer resolve.Release()
+	reject := js.FuncOf(func(_ js.Value, args []js.Value) any {
+		done <- promiseResult{value: args[0], rejected: true}
+		return nil
+	})
+	defer reject.Release()
+	promise.Call("then", resolve, reject)
+	select {
+	case result := <-done:
+		return result
+	case <-time.After(2 * time.Second):
+		t.Fatal("Promise did not settle")
+		return promiseResult{}
+	}
+}
+
+// The non-tiny witness proves collection of the captured closure without
+// inspecting runtime internals or allocating a large scan corpus.
+type lifetimeWitness [64]byte
+
+func trackedWork(fn func() (any, error)) (func() (any, error), <-chan struct{}) {
+	collected := make(chan struct{})
+	witness := new(lifetimeWitness)
+	runtime.SetFinalizer(witness, func(*lifetimeWitness) { close(collected) })
+	return func() (any, error) {
+		defer runtime.KeepAlive(witness)
+		return fn()
+	}, collected
+}
+
+func requireCollected(t *testing.T, collected <-chan struct{}) {
+	t.Helper()
+	for range 5 {
+		runtime.GC()
+		select {
+		case <-collected:
+			return
+		case <-time.After(200 * time.Millisecond):
+		}
+	}
+	t.Fatal("Promise executor still retains its captured work after completion")
+}
+
+func TestNewPromiseReleasesWork(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		work func() (any, error)
+		want string
+	}{
+		{"success", func() (any, error) { return map[string]string{"status": "ok"}, nil }, ""},
+		{"work error", func() (any, error) { return nil, errors.New("scan failed") }, "scan failed"},
+		{"marshal error", func() (any, error) { return make(chan int), nil }, "json: unsupported type: chan int"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			calls := 0
+			work, collected := trackedWork(func() (any, error) {
+				calls++
+				return tc.work()
+			})
+			result := awaitPromise(t, newPromise(work))
+			if calls != 1 {
+				t.Fatalf("work ran %d times, want once", calls)
+			}
+			if tc.want != "" {
+				if !result.rejected || !result.value.InstanceOf(js.Global().Get("Error")) || result.value.Get("message").String() != tc.want {
+					t.Fatalf("expected JavaScript Error %q, got %+v", tc.want, result)
+				}
+			} else if result.rejected || result.value.String() != `{"status":"ok"}` {
+				t.Fatalf("expected JSON success, got %+v", result)
+			}
+			requireCollected(t, collected)
+		})
+	}
+}
+
+func TestNewPromiseWorkCanFinishAfterConstructorReturns(t *testing.T) {
+	resume := make(chan struct{})
+	work, collected := trackedWork(func() (any, error) {
+		<-resume
+		return "completed later", nil
+	})
+	promise := newPromise(work)
+	// No event-loop blocking: work remains alive after the executor returns.
+	runtime.GC()
+	select {
+	case <-collected:
+		t.Fatal("work collected before it completed")
+	default:
+	}
+	close(resume)
+	result := awaitPromise(t, promise)
+	if result.rejected || result.value.String() != `"completed later"` {
+		t.Fatalf("unexpected deferred result: %+v", result)
+	}
+	requireCollected(t, collected)
+}
+
+func TestNewPromiseReleasesExecutorWhenConstructorThrows(t *testing.T) {
+	original := js.Global().Get("Promise")
+	js.Global().Set("Promise", js.Global().Get("Function").New("throw new Error('constructor failed')"))
+	defer js.Global().Set("Promise", original)
+	work, collected := trackedWork(func() (any, error) {
+		t.Error("work must not run when the constructor throws")
+		return nil, nil
+	})
+	func() {
+		defer func() {
+			failure := recover()
+			if err, ok := failure.(js.Error); !ok || err.Value.Get("message").String() != "constructor failed" {
+				t.Errorf("unexpected constructor failure: %v", failure)
+			}
+		}()
+		newPromise(work)
+	}()
+	requireCollected(t, collected)
+}
+
+func TestScanPromiseEntryPoints(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(js.Value, []js.Value) any
+		args []js.Value
+	}{
+		{"scanContent", scanContent, []js.Value{js.ValueOf("Ordinary documentation."), js.ValueOf("sample.txt")}},
+		{"scanContentAs", scanContentAs, []js.Value{js.ValueOf("Ordinary documentation."), js.ValueOf("sample.txt"), js.ValueOf("example-tool")}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			invalid := tc.call(js.Undefined(), nil).(js.Value)
+			if !invalid.InstanceOf(js.Global().Get("Error")) {
+				t.Fatal("missing arguments must return a synchronous Error value")
+			}
+			for range 2 {
+				result := awaitPromise(t, tc.call(js.Undefined(), tc.args).(js.Value))
+				if result.rejected || !json.Valid([]byte(result.value.String())) || !strings.Contains(result.value.String(), `"findings"`) {
+					t.Fatalf("entry point did not return a JSON scan: %+v", result)
+				}
+			}
+		})
+	}
+}

--- a/cmd/wasm/render.test.cjs
+++ b/cmd/wasm/render.test.cjs
@@ -186,6 +186,10 @@ test('real WASM scans and explains results without interpreting document HTML', 
         await page.locator('#scan').click();
         await page.waitForFunction(() => document.querySelector('.clean') !== null);
         assert.equal(await page.locator('.finding').count(), 0);
+        const namedScan = await page.evaluate(async () => JSON.parse(await aguaraScanContentAs(
+            'Ordinary documentation.', 'sample.txt', 'example-tool'
+        )));
+        assert.equal(namedScan.findings.length, 0);
         await page.locator('[data-tab="rules"]').click();
         await page.locator('#rule-id').fill('PROMPT_INJECTION_001');
         await page.locator('#explain-btn').click();


### PR DESCRIPTION
Fixes a memory-retention bug in Aguara's WASM bridge. Each scan registered a
Promise executor callback that stayed registered after the scan finished,
keeping the scan closure and its captured input reachable in long-lived
browser sessions.

The bridge now releases that executor after Promise construction. Pending
work keeps the references it needs to finish, and success and error responses
are unchanged. The exported scan and catalog functions remain available for
the lifetime of the module.

Bounded WASM tests cover successful scans, work and serialization errors,
delayed completion, and constructor failure. A small captured object verifies
that completed work can be collected. Both scan entry points are exercised
under Node and Chromium; the existing 13 browser tests pass with the updated
WASM binary. CI now runs the lifecycle tests explicitly because native Go
tests do not execute JS/WASM-only packages.

Validated with Go 1.25 and 1.26, WASM builds, vet, lint, and the browser suite.
No detection, API, or JSON-format changes. No local fuzzing, stress tests, or
benchmarks; this verifies callback lifetime, not a measured heap-size reduction.