### PR TITLE
Reject unsafe NuGet manifest inputs before checking dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- NuGet dependency checks now reject linked and special-file manifests and
+  enforce a 50 MiB input limit for project files and `packages.lock.json`.
+  Rejected inputs return an error rather than a successful dependency report.
+  Reads remain bounded if a manifest grows after inspection.
 - WASM scans now release their per-call Promise executor callbacks. Completed
   scans no longer remain referenced by those callback registrations in a
   long-lived browser session; asynchronous results and errors are unchanged.

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	github.com/yuin/goldmark v1.8.4
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	golang.org/x/text v0.41.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -79,7 +80,6 @@ require (
 	golang.org/x/mod v0.38.0 // indirect
 	golang.org/x/net v0.58.0 // indirect
 	golang.org/x/sync v0.22.0 // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260526163538-3dc84a4a5aaa // indirect
 	google.golang.org/grpc v1.83.2 // indirect

--- a/internal/packagecheck/discovery.go
+++ b/internal/packagecheck/discovery.go
@@ -264,7 +264,9 @@ func pickMavenTargets(dir string) []Target {
 // in the same dir.
 func pickNuGetTargets(dir string) []Target {
 	var out []Target
-	if statRegular(filepath.Join(dir, "packages.lock.json")) {
+	// Keep linked and special-file candidates visible so parsing reports an
+	// input error instead of silently presenting an incomplete dependency check.
+	if info, err := os.Lstat(filepath.Join(dir, "packages.lock.json")); err == nil && !info.IsDir() {
 		out = append(out, Target{
 			Ecosystem: intel.EcosystemNuGet,
 			Path:      filepath.Join(dir, "packages.lock.json"),

--- a/internal/packagecheck/manifest_open_other.go
+++ b/internal/packagecheck/manifest_open_other.go
@@ -1,0 +1,7 @@
+//go:build !unix
+
+package packagecheck
+
+// Non-Unix platforms retain the metadata checks and bounded read, but do not
+// provide the Unix atomic leaf-symlink rejection at open time.
+const manifestOpenFlags = 0

--- a/internal/packagecheck/manifest_open_unix.go
+++ b/internal/packagecheck/manifest_open_unix.go
@@ -1,0 +1,7 @@
+//go:build unix
+
+package packagecheck
+
+import "golang.org/x/sys/unix"
+
+const manifestOpenFlags = unix.O_NONBLOCK | unix.O_NOFOLLOW

--- a/internal/packagecheck/nuget.go
+++ b/internal/packagecheck/nuget.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/garagon/aguara/internal/intel"
@@ -14,14 +13,14 @@ import (
 // dependencies. Dispatches on target.Source:
 //
 //   - "packages.lock.json" -> parseNuGetLockfile (Direct +
-//                              Transitive entries; the
-//                              resolved-version source of truth
-//                              when central package management is
-//                              enabled)
+//     Transitive entries; the
+//     resolved-version source of truth
+//     when central package management is
+//     enabled)
 //   - "csproj" / "fsproj" / "vbproj" -> parseNuGetProjectFile
-//                              (PackageReference items; the
-//                              version source when no lockfile
-//                              is in use)
+//     (PackageReference items; the
+//     version source when no lockfile
+//     is in use)
 //
 // No external commands (`dotnet restore`, `nuget`). No network.
 // obj/project.assets.json is out of scope; the build cache lives
@@ -50,7 +49,7 @@ func ParseNuGet(target Target) ([]PackageRef, error) {
 // matcher would otherwise count and report the same compromise
 // twice when only the framework differs.
 func parseNuGetLockfile(target Target) ([]PackageRef, error) {
-	data, err := os.ReadFile(target.Path)
+	data, err := readNuGetManifest(target.Path)
 	if err != nil {
 		return nil, fmt.Errorf("open packages.lock.json: %w", err)
 	}
@@ -107,7 +106,7 @@ type nugetLockDep struct {
 // MSBuild built-ins (TargetFramework, Configuration) and external
 // imports are out of scope.
 func parseNuGetProjectFile(target Target) ([]PackageRef, error) {
-	data, err := os.ReadFile(target.Path)
+	data, err := readNuGetManifest(target.Path)
 	if err != nil {
 		return nil, fmt.Errorf("open %s: %w", target.Source, err)
 	}

--- a/internal/packagecheck/nuget_input.go
+++ b/internal/packagecheck/nuget_input.go
@@ -1,0 +1,53 @@
+package packagecheck
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Match the scanner's default per-file limit. NuGet parsing must also enforce
+// the limit when called directly, without directory discovery.
+const maxNuGetManifestBytes int64 = 50 << 20
+
+func readNuGetManifest(path string) ([]byte, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("NuGet input must be a regular file, not a symlink or special file")
+	}
+	if info.Size() > maxNuGetManifestBytes {
+		return nil, fmt.Errorf("NuGet input exceeds %d-byte limit", maxNuGetManifestBytes)
+	}
+	// Reject leaf symlinks at open time on Unix and verify the opened identity
+	// before reading. This is not a snapshot of the discovery directory tree.
+	f, err := os.OpenFile(path, os.O_RDONLY|manifestOpenFlags, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	opened, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	if !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
+		return nil, fmt.Errorf("NuGet input changed while opening")
+	}
+	if opened.Size() > maxNuGetManifestBytes {
+		return nil, fmt.Errorf("NuGet input exceeds %d-byte limit", maxNuGetManifestBytes)
+	}
+	return readNuGetBytes(f, maxNuGetManifestBytes)
+}
+
+func readNuGetBytes(r io.Reader, limit int64) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("NuGet input exceeds %d-byte limit", limit)
+	}
+	return data, nil
+}

--- a/internal/packagecheck/nuget_input_test.go
+++ b/internal/packagecheck/nuget_input_test.go
@@ -1,0 +1,154 @@
+package packagecheck
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+)
+
+func TestNuGetRejectsSymlinkInputs(t *testing.T) {
+	for _, source := range []string{"csproj", "fsproj", "vbproj", "packages.lock.json"} {
+		t.Run(source, func(t *testing.T) {
+			outside := filepath.Join(t.TempDir(), "manifest")
+			content := `<Project><ItemGroup><PackageReference Include="Example" Version="1.0.0" /></ItemGroup></Project>`
+			if source == "packages.lock.json" {
+				content = `{"dependencies":{"net8.0":{"Example":{"resolved":"1.0.0"}}}}`
+			}
+			writeFile(t, outside, content)
+			if refs, err := ParseNuGet(Target{Path: outside, Source: source}); err != nil || len(refs) != 1 {
+				t.Fatalf("regular-file control: refs=%v err=%v", refs, err)
+			}
+			path := filepath.Join(t.TempDir(), "linked."+source)
+			if err := os.Symlink(outside, path); err != nil {
+				t.Skipf("symlink unavailable: %v", err)
+			}
+			refs, err := ParseNuGet(Target{Path: path, Source: source})
+			if err == nil || len(refs) != 0 {
+				t.Fatalf("symlink accepted: refs=%v err=%v", refs, err)
+			}
+		})
+	}
+}
+
+func TestNuGetDiscoveryReportsSymlinks(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "project")
+	writeFile(t, outside, "<Project />")
+	for _, name := range []string{"linked.csproj", "linked.fsproj", "linked.vbproj", "packages.lock.json", "dangling.csproj"} {
+		target := outside
+		if strings.HasPrefix(name, "dangling") {
+			target += ".missing"
+		}
+		if err := os.Symlink(target, filepath.Join(dir, name)); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+	}
+	writeFile(t, filepath.Join(dir, "Real.CSPROJ"), "<Project />")
+	targets, err := Discover(dir, []string{intel.EcosystemNuGet})
+	if err != nil || len(targets) != 6 {
+		t.Fatalf("unexpected targets: %+v err=%v", targets, err)
+	}
+	for _, target := range targets {
+		refs, err := ParseNuGet(target)
+		if filepath.Base(target.Path) == "Real.CSPROJ" {
+			if err != nil {
+				t.Fatalf("regular project: %v", err)
+			}
+		} else if err == nil || len(refs) != 0 {
+			t.Fatalf("linked candidate accepted: %+v refs=%v err=%v", target, refs, err)
+		}
+	}
+	runner := &Runner{Matcher: intel.NewMatcher(intel.Snapshot{})}
+	if result, err := runner.Run(targets); err == nil || result != nil {
+		t.Fatalf("unsafe discovery returned success: result=%+v err=%v", result, err)
+	}
+}
+
+func TestNuGetRunnerRejectsOversizeWithoutPartialResults(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "Good.csproj")
+	writeFile(t, good, `<Project><ItemGroup><PackageReference Include="Example" Version="1.0.0" /></ItemGroup></Project>`)
+	bad := filepath.Join(dir, "packages.lock.json")
+	f, err := os.Create(bad)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sizeErr := f.Truncate(maxNuGetManifestBytes + 1)
+	closeErr := f.Close()
+	if sizeErr != nil || closeErr != nil {
+		t.Fatalf("sparse fixture: %v %v", sizeErr, closeErr)
+	}
+	runner := &Runner{Matcher: intel.NewMatcher(intel.Snapshot{})}
+	result, err := runner.Run([]Target{
+		{Ecosystem: intel.EcosystemNuGet, Path: good, Source: "csproj"},
+		{Ecosystem: intel.EcosystemNuGet, Path: bad, Source: "packages.lock.json"},
+	})
+	if result != nil || err == nil || !strings.Contains(err.Error(), bad) || !strings.Contains(err.Error(), "limit") {
+		t.Fatalf("expected contextual error without partial result: result=%+v err=%v", result, err)
+	}
+}
+
+type nugetFailingReader struct{ err error }
+
+func (r nugetFailingReader) Read([]byte) (int, error) { return 0, r.err }
+
+func TestReadNuGetBytesDiscardsPartialReadOnError(t *testing.T) {
+	want := errors.New("read interrupted")
+	input := io.MultiReader(strings.NewReader("<Project>"), nugetFailingReader{err: want})
+	data, err := readNuGetBytes(input, 64)
+	if data != nil || !errors.Is(err, want) {
+		t.Fatalf("partial read returned: data=%q err=%v", data, err)
+	}
+}
+
+func TestNuGetRejectsNonRegularAndOversizedInputs(t *testing.T) {
+	for _, source := range []string{"csproj", "fsproj", "vbproj", "packages.lock.json"} {
+		t.Run(source, func(t *testing.T) {
+			dir := t.TempDir()
+			if _, err := ParseNuGet(Target{Path: dir, Source: source}); err == nil {
+				t.Fatal("accepted directory")
+			}
+			path := filepath.Join(dir, "large")
+			f, err := os.Create(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			err = f.Truncate(maxNuGetManifestBytes + 1)
+			closeErr := f.Close()
+			if err != nil || closeErr != nil {
+				t.Fatalf("create sparse fixture: %v %v", err, closeErr)
+			}
+			refs, err := ParseNuGet(Target{Path: path, Source: source})
+			if err == nil || !strings.Contains(err.Error(), "limit") || len(refs) != 0 {
+				t.Fatalf("oversize input: refs=%v err=%v", refs, err)
+			}
+		})
+	}
+}
+
+func TestReadNuGetBytesBoundaries(t *testing.T) {
+	const limit = 64
+	for _, size := range []int{0, limit - 1, limit, limit + 1, limit * 100} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			source := strings.NewReader(strings.Repeat(" ", size))
+			got, err := readNuGetBytes(source, limit)
+			if size > limit {
+				if err == nil || got != nil {
+					t.Fatalf("overflow returned data: len=%d err=%v", len(got), err)
+				}
+				read, _ := source.Seek(0, io.SeekCurrent)
+				if read != limit+1 {
+					t.Fatalf("read %d bytes beyond bounded request", read)
+				}
+			} else if err != nil || len(got) != size {
+				t.Fatalf("valid boundary: len=%d err=%v", len(got), err)
+			}
+		})
+	}
+}

--- a/internal/packagecheck/nuget_input_unix_test.go
+++ b/internal/packagecheck/nuget_input_unix_test.go
@@ -1,0 +1,84 @@
+//go:build unix
+
+package packagecheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+	"golang.org/x/sys/unix"
+)
+
+func TestNuGetRejectsFIFO(t *testing.T) {
+	for _, source := range []string{"csproj", "fsproj", "vbproj", "packages.lock.json"} {
+		t.Run(source, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "input."+source)
+			if err := unix.Mkfifo(path, 0600); err != nil {
+				t.Fatal(err)
+			}
+			refs, err := ParseNuGet(Target{Path: path, Source: source})
+			if err == nil || len(refs) != 0 {
+				t.Fatalf("FIFO accepted: refs=%v err=%v", refs, err)
+			}
+			// Exercise the actual open flags separately: a FIFO swapped in
+			// after Lstat must open without waiting, then fail the type check.
+			f, err := os.OpenFile(path, os.O_RDONLY|manifestOpenFlags, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
+			info, statErr := f.Stat()
+			closeErr := f.Close()
+			if statErr != nil || closeErr != nil || info.Mode().IsRegular() {
+				t.Fatalf("FIFO open: info=%v stat=%v close=%v", info, statErr, closeErr)
+			}
+		})
+	}
+}
+
+func TestNuGetUnixOpenRejectsLeafSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := filepath.Join(dir, "real")
+	writeFile(t, target, "<Project />")
+	link := filepath.Join(dir, "linked.csproj")
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatal(err)
+	}
+	f, err := os.OpenFile(link, os.O_RDONLY|manifestOpenFlags, 0)
+	if f != nil {
+		_ = f.Close()
+	}
+	if err == nil {
+		t.Fatal("open flags allowed a leaf symlink")
+	}
+}
+
+func TestNuGetDiscoveryReportsFIFO(t *testing.T) {
+	for _, name := range []string{"App.csproj", "App.fsproj", "App.vbproj", "packages.lock.json"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := unix.Mkfifo(filepath.Join(dir, name), 0600); err != nil {
+				t.Fatal(err)
+			}
+			targets, err := Discover(dir, []string{intel.EcosystemNuGet})
+			if err != nil || len(targets) != 1 {
+				t.Fatalf("special-file target hidden: targets=%+v err=%v", targets, err)
+			}
+			runner := &Runner{Matcher: intel.NewMatcher(intel.Snapshot{})}
+			if result, err := runner.Run(targets); err == nil || result != nil {
+				t.Fatalf("FIFO produced success: result=%+v err=%v", result, err)
+			}
+		})
+	}
+}
+
+func TestNuGetRejectsFIFOParent(t *testing.T) {
+	parent := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := unix.Mkfifo(parent, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ParseNuGet(Target{Path: filepath.Join(parent, "App.csproj"), Source: "csproj"}); err == nil {
+		t.Fatal("accepted FIFO parent")
+	}
+}


### PR DESCRIPTION
A dependency check should not follow a repository's project-file symlink or wait for input from a named pipe. Aguara previously read NuGet manifests without enforcing a file-type or size boundary.

This change requires regular files for `.csproj`, `.fsproj`, `.vbproj`, and `packages.lock.json`, with a 50 MiB input limit. Linked and special-file candidates remain visible during discovery so the check reports an error instead of silently omitting them. A rejected manifest cannot produce a successful or partial dependency report.

The parser checks the opened file and bounds the read itself, including when a file grows after inspection. On Unix, the open also rejects leaf symlinks and uses nonblocking mode to avoid waiting on a replacement FIFO. Other platforms retain the metadata checks and bounded read without the same atomic no-follow guarantee. This is not directory confinement or a filesystem snapshot.

Dependency interpretation is unchanged: project references, same-file MSBuild properties, resolved lockfile versions, and cross-framework deduplication retain their existing behavior.

Regression tests cover all four sources, ordinary files, symlinks, Unix FIFOs, oversized sparse files, read-limit boundaries, read errors, and error propagation through discovery and the runner. No detection rules, severities, or catalog counts change.