### PR TITLE
Keep filenames and finding text from controlling terminal reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Terminal reports now display control characters in filenames, finding text,
+  and discovered MCP server fields as visible escapes instead of letting them
+  alter the terminal. This applies with or without color; structured report
+  values and detection behavior are unchanged.
 - Report, baseline, and monitor-state writes now reject linked or special-file
   destinations and use unique sibling temporary files. A failed write leaves
   the existing artifact intact instead of truncating it. On Unix, saved files

--- a/cmd/aguara/commands/audit.go
+++ b/cmd/aguara/commands/audit.go
@@ -676,7 +676,7 @@ func writeAuditTerminal(result *AuditResult) error {
 
 	fmt.Printf("\n%s\n", sep)
 	fmt.Printf("  %s\n", st.Bold("AGUARA AUDIT"))
-	fmt.Printf("  Target: %s\n", result.Target)
+	fmt.Printf("  Target: %s\n", output.TerminalText(result.Target))
 	fmt.Printf("%s\n", sep)
 
 	fmt.Printf("\n%s\n", st.SectionHeader("PACKAGE CHECK", width))
@@ -684,10 +684,10 @@ func writeAuditTerminal(result *AuditResult) error {
 		fmt.Printf("\n  %s\n", st.OK("No known-compromised packages or persistence artifacts found."))
 	} else {
 		for _, f := range result.Check.Findings {
-			label := string(f.Severity)
-			fmt.Printf("\n  %s %s %s\n", st.SeverityIcon(label), st.SeverityLabel(fmt.Sprintf("%-8s", label)), f.Title)
+			label := output.TerminalText(string(f.Severity))
+			fmt.Printf("\n  %s %s %s\n", st.SeverityIcon(label), st.SeverityLabel(fmt.Sprintf("%-8s", label)), output.TerminalText(f.Title))
 			if f.Path != "" {
-				fmt.Printf("             %s\n", st.Dim(f.Path))
+				fmt.Printf("             %s\n", st.Dim(output.TerminalText(f.Path)))
 			}
 		}
 	}
@@ -709,9 +709,9 @@ func writeAuditTerminal(result *AuditResult) error {
 			label := f.Severity.String()
 			fmt.Printf("  %s %s %s %s\n",
 				st.SeverityIcon(label),
-				st.Bold(st.Cell(f.RuleID, 24)),
-				st.Cell(f.RuleName, 36),
-				st.Cyan(fmt.Sprintf("%s:%d", f.FilePath, f.Line)))
+				st.Bold(st.Cell(output.TerminalText(f.RuleID), 24)),
+				st.Cell(output.TerminalText(f.RuleName), 36),
+				st.Cyan(fmt.Sprintf("%s:%d", output.TerminalText(f.FilePath), f.Line)))
 			shown++
 		}
 		if !flagAuditVerbose && len(result.Scan.Findings) > maxList {
@@ -731,7 +731,7 @@ func writeAuditTerminal(result *AuditResult) error {
 	// Green is reserved for a clean pass: FINDINGS exits 0 but still
 	// means unresolved findings exist, so it renders yellow with the
 	// medium-tier icon; FAIL is red with the critical icon.
-	verdict := fmt.Sprintf("Verdict: %s", strings.ToUpper(result.Verdict.Status))
+	verdict := fmt.Sprintf("Verdict: %s", output.TerminalText(strings.ToUpper(result.Verdict.Status)))
 	counts := fmt.Sprintf("(check: %d critical / %d warning, scan: %d critical / %d high)",
 		result.Verdict.CheckCriticals, result.Verdict.CheckWarnings,
 		result.Verdict.ScanCriticals, result.Verdict.ScanHighs)
@@ -759,10 +759,10 @@ func writeAuditTerminal(result *AuditResult) error {
 		}
 		fmt.Printf("  %s\n", triageLine)
 		if result.Triage.Summary != "" {
-			fmt.Printf("  %s\n", st.Dim(result.Triage.Summary))
+			fmt.Printf("  %s\n", st.Dim(output.TerminalText(result.Triage.Summary)))
 		}
 		if len(result.Triage.RecommendedNextSteps) > 0 {
-			fmt.Printf("  %s\n", st.Dim("Next: "+result.Triage.RecommendedNextSteps[0]))
+			fmt.Printf("  %s\n", st.Dim("Next: "+output.TerminalText(result.Triage.RecommendedNextSteps[0])))
 		}
 	}
 
@@ -778,13 +778,13 @@ func writeAuditTerminal(result *AuditResult) error {
 		}
 		fmt.Printf("  %s\n", handoffLine)
 		if result.Handoff.Summary != "" {
-			fmt.Printf("  %s\n", st.Dim(result.Handoff.Summary))
+			fmt.Printf("  %s\n", st.Dim(output.TerminalText(result.Handoff.Summary)))
 		}
 		if len(result.Handoff.AllowedActions) > 0 {
-			fmt.Printf("  %s\n", st.Dim("Allowed: "+result.Handoff.AllowedActions[0]))
+			fmt.Printf("  %s\n", st.Dim("Allowed: "+output.TerminalText(result.Handoff.AllowedActions[0])))
 		}
 		if len(result.Handoff.BlockedActions) > 0 {
-			fmt.Printf("  %s\n", st.Dim("Blocked: "+result.Handoff.BlockedActions[0]))
+			fmt.Printf("  %s\n", st.Dim("Blocked: "+output.TerminalText(result.Handoff.BlockedActions[0])))
 		}
 	}
 
@@ -798,11 +798,11 @@ func writeAuditTerminal(result *AuditResult) error {
 			installStatus = "no"
 		}
 		fmt.Printf("  %s\n", st.Dim(fmt.Sprintf("Action plan: install=%s execute=%s trust_state=%s",
-			installStatus, execStatus, result.Plan.TrustState)))
+			installStatus, execStatus, output.TerminalText(result.Plan.TrustState))))
 	}
 
 	if rule := topScanRule(result.Scan.Findings); rule != "" {
-		fmt.Printf("  %s\n", st.Dim("Next: aguara explain "+rule))
+		fmt.Printf("  %s\n", st.Dim("Next: aguara explain "+output.TerminalText(rule)))
 	}
 	return nil
 }

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -982,7 +982,7 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 	default:
 		meta = fmt.Sprintf("%d packages · %d .pth files", result.PackagesRead, result.PthScanned)
 	}
-	fmt.Printf("  Target: %s  ·  %s  ·  %s\n", result.Environment, envLabel, meta)
+	fmt.Printf("  Target: %s  ·  %s  ·  %s\n", output.TerminalText(result.Environment), envLabel, meta)
 	fmt.Printf("%s\n\n", sep)
 
 	// Provenance line: which intel answered this scan, and how old it is.
@@ -996,13 +996,13 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 	}
 
 	for _, f := range result.Findings {
-		label := string(f.Severity)
-		fmt.Printf("  %s %s %s\n", st.SeverityIcon(label), st.SeverityLabel(fmt.Sprintf("%-8s", label)), f.Title)
+		label := output.TerminalText(string(f.Severity))
+		fmt.Printf("  %s %s %s\n", st.SeverityIcon(label), st.SeverityLabel(fmt.Sprintf("%-8s", label)), output.TerminalText(f.Title))
 		if f.Path != "" {
-			fmt.Printf("             %s\n", st.Dim("Path: "+f.Path))
+			fmt.Printf("             %s\n", st.Dim("Path: "+output.TerminalText(f.Path)))
 		}
 		if f.Detail != "" {
-			fmt.Printf("             %s\n", st.Dim(f.Detail))
+			fmt.Printf("             %s\n", st.Dim(output.TerminalText(f.Detail)))
 		}
 		fmt.Println()
 	}
@@ -1018,7 +1018,7 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 		fmt.Printf("%s\n\n", st.SectionHeader("CREDENTIALS AT RISK", width))
 		for _, c := range result.Credentials {
 			if c.Exists {
-				fmt.Printf("  %-30s %s  %s\n", c.Path, st.Red("EXISTS"), st.Dim(c.Guidance))
+				fmt.Printf("  %-30s %s  %s\n", output.TerminalText(c.Path), st.Red("EXISTS"), st.Dim(output.TerminalText(c.Guidance)))
 			}
 		}
 		fmt.Println()

--- a/cmd/aguara/commands/terminal_controls_test.go
+++ b/cmd/aguara/commands/terminal_controls_test.go
@@ -1,0 +1,75 @@
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/garagon/aguara/internal/incident"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAuditTerminalEscapesUntrustedControls(t *testing.T) {
+	for _, noColor := range []bool{true, false} {
+		resetFlags()
+		flagNoColor = noColor
+		res := stubAuditResult(t, 1, 0, 1, 0, 0, 0)
+		res.Target = "repo\x1b[2J"
+		res.Check.Findings[0].Title = "package\rspoof"
+		res.Check.Findings[0].Path = "lock\x1b]0;spoof\x07"
+		res.Scan.Findings[0].RuleID = "TEST\x1b[2J"
+		res.Scan.Findings[0].RuleName = strings.Repeat("A", 30) + "\t\u00e9BBBB"
+		res.Scan.Findings[0].FilePath = "skill\x1b[2J\nspoof.md"
+		before, err := json.Marshal(res)
+		require.NoError(t, err)
+		fetch, restore := captureStdout(t)
+		err = writeAuditTerminal(res)
+		restore()
+		require.NoError(t, err)
+		out := fetch()
+		require.True(t, utf8.ValidString(out), "rendered output must remain valid UTF-8")
+		for _, bad := range []string{"\x1b[2J", "\x1b]", "\x07", "\r", "\b", "\nspoof"} {
+			if strings.Contains(out, bad) {
+				t.Fatalf("untrusted control %q survived (noColor=%v)", bad, noColor)
+			}
+		}
+		require.Contains(t, out, "AGUARA AUDIT")
+		after, err := json.Marshal(res)
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(before, after), "source JSON unchanged")
+		if !noColor {
+			require.Contains(t, out, "\x1b[1m", "trusted styling remains")
+		}
+	}
+	resetFlags()
+}
+
+func TestCheckTerminalEscapesUntrustedControls(t *testing.T) {
+	for _, noColor := range []bool{true, false} {
+		resetFlags()
+		flagNoColor = noColor
+		bad := "data\x1b]0;spoof\x07\r\nspoof"
+		res := &incident.CheckResult{Environment: bad, Findings: []incident.Finding{{
+			Severity: incident.SevCritical, Title: bad, Path: bad, Detail: bad,
+		}}}
+		before, err := json.Marshal(res)
+		require.NoError(t, err)
+		fetch, restore := captureStdout(t)
+		err = writeCheckTerminal(res, checkPlan{})
+		restore()
+		require.NoError(t, err)
+		out := fetch()
+		for _, control := range []string{"\x1b]", "\x07", "\r", "\nspoof"} {
+			if strings.Contains(out, control) {
+				t.Fatalf("control survived: %q", control)
+			}
+		}
+		require.Contains(t, out, `\x1b]0;spoof\a\r\nspoof`)
+		after, err := json.Marshal(res)
+		require.NoError(t, err)
+		require.True(t, bytes.Equal(before, after))
+	}
+	resetFlags()
+}

--- a/discover/discover.go
+++ b/discover/discover.go
@@ -3,6 +3,8 @@ package discover
 import (
 	"fmt"
 	"strings"
+
+	"github.com/garagon/aguara/internal/output"
 )
 
 // sensitiveEnvKeys matches env variable names that likely contain secrets.
@@ -163,7 +165,7 @@ func FormatTree(result *Result) string {
 	fmt.Fprintf(&b, "Found %d MCP configuration(s):\n\n", result.TotalClients())
 
 	for _, cr := range result.Clients {
-		fmt.Fprintf(&b, "  %s  %s\n", clientDisplayName(cr.Client), cr.Path)
+		fmt.Fprintf(&b, "  %s  %s\n", output.TerminalText(clientDisplayName(cr.Client)), output.TerminalText(cr.Path))
 		for i, srv := range cr.Servers {
 			prefix := "├──"
 			if i == len(cr.Servers)-1 {
@@ -173,7 +175,7 @@ func FormatTree(result *Result) string {
 			if len(srv.Args) > 0 {
 				cmdStr += " " + strings.Join(srv.Args, " ")
 			}
-			fmt.Fprintf(&b, "    %s %-20s %s\n", prefix, srv.Name, cmdStr)
+			fmt.Fprintf(&b, "    %s %-20s %s\n", prefix, output.TerminalText(srv.Name), output.TerminalText(cmdStr))
 		}
 		b.WriteString("\n")
 	}

--- a/discover/terminal_controls_test.go
+++ b/discover/terminal_controls_test.go
@@ -1,0 +1,36 @@
+package discover
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestFormatTreeEscapesParsedControls(t *testing.T) {
+	var raw map[string]json.RawMessage
+	err := json.Unmarshal([]byte(`{"mcpServers":{"server\u001b[2J":{"command":"node\rspoof","args":["arg\u001b]0;spoof\u0007"]}}}`), &raw)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result := &Result{Clients: []ClientResult{{Client: "cursor", Path: "caf\u00e9/config\nspoof.json", Servers: extractServersFromKey(raw, "mcpServers")}}}
+	if len(result.Clients[0].Servers) != 1 {
+		t.Fatal("fixture did not parse")
+	}
+	before, _ := json.Marshal(result)
+	out := FormatTree(result)
+	for _, control := range []string{"\x1b", "\r", "\x07", "\nspoof"} {
+		if strings.Contains(out, control) {
+			t.Fatalf("control survived: %q", control)
+		}
+	}
+	for _, want := range []string{`server\x1b[2J`, `node\rspoof`, `arg\x1b]0;spoof\a`, "caf\u00e9", "Cursor"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q", want)
+		}
+	}
+	after, _ := json.Marshal(result)
+	if !bytes.Equal(before, after) {
+		t.Error("source JSON changed")
+	}
+}

--- a/internal/output/terminal.go
+++ b/internal/output/terminal.go
@@ -112,7 +112,7 @@ func (f *TerminalFormatter) printHeader(w io.Writer, result *scanner.ScanResult)
 
 	parts := []string{}
 	if result.Target != "" {
-		parts = append(parts, fmt.Sprintf("Target: %s", result.Target))
+		parts = append(parts, fmt.Sprintf("Target: %s", TerminalText(result.Target)))
 	}
 	parts = append(parts, fmt.Sprintf("%d files", result.FilesScanned))
 	parts = append(parts, fmt.Sprintf("%d rules", result.RulesLoaded))
@@ -167,7 +167,7 @@ func (f *TerminalFormatter) printSeveritySection(w io.Writer, sev scanner.Severi
 
 	grouped := groupByFile(findings)
 	for _, group := range grouped {
-		fmt.Fprintf(w, "\n  %s\n", f.color(bold+underline, group.filePath))
+		fmt.Fprintf(w, "\n  %s\n", f.color(bold+underline, TerminalText(group.filePath)))
 		for _, finding := range group.findings {
 			if sev == scanner.SeverityCritical {
 				f.printFindingExpanded(w, finding)
@@ -180,10 +180,10 @@ func (f *TerminalFormatter) printSeveritySection(w io.Writer, sev scanner.Severi
 
 func (f *TerminalFormatter) printFindingExpanded(w io.Writer, finding scanner.Finding) {
 	icon := f.severityIcon(finding.Severity)
-	ruleID := fmt.Sprintf("%-*s", ruleIDWidth, finding.RuleID)
-	name := truncate(finding.RuleName, nameWidth)
+	ruleID := fmt.Sprintf("%-*s", ruleIDWidth, TerminalText(finding.RuleID))
+	name := truncate(TerminalText(finding.RuleName), nameWidth)
 	namePadded := fmt.Sprintf("%-*s", nameWidth, name)
-	lineStr := fmt.Sprintf("%s:%d", finding.FilePath, finding.Line)
+	lineStr := fmt.Sprintf("%s:%d", TerminalText(finding.FilePath), finding.Line)
 	if finding.InCodeBlock {
 		lineStr += " " + f.color(dim, "[code]")
 	}
@@ -199,23 +199,23 @@ func (f *TerminalFormatter) printFindingExpanded(w io.Writer, finding scanner.Fi
 	)
 
 	if finding.MatchedText != "" {
-		preview := truncate(finding.MatchedText, previewWidth)
+		preview := truncate(TerminalText(finding.MatchedText), previewWidth)
 		fmt.Fprintf(w, "      %s %s\n", f.color(dim, "\u2502"), f.color(dim, preview))
 	}
 	if f.Verbose && finding.Description != "" {
-		fmt.Fprintf(w, "      %s %s\n", f.color(dim, "\u2502"), f.color(yellow, finding.Description))
+		fmt.Fprintf(w, "      %s %s\n", f.color(dim, "\u2502"), f.color(yellow, TerminalText(finding.Description)))
 	}
 	if finding.Remediation != "" {
-		fmt.Fprintf(w, "      %s %s %s\n", f.color(dim, "\u2502"), f.color(dim, "Fix:"), f.color(cyan, finding.Remediation))
+		fmt.Fprintf(w, "      %s %s %s\n", f.color(dim, "\u2502"), f.color(dim, "Fix:"), f.color(cyan, TerminalText(finding.Remediation)))
 	}
 }
 
 func (f *TerminalFormatter) printFindingCompact(w io.Writer, finding scanner.Finding) {
 	icon := f.severityIcon(finding.Severity)
-	ruleID := fmt.Sprintf("%-*s", ruleIDWidth, finding.RuleID)
-	name := truncate(finding.RuleName, nameWidth)
+	ruleID := fmt.Sprintf("%-*s", ruleIDWidth, TerminalText(finding.RuleID))
+	name := truncate(TerminalText(finding.RuleName), nameWidth)
 	namePadded := fmt.Sprintf("%-*s", nameWidth, name)
-	lineStr := fmt.Sprintf("%s:%d", finding.FilePath, finding.Line)
+	lineStr := fmt.Sprintf("%s:%d", TerminalText(finding.FilePath), finding.Line)
 	if finding.InCodeBlock {
 		lineStr += " " + f.color(dim, "[code]")
 	}
@@ -230,10 +230,10 @@ func (f *TerminalFormatter) printFindingCompact(w io.Writer, finding scanner.Fin
 		f.color(cyan, lineStr),
 	)
 	if f.Verbose && finding.Severity >= scanner.SeverityHigh && finding.Description != "" {
-		fmt.Fprintf(w, "      %s %s\n", f.color(dim, "\u2502"), f.color(yellow, finding.Description))
+		fmt.Fprintf(w, "      %s %s\n", f.color(dim, "\u2502"), f.color(yellow, TerminalText(finding.Description)))
 	}
 	if f.Verbose && finding.Remediation != "" {
-		fmt.Fprintf(w, "      %s %s %s\n", f.color(dim, "\u2502"), f.color(dim, "Fix:"), f.color(cyan, finding.Remediation))
+		fmt.Fprintf(w, "      %s %s %s\n", f.color(dim, "\u2502"), f.color(dim, "Fix:"), f.color(cyan, TerminalText(finding.Remediation)))
 	}
 }
 
@@ -267,7 +267,7 @@ func (f *TerminalFormatter) printTopFiles(w io.Writer, findings []scanner.Findin
 	fmt.Fprintf(w, "\n%s\n\n", f.color(bold, header))
 
 	for i := range limit {
-		fmt.Fprintf(w, "  %4d  %s\n", sorted[i].count, sorted[i].path)
+		fmt.Fprintf(w, "  %4d  %s\n", sorted[i].count, TerminalText(sorted[i].path))
 	}
 }
 
@@ -299,7 +299,7 @@ func (f *TerminalFormatter) printFooter(w io.Writer, result *scanner.ScanResult)
 	fmt.Fprintf(w, "%s\n", f.color(dim, sep))
 
 	if rule := topRuleID(result.Findings); rule != "" {
-		fmt.Fprintf(w, "  %s\n", f.color(dim, "Next: aguara explain "+rule))
+		fmt.Fprintf(w, "  %s\n", f.color(dim, "Next: aguara explain "+TerminalText(rule)))
 	}
 }
 
@@ -369,7 +369,15 @@ func truncate(s string, maxLen int) string {
 	if len(s) <= maxLen {
 		return s
 	}
-	return s[:maxLen-3] + "..."
+	if maxLen <= 3 {
+		return strings.Repeat(".", max(maxLen, 0))
+	}
+	// Preserve the byte budget without splitting a UTF-8 character.
+	end := maxLen - 3
+	for end > 0 && !utf8.RuneStart(s[end]) {
+		end--
+	}
+	return s[:end] + "..."
 }
 
 type fileGroup struct {

--- a/internal/output/terminal_text.go
+++ b/internal/output/terminal_text.go
@@ -1,0 +1,30 @@
+package output
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// TerminalText escapes control characters in a data field before styling it.
+// It is not for formatted output: layout newlines and trusted ANSI codes must
+// be added after this boundary. The source value remains unchanged.
+func TerminalText(s string) string {
+	var b strings.Builder
+	for len(s) > 0 {
+		r, size := utf8.DecodeRuneInString(s)
+		if r == utf8.RuneError && size == 1 {
+			fmt.Fprintf(&b, "\\x%02x", s[0])
+		} else if unicode.IsControl(r) || r == '\u2028' || r == '\u2029' ||
+			(r >= '\u202a' && r <= '\u202e') || (r >= '\u2066' && r <= '\u2069') {
+			quoted := strconv.QuoteRune(r)
+			b.WriteString(quoted[1 : len(quoted)-1])
+		} else {
+			b.WriteString(s[:size])
+		}
+		s = s[size:]
+	}
+	return b.String()
+}

--- a/internal/output/terminal_text_test.go
+++ b/internal/output/terminal_text_test.go
@@ -1,0 +1,61 @@
+package output
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/garagon/aguara/internal/scanner"
+)
+
+func TestTerminalText(t *testing.T) {
+	for _, tc := range []struct{ input, want string }{
+		{"normal/path with spaces", "normal/path with spaces"},
+		{"caf\u00e9/\u65e5\u672c.md", "caf\u00e9/\u65e5\u672c.md"},
+		{`C:\Users\dev`, `C:\Users\dev`},
+		{"\x1b[2J\x1b]0;x\x07", `\x1b[2J\x1b]0;x\a`},
+		{"\r\n\t\b\x00\x7f", `\r\n\t\b\x00\x7f`},
+		{"\u009b31m\u009d", `\u009b31m\u009d`},
+		{"\x9b\xff", `\x9b\xff`},
+		{"\u202e\u2066\u2028", `\u202e\u2066\u2028`},
+	} {
+		if got := TerminalText(tc.input); got != tc.want || !utf8.ValidString(got) {
+			t.Errorf("input=%q got=%q want=%q", tc.input, got, tc.want)
+		}
+	}
+}
+
+func TestTerminalFormatterEscapesDataWithoutChangingResult(t *testing.T) {
+	for _, noColor := range []bool{true, false} {
+		t.Setenv("NO_COLOR", "")
+		bad := "sample\x1b[2J\r\nspoof\u009d"
+		name := strings.Repeat("A", 30) + "\t\u00e9BBBB"
+		result := &scanner.ScanResult{Target: bad, Findings: []scanner.Finding{
+			{RuleID: bad, RuleName: name, FilePath: bad, MatchedText: strings.Repeat("A", 54) + "\t\u00e9BBBB", Description: bad, Remediation: bad, Severity: scanner.SeverityCritical},
+			{RuleID: bad, RuleName: name, FilePath: bad, Description: bad, Remediation: bad, Severity: scanner.SeverityHigh},
+		}}
+		before, _ := json.Marshal(result)
+		var buf bytes.Buffer
+		f := TerminalFormatter{NoColor: noColor, Verbose: true}
+		if err := f.Format(&buf, result); err != nil {
+			t.Fatal(err)
+		}
+		for _, control := range []string{"\x1b[2J", "\r", "\nspoof", "\u009d"} {
+			if strings.Contains(buf.String(), control) {
+				t.Errorf("control survived: %q", control)
+			}
+		}
+		if !noColor && !strings.Contains(buf.String(), "\x1b[1m") {
+			t.Error("trusted style lost")
+		}
+		if !utf8.Valid(buf.Bytes()) {
+			t.Error("rendered output splits a Unicode character")
+		}
+		after, _ := json.Marshal(result)
+		if !bytes.Equal(before, after) {
+			t.Error("terminal rendering mutated result")
+		}
+	}
+}


### PR DESCRIPTION
A filename or MCP server name can contain terminal escape sequences. Printing those bytes directly lets the input change how a scan report appears, even with `--no-color`.

This change renders control characters as visible escapes in the terminal output of `scan`, `check`, `audit`, and the `discover` tree. It covers paths, finding text, package-check details, and discovered server names, commands, and arguments. The escaping happens before Aguara applies its own colors and layout.

JSON and source result values stay unchanged. Findings, severity, verdicts, and scan behavior are unaffected. Ordinary paths, spaces, printable Unicode, and Windows backslashes remain readable.

Regression tests cover ANSI/OSC sequences, carriage returns, line breaks, C1 controls, invalid UTF-8 bytes, and directional controls. Renderer tests exercise both color modes, preserve trusted styling, and verify that rendering does not mutate the source JSON. Truncation now preserves UTF-8 character boundaries, including when an escaped control shifts a long name or preview. Discovery coverage starts with escaped controls parsed from a JSON configuration.

This PR addresses terminal report fields, not Markdown rendering, shell quoting, or credential redaction.
