### PR TITLE
Stop treating incidental malware mentions as malicious-package evidence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Dependency checks no longer classify a package as malicious solely because a
+  vulnerability description or reference mentions malware. OSV imports require
+  source evidence or reviewed exact versions. The same policy filters older
+  embedded and cached intelligence, while retaining manual incident records,
+  MAL advisories and reviewed historical compromises. Generic vulnerability
+  reports are not treated as evidence that an installed package contains malware.
 - Intel downloaded with `--insecure-intel` is now labeled unverified and cannot
   become trusted input to later default checks or `--allow-stale`. Unverified
   saves clear previous verification markers. Older markers require a new signed

--- a/README.md
+++ b/README.md
@@ -110,6 +110,14 @@ The npm checks read `package.json` and project `.npmrc`; pnpm checks read `pnpm-
 
 The binary includes an advisory snapshot sourced from [OSV](https://osv.dev), including [OpenSSF Malicious Packages](https://github.com/ossf/malicious-packages), alongside manually curated incident records. OSV is an open-source vulnerability database developed by Google; Aguara imports a malicious-package-focused subset, not its entire CVE database.
 
+Descriptions mentioning malware are not enough to classify a package as malicious.
+Imports require source evidence or explicitly reviewed affected versions. Older
+OSV snapshots are filtered before use, including the embedded data and verified
+cache, so past keyword-based classifications cannot reappear after a refresh.
+See the [admission policy](internal/intel/ADMISSION.md) for accepted evidence and
+the bounded historical compatibility list. This filtering requires an updated
+binary; an intel refresh alone does not change older binaries.
+
 A package finding identifies the advisory behind the match. Check that record and its affected versions when investigating; the snapshot is not a complete inventory of every malicious package.
 
 Checks use embedded intelligence and any configured local cache without fetching the files being scanned. Refreshing intelligence is an explicit network operation:

--- a/cmd/aguara/commands/check.go
+++ b/cmd/aguara/commands/check.go
@@ -1188,7 +1188,7 @@ func localOrEmbeddedOverride(store *intel.Store) *incident.IntelOverride {
 		return nil
 	}
 	snaps := append([]intel.Snapshot{}, incident.EmbeddedSnapshots()...)
-	snaps = append(snaps, *snap)
+	snaps = append(snaps, intel.ApplyOSVAdmissionPolicy(*snap))
 	return &incident.IntelOverride{
 		Snapshots:     snaps,
 		Mode:          "offline",

--- a/cmd/aguara/commands/freshintel.go
+++ b/cmd/aguara/commands/freshintel.go
@@ -94,7 +94,7 @@ func fetchIntelSnapshot(ctx context.Context, baseURL string, insecure bool) (fet
 		if err != nil {
 			return fetchedIntel{}, err
 		}
-		return fetchedIntel{Snapshot: snap}, nil
+		return fetchedIntel{Snapshot: intel.ApplyOSVAdmissionPolicy(snap)}, nil
 	}
 	bundleBytes, err := get("generated_intel.meta.json.bundle")
 	if err != nil {
@@ -104,5 +104,5 @@ func fetchIntelSnapshot(ctx context.Context, baseURL string, insecure bool) (fet
 	if err != nil {
 		return fetchedIntel{}, err
 	}
-	return fetchedIntel{Snapshot: snap, Verified: true}, nil
+	return fetchedIntel{Snapshot: intel.ApplyOSVAdmissionPolicy(snap), Verified: true}, nil
 }

--- a/cmd/aguara/commands/intel_admission_test.go
+++ b/cmd/aguara/commands/intel_admission_test.go
@@ -1,0 +1,31 @@
+package commands
+
+import (
+	"testing"
+
+	"github.com/garagon/aguara/internal/incident"
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLocalVerifiedLegacyIntelCannotRestoreRejectedClassification(t *testing.T) {
+	s := &intel.Store{Dir: t.TempDir()}
+	legacy := intel.Snapshot{SchemaVersion: intel.CurrentSchemaVersion, Records: []intel.Record{
+		{ID: "GHSA-generic", Ecosystem: "PyPI", Name: "pip", Kind: intel.KindMalicious, Versions: []string{"25.1"}},
+		{ID: "GHSA-pjxp-f379-6284", Ecosystem: "npm", Name: "@fangrong/xoc", Kind: intel.KindMalicious, Versions: []string{"1.0.5", "1.0.6"}},
+	}}
+	require.NoError(t, s.SaveVerified(legacy))
+	ov := localOrEmbeddedOverride(s)
+	require.NotNil(t, ov)
+	last := ov.Snapshots[len(ov.Snapshots)-1]
+	require.Len(t, last.Records, 1)
+	require.Equal(t, []string{"1.0.6"}, last.Records[0].Versions)
+	m := incident.MatcherForOverride(ov)
+	require.Empty(t, m.MatchPackage(intel.MatchInput{Ecosystem: "PyPI", Name: "pip", Version: "25.1"}))
+	require.Empty(t, m.MatchPackage(intel.MatchInput{Ecosystem: "npm", Name: "@fangrong/xoc", Version: "1.0.5"}))
+	require.NotEmpty(t, m.MatchPackage(intel.MatchInput{Ecosystem: "npm", Name: "@fangrong/xoc", Version: "1.0.6"}))
+	// The reader does not rewrite authenticated cache bytes or its marker.
+	stored, err := s.LoadVerified()
+	require.NoError(t, err)
+	require.Equal(t, legacy, *stored)
+}

--- a/internal/incident/admission_test.go
+++ b/internal/incident/admission_test.go
@@ -1,0 +1,44 @@
+package incident
+
+import (
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestEmbeddedAdmissionExcludesVulnerableButNotMaliciousPackages(t *testing.T) {
+	m := defaultIntelMatcher()
+	for _, target := range []intel.MatchInput{
+		{Ecosystem: "PyPI", Name: "ansible", Version: "2.8.0"},
+		{Ecosystem: "PyPI", Name: "dbt-core", Version: "1.6.0"},
+		{Ecosystem: "PyPI", Name: "guardrails-ai", Version: "0.10.0"},
+		{Ecosystem: "PyPI", Name: "guardrails-ai", Version: "0.10.2"},
+		{Ecosystem: "Maven", Name: "org.apache.dubbo:dubbo", Version: "3.1.0"},
+		{Ecosystem: "npm", Name: "@fangrong/xoc", Version: "1.0.5"},
+	} {
+		require.Empty(t, m.MatchPackage(target), "%s@%s", target.Name, target.Version)
+	}
+	for _, target := range []intel.MatchInput{
+		{Ecosystem: "PyPI", Name: "guardrails-ai", Version: "0.10.1"},
+		{Ecosystem: "npm", Name: "@fangrong/xoc", Version: "1.0.6"},
+		{Ecosystem: "npm", Name: "flatmap-stream", Version: "0.1.1"},
+		{Ecosystem: "npm", Name: "nx", Version: "21.5.0"},
+	} {
+		require.NotEmpty(t, m.MatchPackage(target), "%s@%s", target.Name, target.Version)
+	}
+	idx := buildPyPIFilenameIndex(EmbeddedSnapshots())
+	require.NotContains(t, idx, "ansible")
+	require.NotContains(t, idx, "dbt-core")
+	require.Contains(t, idx, "guardrails-ai")
+}
+
+func TestEmbeddedAdmissionPreservesManualAndMALCoverage(t *testing.T) {
+	raw, err := intel.DecodeSnapshotGZIP(generatedIntelGZ)
+	require.NoError(t, err)
+	filtered := EmbeddedIntelSnapshot()
+	require.Less(t, len(filtered.Records), len(raw.Records))
+	require.Equal(t, raw.AllVersions, filtered.AllVersions)
+	require.Equal(t, KnownCompromisedSnapshot(), EmbeddedSnapshots()[0])
+	t.Logf("embedded records: %d -> %d; all-versions: %d unchanged", len(raw.Records), len(filtered.Records), len(filtered.AllVersions))
+}

--- a/internal/incident/generated_intel.go
+++ b/internal/incident/generated_intel.go
@@ -38,7 +38,7 @@ func EmbeddedIntelSnapshot() intel.Snapshot {
 		if err != nil {
 			panic("incident: decode embedded intel snapshot: " + err.Error())
 		}
-		embeddedIntel = snap
+		embeddedIntel = intel.ApplyOSVAdmissionPolicy(snap)
 	})
 	return embeddedIntel
 }

--- a/internal/incident/generated_intel_test.go
+++ b/internal/incident/generated_intel_test.go
@@ -56,8 +56,11 @@ func TestEmbeddedIntelMetaMatchesBlob(t *testing.T) {
 	}
 
 	// record_count / source_count / schema / generated_at must match
-	// the decoded snapshot the runtime actually serves.
-	snap := EmbeddedIntelSnapshot()
+	// the decoded artifact, before runtime admission migration.
+	snap, err := intel.DecodeSnapshotGZIP(generatedIntelGZ)
+	if err != nil {
+		t.Fatal(err)
+	}
 	if meta.RecordCount != len(snap.Records) {
 		t.Errorf("record_count mismatch: meta=%d snapshot=%d", meta.RecordCount, len(snap.Records))
 	}

--- a/internal/intel/ADMISSION.md
+++ b/internal/intel/ADMISSION.md
@@ -1,0 +1,38 @@
+# OSV admission
+
+An advisory mentioning malware does not establish that its affected package is
+malicious. The importer accepts MAL namespace records and structurally parsed
+OpenSSF origins. Exact-version entries also accept GitHub-reviewed CWE-506
+(Embedded Malicious Code). This does not broaden the range-admission channels.
+
+Some historical GHSA advisories lack that structured classification. The
+`reviewed_osv.json` compatibility list preserves reviewed exact tuples, never
+all future versions or other packages under the same advisory ID. Each entry
+records its OSV API source and the SHA-256 of the raw response inspected on
+2026-09-10. Version lists were intersected with the existing embedded and retained
+2026-09-07 snapshots; no versions were inferred from summaries or ranges.
+
+The review included historical credential-stealing browser packages, unauthorized
+releases, and structured GitHub CWE-506 records. PYSEC-2026-206 is excluded:
+its version list includes guardrails-ai 0.10.0, which its own report identifies
+as unaffected. GHSA-xmpw-2vmm-p4p6 preserves the malicious 0.10.1 release.
+GHSA-cxm3-wv7p-598c was not grandfathered: OSV marks it withdrawn on 2026-07-28.
+Its MAL counterparts are unaffected by that exclusion.
+
+To add a compatibility entry, inspect the original advisory, verify that it
+describes malicious code in the named package (not a vulnerability exploitable
+by a different malicious package), and verify each exact version. Record the
+source response digest and add positive and clean-neighbor tests. Do not turn
+summary keywords, URLs, CVE aliases or the GHSA prefix into an authorization rule.
+
+Generated snapshots carry `admission_policy: 1`. This is classification metadata,
+not a signature. Downloads still require the existing verification or explicit
+insecure opt-in. Legacy/unknown-policy OSV snapshots are filtered before use:
+MAL entries and real withdrawal records remain; other live records are restricted
+to the reviewed tuples with ranges removed. Source labels cannot exempt a mixed
+snapshot. The separate built-in manual snapshot is not filtered.
+
+This runtime migration covers the embedded blob, verified local cache and freshly
+downloaded data without changing signed bytes or rewriting the committed blob.
+It protects both matching and raw-record filename checks. Older binaries do not
+apply this policy; users need an updated binary, not only an intel refresh.

--- a/internal/intel/admission.go
+++ b/internal/intel/admission.go
@@ -1,0 +1,92 @@
+package intel
+
+import (
+	_ "embed"
+	"encoding/json"
+	"strings"
+)
+
+// CurrentOSVAdmissionPolicy requires source evidence or reviewed exact tuples,
+// rather than incidental words in vulnerability descriptions.
+const CurrentOSVAdmissionPolicy = 1
+
+//go:embed reviewed_osv.json
+var reviewedOSVJSON []byte
+
+type reviewedOSVKey struct{ id, ecosystem, name string }
+
+var reviewedOSV = func() map[reviewedOSVKey]map[string]bool {
+	var records []Record
+	if err := json.Unmarshal(reviewedOSVJSON, &records); err != nil {
+		panic("intel: invalid reviewed OSV compatibility data: " + err.Error())
+	}
+	out := make(map[reviewedOSVKey]map[string]bool, len(records))
+	for _, r := range records {
+		versions := make(map[string]bool, len(r.Versions))
+		for _, v := range r.Versions {
+			versions[v] = true
+		}
+		out[reviewedOSVKey{r.ID, r.Ecosystem, r.Name}] = versions
+	}
+	return out
+}()
+
+// ReviewedOSVVersions intersects incoming versions with explicitly reviewed
+// advisory/package/version tuples. An ID alone never authorizes new coverage.
+func ReviewedOSVVersions(id, ecosystem, name string, versions []string) []string {
+	allowed := reviewedOSV[reviewedOSVKey{id, ecosystem, name}]
+	var out []string
+	for _, v := range versions {
+		if allowed[v] {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// ApplyOSVAdmissionPolicy makes a generated or downloaded OSV snapshot safe to
+// consume under the current classification policy. It does not authenticate
+// the snapshot; callers must verify downloads first (or explicitly opt out).
+// Do not use this on the separate, hand-curated manual snapshot.
+//
+// Legacy data lost its per-record admission evidence. Retain MAL namespace
+// records, withdrawals, and only the reviewed exact tuples for other IDs.
+// Unknown policy revisions receive the same conservative treatment. Source
+// labels cannot exempt records from this migration, including mixed labels.
+func ApplyOSVAdmissionPolicy(s Snapshot) Snapshot {
+	if s.AdmissionPolicy == CurrentOSVAdmissionPolicy {
+		return s
+	}
+	var records []Record
+	for _, r := range s.Records {
+		if r.Withdrawn || strings.HasPrefix(r.ID, "MAL-") {
+			records = append(records, r)
+			continue
+		}
+		r.Versions = ReviewedOSVVersions(r.ID, r.Ecosystem, r.Name, r.Versions)
+		r.Ranges = nil
+		if len(r.Versions) > 0 {
+			records = append(records, r)
+		}
+	}
+	// Legacy all-version data is almost entirely MAL namespace entries. Reuse
+	// that immutable slice unless filtering is needed, avoiding a second copy.
+	all := s.AllVersions
+	for i, entry := range s.AllVersions {
+		if strings.HasPrefix(entry.ID, "MAL-") {
+			continue
+		}
+		all = make([]AllVersionsEntry, 0, len(s.AllVersions)-1)
+		all = append(all, s.AllVersions[:i]...)
+		for _, rest := range s.AllVersions[i+1:] {
+			if strings.HasPrefix(rest.ID, "MAL-") {
+				all = append(all, rest)
+			}
+		}
+		break
+	}
+	s.Records = records
+	s.AllVersions = all
+	s.AdmissionPolicy = CurrentOSVAdmissionPolicy
+	return s
+}

--- a/internal/intel/admission_internal_test.go
+++ b/internal/intel/admission_internal_test.go
@@ -1,0 +1,43 @@
+package intel
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+)
+
+func TestReviewedOSVDataIntegrity(t *testing.T) {
+	var rows []struct {
+		ID        string   `json:"id"`
+		Ecosystem string   `json:"ecosystem"`
+		Name      string   `json:"name"`
+		Versions  []string `json:"versions"`
+		Source    string   `json:"source"`
+		SHA       string   `json:"source_sha256"`
+	}
+	if err := json.Unmarshal(reviewedOSVJSON, &rows); err != nil {
+		t.Fatal(err)
+	}
+	seen := map[reviewedOSVKey]bool{}
+	for _, r := range rows {
+		key := reviewedOSVKey{r.ID, r.Ecosystem, r.Name}
+		if seen[key] || r.ID == "" || r.Name == "" || CanonicaliseEcosystem(r.Ecosystem) != r.Ecosystem || len(r.Versions) == 0 {
+			t.Fatalf("invalid or duplicate compatibility entry: %+v", r)
+		}
+		seen[key] = true
+		if r.Source != "https://api.osv.dev/v1/vulns/"+r.ID {
+			t.Fatalf("missing source: %s", r.ID)
+		}
+		hash, err := hex.DecodeString(r.SHA)
+		if err != nil || len(hash) != 32 {
+			t.Fatalf("invalid evidence digest: %s", r.ID)
+		}
+		versions := map[string]bool{}
+		for _, v := range r.Versions {
+			if v == "" || versions[v] {
+				t.Fatalf("invalid version for %s", r.ID)
+			}
+			versions[v] = true
+		}
+	}
+}

--- a/internal/intel/admission_test.go
+++ b/internal/intel/admission_test.go
@@ -1,0 +1,60 @@
+package intel_test
+
+import (
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOSVAdmissionMigratesLegacyWithoutMutatingInput(t *testing.T) {
+	s := intel.Snapshot{Sources: []intel.SourceMeta{{Kind: intel.SourceOSV}, {Kind: intel.SourceManual}}, Records: []intel.Record{
+		{ID: "GHSA-generic", Name: "pip", Ecosystem: "PyPI", Versions: []string{"25.1"}},
+		{ID: "MAL-2026-1", Name: "bad", Ecosystem: "npm", Versions: []string{"1.0.0"}},
+		{ID: "GHSA-pjxp-f379-6284", Name: "@fangrong/xoc", Ecosystem: "npm", Versions: []string{"1.0.5", "1.0.6"}, Ranges: []intel.VersionRange{{Introduced: "0"}}},
+		{ID: "GHSA-withdrawn", Name: "old", Ecosystem: "npm", Withdrawn: true},
+	}, AllVersions: []intel.AllVersionsEntry{
+		{ID: "MAL-2026-2", Name: "all-bad", Ecosystem: "npm"},
+		{ID: "GHSA-unproven", Name: "other", Ecosystem: "npm"},
+	}}
+	for _, revision := range []int{0, 999} {
+		s.AdmissionPolicy = revision
+		got := intel.ApplyOSVAdmissionPolicy(s)
+		require.Equal(t, intel.CurrentOSVAdmissionPolicy, got.AdmissionPolicy)
+		require.Len(t, got.Records, 3)
+		require.Equal(t, "MAL-2026-1", got.Records[0].ID)
+		require.Equal(t, []string{"1.0.6"}, got.Records[1].Versions)
+		require.Empty(t, got.Records[1].Ranges)
+		require.True(t, got.Records[2].Withdrawn)
+		require.Len(t, got.AllVersions, 1)
+		require.Equal(t, got, intel.ApplyOSVAdmissionPolicy(got))
+	}
+	require.Len(t, s.Records, 4)
+	require.Equal(t, []string{"1.0.5", "1.0.6"}, s.Records[2].Versions)
+	require.Len(t, s.Records[2].Ranges, 1)
+	require.Len(t, s.AllVersions, 2)
+}
+
+func TestOSVAdmissionReviewedTupleDoesNotAuthorizeAnotherTarget(t *testing.T) {
+	for _, pair := range [][2]string{{"PyPI", "@fangrong/xoc"}, {"npm", "other"}} {
+		require.Empty(t, intel.ReviewedOSVVersions("GHSA-pjxp-f379-6284", pair[0], pair[1], []string{"1.0.6"}))
+	}
+	require.Empty(t, intel.ReviewedOSVVersions("GHSA-unknown", "npm", "@fangrong/xoc", []string{"1.0.6"}))
+	require.Empty(t, intel.ReviewedOSVVersions("GHSA-pjxp-f379-6284", "npm", "@fangrong/xoc", []string{"1.0.5", "9.0.0"}))
+}
+
+func TestOSVAdmissionCurrentPolicyPreservesProducerCoverage(t *testing.T) {
+	s := intel.Snapshot{AdmissionPolicy: intel.CurrentOSVAdmissionPolicy, Records: []intel.Record{{ID: "GHSA-reviewed-source", Name: "new-package", Ecosystem: "npm", Versions: []string{"1.0.0"}}}}
+	require.Equal(t, s, intel.ApplyOSVAdmissionPolicy(s))
+}
+
+func TestOSVAdmissionRejectsContradictedGuardrailsVersions(t *testing.T) {
+	s := intel.Snapshot{Records: []intel.Record{
+		{ID: "PYSEC-2026-206", Name: "guardrails-ai", Ecosystem: "PyPI", Versions: []string{"0.1.0", "0.10.0"}},
+		{ID: "GHSA-xmpw-2vmm-p4p6", Name: "guardrails-ai", Ecosystem: "PyPI", Versions: []string{"0.10.0", "0.10.1", "0.10.2"}},
+	}}
+	got := intel.ApplyOSVAdmissionPolicy(s)
+	require.Len(t, got.Records, 1)
+	require.Equal(t, "GHSA-xmpw-2vmm-p4p6", got.Records[0].ID)
+	require.Equal(t, []string{"0.10.1"}, got.Records[0].Versions)
+}

--- a/internal/intel/osvimport/admission_test.go
+++ b/internal/intel/osvimport/admission_test.go
@@ -1,0 +1,98 @@
+package osvimport_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/garagon/aguara/internal/intel/osvimport"
+	"github.com/stretchr/testify/require"
+)
+
+func TestImportRejectsIncidentalMalwareText(t *testing.T) {
+	for _, text := range []string{
+		"pip can load from a malicious package index",
+		"This is not a malicious package",
+		"An injection flaw allows credential exfiltration",
+	} {
+		t.Run(text, func(t *testing.T) {
+			raw := mustMarshal(t, osvRecordFixture{
+				ID: "GHSA-generic-cve", Details: text,
+				Affected: []affectedFixture{{Package: packageFixture{Name: "pip", Ecosystem: "PyPI"}, Versions: []string{"25.1"}}},
+			})
+			snap, err := osvimport.Import([][]byte{raw}, osvimport.Options{})
+			require.NoError(t, err)
+			require.Empty(t, snap.Records)
+			_, status := osvimport.ClassifyForEcosystem(raw, "PyPI")
+			require.Equal(t, osvimport.StatusNeither, status)
+		})
+	}
+}
+
+func TestImportReviewedClassificationAndExactExceptions(t *testing.T) {
+	tests := []struct {
+		name, id, packageName, metadata string
+		versions, want                  []string
+	}{
+		{"reviewed cwe", "GHSA-new-advisory", "new-package", `{"github_reviewed":true,"cwe_ids":["CWE-506"]}`, []string{"1.0.0"}, []string{"1.0.0"}},
+		{"unreviewed cwe", "GHSA-new-advisory", "new-package", `{"github_reviewed":false,"cwe_ids":["CWE-506"]}`, []string{"1.0.0"}, nil},
+		{"unrelated cwe", "GHSA-new-advisory", "new-package", `{"github_reviewed":true,"cwe_ids":["CWE-94"]}`, []string{"1.0.0"}, nil},
+		{"cwe in value", "GHSA-new-advisory", "new-package", `{"github_reviewed":true,"notes":"CWE-506"}`, []string{"1.0.0"}, nil},
+		{"wrong review type", "GHSA-new-advisory", "new-package", `{"github_reviewed":"true","cwe_ids":["CWE-506"]}`, []string{"1.0.0"}, nil},
+		{"non github", "CVE-2026-1234", "new-package", `{"github_reviewed":true,"cwe_ids":["CWE-506"]}`, []string{"1.0.0"}, nil},
+		{"historical exact", "GHSA-pjxp-f379-6284", "@fangrong/xoc", `{}`, []string{"1.0.5", "1.0.6", "9.0.0"}, []string{"1.0.6"}},
+		{"historical wrong package", "GHSA-pjxp-f379-6284", "other", `{}`, []string{"1.0.6"}, nil},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := mustMarshal(t, osvRecordFixture{ID: tt.id, DatabaseSpecific: json.RawMessage(tt.metadata), Affected: []affectedFixture{{Package: packageFixture{Name: tt.packageName, Ecosystem: "npm"}, Versions: tt.versions}}})
+			snap, err := osvimport.Import([][]byte{raw}, osvimport.Options{})
+			require.NoError(t, err)
+			require.Equal(t, intel.CurrentOSVAdmissionPolicy, snap.AdmissionPolicy)
+			rec, status := osvimport.ClassifyForEcosystem(raw, "npm")
+			if len(tt.want) == 0 {
+				require.Empty(t, snap.Records)
+				require.Equal(t, osvimport.StatusNeither, status)
+				return
+			}
+			require.Len(t, snap.Records, 1)
+			require.Equal(t, tt.want, snap.Records[0].Versions)
+			require.Equal(t, osvimport.StatusKept, status)
+			require.Equal(t, rec, snap.Records[0])
+		})
+	}
+}
+
+func TestImportRejectsImpostorOriginMetadata(t *testing.T) {
+	for _, value := range []string{
+		`{"note":"malicious-packages-origins"}`,
+		`{"nested":{"malicious-packages-origins":[{"source":"ossf"}]}}`,
+		`{"malicious-packages-origins":"yes"}`,
+		`{"malicious-packages-origins":[]}`,
+		`{"malicious-packages-origins":[{}]}`,
+	} {
+		t.Run(value, func(t *testing.T) {
+			raw := mustMarshal(t, osvRecordFixture{
+				ID: "GHSA-metadata-impostor", DatabaseSpecific: json.RawMessage(value),
+				Affected: []affectedFixture{{Package: packageFixture{Name: "normal", Ecosystem: "npm"}, Versions: []string{"1.0.0"}}},
+			})
+			snap, err := osvimport.Import([][]byte{raw}, osvimport.Options{})
+			require.NoError(t, err)
+			require.Empty(t, snap.Records)
+		})
+	}
+}
+
+func TestImportRejectsContradictedPYSECGuardrailsVersions(t *testing.T) {
+	// The PYSEC list includes 0.10.0 despite its own text identifying it as
+	// unaffected. The GHSA counterpart lists only the malicious 0.10.1 release.
+	raw := mustMarshal(t, osvRecordFixture{
+		ID: "PYSEC-2026-206", Details: "Malicious version 0.10.1; 0.10.0 is unaffected.",
+		Affected: []affectedFixture{{Package: packageFixture{Name: "guardrails-ai", Ecosystem: "PyPI"}, Versions: []string{"0.1.0", "0.10.0"}}},
+	})
+	snap, err := osvimport.Import([][]byte{raw}, osvimport.Options{})
+	require.NoError(t, err)
+	require.Empty(t, snap.Records)
+	_, status := osvimport.ClassifyForEcosystem(raw, "PyPI")
+	require.Equal(t, osvimport.StatusNeither, status)
+}

--- a/internal/intel/osvimport/osvimport.go
+++ b/internal/intel/osvimport/osvimport.go
@@ -2,10 +2,8 @@
 // values that the runtime matcher can consume.
 //
 // Scope is deliberately narrow: only high-confidence malicious or
-// compromised package records survive the filter. Records without
-// an exact affected-version list are dropped, because the runtime
-// matcher refuses to consult ranges until a tested semver / PEP 440
-// layer lands. A wrong match is worse than no match.
+// compromised package records survive the filter. Exact versions, all-version
+// advisories and supported npm ranges are retained only with admission evidence.
 //
 // This package is pure: it does no I/O of its own. ImportFromZip
 // (in zip.go) is a small helper that reads OSV's all.zip dumps and
@@ -26,8 +24,8 @@ import (
 
 // Options control which records survive the filter. All fields are
 // optional; the zero value selects the production-default filter
-// (MAL- IDs, OpenSSF malicious-packages source, or a high-confidence
-// keyword + exact versions).
+// (MAL- IDs, structured OpenSSF origins, and exact-version admissions from
+// reviewed GitHub CWE-506 classifications or the reviewed compatibility list).
 type Options struct {
 	// Ecosystems is the set of OSV ecosystem strings to keep.
 	// Empty means "no filter" -- import everything OSV emits, which
@@ -60,9 +58,7 @@ type Options struct {
 //     a name, and an optional Versions list of exact strings.
 //   - DatabaseSpecific carries source-specific metadata; OpenSSF
 //     Malicious Packages records populate it with origin info.
-//   - References lists URLs / publishings; we use them only to feed
-//     the keyword scanner because OSV's free-form text is the only
-//     place a "credential exfiltration" hint actually appears.
+//   - References lists supporting URLs; these are not admission evidence.
 type osvRecord struct {
 	ID               string          `json:"id"`
 	Aliases          []string        `json:"aliases,omitempty"`
@@ -174,24 +170,6 @@ type osvReference struct {
 	URL  string `json:"url,omitempty"`
 }
 
-// highConfidenceKeywords is the conservative keyword list the
-// filter consults for records that do NOT come from a known-good
-// source (MAL- ID or OpenSSF Malicious Packages). The list is small
-// on purpose: a longer list pulls in generic-CVE noise (e.g. "DoS",
-// "vulnerable to") that does not belong in the malicious-package
-// snapshot. New keywords should only be added when the
-// TestOSVImporterDropsGenericCVERecords baseline keeps holding.
-var highConfidenceKeywords = []string{
-	"malicious package",
-	"malicious npm package",
-	"malicious python package",
-	"compromised package",
-	"credential stealing",
-	"credential exfiltration",
-	"typosquat malware",
-	"install script malware",
-}
-
 // Import returns the intel.Snapshot for the given OSV record set.
 // Caller is responsible for feeding the full set of records they
 // want considered; Import does not perform any I/O. Records that
@@ -209,8 +187,9 @@ func Import(raw [][]byte, opts Options) (intel.Snapshot, error) {
 	}
 
 	snap := intel.Snapshot{
-		SchemaVersion: intel.CurrentSchemaVersion,
-		GeneratedAt:   opts.GeneratedAt,
+		SchemaVersion:   intel.CurrentSchemaVersion,
+		AdmissionPolicy: intel.CurrentOSVAdmissionPolicy,
+		GeneratedAt:     opts.GeneratedAt,
 	}
 	if snap.GeneratedAt.IsZero() {
 		snap.GeneratedAt = time.Now().UTC()
@@ -280,12 +259,11 @@ func convertOSVRecord(raw []byte, ecoFilter map[string]struct{}) ([]intel.Record
 	// intel.Record so the matcher's tombstone path retracts any
 	// earlier live copy from another source. The tombstone keys
 	// off (ecosystem, name, ID) only, so a withdrawn record does
-	// not need to satisfy the empty-versions or signal/keyword
+	// not need to satisfy the empty-versions or admission
 	// gates that live records do.
 	withdrawn := osv.Withdrawn != ""
 
 	signal := hasHighConfidenceSignal(osv)
-	keywordHit := hasKeywordMatch(osv)
 
 	var out []intel.Record
 	var entries []intel.AllVersionsEntry
@@ -301,7 +279,7 @@ func convertOSVRecord(raw []byte, ecoFilter map[string]struct{}) ([]intel.Record
 		}
 
 		// Withdrawn records bypass both the empty-versions skip
-		// and the signal/keyword gate. They exist purely so the
+		// and the admission gate. They exist purely so the
 		// matcher can tombstone an earlier live copy with the
 		// same advisory ID; if we filter them out here, the live
 		// copy keeps matching forever after the retraction.
@@ -318,7 +296,7 @@ func convertOSVRecord(raw []byte, ecoFilter map[string]struct{}) ([]intel.Record
 				// false positive on a range flags every version below
 				// the bound (measured leak: axios, @angular/core,
 				// playwright CVEs arriving as "malicious"). The
-				// keyword channel stays exact-version only.
+				// Exact-version admissions are handled separately below.
 				if signal && rangesAllVersionsShape(aff.Ranges) {
 					entries = append(entries, intel.AllVersionsEntry{
 						ID:        osv.ID,
@@ -354,11 +332,9 @@ func convertOSVRecord(raw []byte, ecoFilter map[string]struct{}) ([]intel.Record
 				}
 				continue
 			}
-			// Filter: keep when there is a high-confidence
-			// source signal, OR a keyword hit on the free-form
-			// text. The "exact versions present" check above
-			// gates both paths.
-			if !signal && !keywordHit {
+			// Exact versions define affected scope, not malicious intent.
+			aff.Versions = admittedExactVersions(osv, eco, aff, signal)
+			if len(aff.Versions) == 0 {
 				continue
 			}
 		}
@@ -400,9 +376,8 @@ const (
 	// ranges, no exact versions. The matcher consumes exact
 	// versions only, so the record is dropped from the snapshot.
 	StatusRangesOnly
-	// StatusNeither: the record has exact versions but fails both
-	// the high-confidence signal gate (MAL- prefix / OpenSSF
-	// origin) and the keyword gate. CVE-flavoured records land
+	// StatusNeither: the record has exact versions but lacks source
+	// evidence or explicitly reviewed tuples. Generic CVEs land
 	// here and do not belong in a malicious-package snapshot.
 	StatusNeither
 	// StatusKept: the record survives the filter and becomes an
@@ -459,7 +434,6 @@ func ClassifyForEcosystem(raw []byte, targetEcosystem string) (intel.Record, Rec
 		return intel.Record{}, StatusWithdrawn
 	}
 	signal := hasHighConfidenceSignal(osv)
-	malicious := signal || hasKeywordMatch(osv)
 	if len(aff.Versions) == 0 {
 		// Mirrors Import: the range channels (all-versions entries and
 		// npm bounded ranges) require the firm malicious-package
@@ -502,7 +476,8 @@ func ClassifyForEcosystem(raw []byte, targetEcosystem string) (intel.Record, Rec
 		}
 		return intel.Record{}, StatusRangesOnly
 	}
-	if !malicious {
+	versions := admittedExactVersions(osv, canon, *aff, signal)
+	if len(versions) == 0 {
 		return intel.Record{}, StatusNeither
 	}
 	return intel.Record{
@@ -512,7 +487,7 @@ func ClassifyForEcosystem(raw []byte, targetEcosystem string) (intel.Record, Rec
 		Name:       aff.Package.Name,
 		Kind:       intel.KindMalicious,
 		Summary:    pickSummary(osv),
-		Versions:   append([]string(nil), aff.Versions...),
+		Versions:   append([]string(nil), versions...),
 		References: extractReferenceURLs(osv.References),
 	}, StatusKept
 }
@@ -605,68 +580,50 @@ func canonicaliseEcosystem(raw string) string {
 // text:
 //
 //   - The ID starts with MAL- (OSV's malicious-package namespace).
-//   - DatabaseSpecific holds an `malicious-packages-origins` field,
-//     which OpenSSF Malicious Packages populates.
-//
-// Either signal short-circuits the keyword scan so MAL- entries
-// with sparse free-form text still survive.
+//   - DatabaseSpecific holds a top-level malicious-packages-origins
+//     array with a nonempty source, as populated by OpenSSF.
 func hasHighConfidenceSignal(osv osvRecord) bool {
 	if strings.HasPrefix(osv.ID, "MAL-") {
 		return true
 	}
-	if len(osv.DatabaseSpecific) > 0 {
-		// We do not fully unmarshal database_specific; a simple
-		// substring check on the raw bytes is enough to detect
-		// the OpenSSF source without owning their schema.
-		if strings.Contains(string(osv.DatabaseSpecific), "malicious-packages-origins") {
+	var fields map[string]json.RawMessage
+	if json.Unmarshal(osv.DatabaseSpecific, &fields) != nil {
+		return false
+	}
+	var origins []struct {
+		Source string `json:"source"`
+	}
+	if json.Unmarshal(fields["malicious-packages-origins"], &origins) != nil {
+		return false
+	}
+	for _, origin := range origins {
+		if strings.TrimSpace(origin.Source) != "" {
 			return true
 		}
 	}
 	return false
 }
 
-// hasKeywordMatch returns true when summary, details, or any
-// reference URL contains one of the high-confidence keywords. The
-// match is case-insensitive substring; matching is intentionally
-// narrow because the broader the keyword list, the more generic
-// CVEs leak into the malicious-package snapshot.
-//
-// References are scanned because OSV advisories often point to a
-// Socket / Snyk / vendor blog post whose URL slug carries the
-// signal ("malicious-package-foo", "credential-stealing-bar") even
-// when the summary text is a generic vulnerability sentence. Without
-// scanning the URL, those records would silently drop.
-func hasKeywordMatch(osv osvRecord) bool {
-	for _, hay := range []string{osv.Summary, osv.Details} {
-		if hay == "" {
-			continue
-		}
-		lower := strings.ToLower(hay)
-		for _, kw := range highConfidenceKeywords {
-			if strings.Contains(lower, kw) {
-				return true
+// Reviewed GitHub CWE-506 explicitly identifies embedded malicious code, unlike
+// prose about exploiting otherwise legitimate software. Keep this exact-only;
+// the range channels retain their existing MAL/OpenSSF source requirement.
+func admittedExactVersions(osv osvRecord, eco string, aff osvAffected, sourceSignal bool) []string {
+	if sourceSignal {
+		return aff.Versions
+	}
+	var fields map[string]json.RawMessage
+	if strings.HasPrefix(osv.ID, "GHSA-") && json.Unmarshal(osv.DatabaseSpecific, &fields) == nil {
+		var reviewed bool
+		var cwes []string
+		if json.Unmarshal(fields["github_reviewed"], &reviewed) == nil && reviewed && json.Unmarshal(fields["cwe_ids"], &cwes) == nil {
+			for _, cwe := range cwes {
+				if cwe == "CWE-506" {
+					return aff.Versions
+				}
 			}
 		}
 	}
-	for _, ref := range osv.References {
-		if ref.URL == "" {
-			continue
-		}
-		// URL slugs use `-`, `_`, and `/` as word separators
-		// (`/blog/malicious-package-foo-bar`). Normalise to
-		// spaces so the keyword scan can match phrases like
-		// "malicious package" against the slug form.
-		normalised := strings.ToLower(ref.URL)
-		for _, sep := range []string{"-", "_", "/"} {
-			normalised = strings.ReplaceAll(normalised, sep, " ")
-		}
-		for _, kw := range highConfidenceKeywords {
-			if strings.Contains(normalised, kw) {
-				return true
-			}
-		}
-	}
-	return false
+	return intel.ReviewedOSVVersions(osv.ID, eco, aff.Package.Name, aff.Versions)
 }
 
 // pickSummary returns the most informative single-line text for a

--- a/internal/intel/osvimport/osvimport_test.go
+++ b/internal/intel/osvimport/osvimport_test.go
@@ -96,12 +96,8 @@ func TestImportKeepsOpenSSFSource(t *testing.T) {
 	require.Equal(t, "GHSA-aaaa-bbbb-cccc", snap.Records[0].ID)
 }
 
-func TestImportKeywordMatchOnReferenceURL(t *testing.T) {
-	// Codex P2 regression (PR 3 review): the keyword scan must
-	// consult OSV reference URLs too, because Socket / Snyk
-	// blog-post URLs sometimes carry the only "malicious package"
-	// hint a record has. Without scanning References, such
-	// records silently drop.
+func TestImportRejectsKeywordOnlyReferenceURL(t *testing.T) {
+	// A link about a malicious package does not classify this package.
 	rec := struct {
 		ID         string            `json:"id"`
 		Summary    string            `json:"summary"`
@@ -129,13 +125,11 @@ func TestImportKeywordMatchOnReferenceURL(t *testing.T) {
 		osvimport.Options{Ecosystems: []string{"npm"}, GeneratedAt: time.Unix(0, 0)},
 	)
 	require.NoError(t, err)
-	require.Len(t, snap.Records, 1, "URL keyword 'malicious package' must qualify the record")
-	require.Equal(t, "GHSA-ref-hit", snap.Records[0].ID)
+	require.Empty(t, snap.Records)
 }
 
-func TestImportKeepsKeywordMatchWithVersions(t *testing.T) {
-	// The keyword path requires (a) one of the high-confidence
-	// terms in summary/details AND (b) exact affected versions.
+func TestImportRejectsKeywordOnlyExactVersions(t *testing.T) {
+	// Exact affected versions do not establish malicious intent.
 	rec := osvRecordFixture{
 		ID:      "GHSA-keyword-hit",
 		Summary: "Compromised package: credential exfiltration via install script",
@@ -149,8 +143,7 @@ func TestImportKeepsKeywordMatchWithVersions(t *testing.T) {
 		osvimport.Options{Ecosystems: []string{"PyPI"}, GeneratedAt: time.Unix(0, 0)},
 	)
 	require.NoError(t, err)
-	require.Len(t, snap.Records, 1)
-	require.Equal(t, "GHSA-keyword-hit", snap.Records[0].ID)
+	require.Empty(t, snap.Records)
 }
 
 func TestImportDropsGenericCVERecords(t *testing.T) {
@@ -565,7 +558,7 @@ func TestClassifyForEcosystem_FunnelStatuses(t *testing.T) {
 		}, got2.Ranges)
 	})
 	t.Run("keyword-qualified ranges never import (signal-only channels)", func(t *testing.T) {
-		// A keyword hit qualifies exact-version records only. On the
+		// A keyword hit no longer qualifies any record. On the
 		// range channels the blast radius of a keyword false positive
 		// is every version below the bound (real leak: axios,
 		// @angular/core, playwright CVEs whose text or reference
@@ -595,8 +588,7 @@ func TestClassifyForEcosystem_FunnelStatuses(t *testing.T) {
 		_, status = osvimport.ClassifyForEcosystem(mustMarshal(t, bounded), "npm")
 		require.Equal(t, osvimport.StatusRangesOnly, status)
 
-		// The same keyword-qualified record WITH exact versions keeps
-		// importing: the exact channel is where keywords belong.
+		// Exact versions must also pass source-based admission.
 		exact := osvRecordFixture{
 			ID:      "GHSA-kw-exact",
 			Summary: "Malicious package found in acme-lib",
@@ -606,7 +598,7 @@ func TestClassifyForEcosystem_FunnelStatuses(t *testing.T) {
 			}},
 		}
 		_, status = osvimport.ClassifyForEcosystem(mustMarshal(t, exact), "npm")
-		require.Equal(t, osvimport.StatusKept, status)
+		require.Equal(t, osvimport.StatusNeither, status)
 	})
 	t.Run("git-typed npm ranges import as nothing", func(t *testing.T) {
 		rec := osvRecordFixture{

--- a/internal/intel/reviewed_osv.json
+++ b/internal/intel/reviewed_osv.json
@@ -1,0 +1,806 @@
+[
+  {
+    "id": "GHSA-27f5-xjrr-q9ff",
+    "ecosystem": "npm",
+    "name": "@opensearch-project/opensearch",
+    "versions": [
+      "3.5.3",
+      "3.6.2",
+      "3.7.0",
+      "3.8.0"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-27f5-xjrr-q9ff",
+    "source_sha256": "872d5431fd0634f664b5df74e9bb1bc5d5878d47ffdf1699c221e7189bbb60c0"
+  },
+  {
+    "id": "GHSA-28f8-hqmc-7ph8",
+    "ecosystem": "npm",
+    "name": "ember-power-timepicker",
+    "versions": [
+      "1.0.8"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-28f8-hqmc-7ph8",
+    "source_sha256": "e7a4183e1b901737d964f5ba83f91afd65cf025cf3a82595a0969902c2bab10d"
+  },
+  {
+    "id": "GHSA-28xx-8j99-m32j",
+    "ecosystem": "npm",
+    "name": "nginxbeautifier",
+    "versions": [
+      "1.0.14"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-28xx-8j99-m32j",
+    "source_sha256": "e15b4581889c8cb71ae8bbea4f2a842706e3243513e9667490cf131f13a8ee02"
+  },
+  {
+    "id": "GHSA-2p62-c4rm-mr72",
+    "ecosystem": "npm",
+    "name": "another-date-picker",
+    "versions": [
+      "2.0.43"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-2p62-c4rm-mr72",
+    "source_sha256": "fec0cf47bd1f84e14177e83ae56d5f9616415421efd9e5cf50b9ebfe4707bb81"
+  },
+  {
+    "id": "GHSA-2q6w-rxf3-4wc9",
+    "ecosystem": "npm",
+    "name": "codify",
+    "versions": [
+      "0.3.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-2q6w-rxf3-4wc9",
+    "source_sha256": "14168ff3a21ad125b402188acdcf69e044dcc7eda0270197b340b4ce4f96449b"
+  },
+  {
+    "id": "GHSA-2vqq-jgxx-fxjc",
+    "ecosystem": "npm",
+    "name": "motiv.scss",
+    "versions": [
+      "0.4.20"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-2vqq-jgxx-fxjc",
+    "source_sha256": "49c9d360c2e10093051dad8dac893aa07f5dc3029644a97db8ef3bca04a9bb03"
+  },
+  {
+    "id": "GHSA-2xw5-3767-qxvm",
+    "ecosystem": "npm",
+    "name": "ng-ui-library",
+    "versions": [
+      "1.0.987"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-2xw5-3767-qxvm",
+    "source_sha256": "c7f144c956be0ce409059c22c1f770d91b3b3f3c49ba8ec294cde7bac73110fa"
+  },
+  {
+    "id": "GHSA-377f-vvrc-9wgg",
+    "ecosystem": "npm",
+    "name": "zemen",
+    "versions": [
+      "0.0.5"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-377f-vvrc-9wgg",
+    "source_sha256": "375dd90d67e08da7bc74558fd631882689d9c0f0cacbab13d12c909cb61235f9"
+  },
+  {
+    "id": "GHSA-3fv6-q5xv-fhpw",
+    "ecosystem": "npm",
+    "name": "coffee-project",
+    "versions": [
+      "1.7.5"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-3fv6-q5xv-fhpw",
+    "source_sha256": "959c288936cc1d1bab20456c35bd474dc4aa20e58fb1a79b711301fc736f0d79"
+  },
+  {
+    "id": "GHSA-3wh2-2pp3-2823",
+    "ecosystem": "npm",
+    "name": "simple-alipay",
+    "versions": [
+      "1.0.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-3wh2-2pp3-2823",
+    "source_sha256": "7da265dd2966ceb67fd332d943b2a1572af2de49c65eeb8fd3f0a6d8f926081f"
+  },
+  {
+    "id": "GHSA-3wjm-33mw-h388",
+    "ecosystem": "npm",
+    "name": "s3asy",
+    "versions": [
+      "0.4.8"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-3wjm-33mw-h388",
+    "source_sha256": "45de02e669ca9cfb2f672a2f0c13b7bdadd9020ed518f9ccbf4b156253768155"
+  },
+  {
+    "id": "GHSA-45cp-hpc9-8347",
+    "ecosystem": "npm",
+    "name": "css_transform_support",
+    "versions": [
+      "1.0.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-45cp-hpc9-8347",
+    "source_sha256": "15938d456775ed1972c53b1cc94e617b6cc73d4d61836e23f25a7b2ca3f7a1e8"
+  },
+  {
+    "id": "GHSA-4627-w373-375v",
+    "ecosystem": "npm",
+    "name": "grunt-radical",
+    "versions": [
+      "0.0.14"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-4627-w373-375v",
+    "source_sha256": "c45f353c7038ac0b1285380ca4789f0fec7dc4cda23273ccc6c5ca40785f3f0d"
+  },
+  {
+    "id": "GHSA-48hw-37g6-3gw4",
+    "ecosystem": "npm",
+    "name": "mx-nested-menu",
+    "versions": [
+      "0.1.30"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-48hw-37g6-3gw4",
+    "source_sha256": "811df326a23144d3426f3a5d64f9f9fc042ce1ea2c9c48381c81faaf727f9fc8"
+  },
+  {
+    "id": "GHSA-4c87-gg2q-fc6m",
+    "ecosystem": "npm",
+    "name": "rc-calendar-jhorst",
+    "versions": [
+      "8.4.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-4c87-gg2q-fc6m",
+    "source_sha256": "c6d809894b780660e4ea4c84d6416f81b707d9f02e7085b3ce04187f30800767"
+  },
+  {
+    "id": "GHSA-4j54-mmmv-hjpm",
+    "ecosystem": "npm",
+    "name": "slush-fullstack-framework",
+    "versions": [
+      "0.9.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-4j54-mmmv-hjpm",
+    "source_sha256": "73bafcc4852f158b87b9eb4c4ff5467441c982bd219e92a317d0d963023d16a1"
+  },
+  {
+    "id": "GHSA-4rx9-58m7-gr8w",
+    "ecosystem": "npm",
+    "name": "css_transform_step",
+    "versions": [
+      "1.0.6"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-4rx9-58m7-gr8w",
+    "source_sha256": "ab87ad3fe97836e523313d6972f1a4a16ff69d92771056f6f710270fb97c6a36"
+  },
+  {
+    "id": "GHSA-53jx-4wwh-gcqj",
+    "ecosystem": "npm",
+    "name": "angular-location-update",
+    "versions": [
+      "0.0.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-53jx-4wwh-gcqj",
+    "source_sha256": "6c2eb23a006ba4ce5754a157e5931e79e0cf8ea2870c1e1ef120d231f3854683"
+  },
+  {
+    "id": "GHSA-54cr-gv8w-8324",
+    "ecosystem": "npm",
+    "name": "xoc",
+    "versions": [
+      "1.0.7"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-54cr-gv8w-8324",
+    "source_sha256": "3d55802091425ef9be3597ce1de085f22c26b013e09d8382b8b742bbbbc4f64b"
+  },
+  {
+    "id": "GHSA-5635-9mvj-r6hp",
+    "ecosystem": "npm",
+    "name": "vue-backbone",
+    "versions": [
+      "0.1.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-5635-9mvj-r6hp",
+    "source_sha256": "fccbd8428eb0f74a9c9dbf58ad1afd9dfa8b19bc802aa09b911c547f96ae4329"
+  },
+  {
+    "id": "GHSA-563h-697m-j7x5",
+    "ecosystem": "npm",
+    "name": "device-mqtt",
+    "versions": [
+      "1.0.11"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-563h-697m-j7x5",
+    "source_sha256": "2ebfd6db79fe614b8e62a82ce7619f70a5f00b1f9cb5c760fcc62c88d286f78f"
+  },
+  {
+    "id": "GHSA-5645-gc7h-98h8",
+    "ecosystem": "npm",
+    "name": "react-dates-sc",
+    "versions": [
+      "0.3.0"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-5645-gc7h-98h8",
+    "source_sha256": "6a7ba4b6a29ffedc6ac28cb37255460bbecc058efc06614ac91e69bce21c2815"
+  },
+  {
+    "id": "GHSA-56r9-v65c-34jm",
+    "ecosystem": "npm",
+    "name": "radicjs",
+    "versions": [
+      "0.2.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-56r9-v65c-34jm",
+    "source_sha256": "0686874603020a27b215ec7b98d3f1c37a6fff6b8cfea6b76b1e99351e97effc"
+  },
+  {
+    "id": "GHSA-5w4r-wwc3-6qcp",
+    "ecosystem": "npm",
+    "name": "precode.js",
+    "versions": [
+      "1.1.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-5w4r-wwc3-6qcp",
+    "source_sha256": "9717712b28923a03292ea39d3833afb9b8d3d8dddf34eeb4bd3da0f69acae8aa"
+  },
+  {
+    "id": "GHSA-76wf-2xcf-6wmx",
+    "ecosystem": "npm",
+    "name": "ngx-pica",
+    "versions": [
+      "1.1.5"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-76wf-2xcf-6wmx",
+    "source_sha256": "89785137777f10983dd651d1cb3038689b12985f4721313b71d49809ea84e5ad"
+  },
+  {
+    "id": "GHSA-78p3-96hc-3j47",
+    "ecosystem": "npm",
+    "name": "jquery-airload",
+    "versions": [
+      "0.2.5"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-78p3-96hc-3j47",
+    "source_sha256": "146ef2db4ad06540c7317164482c185cce98cf57709c8e89d16b615fe1756da1"
+  },
+  {
+    "id": "GHSA-7xfq-xh6v-4mrm",
+    "ecosystem": "npm",
+    "name": "json-serializer",
+    "versions": [
+      "2.0.10"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-7xfq-xh6v-4mrm",
+    "source_sha256": "f57f77ddc992ab3a5b965dd9e68b46c30783ddde31d55d236a0d5a4f803094f5"
+  },
+  {
+    "id": "GHSA-84qj-9qf2-q92r",
+    "ecosystem": "npm",
+    "name": "pm-controls",
+    "versions": [
+      "1.1.8"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-84qj-9qf2-q92r",
+    "source_sha256": "5e21e1e7fda83b74f1cc8a6d8564922cb139329f1925b47e0f47fa5ab2c6182c"
+  },
+  {
+    "id": "GHSA-8qh7-xw58-3ww7",
+    "ecosystem": "npm",
+    "name": "radic-util",
+    "versions": [
+      "1.0.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-8qh7-xw58-3ww7",
+    "source_sha256": "2a384dfef7f9f22ccfa3ea713fd8f52fe03a955bd38da0d6ef92200fcdc0c5c3"
+  },
+  {
+    "id": "GHSA-8qm2-24qc-c4qg",
+    "ecosystem": "npm",
+    "name": "freshdom",
+    "versions": [
+      "0.0.6"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-8qm2-24qc-c4qg",
+    "source_sha256": "a6605f250282726a37ccd19dce836529d3546562842bef200a5a6212a6127160"
+  },
+  {
+    "id": "GHSA-8rxg-9g6f-vq9p",
+    "ecosystem": "npm",
+    "name": "another-date-range-picker",
+    "versions": [
+      "4.1.48"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-8rxg-9g6f-vq9p",
+    "source_sha256": "40ad85d54631e1e4e748282bab6b803937d47a9846c37ff8a43a33f6206b0b53"
+  },
+  {
+    "id": "GHSA-92px-q4w8-hrr5",
+    "ecosystem": "npm",
+    "name": "impala",
+    "versions": [
+      "1.1.7"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-92px-q4w8-hrr5",
+    "source_sha256": "c65ef9d821c8efad63153722e24fd87f00e510ab7c5ae47f2d888a5aad769f2b"
+  },
+  {
+    "id": "GHSA-94m7-w873-6wwf",
+    "ecosystem": "npm",
+    "name": "modlibrary",
+    "versions": [
+      "0.1.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-94m7-w873-6wwf",
+    "source_sha256": "b3aa84346220b6d0b662b21120b88f274946c7cc102d56eb2928224c15b065c7"
+  },
+  {
+    "id": "GHSA-9cq4-mhmr-84gm",
+    "ecosystem": "npm",
+    "name": "jasmin",
+    "versions": [
+      "0.0.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-9cq4-mhmr-84gm",
+    "source_sha256": "2590782f46f7dca69101df0221815ff3d1019fd97be3ba89b7c13857678331dd"
+  },
+  {
+    "id": "GHSA-9p49-cwh3-4qhf",
+    "ecosystem": "npm",
+    "name": "grunt-radic",
+    "versions": [
+      "0.1.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-9p49-cwh3-4qhf",
+    "source_sha256": "b3feb59eba29744bbb57ff0ed5dc96fe8386d6266a1832fbca08c063c7859421"
+  },
+  {
+    "id": "GHSA-9x64-5r7x-2q53",
+    "ecosystem": "npm",
+    "name": "flatmap-stream",
+    "versions": [
+      "0.1.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-9x64-5r7x-2q53",
+    "source_sha256": "73a0c8bbce213f81c465e58cf2629c97924e338982d8a2d762f147dbb86b7414"
+  },
+  {
+    "id": "GHSA-c722-pv5w-cfg2",
+    "ecosystem": "npm",
+    "name": "github-jquery-widgets",
+    "versions": [
+      "0.1.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-c722-pv5w-cfg2",
+    "source_sha256": "5e7f35a51d5391e02db9cb05bfe93a20161386a5f2b71c1e445b94e67cd3842e"
+  },
+  {
+    "id": "GHSA-c82c-8pjw-6829",
+    "ecosystem": "npm",
+    "name": "@impala/bmap",
+    "versions": [
+      "1.0.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-c82c-8pjw-6829",
+    "source_sha256": "c41d4e103e36b4c2ea5cf8b37b62883f1acebac613171d25ebebea37b704d9d2"
+  },
+  {
+    "id": "GHSA-c8h6-89q2-mgv8",
+    "ecosystem": "npm",
+    "name": "dossier",
+    "versions": [
+      "0.0.4"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-c8h6-89q2-mgv8",
+    "source_sha256": "1bee77ce926bb2c27506cf385b88b85d586de2bba507986c6512f07da1a2386c"
+  },
+  {
+    "id": "GHSA-chh2-rvhg-wqwr",
+    "ecosystem": "npm",
+    "name": "json-serializer",
+    "versions": [
+      "2.0.10"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-chh2-rvhg-wqwr",
+    "source_sha256": "71f679c92292e001f63e5a8979f5f268a23ea4dde2bc54a22a8edf86067d51cf"
+  },
+  {
+    "id": "GHSA-cxcf-78mr-wpg7",
+    "ecosystem": "npm",
+    "name": "oauth-validator",
+    "versions": [
+      "1.0.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-cxcf-78mr-wpg7",
+    "source_sha256": "d6aef457d7d7cde552a5040f3f0ff298198580b846d7b936d522a3f347751a9a"
+  },
+  {
+    "id": "GHSA-fgfj-rj24-mj7q",
+    "ecosystem": "npm",
+    "name": "kraken-api",
+    "versions": [
+      "0.1.8"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-fgfj-rj24-mj7q",
+    "source_sha256": "0af35a76e5d7e6b5c95b7058c777f927c3fad5dbdc48831c8af92b5a72613733"
+  },
+  {
+    "id": "GHSA-fwvp-x5gj-773j",
+    "ecosystem": "npm",
+    "name": "react-server-native",
+    "versions": [
+      "0.0.7"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-fwvp-x5gj-773j",
+    "source_sha256": "288c8ade61ebc4d7bde1429d665975f6c29c935d9ba9960e5c6a6c6047b2c8cb"
+  },
+  {
+    "id": "GHSA-fx6f-fpfv-5hmc",
+    "ecosystem": "npm",
+    "name": "uploader-plugin",
+    "versions": [
+      "1.0.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-fx6f-fpfv-5hmc",
+    "source_sha256": "a699ee7d897975e4406471c458e4baec4d08605562f9168f0a4da65ba4c6b501"
+  },
+  {
+    "id": "GHSA-gjc9-932x-c59p",
+    "ecosystem": "npm",
+    "name": "leaflet-gpx",
+    "versions": [
+      "1.0.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-gjc9-932x-c59p",
+    "source_sha256": "ace1d956c2f3f12c569b1c6d75a4270989cac5826cd002433508f39b47ac919d"
+  },
+  {
+    "id": "GHSA-hfc6-79wv-5hpw",
+    "ecosystem": "npm",
+    "name": "blingjs",
+    "versions": [
+      "0.0.4"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-hfc6-79wv-5hpw",
+    "source_sha256": "c3f6b3f8956e54c7f46c6576a5ec7e17554ea5c37b49dc905ba53c430aee8fc7"
+  },
+  {
+    "id": "GHSA-hxxf-q3w9-4xgw",
+    "ecosystem": "npm",
+    "name": "eslint-config-eslint",
+    "versions": [
+      "5.0.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-hxxf-q3w9-4xgw",
+    "source_sha256": "62a7a2dbbb7b49105884594406ae168b39a98197bbc38ba873dd35073815b8bc"
+  },
+  {
+    "id": "GHSA-hxxf-q3w9-4xgw",
+    "ecosystem": "npm",
+    "name": "eslint-scope",
+    "versions": [
+      "3.7.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-hxxf-q3w9-4xgw",
+    "source_sha256": "62a7a2dbbb7b49105884594406ae168b39a98197bbc38ba873dd35073815b8bc"
+  },
+  {
+    "id": "GHSA-j4ch-mw66-xmqv",
+    "ecosystem": "npm",
+    "name": "pensi-scheduler",
+    "versions": [
+      "1.1.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-j4ch-mw66-xmqv",
+    "source_sha256": "6c4b3a4f9c80d91d8b86caf3e6f118404146af8ab91ce0c2b750405f457ea57e"
+  },
+  {
+    "id": "GHSA-j5jc-jf8f-86q7",
+    "ecosystem": "npm",
+    "name": "dictum.js",
+    "versions": [
+      "1.0.5"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-j5jc-jf8f-86q7",
+    "source_sha256": "da38fd9fd8201604c09ab78f786d38f6e2384d6cbf130e5ed7a7ad994580721b"
+  },
+  {
+    "id": "GHSA-j5qg-46p9-w2rp",
+    "ecosystem": "npm",
+    "name": "jekyll-for-github-projects",
+    "versions": [
+      "0.2.12"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-j5qg-46p9-w2rp",
+    "source_sha256": "f4fd1fd866eefef63e7e1706e96d00ea8218c2884cdd67784ac470e7e76a3d80"
+  },
+  {
+    "id": "GHSA-jf55-rgpx-p6rx",
+    "ecosystem": "npm",
+    "name": "iie-viz",
+    "versions": [
+      "1.0.4"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-jf55-rgpx-p6rx",
+    "source_sha256": "4bd693947a3122442ce6f418cb8a94bbfdd4d32ddffda68b24de8644ad80f22e"
+  },
+  {
+    "id": "GHSA-jpvj-wpmj-h7rv",
+    "ecosystem": "npm",
+    "name": "@cap-js/openapi",
+    "versions": [
+      "1.4.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-jpvj-wpmj-h7rv",
+    "source_sha256": "1235c055233ac65ada9c1fb878d629a9718cdf34e650c7b511ae6283c9cd34be"
+  },
+  {
+    "id": "GHSA-jxf5-7x3j-8j9m",
+    "ecosystem": "npm",
+    "name": "load-from-cwd-or-npm",
+    "versions": [
+      "3.0.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-jxf5-7x3j-8j9m",
+    "source_sha256": "273c13180ae30564b8be1778a73d5797be895f290392ff9110b39136b983468b"
+  },
+  {
+    "id": "GHSA-jxr6-qrxx-2ph2",
+    "ecosystem": "PyPI",
+    "name": "num2words",
+    "versions": [
+      "0.5.15",
+      "0.5.16"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-jxr6-qrxx-2ph2",
+    "source_sha256": "8910c3f1c20779557be73390e616d2fea8e9d2c8502e8d977c3135d5555866ef"
+  },
+  {
+    "id": "GHSA-m25q-fwg4-9v2p",
+    "ecosystem": "npm",
+    "name": "awesome_react_utility",
+    "versions": [
+      "1.0.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-m25q-fwg4-9v2p",
+    "source_sha256": "886227abffefdb04a5628e96661c00f26fdce25c5a632037a6c5580ed5c0b117"
+  },
+  {
+    "id": "GHSA-m5pf-5894-jmx7",
+    "ecosystem": "npm",
+    "name": "sailclothjs",
+    "versions": [
+      "1.2.6"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-m5pf-5894-jmx7",
+    "source_sha256": "b664072dc1bf5eca2f1b7f31f9e9d4ceb127f8f7750e674af3d16d00dc2d4fab"
+  },
+  {
+    "id": "GHSA-m7xv-7p93-g6q8",
+    "ecosystem": "npm",
+    "name": "libubx",
+    "versions": [
+      "1.0.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-m7xv-7p93-g6q8",
+    "source_sha256": "259046876564caa1fd0623d945a6552ce247f353f24ec8bc6f9848c24095e4c1"
+  },
+  {
+    "id": "GHSA-m852-866j-69j8",
+    "ecosystem": "npm",
+    "name": "eslint-config-airbnb-standard",
+    "versions": [
+      "2.0.0"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-m852-866j-69j8",
+    "source_sha256": "be32028d11643efcd3d4202371fce527faff381a19aee6fbd5e8e7bdc0d6dbd2"
+  },
+  {
+    "id": "GHSA-p32g-242c-76h3",
+    "ecosystem": "npm",
+    "name": "geoheat",
+    "versions": [
+      "1.3.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-p32g-242c-76h3",
+    "source_sha256": "a2eb46d819c6807c7d0a675bbc217a04b813e7a513550e6779cc5270768a51e9"
+  },
+  {
+    "id": "GHSA-p59g-6cqr-m73w",
+    "ecosystem": "npm",
+    "name": "bmap",
+    "versions": [
+      "1.0.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-p59g-6cqr-m73w",
+    "source_sha256": "9177c9a62b2dfc4c2c354d105db190aa3d77a9928ac21d0c8da84cc3cbda1124"
+  },
+  {
+    "id": "GHSA-p7w2-mc6m-mfx2",
+    "ecosystem": "npm",
+    "name": "scroool",
+    "versions": [
+      "0.1.7"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-p7w2-mc6m-mfx2",
+    "source_sha256": "041bc130605414c77547da164edeb44a8e277f530f69aed33f2740deb4dfc03b"
+  },
+  {
+    "id": "GHSA-pjxp-f379-6284",
+    "ecosystem": "npm",
+    "name": "@fangrong/xoc",
+    "versions": [
+      "1.0.6"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-pjxp-f379-6284",
+    "source_sha256": "0ec18a3124db4de7f185fb008928634f3a44d0f06d6a980d5e1e9a2ac1cea8b3"
+  },
+  {
+    "id": "GHSA-pv55-r6j3-wp94",
+    "ecosystem": "npm",
+    "name": "eslint-config-eslint",
+    "versions": [
+      "5.0.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-pv55-r6j3-wp94",
+    "source_sha256": "e9d37fa6491285a81a4c0422379a2ffee35242e03a614b36fb8f346ceec5d920"
+  },
+  {
+    "id": "GHSA-pvw4-cvr4-97p8",
+    "ecosystem": "npm",
+    "name": "@cap-js/db-service",
+    "versions": [
+      "2.10.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-pvw4-cvr4-97p8",
+    "source_sha256": "8e59d01b5f2e56109e73d00d887c0210f0817a291cd4e3a9b92c7b310d7ac822"
+  },
+  {
+    "id": "GHSA-pvw4-cvr4-97p8",
+    "ecosystem": "npm",
+    "name": "@cap-js/postgres",
+    "versions": [
+      "2.2.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-pvw4-cvr4-97p8",
+    "source_sha256": "8e59d01b5f2e56109e73d00d887c0210f0817a291cd4e3a9b92c7b310d7ac822"
+  },
+  {
+    "id": "GHSA-pvw4-cvr4-97p8",
+    "ecosystem": "npm",
+    "name": "@cap-js/sqlite",
+    "versions": [
+      "2.2.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-pvw4-cvr4-97p8",
+    "source_sha256": "8e59d01b5f2e56109e73d00d887c0210f0817a291cd4e3a9b92c7b310d7ac822"
+  },
+  {
+    "id": "GHSA-qmxf-fxq7-w59f",
+    "ecosystem": "npm",
+    "name": "angular-material-sidenav-rnd",
+    "versions": [
+      "0.1.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-qmxf-fxq7-w59f",
+    "source_sha256": "a7d3064860073288355f14d60337e09da8c954fbd8a08e4152c03fbc4db25d32"
+  },
+  {
+    "id": "GHSA-v6vv-hhqc-6hh2",
+    "ecosystem": "npm",
+    "name": "pyramid-proportion",
+    "versions": [
+      "1.0.5"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-v6vv-hhqc-6hh2",
+    "source_sha256": "893613dc0675118302e90c309e6d9aa0148f7e10cf6427aa08533fcc7f0b6d14"
+  },
+  {
+    "id": "GHSA-vp8g-53fw-r9f2",
+    "ecosystem": "npm",
+    "name": "dynamo-schema",
+    "versions": [
+      "0.0.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-vp8g-53fw-r9f2",
+    "source_sha256": "e74c4ba6989a8e48304029755ca5a2536d6cfb9aa59b6cfd078ad059a6ca46fa"
+  },
+  {
+    "id": "GHSA-w62p-hx95-gf2c",
+    "ecosystem": "npm",
+    "name": "@duckdb/duckdb-wasm",
+    "versions": [
+      "1.29.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-w62p-hx95-gf2c",
+    "source_sha256": "941095d7a787b126835484d7b700bd53083b751ee29ee7738a426f1c57644ae6"
+  },
+  {
+    "id": "GHSA-w62p-hx95-gf2c",
+    "ecosystem": "npm",
+    "name": "@duckdb/node-api",
+    "versions": [
+      "1.3.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-w62p-hx95-gf2c",
+    "source_sha256": "941095d7a787b126835484d7b700bd53083b751ee29ee7738a426f1c57644ae6"
+  },
+  {
+    "id": "GHSA-w62p-hx95-gf2c",
+    "ecosystem": "npm",
+    "name": "@duckdb/node-bindings",
+    "versions": [
+      "1.3.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-w62p-hx95-gf2c",
+    "source_sha256": "941095d7a787b126835484d7b700bd53083b751ee29ee7738a426f1c57644ae6"
+  },
+  {
+    "id": "GHSA-w62p-hx95-gf2c",
+    "ecosystem": "npm",
+    "name": "duckdb",
+    "versions": [
+      "1.3.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-w62p-hx95-gf2c",
+    "source_sha256": "941095d7a787b126835484d7b700bd53083b751ee29ee7738a426f1c57644ae6"
+  },
+  {
+    "id": "GHSA-w6xj-45gv-fw35",
+    "ecosystem": "npm",
+    "name": "stream-combine",
+    "versions": [
+      "2.0.2"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-w6xj-45gv-fw35",
+    "source_sha256": "edf1fcf14969e242636bd32d69ab5a22c7d42261e95b768c937eb60c5fc8228c"
+  },
+  {
+    "id": "GHSA-w8hg-mxvh-9h57",
+    "ecosystem": "npm",
+    "name": "angular-bmap",
+    "versions": [
+      "0.0.9"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-w8hg-mxvh-9h57",
+    "source_sha256": "49f92a2e8c2fe1ac3044e9f609785a0c2af0b157d17b7f42e46e98782d544761"
+  },
+  {
+    "id": "GHSA-x48m-gp6r-gp4v",
+    "ecosystem": "npm",
+    "name": "rate-map",
+    "versions": [
+      "1.0.3"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-x48m-gp6r-gp4v",
+    "source_sha256": "8a7e32ac231c3e633dd14b9defc8d9ee85c5890f4f0aa89970d09c07cc70d4a8"
+  },
+  {
+    "id": "GHSA-x9gm-qxhh-rf75",
+    "ecosystem": "npm",
+    "name": "cordova-plugin-china-picker",
+    "versions": [
+      "1.0.910"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-x9gm-qxhh-rf75",
+    "source_sha256": "fb4c53afa1cab1181d5cccdfccb012a43193a7693552de2034b599a49337ad9c"
+  },
+  {
+    "id": "GHSA-xmpw-2vmm-p4p6",
+    "ecosystem": "PyPI",
+    "name": "guardrails-ai",
+    "versions": [
+      "0.10.1"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-xmpw-2vmm-p4p6",
+    "source_sha256": "4e15f63747bbb420728cdad186966ea1c84419bebc441c31287d55a2666aa9a2"
+  },
+  {
+    "id": "GHSA-xwg3-gjxh-c8pm",
+    "ecosystem": "npm",
+    "name": "ngx-context-menu",
+    "versions": [
+      "0.0.26"
+    ],
+    "source": "https://api.osv.dev/v1/vulns/GHSA-xwg3-gjxh-c8pm",
+    "source_sha256": "710d51c082e17412de8037a7a71d93ef4ed8ce93752550b2a27e664630c39e42"
+  }
+]

--- a/internal/intel/types.go
+++ b/internal/intel/types.go
@@ -54,10 +54,13 @@ const (
 // changes incompatibly; Load() rejects unknown schema versions
 // rather than guessing how to read them.
 type Snapshot struct {
-	SchemaVersion int          `json:"schema_version"`
-	GeneratedAt   time.Time    `json:"generated_at"`
-	Sources       []SourceMeta `json:"sources"`
-	Records       []Record     `json:"records"`
+	SchemaVersion int `json:"schema_version"`
+	// AdmissionPolicy identifies the OSV classification policy applied by the
+	// producer, independently of bundle authentication and serialization schema.
+	AdmissionPolicy int          `json:"admission_policy,omitempty"`
+	GeneratedAt     time.Time    `json:"generated_at"`
+	Sources         []SourceMeta `json:"sources"`
+	Records         []Record     `json:"records"`
 	// AllVersions lists packages where EVERY version is marked
 	// malicious (OSV range shape: introduced 0/absent, no fixed, no
 	// last_affected). They are stored as compact entries instead of

--- a/tools/update-intel/main.go
+++ b/tools/update-intel/main.go
@@ -102,7 +102,8 @@ func main() {
 	}
 
 	merged := intel.Snapshot{
-		SchemaVersion: intel.CurrentSchemaVersion,
+		AdmissionPolicy: intel.CurrentOSVAdmissionPolicy,
+		SchemaVersion:   intel.CurrentSchemaVersion,
 	}
 	if !generatedAt.IsZero() {
 		merged.GeneratedAt = generatedAt


### PR DESCRIPTION
## Summary

A vulnerability report can mention a malicious package without saying that the affected package is malware. Aguara was using those mentions to admit exact-version OSV records into its malicious-package intelligence. That could turn an ordinary vulnerability in a legitimate dependency into a malicious-package finding.

This change removes that keyword-based admission. MAL records and structured OpenSSF origins remain accepted. Exact-version records may also qualify through GitHub-reviewed CWE-506 metadata or a reviewed advisory/package/version list. Descriptions, reference URLs and the GHSA prefix alone no longer qualify a record; the existing range admission remains restricted to MAL/OpenSSF evidence.

The correction also applies to older embedded, cached and downloaded snapshots before they reach package matching or Python wheel-filename checks. Historical compromises are preserved through 80 reviewed advisory/package entries containing 84 exact versions, with source URLs and response digests. Manual incident intelligence and withdrawal handling remain separate and unchanged.

Regression coverage includes legitimate Ansible and dbt-core versions that previously inherited a malware classification, and a contradictory PYSEC record that included guardrails-ai 0.10.0 despite identifying it as unaffected. The clean version now stays clean; the malicious 0.10.1 release remains detected through its GHSA record.

The committed snapshot is not regenerated, and reading an older cache does not rewrite its authenticated bytes. Users need an updated Aguara binary to apply the correction to existing intelligence; refreshing data alone cannot change older binaries.

## Validation

- Focused race tests cover importer/classifier agreement, malformed source metadata, exact-version boundaries, legacy migration, verified-cache reuse, embedded matching and Python filename indexing.
- Signed and explicitly unverified refresh tests, build, scoped vet and lint pass locally.
- A migration check against the embedded and retained September snapshots preserves their 202,526 and 203,639 all-version entries. Known-malicious controls remain detected, including flatmap-stream, Nx and @fangrong/xoc.
- The full repository suite runs in CI. No local fuzzing, benchmarks or stress tests were run.

No new detection rules, version pins or release artifacts.
