### PR TITLE
Keep Cargo dependencies visible across valid TOML syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
   or credential tails after a second `@`. Dependency and shell evidence keeps
   the destination visible; default redaction also covers URLs in neighboring
   finding context and descriptions.
+- Cargo dependency checks now parse TOML structure, so inline comments, quoted
+  keys and escaped strings cannot hide a locked crates.io package. Private
+  registries remain excluded. Invalid TOML syntax or package identity fields
+  return an error instead of a successful partial result, and reads are limited
+  to 50 MiB. Unrelated metadata is parsed without decoding a whole document.
 - Dependency checks no longer classify a package as malicious solely because a
   vulnerability description or reference mentions malware. OSV imports require
   source evidence or reviewed exact versions. The same policy filters older

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/garagon/aguara
 go 1.25.8
 
 require (
+	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20250424160509-463d218d4745
 	github.com/sigstore/sigstore-go v1.2.2
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -230,6 +230,8 @@ github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNs
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/petar-dambovaliev/aho-corasick v0.0.0-20250424160509-463d218d4745 h1:Vpr4VgAizEgEZsaMohpw6JYDP+i9Of9dmdY4ufNP6HI=
 github.com/petar-dambovaliev/aho-corasick v0.0.0-20250424160509-463d218d4745/go.mod h1:EHPiTAKtiFmrMldLUNswFwfZ2eJIYBHktdaUTZxYWRw=
 github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c h1:+mdjkGKdHQG3305AYmdv1U2eRNDiU2ErMBj1gwrq8eQ=

--- a/internal/packagecheck/cargo.go
+++ b/internal/packagecheck/cargo.go
@@ -1,113 +1,111 @@
 package packagecheck
 
 import (
-	"bufio"
 	"fmt"
 	"os"
-	"strings"
 
 	"github.com/garagon/aguara/internal/intel"
+	"github.com/pelletier/go-toml/v2/unstable"
 )
 
-// ParseCargo reads a Cargo.lock file and returns the declared
-// crates.io dependencies. The parser is intentionally a
-// block-level reader, not a full TOML implementation: Cargo.lock
-// is a stable, machine-generated format whose only fields we need
-// (name, version, source) are flat key/value pairs inside repeated
-// `[[package]]` arrays.
-//
-// Only entries sourced from the crates.io registry are returned;
-// see isCratesIORegistrySource. Cargo lockfile entries from
-// private registries, git sources, path dependencies, or
-// workspace members are skipped: the OSV matcher resolves
-// identifiers under the crates.io ecosystem, so non-crates.io
-// crates would either never match (best case) or false-positive
-// on a name collision with a public crate (worst case). The
-// allowlist closes the false-positive door.
-//
-// No external commands. No network.
+// ParseCargo decodes Cargo.lock as TOML and returns only packages from the
+// public crates.io registries. Unknown tables and fields are not package data.
+// It does not execute Cargo, resolve dependencies, or access the network.
 func ParseCargo(target Target) ([]PackageRef, error) {
+	info, err := os.Stat(target.Path)
+	if err != nil {
+		return nil, fmt.Errorf("stat Cargo.lock: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("read Cargo.lock: input must be a regular file")
+	}
+	if info.Size() > maxManifestBytes {
+		return nil, fmt.Errorf("read Cargo.lock: input exceeds %d-byte limit", maxManifestBytes)
+	}
 	f, err := os.Open(target.Path)
 	if err != nil {
 		return nil, fmt.Errorf("open Cargo.lock: %w", err)
 	}
 	defer func() { _ = f.Close() }()
-
-	var (
-		refs    []PackageRef
-		inBlock bool
-		cur     cargoPkg
-	)
-	flush := func() {
-		// Only emit when the block declared a crates.io registry
-		// source AND we captured name + version. Private registries,
-		// git deps, path deps, and workspace members (no source)
-		// fall through silently: the OSV matcher resolves
-		// identifiers under the crates.io ecosystem only, so
-		// emitting a private-registry crate with a name that
-		// collides with a public advisory would false-positive.
-		if isCratesIORegistrySource(cur.source) && cur.name != "" && cur.version != "" {
-			refs = append(refs, PackageRef{
-				Ecosystem: intel.EcosystemCargo,
-				Name:      cur.name,
-				Version:   cur.version,
-				Path:      target.Path,
-				Source:    "Cargo.lock",
-			})
-		}
-		cur = cargoPkg{}
-	}
-
-	scanner := bufio.NewScanner(f)
-	for scanner.Scan() {
-		raw := scanner.Text()
-		line := strings.TrimSpace(raw)
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-		switch {
-		case line == "[[package]]":
-			if inBlock {
-				flush()
-			}
-			inBlock = true
-			continue
-		case strings.HasPrefix(line, "[["), strings.HasPrefix(line, "["):
-			// Any other table / array-of-tables header
-			// ([metadata], [[patch]]) terminates the current
-			// package block.
-			if inBlock {
-				flush()
-			}
-			inBlock = false
-			continue
-		}
-		if !inBlock {
-			continue
-		}
-		key, value, ok := parseCargoKV(line)
-		if !ok {
-			continue
-		}
-		switch key {
-		case "name":
-			cur.name = value
-		case "version":
-			cur.version = value
-		case "source":
-			cur.source = value
-		}
-	}
-	if inBlock {
-		flush()
-	}
-	if err := scanner.Err(); err != nil {
+	data, err := readBoundedManifestBytes(f, maxManifestBytes, "Cargo.lock")
+	if err != nil {
 		return nil, fmt.Errorf("read Cargo.lock: %w", err)
 	}
+
+	return parseCargoBytes(data, target.Path)
+}
+
+// Parse syntax expression-by-expression instead of materializing arbitrary
+// metadata. The general TOML decoder's duplicate-key tracker searches all prior
+// siblings; using it on untrusted metadata can turn a bounded file into quadratic
+// work. Only Cargo's [[package]] identity fields need semantic interpretation.
+func parseCargoBytes(data []byte, path string) ([]PackageRef, error) {
+	var parser unstable.Parser
+	parser.Reset(data)
+	var refs []PackageRef
+	var fields map[string]string
+	flush := func() {
+		if isCratesIORegistrySource(fields["source"]) && fields["name"] != "" && fields["version"] != "" {
+			refs = append(refs, PackageRef{Ecosystem: intel.EcosystemCargo, Name: fields["name"], Version: fields["version"], Path: path, Source: "Cargo.lock"})
+		}
+	}
+	atRoot := true
+	for parser.NextExpression() {
+		expr := parser.Expression()
+		keys := expr.Key()
+		var first, second string
+		count := 0
+		for keys.Next() {
+			count++
+			switch count {
+			case 1:
+				first = string(keys.Node().Data)
+			case 2:
+				second = string(keys.Node().Data)
+			}
+		}
+		switch expr.Kind {
+		case unstable.Table, unstable.ArrayTable:
+			flush()
+			fields = nil
+			atRoot = false
+			if first == "package" {
+				if count == 1 {
+					if expr.Kind != unstable.ArrayTable {
+						return nil, fmt.Errorf("parse Cargo.lock: package must be an array of tables")
+					}
+					fields = make(map[string]string, 3)
+				} else if cargoIdentityField(second) {
+					return nil, fmt.Errorf("parse Cargo.lock: package identity cannot be a table")
+				}
+			}
+		case unstable.KeyValue:
+			if atRoot && first == "package" {
+				return nil, fmt.Errorf("parse Cargo.lock: expected [[package]] tables")
+			}
+			if fields == nil || !cargoIdentityField(first) {
+				continue
+			}
+			if count != 1 || expr.Value().Kind != unstable.String {
+				return nil, fmt.Errorf("parse Cargo.lock: package %s must be a string", first)
+			}
+			if _, exists := fields[first]; exists {
+				return nil, fmt.Errorf("parse Cargo.lock: duplicate package %s", first)
+			}
+			fields[first] = string(expr.Value().Data)
+		}
+	}
+	if parser.Error() != nil {
+		// Parser diagnostics may quote credential-bearing input.
+		return nil, fmt.Errorf("parse Cargo.lock: invalid TOML syntax")
+	}
+	flush()
 	return refs, nil
 }
 
-type cargoPkg struct{ name, version, source string }
+func cargoIdentityField(key string) bool {
+	return key == "name" || key == "version" || key == "source"
+}
 
 // isCratesIORegistrySource is the allowlist of `source = "..."`
 // values that mean "this crate came from the public crates.io
@@ -140,25 +138,4 @@ func isCratesIORegistrySource(source string) bool {
 	default:
 		return false
 	}
-}
-
-// parseCargoKV splits a single `key = "value"` line into its parts
-// and strips the surrounding double quotes. Returns ok=false for
-// lines that do not match the simple flat-string shape (e.g.
-// `dependencies = [...]`), which the caller silently skips.
-func parseCargoKV(line string) (string, string, bool) {
-	eq := strings.IndexByte(line, '=')
-	if eq < 0 {
-		return "", "", false
-	}
-	key := strings.TrimSpace(line[:eq])
-	value := strings.TrimSpace(line[eq+1:])
-	if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
-		// Array values (dependencies = [...]) and other shapes
-		// land here. Cargo.lock fields we consume are always
-		// quoted strings, so ignoring the rest is safe.
-		return "", "", false
-	}
-	value = value[1 : len(value)-1]
-	return key, value, true
 }

--- a/internal/packagecheck/cargo_syntax_test.go
+++ b/internal/packagecheck/cargo_syntax_test.go
@@ -1,0 +1,150 @@
+package packagecheck
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCargoEquivalentTOMLSyntax(t *testing.T) {
+	for _, content := range []string{
+		"[[package]] # comment\nname = \"sample\" # name\nversion = \"1.2.3\" # version\nsource = \"sparse+https://index.crates.io/\" # source\n",
+		"[[ 'package' ]]\n'name' = 'sample'\n\"version\" = \"1.2.3\"\nsource = 'sparse+https://index.crates.io/'",
+		"[[package]]\nname = \"sam\\u0070le\"\nversion = \"1.2.3\"\nsource = \"sparse+https://index.crates.io/\"\n",
+	} {
+		path := filepath.Join(t.TempDir(), "Cargo.lock")
+		writeFile(t, path, content)
+		refs, err := ParseCargo(Target{Path: path})
+		require.NoError(t, err)
+		require.Equal(t, []PackageRef{{Ecosystem: intel.EcosystemCargo, Name: "sample", Version: "1.2.3", Path: path, Source: "Cargo.lock"}}, refs)
+	}
+}
+
+func TestCargoUnknownTablesAndMultilineData(t *testing.T) {
+	content := `version = 4
+notes = '''
+[[package]]
+name = "phantom"
+version = "9.9.9"
+source = "sparse+https://index.crates.io/"
+'''
+[[package]]
+name = "sample"
+version = "1.2.3"
+source = "sparse+https://index.crates.io/"
+[package.metadata]
+name = "not-the-package"
+version = "9.9.9"
+[[package]]
+name = "sample"
+version = "1.2.3"
+source = "registry+https://private.example/index"
+[[Package]]
+name = "wrong-case"
+version = "1.2.3"
+source = "sparse+https://index.crates.io/"
+`
+	path := filepath.Join(t.TempDir(), "Cargo.lock")
+	writeFile(t, path, content)
+	refs, err := ParseCargo(Target{Path: path})
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	require.Equal(t, "sample", refs[0].Name)
+	require.Equal(t, "1.2.3", refs[0].Version)
+}
+
+func TestCargoInvalidDocumentReturnsNoPartialPackages(t *testing.T) {
+	valid := "[[package]]\nname='sample'\nversion='1.2.3'\nsource='sparse+https://index.crates.io/'\n"
+	for _, suffix := range []string{"name='duplicate'", "garbage = \"unterminated", "[[package]]\nname=123", "[[package]]\nsource=false", "[[package]]\nversion={ value='1.0.0' }"} {
+		path := filepath.Join(t.TempDir(), "Cargo.lock")
+		writeFile(t, path, valid+suffix)
+		refs, err := ParseCargo(Target{Path: path})
+		require.Error(t, err)
+		require.Nil(t, refs)
+	}
+}
+
+func TestCargoRunnerEquivalentSyntaxPreservesHit(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Cargo.lock")
+	writeFile(t, path, "[[package]] # valid comment\nname='sample'\nversion='1.2.3'\nsource='sparse+https://index.crates.io/'\n")
+	runner := Runner{Matcher: intel.NewMatcher(intel.Snapshot{Records: []intel.Record{{ID: "MAL-CARGO-FIXTURE", Ecosystem: intel.EcosystemCargo, Name: "sample", Kind: intel.KindMalicious, Versions: []string{"1.2.3"}}}})}
+	target := Target{Ecosystem: intel.EcosystemCargo, Path: path, Source: "Cargo.lock"}
+	result, err := runner.Run([]Target{target})
+	require.NoError(t, err)
+	require.Len(t, result.Hits, 1)
+	require.Equal(t, 1, result.Ecosystems[0].PackagesRead)
+	require.Equal(t, "MAL-CARGO-FIXTURE", result.Hits[0].Record.ID)
+	bad := filepath.Join(t.TempDir(), "Cargo.lock")
+	writeFile(t, bad, "name = \"unterminated")
+	result, err = runner.Run([]Target{target, {Ecosystem: intel.EcosystemCargo, Path: bad, Source: "Cargo.lock"}})
+	require.Error(t, err)
+	require.Nil(t, result)
+}
+
+func TestCargoInputBoundaries(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Cargo.lock")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	require.NoError(t, f.Truncate(maxManifestBytes+1))
+	require.NoError(t, f.Close())
+	refs, err := ParseCargo(Target{Path: path})
+	require.ErrorContains(t, err, "limit")
+	require.Nil(t, refs)
+	for _, n := range []int{15, 16, 17} {
+		r := strings.NewReader(strings.Repeat(" ", n))
+		b, err := readBoundedManifestBytes(r, 16, "Cargo.lock")
+		if n > 16 {
+			require.Error(t, err)
+			require.Nil(t, b)
+		} else {
+			require.NoError(t, err)
+			require.Len(t, b, n)
+		}
+	}
+	want := errors.New("interrupted")
+	b, err := readBoundedManifestBytes(io.MultiReader(strings.NewReader("# comment"), nugetFailingReader{err: want}), 32, "Cargo.lock")
+	require.ErrorIs(t, err, want)
+	require.Nil(t, b)
+}
+
+func TestCargoMetadataDoesNotChangeIdentity(t *testing.T) {
+	// Small compatibility fixture, not a load test: arbitrary metadata must not
+	// enter the package identity map or require whole-document decoding.
+	var input strings.Builder
+	input.WriteString("version=4\n[metadata]\n")
+	for i := 0; i < 64; i++ {
+		fmt.Fprintf(&input, "key%d='ignored'\n", i)
+	}
+	input.WriteString("[[package]]\nname='sample'\nversion='1.2.3'\nsource='sparse+https://index.crates.io/'\n")
+	refs, err := parseCargoBytes([]byte(input.String()), "Cargo.lock")
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	require.Equal(t, "sample", refs[0].Name)
+}
+
+func TestCargoInvalidIdentityShapesFailLoudly(t *testing.T) {
+	for _, content := range []string{
+		"package = [{ name='sample' }]", // Cargo uses [[package]] tables.
+		"[package]\nname='sample'",
+		"[[package]]\nname.value='sample'",
+		"[[package]]\nname='sample'\nversion='1.2.3'\nsource='sparse+https://index.crates.io/'\n[package.name]\nvalue='other'",
+	} {
+		refs, err := parseCargoBytes([]byte(content), "Cargo.lock")
+		require.Error(t, err)
+		require.Nil(t, refs)
+	}
+}
+
+func TestCargoSyntaxErrorDoesNotEchoInput(t *testing.T) {
+	refs, err := parseCargoBytes([]byte("[[package]]\nname = secretFixtureTOKEN"), "Cargo.lock")
+	require.Nil(t, refs)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), "secretFixtureTOKEN")
+}

--- a/internal/packagecheck/manifest_bytes.go
+++ b/internal/packagecheck/manifest_bytes.go
@@ -1,0 +1,19 @@
+package packagecheck
+
+import (
+	"fmt"
+	"io"
+)
+
+const maxManifestBytes int64 = 50 << 20
+
+func readBoundedManifestBytes(r io.Reader, limit int64, label string) ([]byte, error) {
+	data, err := io.ReadAll(io.LimitReader(r, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("%s input exceeds %d-byte limit", label, limit)
+	}
+	return data, nil
+}

--- a/internal/packagecheck/nuget_input.go
+++ b/internal/packagecheck/nuget_input.go
@@ -8,7 +8,7 @@ import (
 
 // Match the scanner's default per-file limit. NuGet parsing must also enforce
 // the limit when called directly, without directory discovery.
-const maxNuGetManifestBytes int64 = 50 << 20
+const maxNuGetManifestBytes int64 = maxManifestBytes
 
 func readNuGetManifest(path string) ([]byte, error) {
 	info, err := os.Lstat(path)
@@ -42,12 +42,5 @@ func readNuGetManifest(path string) ([]byte, error) {
 }
 
 func readNuGetBytes(r io.Reader, limit int64) ([]byte, error) {
-	data, err := io.ReadAll(io.LimitReader(r, limit+1))
-	if err != nil {
-		return nil, err
-	}
-	if int64(len(data)) > limit {
-		return nil, fmt.Errorf("NuGet input exceeds %d-byte limit", limit)
-	}
-	return data, nil
+	return readBoundedManifestBytes(r, limit, "NuGet")
 }


### PR DESCRIPTION
Cargo.lock is TOML, but the dependency reader treated it as a sequence of
exactly formatted lines. A comment after `[[package]]` or after an identity
field could make a locked crates.io package disappear from the check. Quoted
keys and escaped strings had the same problem.

This change reads Cargo package identities from parsed TOML expressions.
Comments, quoted keys, literal strings and Unicode escapes preserve the same
package name, version and registry source. Private registries, git dependencies
and workspace packages remain excluded from crates.io advisory matching.

Invalid syntax, duplicate identity fields and incorrectly typed identity values
return an error without partial package results. Reads are capped at 50 MiB,
including direct parser calls. The byte-limit helper is shared with NuGet;
NuGet's existing file-opening restrictions remain unchanged.

The parser processes expressions rather than decoding an arbitrary metadata
document. Unknown tables are not interpreted as packages. Cargo's `[[package]]`
layout is supported; alternative root `package = ...` shapes fail explicitly.
This is a dependency reader, not a general TOML semantic validator.

Validation covers equivalent syntax, private-registry name collisions, nested
metadata, strings containing fake package blocks, invalid fields, bounded reads
and a real Runner lookup against a synthetic malicious-package record. The
comment case failed before the fix and now preserves the advisory hit. Focused
race tests, vet and lint pass. No local fuzzing or stress workload was run.
