### PR TITLE
Preserve npm manifest evidence across case variants and duplicate keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,12 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- npm manifest checks now distinguish exact JSON field names. Unrelated keys
+  such as `Scripts` or `DEPENDENCIES` can no longer erase or introduce lifecycle
+  and dependency evidence; the same correction applies to publish provenance.
+  Repeated exact keys use the final value instead of merging earlier objects.
+  Inline scans preserve original manifest bytes for this check while retaining
+  Unicode normalization for text detection.
 - Findings no longer expose username-only URL tokens, empty-password credentials,
   or credential tails after a second `@`. Dependency and shell evidence keeps
   the destination visible; default redaction also covers URLs in neighboring

--- a/aguara.go
+++ b/aguara.go
@@ -148,7 +148,8 @@ func Scan(ctx context.Context, path string, opts ...Option) (*ScanResult, error)
 // commonly the object of a trust decision. Pass WithTrustedTargetPolicy only
 // for content whose suppression directives are controlled by the caller.
 // filename is a hint for rule target matching (e.g. "skill.md", "config.json").
-// Content is NFKC-normalized before scanning to prevent Unicode evasion attacks.
+// Text detection uses NFKC normalization; npm manifest parsing retains original
+// syntax so normalization cannot change JSON member identity.
 func ScanContent(ctx context.Context, content string, filename string, opts ...Option) (*ScanResult, error) {
 	return scanContentInternal(ctx, content, filename, "", opts)
 }
@@ -156,7 +157,7 @@ func ScanContent(ctx context.Context, content string, filename string, opts ...O
 // ScanContentAs scans inline content with tool context for false-positive reduction.
 // toolName identifies the tool that generated the content (e.g. "Bash", "Edit", "WebFetch").
 // When provided, built-in tool exemptions and scan profiles can reduce false positives.
-// Content is NFKC-normalized before scanning to prevent Unicode evasion attacks.
+// Text detection uses NFKC normalization; npm manifest parsing retains original syntax.
 func ScanContentAs(ctx context.Context, content string, filename string, toolName string, opts ...Option) (*ScanResult, error) {
 	return scanContentInternal(ctx, content, filename, toolName, opts)
 }
@@ -165,9 +166,6 @@ func scanContentInternal(ctx context.Context, content string, filename string, t
 	if filename == "" {
 		filename = "skill.md"
 	}
-	// NFKC normalization prevents Unicode evasion (e.g. fullwidth "Ｉｇｎｏｒｅ" → "Ignore")
-	content = norm.NFKC.String(content)
-
 	cfg := applyOpts(opts)
 	if cfg.targetPolicy == nil {
 		enabled := false
@@ -181,10 +179,7 @@ func scanContentInternal(ctx context.Context, content string, filename string, t
 	if err != nil {
 		return nil, err
 	}
-	targets := []*scanner.Target{{
-		RelPath: filename,
-		Content: []byte(content),
-	}}
+	targets := []*scanner.Target{inlineTarget(content, filename)}
 	result, err := s.ScanTargets(ctx, targets)
 	if err != nil {
 		return nil, err
@@ -293,7 +288,7 @@ func NewScanner(opts ...Option) (*Scanner, error) {
 }
 
 // ScanContent scans inline content using the pre-compiled scanner.
-// Content is NFKC-normalized before scanning to prevent Unicode evasion.
+// Text detection uses NFKC normalization; npm manifest parsing retains original syntax.
 func (sc *Scanner) ScanContent(ctx context.Context, content string, filename string) (*ScanResult, error) {
 	return sc.scanContent(ctx, content, filename, "")
 }
@@ -307,22 +302,28 @@ func (sc *Scanner) scanContent(ctx context.Context, content string, filename str
 	if filename == "" {
 		filename = "skill.md"
 	}
-	content = norm.NFKC.String(content)
-
 	s, err := sc.buildInternalScanner(toolName)
 	if err != nil {
 		return nil, err
 	}
-	targets := []*scanner.Target{{
-		RelPath: filename,
-		Content: []byte(content),
-	}}
+	targets := []*scanner.Target{inlineTarget(content, filename)}
 	result, err := s.ScanTargets(ctx, targets)
 	if err != nil {
 		return nil, err
 	}
 	result.RulesLoaded = len(sc.compiled)
 	return result, nil
+}
+
+func inlineTarget(content, filename string) *scanner.Target {
+	// Text detectors keep their existing NFKC view. Preserve the original only
+	// when it differs, so manifest parsing cannot merge distinct JSON keys.
+	target := &scanner.Target{RelPath: filename, Content: []byte(content)}
+	if normalized := norm.NFKC.String(content); normalized != content {
+		target.OriginalContent = target.Content
+		target.Content = []byte(normalized)
+	}
+	return target
 }
 
 // Scan scans a file or directory on disk using the pre-compiled scanner.

--- a/aguara_inline_target_test.go
+++ b/aguara_inline_target_test.go
@@ -1,0 +1,27 @@
+package aguara
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestInlineTargetPreservesSource(t *testing.T) {
+	for _, tc := range []struct {
+		input, normalized string
+		changed           bool
+	}{
+		{"plain", "plain", false},
+		{"\uff49gnore", "ignore", true},
+	} {
+		target := inlineTarget(tc.input, "package.json")
+		if string(target.Content) != tc.normalized || string(target.SourceContent()) != tc.input {
+			t.Fatalf("lost source/text distinction: %+v", target)
+		}
+		if (target.OriginalContent != nil) != tc.changed {
+			t.Fatal("unnecessary source copy")
+		}
+		if !bytes.Equal(target.Content, []byte(target.StringContent())) {
+			t.Fatal("text view changed")
+		}
+	}
+}

--- a/aguara_npm_exact_keys_test.go
+++ b/aguara_npm_exact_keys_test.go
@@ -1,0 +1,58 @@
+package aguara_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/garagon/aguara"
+)
+
+func TestScanContentExactNPMKeys(t *testing.T) {
+	sc, err := aguara.NewScanner()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		src  string
+		want bool
+	}{
+		{"{\n\"scripts\":{\"preinstall\":\"node index.js\"},\n\"Scripts\":null\n}", true},
+		{`{"Scripts":{"preinstall":"node index.js"}}`, false},
+		{`{"scripts":{"preinstall":"node index.js"},"SCRIPTS":false}`, true},
+		{"{\"scripts\":{\"preinstall\":\"node index.js\"},\"\uff53cripts\":null}", true},
+		{`{"scripts":{"preinstall":"node index.js"},"\uff53cripts":null}`, true},
+	} {
+		for _, scan := range []func(context.Context, string, string) (*aguara.ScanResult, error){
+			func(ctx context.Context, src, name string) (*aguara.ScanResult, error) {
+				return aguara.ScanContent(ctx, src, name)
+			},
+			func(ctx context.Context, src, name string) (*aguara.ScanResult, error) {
+				return sc.ScanContent(ctx, src, name)
+			},
+			func(ctx context.Context, src, name string) (*aguara.ScanResult, error) {
+				return aguara.ScanContentAs(ctx, src, name, "")
+			},
+			func(ctx context.Context, src, name string) (*aguara.ScanResult, error) {
+				return sc.ScanContentAs(ctx, src, name, "")
+			},
+		} {
+			r, err := scan(context.Background(), tc.src, "package.json")
+			if err != nil {
+				t.Fatal(err)
+			}
+			found := false
+			for _, f := range r.Findings {
+				if f.RuleID == "SUPPLY_026" {
+					found = true
+					if f.Analyzer != "pkgmeta" || !strings.Contains(f.MatchedText, "node index.js") {
+						t.Fatalf("lost evidence: %+v", f)
+					}
+				}
+			}
+			if found != tc.want {
+				t.Fatalf("SUPPLY_026 = %v, want %v on %s", found, tc.want, tc.src)
+			}
+		}
+	}
+}

--- a/internal/engine/pkgmeta/exact_keys_test.go
+++ b/internal/engine/pkgmeta/exact_keys_test.go
@@ -1,0 +1,112 @@
+package pkgmeta
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestManifestExactScriptKeys(t *testing.T) {
+	for _, alias := range []string{"Scripts", "SCRIPTS", `\u0053cripts`, `\u017fcripts`} {
+		for _, value := range []string{"null", "false", "{}", `{"preinstall":"node --version"}`} {
+			for _, src := range []string{
+				fmt.Sprintf(`{"scripts":{"preinstall":"node index.js"},"%s":%s}`, alias, value),
+				fmt.Sprintf(`{"%s":%s,"scripts":{"preinstall":"node index.js"}}`, alias, value),
+			} {
+				m, err := parseManifest([]byte(src))
+				if err != nil || m.Scripts["preinstall"] != "node index.js" {
+					t.Fatalf("canonical script lost for %s: %+v / %v", src, m, err)
+				}
+				if !hasRule(analyze(t, "package.json", src), RuleLocalJSLifecycle) {
+					t.Fatalf("lifecycle finding missing for %s", src)
+				}
+			}
+		}
+	}
+	for _, src := range []string{`{"Scripts":{"preinstall":"node index.js"}}`, `{"scripts":{"Preinstall":"node index.js"}}`} {
+		if hasRule(analyze(t, "package.json", src), RuleLocalJSLifecycle) {
+			t.Fatalf("noncanonical script became executable policy: %s", src)
+		}
+	}
+	if !hasRule(analyze(t, "package.json", `{"\u0073cripts":{"preinstall":"node index.js"}}`), RuleLocalJSLifecycle) {
+		t.Fatal("escaped exact key must be decoded")
+	}
+}
+
+func TestManifestExactDependencyKeys(t *testing.T) {
+	for _, key := range []string{"dependencies", "devDependencies", "optionalDependencies", "peerDependencies"} {
+		for _, aliasValue := range []string{"null", "42", `{"x":"1.0.0"}`} {
+			src := fmt.Sprintf(`{"%s":{"x":"git+https://github.com/example/project.git"},"%s":%s}`, key, strings.ToUpper(key), aliasValue)
+			m, err := parseManifest([]byte(src))
+			if err != nil {
+				t.Fatal(err)
+			}
+			got := map[string]map[string]string{"dependencies": m.Dependencies, "devDependencies": m.DevDependencies, "optionalDependencies": m.OptionalDependencies, "peerDependencies": m.PeerDependencies}
+			if got[key]["x"] != "git+https://github.com/example/project.git" {
+				t.Fatalf("exact dependency overwritten: %s", src)
+			}
+			fs := analyze(t, "package.json", src)
+			if !hasRule(fs, RuleGitInstallTrust) && !hasRule(fs, RuleOptionalGit) {
+				t.Fatalf("git evidence missing: %s", src)
+			}
+		}
+	}
+}
+
+func TestManifestExactPublishKeys(t *testing.T) {
+	for _, src := range []string{
+		`{"publishConfig":{"provenance":true},"PublishConfig":null}`,
+		`{"publishConfig":{"provenance":true,"Provenance":false}}`,
+		`{"publishConfig":{"provenance":true,"Provenance":null}}`,
+		`{"publishConfig":{"provenance":true,"PROVENANCE":"wrong type"}}`,
+	} {
+		m, err := parseManifest([]byte(src))
+		if err != nil || !manifestReferencesProvenance(m) {
+			t.Fatalf("provenance lost: %s (%v)", src, err)
+		}
+	}
+	for _, src := range []string{`{"PublishConfig":{"provenance":true}}`, `{"publishConfig":{"Provenance":true}}`} {
+		m, err := parseManifest([]byte(src))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if manifestReferencesProvenance(m) {
+			t.Fatalf("noncanonical provenance counted: %s", src)
+		}
+	}
+}
+
+func TestManifestExactKeyCompatibility(t *testing.T) {
+	for _, src := range []string{`{}`, `null`, `{"scripts":null}`, `{"scripts":{},"Name":false,"Version":[],"extension":{"anything":true}}`} {
+		if _, err := parseManifest([]byte(src)); err != nil {
+			t.Fatalf("valid control %s: %v", src, err)
+		}
+	}
+	for _, src := range []string{`[]`, `{"scripts":true}`, `{"dependencies":42}`, `{"name":[]}`, `{"scripts":`} {
+		if _, err := parseManifest([]byte(src)); err == nil {
+			t.Fatalf("invalid recognized field accepted: %s", src)
+		}
+	}
+	m, err := parseManifest([]byte(`{"scripts":{"preinstall":"node index.js"},"scripts":{"test":"echo ok"}}`))
+	if err != nil || len(m.Scripts) != 1 || m.Scripts["test"] != "echo ok" {
+		t.Fatalf("duplicate exact key must use final object: %+v / %v", m, err)
+	}
+}
+
+func TestManifestNestedDuplicateValues(t *testing.T) {
+	for _, src := range []string{
+		`{"scripts":{"preinstall":false,"preinstall":"node index.js"}}`,
+		`{"scripts":{"preinstall":{},"preinstall":"node index.js"}}`,
+	} {
+		if !hasRule(analyze(t, "package.json", src), RuleLocalJSLifecycle) {
+			t.Fatalf("final script lost: %s", src)
+		}
+	}
+	src := `{"dependencies":{"x":false,"x":"git+https://github.com/example/project.git"}}`
+	if !hasRule(analyze(t, "package.json", src), RuleGitInstallTrust) {
+		t.Fatal("final dependency lost")
+	}
+	if hasRule(analyze(t, "package.json", `{"scripts":{"preinstall":"node index.js","preinstall":false}}`), RuleLocalJSLifecycle) {
+		t.Fatal("invalid final value must remain rejected")
+	}
+}

--- a/internal/engine/pkgmeta/npm.go
+++ b/internal/engine/pkgmeta/npm.go
@@ -90,17 +90,18 @@ func (a *Analyzer) Analyze(_ context.Context, target *scanner.Target) ([]types.F
 	if !isManifestTarget(target) {
 		return nil, nil
 	}
-	if len(target.Content) == 0 {
+	content := target.SourceContent()
+	if len(content) == 0 {
 		return nil, nil
 	}
-	pkg, err := parseManifest(target.Content)
+	pkg, err := parseManifest(content)
 	if err != nil || pkg == nil {
 		// Malformed JSON: leave pattern rules to flag what they can; pkgmeta
 		// only reports on shapes it can confidently reason about.
 		return nil, nil
 	}
 	pkg.path = target.RelPath
-	pkg.raw = target.Content
+	pkg.raw = content
 	return detect(pkg), nil
 }
 
@@ -145,9 +146,56 @@ type manifest struct {
 // --- parsing ---
 
 func parseManifest(content []byte) (*manifest, error) {
-	var m manifest
-	if err := json.Unmarshal(content, &m); err != nil {
+	// JSON member names are case-sensitive in npm. Struct decoding alone folds
+	// case and lets an unrelated Scripts field erase the real scripts object.
+	var fields map[string]json.RawMessage
+	if err := json.Unmarshal(content, &fields); err != nil {
 		return nil, err
+	}
+	var m manifest
+	for _, field := range []struct {
+		key string
+		dst any
+	}{
+		{"name", &m.Name},
+		{"version", &m.Version},
+		{"publishConfig", &m.PublishConfig},
+	} {
+		if raw, ok := fields[field.key]; ok {
+			if err := json.Unmarshal(raw, field.dst); err != nil {
+				return nil, err
+			}
+		}
+	}
+	for _, field := range []struct {
+		key string
+		dst *map[string]string
+	}{
+		{"dependencies", &m.Dependencies},
+		{"devDependencies", &m.DevDependencies},
+		{"optionalDependencies", &m.OptionalDependencies},
+		{"peerDependencies", &m.PeerDependencies},
+		{"scripts", &m.Scripts},
+	} {
+		if raw, ok := fields[field.key]; ok {
+			// Resolve duplicates before validating types, including duplicates
+			// whose earlier value had a different type.
+			var values map[string]json.RawMessage
+			if err := json.Unmarshal(raw, &values); err != nil {
+				return nil, err
+			}
+			if values == nil {
+				continue
+			}
+			*field.dst = make(map[string]string, len(values))
+			for key, value := range values {
+				var s string
+				if err := json.Unmarshal(value, &s); err != nil {
+					return nil, err
+				}
+				(*field.dst)[key] = s
+			}
+		}
 	}
 	return &m, nil
 }
@@ -672,12 +720,13 @@ func manifestReferencesProvenance(pkg *manifest) bool {
 	// counts; missing or `false` falls through to the substring checks
 	// below, which look for other ways a trust surface might be wired.
 	if len(pkg.PublishConfig) > 0 {
-		var pc struct {
-			Provenance *bool `json:"provenance"`
-		}
+		var pc map[string]json.RawMessage
 		if err := json.Unmarshal(pkg.PublishConfig, &pc); err == nil {
-			if pc.Provenance != nil && *pc.Provenance {
-				return true
+			if raw, ok := pc["provenance"]; ok {
+				var enabled bool
+				if json.Unmarshal(raw, &enabled) == nil && enabled {
+					return true
+				}
 			}
 		}
 	}

--- a/internal/scanner/target.go
+++ b/internal/scanner/target.go
@@ -19,15 +19,27 @@ const DefaultMaxFileSize = 50 << 20
 
 // Target represents a file to be scanned.
 type Target struct {
-	Path        string
-	RelPath     string
-	Content     []byte
-	MaxFileSize int64 // 0 means use DefaultMaxFileSize
+	Path    string
+	RelPath string
+	Content []byte
+	// OriginalContent is set by inline callers when text normalization changed
+	// the bytes. Structured parsers use SourceContent to preserve key identity.
+	OriginalContent []byte
+	MaxFileSize     int64 // 0 means use DefaultMaxFileSize
 
 	linesOnce  sync.Once
 	lines      []string
 	strOnce    sync.Once
 	strContent string
+}
+
+// SourceContent returns original syntax bytes, falling back to Content for
+// disk targets and inline content that did not need normalization.
+func (t *Target) SourceContent() []byte {
+	if t.OriginalContent != nil {
+		return t.OriginalContent
+	}
+	return t.Content
 }
 
 // LoadContent reads the file content into memory.


### PR DESCRIPTION
`scripts` and `Scripts` are different JSON properties. Aguara's npm manifest
decoder treated them as the same field, so an unrelated `Scripts: null` could
erase a real install hook from the analysis. The same behavior affected
dependency sections and publish provenance, and could also introduce findings
from fields npm does not use.

The package metadata analyzer now selects exact decoded member names before
interpreting their values. Repeated exact keys use the final value, including
within scripts and dependency maps; an overwritten invalid value no longer
suppresses the valid value that follows it. Invalid surviving values retain
the existing parse-error behavior.

Inline scans also preserve the original manifest bytes when Unicode
normalization changes the input. This prevents a visually similar but distinct
property from becoming `scripts` before JSON parsing. Text detectors keep their
existing normalized input and Unicode-evasion coverage. Disk scanning already
provides the original bytes.

Tests cover case variants before and after real fields, misleading metadata,
escaped keys, duplicate values, dependency and provenance evidence, and all four
inline scan entry points. Both additional cases found during review were
reproduced before correction. Existing URL redaction and Unicode prompt
detection are checked alongside the fix.

No rule IDs, severities or runtime policy changes. This PR fixes the package
metadata analyzer; it does not change the installed-package or package-lock
readers. Focused race tests, vet and lint pass. Full repository validation runs
in CI; no local fuzzing, stress tests or benchmarks were run.
