### PR TITLE
Keep URL credentials out of dependency findings and report context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Findings no longer expose username-only URL tokens, empty-password credentials,
+  or credential tails after a second `@`. Dependency and shell evidence keeps
+  the destination visible; default redaction also covers URLs in neighboring
+  finding context and descriptions.
 - Dependency checks no longer classify a package as malicious solely because a
   vulnerability description or reference mentions malware. OSV imports require
   source evidence or reviewed exact versions. The same policy filters older

--- a/aguara_url_redaction_test.go
+++ b/aguara_url_redaction_test.go
@@ -1,0 +1,72 @@
+package aguara_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/garagon/aguara"
+	"github.com/garagon/aguara/internal/output"
+)
+
+func TestScanContentURLUserinfoRedaction(t *testing.T) {
+	sc, err := aguara.NewScanner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct{ name, content, rule string }{
+		{"setup.sh", "pip install --index-url http://opaqueTOKEN@packages.example/simple x", "SHELL_UNSAFE_PIP_SOURCE_001"},
+		{"setup.sh", "npm install --registry http://user:part@opaqueTOKEN@packages.example x", "SHELL_UNSAFE_NPM_SOURCE_001"},
+		{"setup.sh", "systemctl --user enable cache.service && pip install --index-url http://opaqueTOKEN@packages.example/simple x", "SC-EX-007"},
+		{"package.json", `{"scripts":{"postinstall":"node hook.js"},"dependencies":{"x":"git+https://user:part@opaqueTOKEN@github.com/org/repo.git"}}`, "NPM_LIFECYCLE_GIT_001"},
+		{"package.json", `{"optionalDependencies":{"x":"git+https://user:part@opaqueTOKEN@github.com/org/repo.git"}}`, "NPM_OPTIONAL_GIT_001"},
+		{"package.json", `{"dependencies":{"x":"git+https://user:part@opaqueTOKEN@github.com/org/repo.git"}}`, "NPM_GIT_INSTALL_TRUST_001"},
+		{"package.json", `{"dependencies":{"x":"https://user:part@opaqueTOKEN@packages.example/x.tgz"}}`, "NPM_REMOTE_INSTALL_TRUST_001"},
+		{"package.json", `{"optionalDependencies":{"x":"git+https://user:opaque'TOKEN@github.com/org/repo.git"}}`, "NPM_OPTIONAL_GIT_001"},
+		{"package.json", "{\n\"scripts\":{\"postinstall\":\"bash setup.sh\"},\n\"dependencies\":{\"x\":\"git+https:\\/\\/opaqueTOKEN@github.com/org/repo.git\"}\n}", "SUPPLY_001"},
+		{"package.json", "{\n\"scripts\":{\"postinstall\":\"bash setup.sh\"},\n\"dependencies\":{\"x\":\"git+https://opaqueTOKEN\\u0040github.com/org/repo.git\"}\n}", "SUPPLY_001"},
+	} {
+		t.Run(tc.rule, func(t *testing.T) {
+			r, err := aguara.ScanContent(context.Background(), tc.content, tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			hit := false
+			for _, f := range r.Findings {
+				if f.RuleID == tc.rule {
+					hit = true
+				}
+			}
+			if !hit {
+				t.Fatalf("missing %s: %+v", tc.rule, r.Findings)
+			}
+			b, err := json.Marshal(r)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(b), "TOKEN") {
+				t.Fatalf("credential leaked: %s", b)
+			}
+			var sarif bytes.Buffer
+			if err := (&output.SARIFFormatter{}).Format(&sarif, r); err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(sarif.String(), "TOKEN") {
+				t.Fatal("credential leaked in SARIF")
+			}
+			reused, err := sc.ScanContent(context.Background(), tc.content, tc.name)
+			if err != nil {
+				t.Fatal(err)
+			}
+			b, err = json.Marshal(reused)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if strings.Contains(string(b), "TOKEN") {
+				t.Fatal("credential leaked through reusable scanner")
+			}
+		})
+	}
+}

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -159,30 +159,7 @@ func parseManifest(content []byte) (*manifest, error) {
 // credential-leak category, so supply-chain findings that emit a raw
 // version must self-sanitize.
 func sanitizeGitURL(version string) string {
-	// Trim before scheme matching: isGitDep already trims, so a value
-	// like " git+https://user:token@github.com/org/repo.git " is treated
-	// as a git dep upstream. Without trimming here, the leading space
-	// breaks the HasPrefix check and the raw credential survives into
-	// Description / MatchedText.
-	v := strings.TrimSpace(version)
-	// Only URL forms can carry credentials. Match the scheme then look
-	// for an `@` that separates `userinfo` from `host`. Drop the
-	// userinfo block.
-	for _, scheme := range []string{"git+ssh://", "git+https://", "git+http://", "git+git://", "git://", "https://", "http://", "ssh://"} {
-		if !strings.HasPrefix(strings.ToLower(v), scheme) {
-			continue
-		}
-		rest := v[len(scheme):]
-		at := strings.Index(rest, "@")
-		slash := strings.Index(rest, "/")
-		// `@` must appear before the first `/` to belong to userinfo;
-		// otherwise it is part of a path (e.g. `@scope/...`).
-		if at > 0 && (slash < 0 || at < slash) {
-			return v[:len(scheme)] + rest[at+1:]
-		}
-		break
-	}
-	return v
+	return types.StripURLUserinfo(strings.TrimSpace(version))
 }
 
 // keyTokenRegex compiles a regex that matches `"key"` followed by any

--- a/internal/engine/pkgmeta/url_redaction_test.go
+++ b/internal/engine/pkgmeta/url_redaction_test.go
@@ -1,0 +1,13 @@
+package pkgmeta
+
+import "testing"
+
+func TestURLUserinfoRedaction(t *testing.T) {
+	for _, scheme := range []string{"git+https://", "git+custom://", "HTTPS://"} {
+		in := scheme + "user:part@TOKEN@github.com/@scope/repo"
+		want := scheme + "github.com/@scope/repo"
+		if got := sanitizeGitURL(in); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	}
+}

--- a/internal/engine/scriptrisk/scriptrisk.go
+++ b/internal/engine/scriptrisk/scriptrisk.go
@@ -57,7 +57,6 @@ var (
 	unsafeHTTPURLRe   = regexp.MustCompile(`(?i)(?:git\+)?http://[^\s'"<>]+`)
 	pipSourceOptionRe = regexp.MustCompile(`(?i)--(?:extra-)?index-url(?:=|\s+)\S*http://`)
 	npmSourceOptionRe = regexp.MustCompile(`(?i)--registry(?:=|\s+)\S*http://`)
-	urlCredentialRe   = regexp.MustCompile(`(?i)(https?://)[^/@\s]+:[^/@\s]+@`)
 	shellSystemctlRe  = regexp.MustCompile(`(?i)^(?:sudo\s+)?systemctl\s+(?:--user\s+)?(?:[^;&|]*\s)?enable\b`)
 	shellCronFeedRe   = regexp.MustCompile(`(?i)(?:@reboot|(?:\*|\d+)(?:/\d+)?\s+(?:\*|\d+))`)
 	shellUnitPathRe   = regexp.MustCompile(`(?i)(?:~|\$\{?HOME\}?|/home/[^/\s]+|/root)/\.config/systemd/user/[^\s]+\.(?:service|timer)`)
@@ -1739,5 +1738,5 @@ func isLoopbackHost(host string) bool {
 }
 
 func redactURLCredentials(s string) string {
-	return urlCredentialRe.ReplaceAllString(s, `${1}[REDACTED]@`)
+	return types.SanitizeURLUserinfo(s, types.RedactedPlaceholder+"@")
 }

--- a/internal/engine/scriptrisk/url_redaction_test.go
+++ b/internal/engine/scriptrisk/url_redaction_test.go
@@ -1,0 +1,13 @@
+package scriptrisk
+
+import "testing"
+
+func TestURLUserinfoRedaction(t *testing.T) {
+	for _, raw := range []string{"TOKEN", "user:", ":TOKEN", "user:part@TOKEN", "user%40TOKEN"} {
+		in := "pip install --index-url http://" + raw + "@packages.example/@scope/x"
+		want := "pip install --index-url http://[REDACTED]@packages.example/@scope/x"
+		if got := redactURLCredentials(in); got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	}
+}

--- a/internal/types/types.go
+++ b/internal/types/types.go
@@ -136,9 +136,8 @@ const RedactedPlaceholder = "[REDACTED]"
 // RedactSensitiveFindings scrubs matched text and context lines for findings
 // that are known to carry a real secret value: either the rule / analyzer set
 // Sensitive == true, or the legacy category-based contract
-// (Category == "credential-leak") still applies. Other findings are left
-// intact because their match is typically a pattern signature rather than a
-// secret.
+// (Category == "credential-leak") still applies. URL userinfo is also scrubbed
+// in every finding's matched text, description and source context.
 //
 // Context redaction differs by source. Sensitive findings treat their entire
 // Context window as secret-bearing because either (a) the analyzer's
@@ -169,6 +168,13 @@ func RedactSensitiveFindings(findings []Finding) {
 	}
 	sensitiveLines := make(map[fileLine]bool)
 	for i := range findings {
+		// URL credentials can occur in non-credential findings and neighboring
+		// source context even when the originating finding was filtered out.
+		findings[i].MatchedText = SanitizeURLUserinfo(findings[i].MatchedText, RedactedPlaceholder+"@")
+		findings[i].Description = SanitizeURLUserinfo(findings[i].Description, RedactedPlaceholder+"@")
+		for j := range findings[i].Context {
+			findings[i].Context[j].Content = SanitizeURLUserinfo(findings[i].Context[j].Content, RedactedPlaceholder+"@")
+		}
 		isSensitive := findings[i].Sensitive
 		isLegacyCred := findings[i].Category == "credential-leak"
 		if !isSensitive && !isLegacyCred {

--- a/internal/types/url_redaction.go
+++ b/internal/types/url_redaction.go
@@ -1,0 +1,66 @@
+package types
+
+import (
+	"encoding/json"
+	"regexp"
+	"strings"
+)
+
+// Match only the authority prefix, ending at its last @. Do not require a
+// valid URL: diagnostics can contain malformed URLs alongside a real finding.
+// Paths, queries, fragments and surrounding quoted source are not authority.
+var urlUserinfo = regexp.MustCompile("[A-Za-z][A-Za-z0-9+.-]*://[^/\\s?#\"<>`]*@")
+var urlScheme = regexp.MustCompile(`^[A-Za-z][A-Za-z0-9+.-]*$`)
+var jsonStringToken = regexp.MustCompile(`"(?:[^"\\\r\n]|\\[^\r\n])*"`)
+
+// StripURLUserinfo handles a complete decoded dependency value, rather than
+// quoted source text. Apostrophes and other raw userinfo bytes must not make
+// the sanitizer less permissive than dependency classification.
+func StripURLUserinfo(value string) string {
+	i := strings.Index(value, "://")
+	if i < 0 || !urlScheme.MatchString(value[:i]) {
+		return value
+	}
+	start := i + 3
+	end := len(value)
+	if n := strings.IndexAny(value[start:], "/?#"); n >= 0 {
+		end = start + n
+	}
+	if at := strings.LastIndexByte(value[start:end], '@'); at >= 0 {
+		return value[:start] + value[start+at+1:]
+	}
+	return value
+}
+
+// SanitizeURLUserinfo replaces complete URL userinfo prefixes in text. The
+// replacement includes its own @ when a caller wants to keep a placeholder.
+// Other URL components and their original escaping are preserved.
+func SanitizeURLUserinfo(text, replacement string) string {
+	// Report context can retain JSON source escapes even when an analyzer
+	// consumed the decoded URL. Decode complete string tokens, never guess
+	// at escape spellings or change the scanned source itself.
+	if strings.Contains(text, `\`) {
+		text = jsonStringToken.ReplaceAllStringFunc(text, func(token string) string {
+			var decoded string
+			if json.Unmarshal([]byte(token), &decoded) != nil {
+				return token
+			}
+			safe := sanitizeLiteralURLUserinfo(decoded, replacement)
+			if safe == decoded {
+				return token
+			}
+			encoded, _ := json.Marshal(safe)
+			return string(encoded)
+		})
+	}
+	return sanitizeLiteralURLUserinfo(text, replacement)
+}
+
+func sanitizeLiteralURLUserinfo(text, replacement string) string {
+	if !strings.Contains(text, "://") || !strings.Contains(text, "@") {
+		return text
+	}
+	return urlUserinfo.ReplaceAllStringFunc(text, func(prefix string) string {
+		return prefix[:strings.Index(prefix, "://")+3] + replacement
+	})
+}

--- a/internal/types/url_redaction_test.go
+++ b/internal/types/url_redaction_test.go
@@ -1,0 +1,36 @@
+package types
+
+import "testing"
+
+func TestSanitizeURLUserinfo(t *testing.T) {
+	for _, tc := range []struct{ in, want string }{
+		{"http://TOKEN@host/x", "http://[REDACTED]@host/x"},
+		{"HTTPS://user:part@TAIL@[::1]:80/@scope/x", "HTTPS://[REDACTED]@[::1]:80/@scope/x"},
+		{"git+custom://user%40TOKEN@host/repo", "git+custom://[REDACTED]@host/repo"},
+		{"http://bad%ZZ@host/x", "http://[REDACTED]@host/x"},
+		{"http://:@host", "http://[REDACTED]@host"},
+		{"http://host/@scope/x?email=a@b#c@d", "http://host/@scope/x?email=a@b#c@d"},
+		{"http://host?email=a@b", "http://host?email=a@b"},
+		{"http://host#email=a@b", "http://host#email=a@b"},
+		{"'http://ONE@host/x' \"https://TWO@other/y\"", "'http://[REDACTED]@host/x' \"https://[REDACTED]@other/y\""},
+		{"github:org/repo#ref", "github:org/repo#ref"},
+	} {
+		got := SanitizeURLUserinfo(tc.in, RedactedPlaceholder+"@")
+		if got != tc.want {
+			t.Errorf("%q: got %q want %q", tc.in, got, tc.want)
+		}
+		if again := SanitizeURLUserinfo(got, RedactedPlaceholder+"@"); again != got {
+			t.Errorf("not idempotent: %q", again)
+		}
+	}
+}
+
+func TestRedactURLUserinfoAcrossFindingFields(t *testing.T) {
+	url := "http://TOKEN@host/simple"
+	fs := []Finding{{Description: url, MatchedText: url, Context: []ContextLine{{Content: url}}}}
+	RedactSensitiveFindings(fs)
+	want := "http://[REDACTED]@host/simple"
+	if fs[0].Description != want || fs[0].MatchedText != want || fs[0].Context[0].Content != want {
+		t.Fatalf("leaked URL: %+v", fs)
+	}
+}


### PR DESCRIPTION
## Summary

A dependency URL can carry a token without a password, or contain more than one `@` in its credentials. Aguara's shell and package evidence could expose those values in reports: one sanitizer required `user:password`, while the other removed credentials only through the first `@`.

This change removes the complete userinfo before displaying the destination. Shell findings retain their redaction marker; package-source findings retain the host and path without credentials. URLs in default-redacted descriptions, matches and neighboring source context are also sanitized, including JSON-escaped URLs that an analyzer has already decoded.

Coverage includes username-only tokens, empty passwords, embedded `@`, apostrophes, percent escapes, alternate Git URL schemes, and escaped JSON separators. `@` in a path, query or fragment is not mistaken for a credential delimiter. Dependency classification and rule severity do not change.

The existing explicit redaction opt-out remains available. The two analyzer-level sanitizers still run unconditionally, as before. Findings whose evidence previously included credentials will have different sanitized snippets and may require baseline review.

## Validation

- Reproduced both original leaks with synthetic credentials before the fix.
- Added regression tests for two additional variants found during review: apostrophes and copied JSON-escaped context.
- Focused race tests cover the sanitizers, existing positive/negative detections, one-shot and reusable library scans, JSON, and SARIF.
- Scoped lint and vet pass; full build and test suite run in CI. No local fuzzing, benchmarks or stress tests.

No new rules, severity changes, version pins or release artifacts.
