### PR TITLE
Read pnpm policy aliases by value, not anchor name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
   or credential tails after a second `@`. Dependency and shell evidence keeps
   the destination visible; default redaction also covers URLs in neighboring
   finding context and descriptions.
+- pnpm policy checks now read the value referenced by a YAML alias, including
+  aliased build-approval mappings. Dangerous settings are no longer missed
+  behind anchors, and a safe value does not trigger a finding merely because
+  its anchor is named `true`, `off`, or `0`. Findings retain the policy key's
+  source line; rule IDs, severities, and merge precedence are unchanged.
 - Dependency checks no longer classify a package as malicious solely because a
   vulnerability description or reference mentions malware. OSV imports require
   source evidence or reviewed exact versions. The same policy filters older

--- a/aguara_pnpm_alias_test.go
+++ b/aguara_pnpm_alias_test.go
@@ -1,0 +1,35 @@
+package aguara_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/garagon/aguara"
+)
+
+func TestScanContentPNPMPolicyAliases(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		want   bool
+	}{
+		{"choice: &enabled true\ndangerouslyAllowAllBuilds: *enabled\n", true},
+		{"choice: &true false\ndangerouslyAllowAllBuilds: *true\n", false},
+	} {
+		r, err := aguara.ScanContent(context.Background(), tc.source, "pnpm-workspace.yaml")
+		if err != nil {
+			t.Fatal(err)
+		}
+		found := false
+		for _, f := range r.Findings {
+			if f.RuleID == "PNPM_DANGEROUS_BUILDS_001" {
+				found = true
+				if f.Line != 2 || f.Analyzer != "pnpm-policy" {
+					t.Fatalf("unexpected attribution: %+v", f)
+				}
+			}
+		}
+		if found != tc.want {
+			t.Fatalf("dangerous builds finding = %v, want %v", found, tc.want)
+		}
+	}
+}

--- a/internal/engine/pnpmpolicy/alias_values_test.go
+++ b/internal/engine/pnpmpolicy/alias_values_test.go
@@ -1,0 +1,70 @@
+package pnpmpolicy
+
+import (
+	"context"
+	"testing"
+
+	"github.com/garagon/aguara/internal/scanner"
+	"gopkg.in/yaml.v3"
+)
+
+func TestAliasPolicyValues(t *testing.T) {
+	cases := []struct {
+		name, src, rule string
+		want            bool
+	}{
+		{"dangerous", "x: &safe true\ndangerouslyAllowAllBuilds: *safe\n", RuleDangerousBuilds, true},
+		{"misleading true", "x: &true false\ndangerouslyAllowAllBuilds: *true\n", RuleDangerousBuilds, false},
+		{"strict", "x: &yes false\nstrictDepBuilds: *yes\n", RuleStrictDepBuildsDisabled, true},
+		{"exotic", "x: &yes false\nblockExoticSubdeps: *yes\n", RuleExoticSubdepsDisabled, true},
+		{"lockfile", "x: &no true\ntrustLockfile: *no\n", RuleTrustLockfile, true},
+		{"zero age", "x: &age 0\nminimumReleaseAge: *age\n", RuleMinReleaseAgeDisabled, true},
+		{"misleading zero", "x: &0 1440\nminimumReleaseAge: *0\n", RuleMinReleaseAgeDisabled, false},
+		{"strict age", "a: &age 1440\ns: &strict false\nminimumReleaseAge: *age\nminimumReleaseAgeStrict: *strict\n", RuleMinReleaseAgeNonStrict, true},
+		{"off", "x: &policy off\ntrustPolicy: *policy\n", RuleTrustPolicyOff, true},
+		{"misleading off", "x: &off no-downgrade\ntrustPolicy: *off\n", RuleTrustPolicyOff, false},
+		{"pending", "x: &pending null\nallowBuilds:\n  sharp: *pending\n", RuleBuildApprovalPending, true},
+		{"mapping", "x: &builds {sharp: null}\nallowBuilds: *builds\n", RuleBuildApprovalPending, true},
+		{"decided", "x: &pending false\nallowBuilds:\n  sharp: *pending\n", RuleBuildApprovalPending, false},
+		{"legacy presence", "x: &old []\nonlyBuiltDependencies: *old\n", RuleLegacyBuildPolicy, true},
+		{"merged value", "x: &choice true\ny: &settings {dangerouslyAllowAllBuilds: *choice}\n<<: *settings\n", RuleDangerousBuilds, true},
+		{"explicit safe wins", "x: &choice true\ny: &settings {dangerouslyAllowAllBuilds: *choice}\n<<: *settings\ndangerouslyAllowAllBuilds: false\n", RuleDangerousBuilds, false},
+		{"alias safe overrides", "x: &choice false\ny: &settings {dangerouslyAllowAllBuilds: true}\n<<: *settings\ndangerouslyAllowAllBuilds: *choice\n", RuleDangerousBuilds, false},
+		{"dynamic", "x: &0 '${AGE}'\nminimumReleaseAge: *0\n", RuleMinReleaseAgeDisabled, false},
+		{"mapping named true", "x: &true {}\ndangerouslyAllowAllBuilds: *true\n", RuleDangerousBuilds, false},
+		{"sequence named off", "x: &off []\ntrustPolicy: *off\n", RuleTrustPolicyOff, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := fires(t, target, tc.src, tc.rule); got != tc.want {
+				t.Fatalf("%s present = %v, want %v", tc.rule, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestAliasFindingLocation(t *testing.T) {
+	src := "x: &setting true\ndangerouslyAllowAllBuilds: *setting\n"
+	fs, err := New().Analyze(context.Background(), &scanner.Target{RelPath: target, Content: []byte(src)})
+	if err != nil || len(fs) != 1 {
+		t.Fatalf("findings %v, error %v", fs, err)
+	}
+	if fs[0].Line != 2 || fs[0].MatchedText != "dangerouslyAllowAllBuilds: *setting" {
+		t.Fatalf("finding must point to policy use, got %+v", fs[0])
+	}
+}
+
+func TestAliasResolutionBounds(t *testing.T) {
+	cycle := &yaml.Node{Kind: yaml.AliasNode, Value: "true"}
+	cycle.Alias = cycle
+	chain := &yaml.Node{Kind: yaml.ScalarNode, Value: "true"}
+	for i := 0; i < maxMergeDepth+2; i++ {
+		chain = &yaml.Node{Kind: yaml.AliasNode, Alias: chain, Value: "true"}
+	}
+	for _, input := range []*yaml.Node{nil, cycle, chain, {Kind: yaml.AliasNode, Value: "true"}} {
+		got := resolveValue(input)
+		if got == nil || got.Value != "" || isNull(got) {
+			t.Fatalf("unresolved alias became a policy value: %+v", got)
+		}
+	}
+}

--- a/internal/engine/pnpmpolicy/pnpmpolicy.go
+++ b/internal/engine/pnpmpolicy/pnpmpolicy.go
@@ -311,7 +311,7 @@ func flattenVisited(node *yaml.Node, depth int, visited map[*yaml.Node]bool) []e
 			merges = append(merges, v)
 			continue
 		}
-		out = append(out, entry{key: k.Value, value: v, line: k.Line})
+		out = append(out, entry{key: k.Value, value: resolveValue(v), line: k.Line})
 	}
 	for _, mn := range merges {
 		for _, tgt := range mergeTargets(mn) {
@@ -322,6 +322,20 @@ func flattenVisited(node *yaml.Node, depth int, visited map[*yaml.Node]bool) []e
 		}
 	}
 	return append(out, merged...)
+}
+
+// resolveValue follows references without expanding their contents. Keep an
+// unresolved entry present for precedence and legacy-key checks, but never
+// interpret an anchor's name (or an unresolved reference) as a policy value.
+func resolveValue(n *yaml.Node) *yaml.Node {
+	for depth := 0; n != nil && depth <= maxMergeDepth; depth++ {
+		if n.Kind != yaml.AliasNode {
+			return n
+		}
+		n = n.Alias
+	}
+	// A zero node is neither a scalar value nor an explicit null decision.
+	return &yaml.Node{}
 }
 
 // mergeTargets resolves the value of a `<<` merge key to the mapping


### PR DESCRIPTION
A pnpm workspace can share policy values through YAML anchors. Aguara was
reading an alias's name instead of the value it referenced: an aliased `true`
could hide unrestricted dependency builds, while a safe value behind an anchor
named `true`, `off`, or `0` could produce a false alert.

This fixes ordinary value resolution in the pnpm policy analyzer, including
aliased `allowBuilds` mappings and undecided entries. The existing rule IDs,
severities, explicit-versus-merged precedence and value interpretation stay
unchanged. Findings point to the policy key that uses the alias, not to its
anchor definition.

References are followed with a fixed depth bound, without expanding their
contents. Unresolved references cannot become boolean, numeric or null policy
decisions.

Validation covers unsafe aliases, misleading anchor names, safe overrides,
merged values, build approvals, source locations and the public `ScanContent`
API. The original false-positive and false-negative cases failed before the
fix and pass with it. Focused race tests, vet and lint pass; independent review
found no remaining issue in this scope. No new detections or dependency changes.
