### PR TITLE
Protect report and state files from linked output paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Report, baseline, and monitor-state writes now reject linked or special-file
+  destinations and use unique sibling temporary files. A failed write leaves
+  the existing artifact intact instead of truncating it. On Unix, saved files
+  are private to the owner (mode 0600, subject to umask); stdout is unchanged.
 - Directory scans now report an incomplete scan when an eligible file exceeds
   the size limit instead of silently omitting it. The error identifies the file
   and limit; configured exclusions and binary-file exclusions remain unchanged.

--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -661,18 +662,11 @@ func auditActionNextCommands(result *AuditResult) []string {
 }
 
 func writeAuditJSON(result *AuditResult) error {
-	w := os.Stdout
-	if flagOutput != "" {
-		f, err := os.Create(flagOutput)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = f.Close() }()
-		w = f
-	}
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(result)
+	return writeReport(func(w io.Writer) error {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	})
 }
 
 func writeAuditTerminal(result *AuditResult) error {

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -949,18 +950,11 @@ func ecosystemFindingText(ecoToken string, hit packagecheck.Hit) (title, remedia
 }
 
 func writeCheckJSON(result *incident.CheckResult) error {
-	w := os.Stdout
-	if flagOutput != "" {
-		f, err := os.Create(flagOutput)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = f.Close() }()
-		w = f
-	}
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(result)
+	return writeReport(func(w io.Writer) error {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	})
 }
 
 func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {

--- a/cmd/aguara/commands/report_file.go
+++ b/cmd/aguara/commands/report_file.go
@@ -1,0 +1,15 @@
+package commands
+
+import (
+	"io"
+	"os"
+
+	"github.com/garagon/aguara/internal/safefile"
+)
+
+func writeReport(render func(io.Writer) error) error {
+	if flagOutput == "" {
+		return render(os.Stdout)
+	}
+	return safefile.Write(flagOutput, render)
+}

--- a/cmd/aguara/commands/report_file_test.go
+++ b/cmd/aguara/commands/report_file_test.go
@@ -1,0 +1,76 @@
+package commands
+
+import (
+	"math"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/scanner"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReportWritersRejectSymlink(t *testing.T) {
+	writers := map[string]func() error{
+		"scan":  func() error { return writeOutput(&scanner.ScanResult{}) },
+		"check": func() error { return writeCheckJSON(&incident.CheckResult{}) },
+		"audit": func() error { return writeAuditJSON(&AuditResult{}) },
+	}
+	for name, write := range writers {
+		t.Run(name, func(t *testing.T) {
+			resetFlags()
+			t.Cleanup(resetFlags)
+			outside := filepath.Join(t.TempDir(), "untouched")
+			require.NoError(t, os.WriteFile(outside, []byte("original"), 0o600))
+			flagOutput = filepath.Join(t.TempDir(), "report.json")
+			flagFormat = "json"
+			if err := os.Symlink(outside, flagOutput); err != nil {
+				t.Skipf("symlink unavailable: %v", err)
+			}
+			err := write()
+			data, readErr := os.ReadFile(outside)
+			require.NoError(t, readErr)
+			require.Equal(t, "original", string(data))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestScanReportFormatsUseSafeFileWriter(t *testing.T) {
+	for _, format := range []string{"json", "sarif", "markdown", "md", "terminal"} {
+		t.Run(format, func(t *testing.T) {
+			resetFlags()
+			t.Cleanup(resetFlags)
+			flagFormat, flagNoColor = format, true
+			dir := t.TempDir()
+			flagOutput = filepath.Join(dir, "report")
+			result := &scanner.ScanResult{}
+			require.NoError(t, writeOutput(result))
+			data, err := os.ReadFile(flagOutput)
+			require.NoError(t, err)
+			require.NotEmpty(t, data)
+			require.NoError(t, writeOutput(result))
+			entries, err := os.ReadDir(dir)
+			require.NoError(t, err)
+			require.Len(t, entries, 1, "no temporary artifacts after replacement")
+		})
+	}
+}
+
+func TestReportEncodingFailurePreservesExistingFile(t *testing.T) {
+	resetFlags()
+	t.Cleanup(resetFlags)
+	flagFormat = "json"
+	dir := t.TempDir()
+	flagOutput = filepath.Join(dir, "report")
+	require.NoError(t, os.WriteFile(flagOutput, []byte("original"), 0o600))
+	err := writeOutput(&scanner.ScanResult{RiskScore: math.NaN()})
+	require.Error(t, err)
+	data, err := os.ReadFile(flagOutput)
+	require.NoError(t, err)
+	require.Equal(t, "original", string(data))
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+}

--- a/cmd/aguara/commands/scan.go
+++ b/cmd/aguara/commands/scan.go
@@ -3,6 +3,7 @@ package commands
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -534,33 +535,25 @@ func scanChangedFiles(ctx context.Context, s *scanner.Scanner, targetPath string
 func writeOutput(result *scanner.ScanResult) error {
 	output.ToolVersion = Version
 
-	w := os.Stdout
-	if flagOutput != "" {
-		f, err := os.Create(flagOutput)
-		if err != nil {
-			return fmt.Errorf("creating output file: %w", err)
+	return writeReport(func(w io.Writer) error {
+		var formatter output.Formatter
+		switch strings.ToLower(flagFormat) {
+		case "json":
+			formatter = &output.JSONFormatter{}
+		case "sarif":
+			formatter = &output.SARIFFormatter{}
+		case "markdown", "md":
+			formatter = &output.MarkdownFormatter{}
+		default:
+			formatter = &output.TerminalFormatter{
+				NoColor: flagNoColor,
+				Verbose: flagVerbose,
+				Width:   output.DetectWidth(w),
+			}
 		}
-		defer func() { _ = f.Close() }()
-		w = f
-	}
 
-	var formatter output.Formatter
-	switch strings.ToLower(flagFormat) {
-	case "json":
-		formatter = &output.JSONFormatter{}
-	case "sarif":
-		formatter = &output.SARIFFormatter{}
-	case "markdown", "md":
-		formatter = &output.MarkdownFormatter{}
-	default:
-		formatter = &output.TerminalFormatter{
-			NoColor: flagNoColor,
-			Verbose: flagVerbose,
-			Width:   output.DetectWidth(w),
-		}
-	}
-
-	return formatter.Format(w, result)
+		return formatter.Format(w, result)
+	})
 }
 
 func isTerminalFormat() bool {

--- a/internal/baseline/baseline.go
+++ b/internal/baseline/baseline.go
@@ -21,11 +21,13 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"sort"
 	"strings"
 	"time"
 
+	"github.com/garagon/aguara/internal/safefile"
 	"github.com/garagon/aguara/internal/types"
 )
 
@@ -161,7 +163,10 @@ func Write(path string, findings []types.Finding, toolVersion string) (written, 
 		return 0, 0, fmt.Errorf("baseline: marshal: %w", err)
 	}
 	data = append(data, '\n')
-	if err := os.WriteFile(path, data, 0o644); err != nil {
+	if err := safefile.Write(path, func(w io.Writer) error {
+		_, err := w.Write(data)
+		return err
+	}); err != nil {
 		return 0, 0, fmt.Errorf("baseline: write %s: %w", path, err)
 	}
 	return len(fps), skipped, nil

--- a/internal/baseline/write_boundary_test.go
+++ b/internal/baseline/write_boundary_test.go
@@ -1,0 +1,23 @@
+package baseline
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestBaselineRejectsSymlinkOutput(t *testing.T) {
+	outside := filepath.Join(t.TempDir(), "untouched")
+	if err := os.WriteFile(outside, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "baseline.json")
+	if err := os.Symlink(outside, path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	_, _, err := Write(path, nil, "test")
+	data, readErr := os.ReadFile(outside)
+	if readErr != nil || string(data) != "original" || err == nil {
+		t.Fatalf("linked output: target=%q read=%v write=%v", data, readErr, err)
+	}
+}

--- a/internal/safefile/write.go
+++ b/internal/safefile/write.go
@@ -1,0 +1,87 @@
+// Package safefile writes private artifacts without following destination links.
+package safefile
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+// Write renders into a unique sibling temporary file, then replaces path.
+// Destinations must be absent or regular files. Files use mode 0600, subject
+// to umask; callers must provide an existing parent directory.
+//
+// Replacement changes the inode rather than modifying existing hard links.
+// Rename is atomic on Unix, but not guaranteed atomic on every platform.
+// This does not provide ancestor confinement or a filesystem snapshot.
+func Write(path string, render func(io.Writer) error) error {
+	if err := checkDestination(path); err != nil {
+		return err
+	}
+	f, err := os.CreateTemp(filepath.Dir(path), ".aguara-output-*")
+	if err != nil {
+		return err
+	}
+	name := f.Name()
+	closed := false
+	defer func() {
+		if !closed {
+			_ = f.Close()
+		}
+		_ = os.Remove(name)
+	}()
+
+	w := &checkedWriter{writer: f}
+	if err := render(w); err != nil {
+		return err
+	}
+	if w.err != nil {
+		return w.err
+	}
+	if err := f.Sync(); err != nil {
+		return err
+	}
+	err = f.Close()
+	closed = true
+	if err != nil {
+		return err
+	}
+	if err := checkDestination(path); err != nil {
+		return err
+	}
+	return os.Rename(name, path)
+}
+
+func checkDestination(path string) error {
+	info, err := os.Lstat(path)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("output destination must be a regular file, not a symlink or special file: %q", path)
+	}
+	return nil
+}
+
+// Some text formatters discard individual fmt write errors. Retain the first
+// failure so a callback returning nil cannot publish an incomplete artifact.
+type checkedWriter struct {
+	writer io.Writer
+	err    error
+}
+
+func (w *checkedWriter) Write(p []byte) (int, error) {
+	if w.err != nil {
+		return 0, w.err
+	}
+	n, err := w.writer.Write(p)
+	if err == nil && n != len(p) {
+		err = io.ErrShortWrite
+	}
+	w.err = err
+	return n, err
+}

--- a/internal/safefile/write_test.go
+++ b/internal/safefile/write_test.go
@@ -1,0 +1,184 @@
+package safefile
+
+import (
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func put(w io.Writer) error {
+	_, err := io.WriteString(w, "complete")
+	return err
+}
+
+func TestWriteReplacesRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report")
+	for range 2 {
+		if err := Write(path, put); err != nil {
+			t.Fatal(err)
+		}
+		data, err := os.ReadFile(path)
+		if err != nil || string(data) != "complete" {
+			t.Fatalf("result=%q err=%v", data, err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if runtime.GOOS != "windows" && info.Mode().Perm()&0o077 != 0 {
+			t.Fatalf("output exposed to group/others: %v", info.Mode())
+		}
+	}
+	assertEntries(t, dir, 1)
+}
+
+func TestWriteFailurePreservesDestination(t *testing.T) {
+	for _, exists := range []bool{false, true} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "report")
+		if exists {
+			if err := os.WriteFile(path, []byte("original"), 0o600); err != nil {
+				t.Fatal(err)
+			}
+		}
+		want := errors.New("render failed")
+		err := Write(path, func(w io.Writer) error {
+			_, _ = io.WriteString(w, "partial")
+			return want
+		})
+		if !errors.Is(err, want) {
+			t.Fatalf("error=%v", err)
+		}
+		data, err := os.ReadFile(path)
+		if exists {
+			if err != nil || string(data) != "original" {
+				t.Fatalf("destination changed: %q %v", data, err)
+			}
+			assertEntries(t, dir, 1)
+		} else {
+			if !os.IsNotExist(err) {
+				t.Fatalf("failed output created: %v", err)
+			}
+			assertEntries(t, dir, 0)
+		}
+	}
+}
+
+func TestWriteRejectsLinkedAndDirectoryDestinations(t *testing.T) {
+	for _, kind := range []string{"symlink", "dangling", "directory"} {
+		t.Run(kind, func(t *testing.T) {
+			dir := t.TempDir()
+			path := filepath.Join(dir, "report")
+			outside := filepath.Join(t.TempDir(), "other")
+			if kind == "directory" {
+				if err := os.Mkdir(path, 0o700); err != nil {
+					t.Fatal(err)
+				}
+			} else {
+				if kind == "symlink" {
+					if err := os.WriteFile(outside, []byte("original"), 0o600); err != nil {
+						t.Fatal(err)
+					}
+				}
+				if err := os.Symlink(outside, path); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+			}
+			called := false
+			err := Write(path, func(w io.Writer) error { called = true; return put(w) })
+			if err == nil || called {
+				t.Fatalf("unsafe destination rendered: called=%v err=%v", called, err)
+			}
+			assertEntries(t, dir, 1)
+			switch kind {
+			case "symlink":
+				data, err := os.ReadFile(outside)
+				if err != nil || string(data) != "original" {
+					t.Fatalf("symlink target changed: %q %v", data, err)
+				}
+			case "dangling":
+				if _, err := os.Stat(outside); !os.IsNotExist(err) {
+					t.Fatalf("dangling target created: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteRechecksDestinationBeforePublishing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report")
+	outside := filepath.Join(t.TempDir(), "other")
+	if err := os.WriteFile(outside, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Verify symlink support before entering the callback.
+	probe := filepath.Join(dir, "probe")
+	if err := os.Symlink(outside, probe); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	if err := os.Remove(probe); err != nil {
+		t.Fatal(err)
+	}
+	err := Write(path, func(w io.Writer) error {
+		if err := put(w); err != nil {
+			return err
+		}
+		return os.Symlink(outside, path)
+	})
+	if err == nil {
+		t.Fatal("published over a newly introduced symlink")
+	}
+	data, err := os.ReadFile(outside)
+	if err != nil || string(data) != "original" {
+		t.Fatalf("outside changed: %q %v", data, err)
+	}
+	assertEntries(t, dir, 1)
+}
+
+func TestWriteCapturesIgnoredWriteAndCloseErrors(t *testing.T) {
+	for _, writeAfterClose := range []bool{false, true} {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "report")
+		err := Write(path, func(w io.Writer) error {
+			f := w.(*checkedWriter).writer.(*os.File)
+			if err := f.Close(); err != nil {
+				return err
+			}
+			if writeAfterClose {
+				_, _ = io.WriteString(w, "ignored error")
+			}
+			return nil
+		})
+		if err == nil {
+			t.Fatal("closed output published")
+		}
+		assertEntries(t, dir, 0)
+	}
+}
+
+type shortWriter struct{}
+
+func (shortWriter) Write(p []byte) (int, error) { return len(p) - 1, nil }
+
+func TestCheckedWriterRejectsShortWrite(t *testing.T) {
+	w := &checkedWriter{writer: shortWriter{}}
+	if _, err := w.Write([]byte("data")); !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("short write: %v", err)
+	}
+	if n, err := w.Write([]byte("again")); n != 0 || !errors.Is(err, io.ErrShortWrite) {
+		t.Fatalf("lost first write error: %d %v", n, err)
+	}
+}
+
+func assertEntries(t *testing.T, dir string, want int) {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil || len(entries) != want {
+		t.Fatalf("unexpected entries: %v err=%v", entries, err)
+	}
+}

--- a/internal/safefile/write_unix_test.go
+++ b/internal/safefile/write_unix_test.go
@@ -1,0 +1,22 @@
+//go:build unix
+
+package safefile
+
+import (
+	"path/filepath"
+	"testing"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestWriteRejectsFIFO(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report")
+	if err := unix.Mkfifo(path, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := Write(path, put); err == nil {
+		t.Fatal("FIFO accepted")
+	}
+	assertEntries(t, dir, 1)
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -6,10 +6,13 @@ package state
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
+
+	"github.com/garagon/aguara/internal/safefile"
 )
 
 // Entry represents a stored hash for a single file or description.
@@ -77,13 +80,6 @@ func (s *Store) Save() error {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
-	// Reject symlinks before writing
-	if info, err := os.Lstat(s.path); err == nil {
-		if info.Mode()&os.ModeSymlink != 0 {
-			return fmt.Errorf("state file is a symlink (rejected for security): %s", s.path)
-		}
-	}
-
 	if err := os.MkdirAll(filepath.Dir(s.path), 0o700); err != nil {
 		return err
 	}
@@ -93,15 +89,10 @@ func (s *Store) Save() error {
 		return err
 	}
 
-	tmpPath := s.path + ".tmp"
-	if err := os.WriteFile(tmpPath, data, 0o600); err != nil {
+	return safefile.Write(s.path, func(w io.Writer) error {
+		_, err := w.Write(data)
 		return err
-	}
-	if err := os.Rename(tmpPath, s.path); err != nil {
-		_ = os.Remove(tmpPath) // best-effort cleanup on rename failure
-		return err
-	}
-	return nil
+	})
 }
 
 // Get returns the entry for the given key and whether it exists.

--- a/internal/state/write_boundary_test.go
+++ b/internal/state/write_boundary_test.go
@@ -1,0 +1,26 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStateSaveIgnoresPreexistingTemporarySymlink(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state.json")
+	outside := filepath.Join(t.TempDir(), "untouched")
+	require.NoError(t, os.WriteFile(outside, []byte("original"), 0o600))
+	if err := os.Symlink(outside, path+".tmp"); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	store := New(path)
+	store.Set("skill.md", "hash")
+	err := store.Save()
+	data, readErr := os.ReadFile(outside)
+	require.NoError(t, readErr)
+	require.Equal(t, "original", string(data))
+	require.NoError(t, err)
+	require.NoError(t, New(path).Load())
+}


### PR DESCRIPTION
Saving a scan report should not overwrite an unrelated file because the output path happens to be a symlink. This change rejects symlink and special-file destinations for scan/check/audit reports, baselines, and monitor state.

Each artifact is written to a private, uniquely named sibling file and replaces the destination only after rendering and file writes succeed. Existing reports remain intact on encoding or write errors. Monitor state no longer uses the predictable `<state>.tmp` path, so a pre-existing link there is neither followed nor removed.

Saved artifacts use mode 0600 on Unix, subject to umask. This deliberately tightens permissions for reports and baselines; replacement also requires write access to the parent directory. Stdout, report schemas, findings, and exit-threshold decisions are unchanged. State persistence keeps its existing best-effort error handling.

Validation covers linked and dangling destinations, special files, normal replacement, failed rendering, ignored write errors, short writes, temporary-file cleanup, and the existing report/baseline workflows. Focused race tests, native build, scoped vet, and lint pass. The directory-size and incomplete-scan regressions also pass against current main.

This is a file-output boundary change, not a filesystem sandbox or a transaction across multiple artifacts. Rename atomicity is not guaranteed on every platform.
