### PR TITLE
Keep unverified intel out of trusted offline checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Intel downloaded with `--insecure-intel` is now labeled unverified and cannot
+  become trusted input to later default checks or `--allow-stale`. Unverified
+  saves clear previous verification markers. Older markers require a new signed
+  `aguara update` because they did not distinguish skipped signature checks.
+  Normal signed refreshes and verified offline fallback remain supported.
 - Terminal reports now display control characters in filenames, finding text,
   and discovered MCP server fields as visible escapes instead of letting them
   alter the terminal. This applies with or without color; structured report

--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ aguara check . --fresh
 
 `update` and `--fresh` fetch and verify Aguara's signed advisory bundle. Later checks can use the verified local cache offline. Snapshot age is context, not evidence that a dependency is safe or malicious.
 
+The explicit `--insecure-intel` escape hatch skips signature verification only
+when `AGUARA_INSECURE_INTEL=1` is also set. Such downloads are labeled unverified
+and cannot be reused by default checks or `--allow-stale`. Older cache markers
+do not reliably establish that a signature was verified; run `aguara update`
+without `--insecure-intel` to restore verified offline use after upgrading.
+
 Release notices are separate from analysis: `aguara version` can check for a newer release, and v0.27.0 also does this during `scan`. Set `AGUARA_NO_UPDATE_CHECK=1` to disable those checks. For network-isolated use, set that variable and avoid `update` and `--fresh`; no online lookup is needed to analyze the content.
 
 ## Adopting Aguara in CI

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -1080,7 +1080,7 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 // The logic is:
 //
 //  1. If --fresh was passed, fetch + verify Aguara's signed advisory
-//     bundle (fetchVerifiedSnapshot); on success save it to the local
+//     bundle (fetchIntelSnapshot); on signed success save it to the local
 //     Store via SaveVerified and override with [embedded..., refreshed].
 //     IntelSummary.Mode = "online", Snapshot = "remote-fresh".
 //  2. If --fresh failed AND --allow-stale was passed, fall back ONLY to
@@ -1097,7 +1097,7 @@ func writeCheckTerminal(result *incident.CheckResult, plan checkPlan) error {
 //
 // A --fresh refresh fetches Aguara's signed advisory bundle and verifies
 // it (signature + identity + manifest/blob digests) before trusting it,
-// via the shared fetchVerifiedSnapshot path. ecosystems still scopes
+// via the shared fetchIntelSnapshot path. ecosystems still scopes
 // WHICH ecosystems the check looks at, but the fetched bundle always
 // covers all of them.
 func resolveCheckIntel(ctx context.Context, ecosystems []string) (*incident.IntelOverride, error) {
@@ -1127,9 +1127,9 @@ func resolveCheckIntel(ctx context.Context, ecosystems []string) (*incident.Inte
 		}
 
 		// Shared trust-root path: fetch + verify the signed advisory
-		// bundle (same as `aguara update`). A verification failure is
-		// fatal; we never trust an unverified fetch.
-		snap, err := fetchVerifiedSnapshot(ctx, intelBundleBaseURL, insecure)
+		// bundle (same as `aguara update`). Explicit insecure mode keeps
+		// its unverified status through output and persistence.
+		fetched, err := fetchIntelSnapshot(ctx, intelBundleBaseURL, insecure)
 		if err != nil {
 			if !flagCheckAllowStale {
 				return nil, fmt.Errorf("--fresh refresh failed: %w (pass --allow-stale to fall back to previously verified local intel)", err)
@@ -1145,18 +1145,21 @@ func resolveCheckIntel(ctx context.Context, ecosystems []string) (*incident.Inte
 			return ov, nil
 		}
 		if store != nil {
-			// SaveVerified writes a provenance marker so a later
-			// --allow-stale can prove the cache was verified.
-			if saveErr := store.SaveVerified(snap); saveErr != nil {
+			if saveErr := fetched.save(store); saveErr != nil {
 				fmt.Fprintf(os.Stderr, "warning: --fresh: save snapshot failed: %v\n", saveErr)
 			}
+		}
+		snap := fetched.Snapshot
+		label := "remote-fresh"
+		if !fetched.Verified {
+			label = "remote-unverified"
 		}
 		snaps := append([]intel.Snapshot{}, incident.EmbeddedSnapshots()...)
 		snaps = append(snaps, snap)
 		return &incident.IntelOverride{
 			Snapshots:     snaps,
 			Mode:          "online",
-			SnapshotLabel: "remote-fresh",
+			SnapshotLabel: label,
 			GeneratedAt:   snap.GeneratedAt,
 		}, nil
 	}

--- a/cmd/aguara/commands/freshintel.go
+++ b/cmd/aguara/commands/freshintel.go
@@ -32,17 +32,29 @@ func resolveInsecureIntel(flag bool) (bool, error) {
 	return true, nil
 }
 
-// fetchVerifiedSnapshot is the single trust-root path shared by
+type fetchedIntel struct {
+	Snapshot intel.Snapshot
+	Verified bool
+}
+
+func (f fetchedIntel) save(store *intel.Store) error {
+	if f.Verified {
+		return store.SaveVerified(f.Snapshot)
+	}
+	return store.Save(f.Snapshot)
+}
+
+// fetchIntelSnapshot is the single trust-root path shared by
 // `aguara update`, `check --fresh`, and `audit --fresh`: fetch the signed
-// advisory bundle from baseURL and return the decoded snapshot. It never
-// returns a snapshot that failed verification.
+// advisory bundle from baseURL and retain its verification status. A normal
+// fetch never returns data that failed signature verification.
 //
 // With insecure=false (default) it verifies the Sigstore signature and
 // pinned publisher identity, then validates the manifest against the blob.
 // With insecure=true it skips only the signature/identity step; the
 // manifest/blob content checks (schema, name, sizes, digests, decode)
 // still run.
-func fetchVerifiedSnapshot(ctx context.Context, baseURL string, insecure bool) (intel.Snapshot, error) {
+func fetchIntelSnapshot(ctx context.Context, baseURL string, insecure bool) (fetchedIntel, error) {
 	get := func(name string) ([]byte, error) {
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, baseURL+"/"+name, nil)
 		if err != nil {
@@ -69,20 +81,28 @@ func fetchVerifiedSnapshot(ctx context.Context, baseURL string, insecure bool) (
 
 	manifest, err := get("generated_intel.meta.json")
 	if err != nil {
-		return intel.Snapshot{}, err
+		return fetchedIntel{}, err
 	}
 	blob, err := get(bundle.ExpectedBlobName)
 	if err != nil {
-		return intel.Snapshot{}, err
+		return fetchedIntel{}, err
 	}
 	if insecure {
 		// The signing bundle is not needed when signature verification
 		// is disabled.
-		return bundle.DecodeUnverified(manifest, blob)
+		snap, err := bundle.DecodeUnverified(manifest, blob)
+		if err != nil {
+			return fetchedIntel{}, err
+		}
+		return fetchedIntel{Snapshot: snap}, nil
 	}
 	bundleBytes, err := get("generated_intel.meta.json.bundle")
 	if err != nil {
-		return intel.Snapshot{}, err
+		return fetchedIntel{}, err
 	}
-	return bundle.VerifyAndDecode(manifest, bundleBytes, blob)
+	snap, err := bundle.VerifyAndDecode(manifest, bundleBytes, blob)
+	if err != nil {
+		return fetchedIntel{}, err
+	}
+	return fetchedIntel{Snapshot: snap, Verified: true}, nil
 }

--- a/cmd/aguara/commands/intel_freshness.go
+++ b/cmd/aguara/commands/intel_freshness.go
@@ -60,6 +60,8 @@ func intelSourceLabel(snapshot string) string {
 		return "local verified"
 	case "remote-fresh":
 		return "remote (fresh)"
+	case "remote-unverified":
+		return "remote (UNVERIFIED: signature verification skipped)"
 	case "":
 		return "embedded"
 	default:

--- a/cmd/aguara/commands/intel_provenance_test.go
+++ b/cmd/aguara/commands/intel_provenance_test.go
@@ -1,0 +1,105 @@
+package commands
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestInsecureUpdateDoesNotEstablishVerifiedCache(t *testing.T) {
+	resetFlags()
+	t.Cleanup(resetFlags)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(intelInsecureEnv, "1")
+	prev := intelBundleBaseURL
+	intelBundleBaseURL = serveBundleBadSignature(t)
+	t.Cleanup(func() { intelBundleBaseURL = prev; rootCmd.SetArgs(nil) })
+	out := filepath.Join(t.TempDir(), "update.json")
+	rootCmd.SetArgs([]string{"update", "--insecure-intel", "--format", "json", "-o", out})
+	require.NoError(t, rootCmd.Execute())
+	s := &intel.Store{Dir: filepath.Join(home, ".aguara", "intel")}
+	_, err := s.LoadVerified()
+	require.Error(t, err, "bypassed signature must not become trusted local intel")
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	var report updateOutput
+	require.NoError(t, json.Unmarshal(data, &report))
+	require.False(t, report.Verified)
+	require.Nil(t, localOrEmbeddedOverride(s))
+}
+
+func TestInsecureFreshCacheCannotBeReusedByDefaultOrStale(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(intelInsecureEnv, "1")
+	require.NoError(t, runCheckFresh(t, t.TempDir(), serveBundleBadSignature(t), "--insecure-intel"))
+	data, err := os.ReadFile(flagOutput)
+	require.NoError(t, err)
+	var report incident.CheckResult
+	require.NoError(t, json.Unmarshal(data, &report))
+	require.Equal(t, "remote-unverified", report.Intel.Snapshot)
+	s := &intel.Store{Dir: filepath.Join(home, ".aguara", "intel")}
+	require.Nil(t, localOrEmbeddedOverride(s), "default check must not reuse unsigned intel")
+	require.Error(t, runCheckFresh(t, t.TempDir(), serveBundleBadSignature(t), "--allow-stale"))
+}
+
+func TestInsecureAuditProvenance(t *testing.T) {
+	resetFlags()
+	t.Cleanup(resetFlags)
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv(intelInsecureEnv, "1")
+	dir := t.TempDir()
+	writeBenignNPM(t, dir)
+	prev := intelBundleBaseURL
+	intelBundleBaseURL = serveBundleBadSignature(t)
+	t.Cleanup(func() { intelBundleBaseURL = prev; rootCmd.SetArgs(nil) })
+	out := filepath.Join(t.TempDir(), "audit.json")
+	rootCmd.SetArgs([]string{"audit", dir, "--fresh", "--insecure-intel", "--format", "json", "-o", out})
+	require.NoError(t, rootCmd.Execute())
+	data, err := os.ReadFile(out)
+	require.NoError(t, err)
+	var report AuditResult
+	require.NoError(t, json.Unmarshal(data, &report))
+	require.Equal(t, "remote-unverified", report.Intel.Snapshot)
+	require.Equal(t, report.Intel.Snapshot, report.Check.Intel.Snapshot)
+	s := &intel.Store{Dir: filepath.Join(home, ".aguara", "intel")}
+	_, err = s.LoadVerified()
+	require.Error(t, err)
+}
+
+func TestIntelFetchVerificationStatusAndContentChecks(t *testing.T) {
+	t.Setenv(intelInsecureEnv, "1")
+	insecure, err := resolveInsecureIntel(false)
+	require.NoError(t, err)
+	require.False(t, insecure, "env alone is not authorization")
+	_, err = fetchIntelSnapshot(context.Background(), serveBundleBadSignature(t), insecure)
+	require.Error(t, err)
+	_, err = fetchIntelSnapshot(context.Background(), serveSignedBundle(t, true), true)
+	require.Error(t, err, "bypass must not skip content integrity")
+	fetched, err := fetchIntelSnapshot(context.Background(), serveSignedBundle(t, false), false)
+	require.NoError(t, err)
+	require.True(t, fetched.Verified)
+	s := &intel.Store{Dir: t.TempDir()}
+	require.NoError(t, fetched.save(s))
+	_, err = s.LoadVerified()
+	require.NoError(t, err)
+}
+
+func TestUnverifiedUpdateTerminalIsExplicit(t *testing.T) {
+	resetFlags()
+	t.Cleanup(resetFlags)
+	out := captureStdoutBytes(t, func() {
+		require.NoError(t, writeUpdateOutput(intel.Snapshot{}, t.TempDir(), false))
+	})
+	require.Contains(t, string(out), "UNVERIFIED")
+	require.NotContains(t, string(out), "(verified signed bundle)")
+	require.Contains(t, intelSourceLabel("remote-unverified"), "UNVERIFIED")
+}

--- a/cmd/aguara/commands/update.go
+++ b/cmd/aguara/commands/update.go
@@ -97,24 +97,24 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	// name, gzip/json digests + sizes, and bundle_schema_version against
 	// the decoded snapshot. A failure leaves the cache untouched (no
 	// partial writes).
-	snap, err := fetchVerifiedSnapshot(ctx, intelBundleBaseURL, insecure)
+	fetched, err := fetchIntelSnapshot(ctx, intelBundleBaseURL, insecure)
 	if err != nil {
 		return fmt.Errorf("aguara update: %w", err)
 	}
 
-	// A verified-but-empty bundle is almost certainly a publishing
+	snap := fetched.Snapshot
+	// An empty bundle is almost certainly a publishing
 	// fault; preserve cached intel unless the operator opts in.
 	if len(snap.Records) == 0 && !flagUpdateAllowEmpty {
-		return fmt.Errorf("aguara update: verified bundle has 0 records; refusing to overwrite cached intel (pass --allow-empty to save anyway)")
+		return fmt.Errorf("aguara update: bundle has 0 records; refusing to overwrite cached intel (pass --allow-empty to save anyway)")
 	}
 
-	// SaveVerified writes a provenance marker so a later --allow-stale
-	// fallback can prove this cache came from a verified signed bundle.
-	if err := store.SaveVerified(snap); err != nil {
+	// Only signature-verified downloads establish reusable cache trust.
+	if err := fetched.save(store); err != nil {
 		return fmt.Errorf("aguara update: save snapshot: %w", err)
 	}
 
-	return writeUpdateOutput(snap, store.Dir)
+	return writeUpdateOutput(snap, store.Dir, fetched.Verified)
 }
 
 // updateOutput is the JSON-stable shape `aguara update --format json`
@@ -128,7 +128,7 @@ type updateOutput struct {
 	Verified     bool      `json:"verified"`
 }
 
-func buildUpdateOutput(snap intel.Snapshot, storeDir string) updateOutput {
+func buildUpdateOutput(snap intel.Snapshot, storeDir string, verified bool) updateOutput {
 	ecos := intel.EcosystemsFromSources(snap.Sources)
 	if ecos == nil {
 		ecos = []string{}
@@ -139,15 +139,15 @@ func buildUpdateOutput(snap intel.Snapshot, storeDir string) updateOutput {
 		GeneratedAt:  snap.GeneratedAt,
 		Ecosystems:   ecos,
 		Source:       "intel-latest",
-		Verified:     true,
+		Verified:     verified,
 	}
 }
 
 // writeUpdateOutput dispatches between the JSON and terminal writers
 // based on the global --format flag. The -o flag redirects either format
 // to a file; otherwise both go to stdout.
-func writeUpdateOutput(snap intel.Snapshot, storeDir string) error {
-	out := buildUpdateOutput(snap, storeDir)
+func writeUpdateOutput(snap intel.Snapshot, storeDir string, verified bool) error {
+	out := buildUpdateOutput(snap, storeDir, verified)
 	if strings.ToLower(flagFormat) == "json" {
 		return writeUpdateJSON(out)
 	}
@@ -179,7 +179,12 @@ func writeUpdateTerminal(out updateOutput) error {
 		defer func() { _ = f.Close() }()
 		w = f
 	}
-	fmt.Fprintf(w, "Aguara threat intel updated (verified signed bundle)\n")
+	if out.Verified {
+		fmt.Fprintf(w, "Aguara threat intel updated (verified signed bundle)\n")
+	} else {
+		fmt.Fprintf(w, "Aguara threat intel updated (UNVERIFIED: signature verification skipped)\n")
+		fmt.Fprintf(w, "  Not eligible for default checks or --allow-stale; run aguara update without --insecure-intel to verify.\n")
+	}
 	fmt.Fprintf(w, "  records:    %d\n", out.Records)
 	fmt.Fprintf(w, "  ecosystems: %s\n", strings.Join(out.Ecosystems, ", "))
 	fmt.Fprintf(w, "  written:    %s\n", out.SnapshotPath)

--- a/cmd/aguara/commands/update_test.go
+++ b/cmd/aguara/commands/update_test.go
@@ -63,7 +63,7 @@ func TestWriteUpdateJSONShape(t *testing.T) {
 	storeDir := "/home/user/.aguara/intel"
 
 	out := captureStdoutBytes(t, func() {
-		require.NoError(t, writeUpdateOutput(snap, storeDir))
+		require.NoError(t, writeUpdateOutput(snap, storeDir, true))
 	})
 
 	var parsed updateOutput
@@ -90,7 +90,7 @@ func TestWriteUpdateJSONEmptyEcosystems(t *testing.T) {
 
 	snap := intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion, GeneratedAt: time.Unix(0, 0).UTC()}
 	out := captureStdoutBytes(t, func() {
-		require.NoError(t, writeUpdateOutput(snap, "/tmp"))
+		require.NoError(t, writeUpdateOutput(snap, "/tmp", true))
 	})
 	require.Contains(t, string(out), `"ecosystems": []`,
 		"empty ecosystems must serialise as [] not null; got: %s", string(out))
@@ -107,7 +107,7 @@ func TestWriteUpdateJSONToFile(t *testing.T) {
 
 	snap := makeSnapshot(20, time.Date(2026, time.May, 28, 0, 0, 0, 0, time.UTC))
 	stdoutBytes := captureStdoutBytes(t, func() {
-		require.NoError(t, writeUpdateOutput(snap, "/home/user/.aguara/intel"))
+		require.NoError(t, writeUpdateOutput(snap, "/home/user/.aguara/intel", true))
 	})
 	require.Empty(t, stdoutBytes, "--format json -o file must leave stdout empty")
 
@@ -125,7 +125,7 @@ func TestWriteUpdateTerminalDefault(t *testing.T) {
 
 	snap := makeSnapshot(15, time.Unix(0, 0))
 	out := captureStdoutBytes(t, func() {
-		require.NoError(t, writeUpdateOutput(snap, "/home/user/.aguara/intel"))
+		require.NoError(t, writeUpdateOutput(snap, "/home/user/.aguara/intel", true))
 	})
 	s := string(out)
 	require.Contains(t, s, "Aguara threat intel updated")
@@ -144,7 +144,7 @@ func TestWriteUpdateTerminalRespectsOutputFile(t *testing.T) {
 
 	snap := makeSnapshot(15, time.Unix(0, 0))
 	stdoutBytes := captureStdoutBytes(t, func() {
-		require.NoError(t, writeUpdateOutput(snap, "/home/user/.aguara/intel"))
+		require.NoError(t, writeUpdateOutput(snap, "/home/user/.aguara/intel", true))
 	})
 	require.Empty(t, stdoutBytes, "with -o, stdout must be empty regardless of format")
 	fileBytes, err := os.ReadFile(outFile)

--- a/internal/incident/checker.go
+++ b/internal/incident/checker.go
@@ -70,7 +70,8 @@ type CheckResult struct {
 //     (an --fresh refresh ran in this invocation).
 //   - Snapshot is one of: "embedded" (binary's built-in snapshot),
 //     "local" (the on-disk cache at ~/.aguara/intel), or
-//     "remote-fresh" (downloaded this invocation).
+//     "local-verified" (verified cache), "remote-fresh" (verified this
+//     invocation), or "remote-unverified" (explicit signature bypass).
 //   - Sources lists the SourceMeta.Kind values that fed the
 //     snapshot, deduplicated.
 //   - Stale is true when the snapshot is older than a freshness
@@ -118,7 +119,7 @@ type CheckOptions struct {
 type IntelOverride struct {
 	Snapshots     []intel.Snapshot
 	Mode          string // "offline" | "online"
-	SnapshotLabel string // "embedded" | "local" | "local-verified" | "remote-fresh"
+	SnapshotLabel string // "embedded" | "local" | "local-verified" | "remote-fresh" | "remote-unverified"
 	// GeneratedAt is the timestamp of the snapshot the SnapshotLabel
 	// names (e.g. the local verified cache), not the newest snapshot in
 	// the set. When a local/fetched cache is layered over the (possibly

--- a/internal/intel/provenance_internal_test.go
+++ b/internal/intel/provenance_internal_test.go
@@ -1,0 +1,48 @@
+package intel
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStagingFailureDoesNotInvalidateProvenance(t *testing.T) {
+	// A missing staging directory exercises the same CreateTemp failure branch
+	// as descriptor/disk exhaustion, without exhausting host resources.
+	store := &Store{Dir: t.TempDir()}
+	if err := store.SaveVerified(Snapshot{SchemaVersion: CurrentSchemaVersion}); err != nil {
+		t.Fatal(err)
+	}
+	staging := &Store{Dir: filepath.Join(t.TempDir(), "missing")}
+	called := false
+	err := staging.atomicWriteBeforeRename(store.snapshotPath(), []byte("replacement"), func() error {
+		called = true
+		return os.Remove(store.verifiedMarkerPath())
+	})
+	if err == nil || called {
+		t.Fatalf("staging failure invalidated provenance: called=%v err=%v", called, err)
+	}
+	if _, err := store.LoadVerified(); err != nil {
+		t.Fatalf("previous cache unusable: %v", err)
+	}
+}
+
+func TestBeforeRenameFailurePreservesSnapshotAndCleansTemp(t *testing.T) {
+	store := &Store{Dir: t.TempDir()}
+	if err := store.SaveVerified(Snapshot{SchemaVersion: CurrentSchemaVersion}); err != nil {
+		t.Fatal(err)
+	}
+	want := errors.New("cannot invalidate")
+	err := store.atomicWriteBeforeRename(store.snapshotPath(), []byte("replacement"), func() error { return want })
+	if !errors.Is(err, want) {
+		t.Fatalf("unexpected failure: %v", err)
+	}
+	if _, err := store.LoadVerified(); err != nil {
+		t.Fatalf("previous cache unusable: %v", err)
+	}
+	entries, err := os.ReadDir(store.Dir)
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("temporary file left behind: %v %v", entries, err)
+	}
+}

--- a/internal/intel/provenance_test.go
+++ b/internal/intel/provenance_test.go
@@ -1,0 +1,75 @@
+package intel_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStorePlainSaveInvalidatesSameSnapshotVerification(t *testing.T) {
+	s := &intel.Store{Dir: t.TempDir()}
+	snap := intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion}
+	require.NoError(t, s.SaveVerified(snap))
+	require.NoError(t, s.Save(snap))
+	_, err := s.LoadVerified()
+	require.Error(t, err, "plain save must not inherit a marker even for identical bytes")
+	_, err = s.Load()
+	require.NoError(t, err, "unverified snapshot remains inspectable")
+	require.NoError(t, s.SaveVerified(snap))
+	_, err = s.LoadVerified()
+	require.NoError(t, err, "signed refresh restores trust")
+}
+
+func TestStoreRejectsLegacyVerificationMarker(t *testing.T) {
+	s := &intel.Store{Dir: t.TempDir()}
+	require.NoError(t, s.SaveVerified(intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion}))
+	path := filepath.Join(s.Dir, "verified.json")
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	var marker map[string]any
+	require.NoError(t, json.Unmarshal(data, &marker))
+	delete(marker, "schema_version")
+	data, err = json.Marshal(marker)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	_, err = s.LoadVerified()
+	require.Error(t, err, "legacy markers cannot prove signature verification occurred")
+	marker["schema_version"] = 999
+	data, err = json.Marshal(marker)
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+	_, err = s.LoadVerified()
+	require.Error(t, err, "future markers cannot silently acquire trust")
+}
+
+func TestStorePlainSaveAbortsWhenMarkerCannotBeInvalidated(t *testing.T) {
+	s := &intel.Store{Dir: t.TempDir()}
+	snap := intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion}
+	require.NoError(t, s.Save(snap))
+	path := filepath.Join(s.Dir, "snapshot.json")
+	before, err := os.ReadFile(path)
+	require.NoError(t, err)
+	markerPath := filepath.Join(s.Dir, "verified.json")
+	require.NoError(t, os.Mkdir(markerPath, 0o700))
+	require.NoError(t, os.WriteFile(filepath.Join(markerPath, "occupied"), []byte("x"), 0o600))
+	snap.Records = []intel.Record{{ID: "different"}}
+	require.Error(t, s.Save(snap))
+	after, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.Equal(t, before, after)
+}
+
+func TestStoreDifferentUnverifiedSnapshotCannotInheritTrust(t *testing.T) {
+	s := &intel.Store{Dir: t.TempDir()}
+	snap := intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion}
+	require.NoError(t, s.SaveVerified(snap))
+	snap.Records = []intel.Record{{ID: "different"}}
+	require.NoError(t, s.Save(snap))
+	_, err := s.LoadVerified()
+	require.Error(t, err)
+	require.NoFileExists(t, filepath.Join(s.Dir, "verified.json"))
+}

--- a/internal/intel/store.go
+++ b/internal/intel/store.go
@@ -35,9 +35,14 @@ const snapshotFileName = "snapshot.json"
 // a local snapshot as "previously verified by a signed bundle".
 const verifiedMarkerFileName = "verified.json"
 
+// Legacy markers could also be written by signature-bypassed refreshes.
+// Their matching digest cannot establish publisher authentication.
+const verifiedMarkerVersion = 2
+
 // verifiedMarker binds a local snapshot to a successful signature
 // verification by recording the SHA-256 of the exact snapshot bytes.
 type verifiedMarker struct {
+	SchemaVersion  int       `json:"schema_version"`
 	SnapshotSHA256 string    `json:"snapshot_sha256"`
 	VerifiedAt     time.Time `json:"verified_at"`
 }
@@ -142,6 +147,7 @@ func (s *Store) Load() (*Snapshot, error) {
 // Save validates snap by re-marshalling the JSON before writing so
 // a struct that cannot serialise (e.g. an exotic time) errors out
 // before the on-disk file is touched.
+// Plain saves invalidate any verified marker, even for identical snapshot bytes.
 func (s *Store) Save(snap Snapshot) error {
 	data, err := s.marshalForSave(snap)
 	if err != nil {
@@ -150,7 +156,12 @@ func (s *Store) Save(snap Snapshot) error {
 	if err := s.ensureDir(); err != nil {
 		return fmt.Errorf("intel store: mkdir: %w", err)
 	}
-	return s.atomicWrite(s.snapshotPath(), data)
+	return s.atomicWriteBeforeRename(s.snapshotPath(), data, func() error {
+		if err := os.Remove(s.verifiedMarkerPath()); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("intel store: invalidate verified marker: %w", err)
+		}
+		return nil
+	})
 }
 
 // SaveVerified persists snap AND a provenance marker (verified.json)
@@ -177,6 +188,7 @@ func (s *Store) SaveVerified(snap Snapshot) error {
 	}
 	sum := sha256.Sum256(data)
 	marker := verifiedMarker{
+		SchemaVersion:  verifiedMarkerVersion,
 		SnapshotSHA256: hex.EncodeToString(sum[:]),
 		VerifiedAt:     time.Now().UTC(),
 	}
@@ -212,6 +224,13 @@ func (s *Store) marshalForSave(snap Snapshot) ([]byte, error) {
 // fsynced and chmod 0600, then renamed over dst. A concurrent reader sees
 // only the old or the new file, never a half-written one.
 func (s *Store) atomicWrite(dst string, data []byte) error {
+	return s.atomicWriteBeforeRename(dst, data, nil)
+}
+
+// Prepare the complete replacement before changing provenance. If the final
+// rename fails after invalidation, leave the cache unverified: restoring a
+// marker could bless a concurrent replacement. This is not a two-file transaction.
+func (s *Store) atomicWriteBeforeRename(dst string, data []byte, beforeRename func() error) error {
 	tmp, err := os.CreateTemp(s.Dir, ".intel-*.tmp")
 	if err != nil {
 		return fmt.Errorf("intel store: tempfile: %w", err)
@@ -234,6 +253,12 @@ func (s *Store) atomicWrite(dst string, data []byte) error {
 	if err := os.Chmod(tmpName, 0o600); err != nil {
 		_ = os.Remove(tmpName)
 		return fmt.Errorf("intel store: chmod %s: %w", tmpName, err)
+	}
+	if beforeRename != nil {
+		if err := beforeRename(); err != nil {
+			_ = os.Remove(tmpName)
+			return err
+		}
 	}
 	if err := os.Rename(tmpName, dst); err != nil {
 		_ = os.Remove(tmpName)
@@ -267,6 +292,9 @@ func (s *Store) LoadVerified() (*Snapshot, error) {
 	var marker verifiedMarker
 	if err := json.Unmarshal(markerData, &marker); err != nil {
 		return nil, fmt.Errorf("intel store: decode verified marker: %w", err)
+	}
+	if marker.SchemaVersion != verifiedMarkerVersion {
+		return nil, fmt.Errorf("intel store: cached verification marker is unsupported; run aguara update without --insecure-intel to verify again")
 	}
 	sum := sha256.Sum256(data)
 	if marker.SnapshotSHA256 != hex.EncodeToString(sum[:]) {


### PR DESCRIPTION
Skipping a signature check must not make the next scan trust that download as verified intelligence.

`--insecure-intel` already requires a second opt-in through `AGUARA_INSECURE_INTEL=1`. It intentionally accepts a bundle without authenticating its publisher, while still checking the manifest and content digests. Previously, that result was saved with the same verification marker as a signed bundle and could be reused by a later ordinary check or `--allow-stale`.

This change carries the verification result from download through persistence and reporting:

- Only a successful signature verification creates a reusable verified-cache marker.
- An unverified save removes previous verification, including when the snapshot bytes are identical.
- `update` reports `verified: false` for bypassed downloads. Fresh check/audit reports identify them as `remote-unverified`.
- Default checks and `--allow-stale` do not consume that unverified cache. Explicit insecure runs can still use the downloaded data for that invocation.

Existing cache markers cannot distinguish a signed refresh from a historical bypass. They are no longer accepted as proof of verification. After upgrading, run `aguara update` without `--insecure-intel` to restore verified offline-cache use. Embedded intelligence remains available without a network request.

Regression tests cover signed and unsigned refreshes, subsequent cache reuse, audit output, same-byte replacement, marker invalidation failures, legacy/unknown markers, and restoration through a signed save. Signature failures and content corruption still fail; normal signed refresh and verified stale fallback remain supported.

No advisory classification, matcher, rule, or severity changes. The marker remains a local record of verification, not a defense against another process with permission to rewrite the cache.

The replacement is prepared before existing provenance is invalidated. A failure at the final rename leaves the cache unverified rather than restoring a marker that could apply to an intervening write; snapshot and marker are not a two-file transaction.

Validation: focused race tests for intel persistence and update/check/audit workflows, scoped vet and lint (0 issues), and a full native build passed. Full repository tests run in CI. No local fuzzing, stress tests, or benchmarks were run.
