### PR TITLE
Report oversized files as incomplete scans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Directory scans now report an incomplete scan when an eligible file exceeds
+  the size limit instead of silently omitting it. The error identifies the file
+  and limit; configured exclusions and binary-file exclusions remain unchanged.
+  Disk reads also enforce the limit if a file grows after inspection, without
+  analyzing a truncated prefix. In-memory scanning keeps its existing behavior.
 - NuGet dependency checks now reject linked and special-file manifests and
   enforce a 50 MiB input limit for project files and `packages.lock.json`.
   Rejected inputs return an error rather than a successful dependency report.

--- a/cmd/aguara/commands/incomplete_scan_test.go
+++ b/cmd/aguara/commands/incomplete_scan_test.go
@@ -35,6 +35,35 @@ func TestIncompleteScanDoesNotWriteReportOrBaseline(t *testing.T) {
 	}
 }
 
+func TestOversizeDirectoryDoesNotWriteReportOrBaseline(t *testing.T) {
+	for _, command := range []string{"scan", "audit"} {
+		t.Run(command, func(t *testing.T) {
+			resetFlags()
+			t.Cleanup(resetFlags)
+			dir := t.TempDir()
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"safe","version":"1.0.0"}`), 0o600))
+			f, err := os.Create(filepath.Join(dir, "large.md"))
+			require.NoError(t, err)
+			sizeErr := f.Truncate(scanner.DefaultMaxFileSize + 1)
+			closeErr := f.Close()
+			require.NoError(t, sizeErr)
+			require.NoError(t, closeErr)
+			out, base := filepath.Join(t.TempDir(), "report.json"), filepath.Join(t.TempDir(), "baseline.json")
+			rootCmd.SetOut(new(bytes.Buffer))
+			rootCmd.SetErr(new(bytes.Buffer))
+			rootCmd.SetArgs([]string{command, dir, "--workers", "1", "--format", "json", "-o", out, "--write-baseline", base})
+			t.Cleanup(func() { rootCmd.SetArgs(nil); rootCmd.SetOut(nil); rootCmd.SetErr(nil) })
+			err = rootCmd.Execute()
+			require.ErrorIs(t, err, scanner.ErrIncompleteScan)
+			require.Contains(t, err.Error(), "52428800-byte limit")
+			for _, path := range []string{out, base} {
+				_, err := os.Stat(path)
+				require.ErrorIs(t, err, os.ErrNotExist)
+			}
+		})
+	}
+}
+
 func TestIncompleteChangedScanRejectsMetadataFailure(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git unavailable")

--- a/file_size_test.go
+++ b/file_size_test.go
@@ -1,0 +1,40 @@
+package aguara_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/garagon/aguara"
+)
+
+func TestPublicDirectorySizeLimit(t *testing.T) {
+	ctx := context.Background()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "large.md"), []byte("123456789"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s, err := aguara.NewScanner(aguara.WithWorkers(1), aguara.WithMaxFileSize(8))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, scan := range []func() (*aguara.ScanResult, error){
+		func() (*aguara.ScanResult, error) { return s.Scan(ctx, dir) },
+		func() (*aguara.ScanResult, error) {
+			return aguara.Scan(ctx, dir, aguara.WithWorkers(1), aguara.WithMaxFileSize(8))
+		},
+	} {
+		result, err := scan()
+		if result != nil || !errors.Is(err, aguara.ErrIncompleteScan) || !strings.Contains(err.Error(), "8-byte limit") {
+			t.Fatalf("oversize directory: result=%v err=%v", result, err)
+		}
+	}
+	// Explicit caller exclusions still define the intended scan surface.
+	result, err := aguara.Scan(ctx, dir, aguara.WithWorkers(1), aguara.WithMaxFileSize(8), aguara.WithIgnorePatterns([]string{"large.md"}))
+	if err != nil || result.FilesScanned != 0 {
+		t.Fatalf("caller exclusion: result=%v err=%v", result, err)
+	}
+}

--- a/incomplete_scan_test.go
+++ b/incomplete_scan_test.go
@@ -28,11 +28,10 @@ func TestIncompleteScanPublicAPI(t *testing.T) {
 		r, err = scan(context.Background(), path)
 		require.ErrorIs(t, err, aguara.ErrIncompleteScan)
 		require.Nil(t, r)
-		// Size exclusions during directory discovery remain intentional.
+		// Directory discovery must report the same incomplete coverage.
 		r, err = scan(context.Background(), dir)
-		require.NoError(t, err)
-		require.Zero(t, r.FilesScanned)
-		require.Empty(t, r.Findings)
+		require.ErrorIs(t, err, aguara.ErrIncompleteScan)
+		require.Nil(t, r)
 	}
 	// The reusable API can recover after an operational failure.
 	r, err := s.ScanContent(context.Background(), "A normal sentence.", "input.txt")

--- a/internal/scanner/errors.go
+++ b/internal/scanner/errors.go
@@ -23,6 +23,12 @@ func (e *scanFailure) Is(target error) bool { return target == ErrIncompleteScan
 // display. An empty analyzer name identifies a discovery or read failure.
 func IncompleteScanError(stage, path, analyzer string, cause error) error {
 	message := fmt.Sprintf("%s: %s for %q", ErrIncompleteScan, stage, boundedErrorLabel(path))
+	var sizeErr *fileSizeError
+	if errors.As(cause, &sizeErr) {
+		// Only this internally constructed numeric diagnostic is safe to
+		// display. Arbitrary parser or filesystem causes remain hidden.
+		message += fmt.Sprintf(" (file exceeds %d-byte limit)", sizeErr.limit)
+	}
 	if analyzer != "" {
 		message += fmt.Sprintf(" (analyzer %q)", boundedErrorLabel(analyzer))
 	}

--- a/internal/scanner/size_limit_test.go
+++ b/internal/scanner/size_limit_test.go
@@ -1,0 +1,71 @@
+package scanner_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScanSizeLimitAcrossInputs(t *testing.T) {
+	for _, input := range []string{"file", "directory"} {
+		t.Run(input, func(t *testing.T) {
+			s := scanner.New(1)
+			s.SetMaxFileSize(8)
+			probe := &completionProbe{}
+			s.SetCrossFileAccumulator(probe)
+			s.SetStateStore(probe)
+			data := []byte("123456789")
+			var result *scanner.ScanResult
+			var err error
+			dir := t.TempDir()
+			path := filepath.Join(dir, "input.md")
+			require.NoError(t, os.WriteFile(path, data, 0o600))
+			if input == "directory" {
+				path = dir
+			}
+			result, err = s.Scan(context.Background(), path)
+			require.ErrorIs(t, err, scanner.ErrIncompleteScan)
+			require.Contains(t, err.Error(), "8-byte limit")
+			require.Nil(t, result)
+			require.False(t, probe.finalized)
+			require.False(t, probe.saved)
+		})
+	}
+}
+
+func TestDiscoverySizeLimitPreservesExplicitExclusions(t *testing.T) {
+	for _, name := range []string{"skip.md", "image.png", "node_modules/large.md", "excluded/large.md"} {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, name)
+			require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+			require.NoError(t, os.WriteFile(path, []byte("123456789"), 0o600))
+			require.NoError(t, os.WriteFile(filepath.Join(dir, "ok.md"), []byte("ok"), 0o600))
+			td := scanner.TargetDiscovery{MaxFileSize: 8, IgnorePatterns: []string{"skip.md", "excluded/**"}}
+			targets, err := td.Discover(dir)
+			require.NoError(t, err)
+			require.Len(t, targets, 1)
+			require.Equal(t, "ok.md", targets[0].RelPath)
+		})
+	}
+}
+
+func TestTargetSizeLimitExactBoundary(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "input.md")
+	require.NoError(t, os.WriteFile(path, []byte("12345678"), 0o600))
+	for _, target := range []*scanner.Target{
+		{Path: path, MaxFileSize: 8},
+		{Content: []byte("12345678"), MaxFileSize: 8},
+		{Content: []byte{}, MaxFileSize: 8},
+	} {
+		require.NoError(t, target.LoadContent())
+	}
+	target := &scanner.Target{Path: path, MaxFileSize: 8}
+	require.NoError(t, target.LoadContent())
+	target.MaxFileSize = 7
+	require.NoError(t, target.LoadContent(), "preloaded content retains the in-memory contract")
+}

--- a/internal/scanner/target.go
+++ b/internal/scanner/target.go
@@ -3,6 +3,8 @@ package scanner
 import (
 	"bufio"
 	"fmt"
+	"io"
+	"math"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,8 +13,8 @@ import (
 	"golang.org/x/text/unicode/norm"
 )
 
-// DefaultMaxFileSize is the default maximum file size (50 MB) that will be scanned.
-// Files larger than this are silently skipped during discovery.
+// DefaultMaxFileSize is the default maximum file size (50 MiB) read from disk.
+// Eligible files exceeding it cause an incomplete-scan error.
 const DefaultMaxFileSize = 50 << 20
 
 // Target represents a file to be scanned.
@@ -39,19 +41,47 @@ func (t *Target) LoadContent() error {
 	if limit <= 0 {
 		limit = DefaultMaxFileSize
 	}
-	info, err := os.Stat(t.Path)
+	f, err := os.Open(t.Path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	info, err := f.Stat()
 	if err != nil {
 		return err
 	}
 	if info.Size() > limit {
-		return fmt.Errorf("file too large: %s (%d bytes, max %d)", t.Path, info.Size(), limit)
+		return &fileSizeError{limit: limit}
 	}
-	data, err := os.ReadFile(t.Path)
+	data, err := readTargetBytes(f, limit)
 	if err != nil {
 		return err
 	}
 	t.Content = data
 	return nil
+}
+
+type fileSizeError struct{ limit int64 }
+
+func (e *fileSizeError) Error() string {
+	return fmt.Sprintf("file too large: exceeds %d-byte limit", e.limit)
+}
+
+// Read one extra byte to distinguish a complete input from a truncated prefix.
+// API callers may set any positive int64 limit, including MaxInt64.
+func readTargetBytes(r io.Reader, limit int64) ([]byte, error) {
+	readLimit := limit
+	if readLimit < math.MaxInt64 {
+		readLimit++
+	}
+	data, err := io.ReadAll(io.LimitReader(r, readLimit))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, &fileSizeError{limit: limit}
+	}
+	return data, nil
 }
 
 // StringContent returns the content as a NFKC-normalized string. The result is cached.
@@ -113,16 +143,15 @@ func (td *TargetDiscovery) Discover(root string) ([]*Target, error) {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return nil
 		}
-		// skip binary/large files by extension
+		// Explicit exclusions take precedence over the file-size boundary.
 		if isBinaryExt(path) {
-			return nil
-		}
-		// skip oversized files
-		if info.Size() > limit {
 			return nil
 		}
 		if td.isIgnored(relPath) {
 			return nil
+		}
+		if info.Size() > limit {
+			return IncompleteScanError("discover target", relPath, "", &fileSizeError{limit: limit})
 		}
 		targets = append(targets, &Target{
 			Path:        path,
@@ -168,6 +197,7 @@ func (td *TargetDiscovery) isIgnored(relPath string) bool {
 // Only skip an unreadable subtree when every descendant is excluded. A file
 // glob matching the directory's name alone says nothing about its contents.
 func (td *TargetDiscovery) isIgnoredSubtree(relPath string) bool {
+	relPath = filepath.ToSlash(relPath)
 	if relPath == "." {
 		return false
 	}
@@ -197,6 +227,9 @@ func matchGlob(pattern, relPath string) bool {
 		}
 		return false
 	}
+	// Recursive patterns use slash-delimited segments on every platform.
+	// ToSlash preserves literal backslashes in Unix filenames.
+	relPath = filepath.ToSlash(relPath)
 
 	// "prefix/**" → match anything under prefix/
 	if strings.HasSuffix(pattern, "/**") {

--- a/internal/scanner/target_reader_test.go
+++ b/internal/scanner/target_reader_test.go
@@ -1,0 +1,64 @@
+package scanner
+
+import (
+	"errors"
+	"io"
+	"math"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRecursiveSizeExclusionsUseNativePathSeparators(t *testing.T) {
+	for _, input := range []string{
+		filepath.Join("excluded", "large.md"),
+		filepath.Join("excluded", "nested", "large.md"),
+	} {
+		if !matchGlob("excluded/**", input) {
+			t.Fatalf("recursive exclusion missed native path %q", input)
+		}
+	}
+	td := &TargetDiscovery{IgnorePatterns: []string{"excluded/**"}}
+	if !td.isIgnoredSubtree(filepath.Join("excluded", "nested")) {
+		t.Fatal("excluded subtree not recognized")
+	}
+	if filepath.Separator == '/' && matchGlob("excluded/**", `excluded\large.md`) {
+		t.Fatal("literal Unix backslash reinterpreted as a directory separator")
+	}
+}
+
+func TestReadTargetBytesLimit(t *testing.T) {
+	for _, size := range []int{0, 7, 8, 9, 32} {
+		input := strings.NewReader(strings.Repeat("x", size))
+		data, err := readTargetBytes(input, 8)
+		if size <= 8 {
+			if err != nil || len(data) != size {
+				t.Fatalf("size %d: data=%q err=%v", size, data, err)
+			}
+		} else {
+			var sizeErr *fileSizeError
+			if data != nil || !errors.As(err, &sizeErr) || sizeErr.limit != 8 {
+				t.Fatalf("overflow returned data=%q err=%v", data, err)
+			}
+			if input.Len() != size-9 {
+				t.Fatalf("consumed beyond bounded lookahead: %d", size-input.Len())
+			}
+		}
+	}
+	data, err := readTargetBytes(strings.NewReader("ok"), math.MaxInt64)
+	if err != nil || string(data) != "ok" {
+		t.Fatalf("MaxInt64 limit overflowed: data=%q err=%v", data, err)
+	}
+}
+
+type targetReadError struct{ err error }
+
+func (r targetReadError) Read([]byte) (int, error) { return 0, r.err }
+
+func TestReadTargetBytesDiscardsPartialData(t *testing.T) {
+	want := errors.New("synthetic source error")
+	data, err := readTargetBytes(io.MultiReader(strings.NewReader("prefix"), targetReadError{want}), 8)
+	if data != nil || !errors.Is(err, want) {
+		t.Fatalf("read error returned data=%q err=%v", data, err)
+	}
+}

--- a/internal/scanner/target_test.go
+++ b/internal/scanner/target_test.go
@@ -76,17 +76,12 @@ func TestDiscoveryCustomMaxSize(t *testing.T) {
 	bigData := make([]byte, 3000)
 	require.NoError(t, os.WriteFile(filepath.Join(dir, "big.md"), bigData, 0644))
 
-	// With a 2 KB limit, only small.md should be discovered
+	// An eligible oversized file must not disappear from the scan report.
 	td := &scanner.TargetDiscovery{MaxFileSize: 2048}
 	targets, err := td.Discover(dir)
-	require.NoError(t, err)
-
-	paths := make(map[string]bool)
-	for _, target := range targets {
-		paths[target.RelPath] = true
-	}
-	require.True(t, paths["small.md"])
-	require.False(t, paths["big.md"])
+	require.ErrorIs(t, err, scanner.ErrIncompleteScan)
+	require.Nil(t, targets)
+	require.Contains(t, err.Error(), "2048-byte limit")
 
 	// With default (0), both should be discovered
 	td2 := &scanner.TargetDiscovery{}

--- a/options.go
+++ b/options.go
@@ -84,8 +84,10 @@ func WithIgnorePatterns(patterns []string) Option {
 	}
 }
 
-// WithMaxFileSize sets the maximum file size (in bytes) for scanned files.
-// Zero means use the default (50 MB).
+// WithMaxFileSize sets the maximum accepted size of a file read from disk.
+// Zero means use the default (50 MiB). An eligible file exceeding the limit
+// causes ErrIncompleteScan; explicit ignore patterns still exclude files.
+// This disk-read limit does not apply to ScanContent or ScanContentAs.
 func WithMaxFileSize(bytes int64) Option {
 	return func(c *scanConfig) {
 		c.maxFileSize = bytes


### PR DESCRIPTION
A scan that omits a file because it is too large cannot establish that the directory is clean. Aguara already returned an error for an oversized file selected directly, but directory discovery silently left the same file out.

Directory scans now return an incomplete-scan error when an otherwise eligible file exceeds the configured limit. The message identifies the file and the limit. The CLI does not write a successful report or baseline, and API callers receive no partial scan result.

File reads are also bounded after opening: if a file grows beyond the limit, the scanner rejects it instead of reading without a bound or analyzing a truncated prefix.

Explicit ignore patterns and binary-file exclusions still define which files belong in the scan. The default remains 50 MiB, and caller-provided limits remain supported. This is a disk-read limit; the existing in-memory ScanContent contract is unchanged.

Tests cover direct files and directories, exact boundaries, growth-equivalent bounded reads, partial-read errors, API error handling, and scan/audit report suppression. Fixtures use small limits or sparse files; no large payload needs to be read to exercise the rejection path.

No rules, severities, or catalog counts change.
