### PR TITLE
Resolve Yarn classic aliases to the package being installed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Yarn classic dependency checks now resolve `npm:` aliases to the real package
+  and the lockfile's resolved version. Conflicting package identities, malformed
+  descriptors, non-registry sources and non-exact body versions remain excluded.
 - npm manifest checks now distinguish exact JSON field names. Unrelated keys
   such as `Scripts` or `DEPENDENCIES` can no longer erase or introduce lifecycle
   and dependency evidence; the same correction applies to publish provenance.

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Lockfiles let Aguara check resolved dependencies without installing them. Covera
 
 Matching supports exact versions and advisories affecting every version of a package. Bounded version ranges are supported for npm semver, not arbitrary ranges in every ecosystem. This is malicious-package detection, not comprehensive CVE coverage.
 
-Unambiguous `npm:` aliases resolve to the real package in package-lock, pnpm, Yarn Berry, and Bun. Classic Yarn aliases and ambiguous non-registry identities are skipped rather than assigned a guessed package identity. Binary `bun.lockb` is not parsed; a repository with only that file returns an error asking for text `bun.lock`.
+Unambiguous `npm:` aliases resolve to the real package in package-lock, pnpm, Yarn classic, Yarn Berry, and Bun. Classic Yarn uses the alias target name and the block's resolved version; conflicting descriptors and ambiguous non-registry identities are skipped rather than assigned a guessed package identity. Binary `bun.lockb` is not parsed; a repository with only that file returns an error asking for text `bun.lock`.
 
 ### Behavior and policy
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/garagon/aguara
 go 1.25.8
 
 require (
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/petar-dambovaliev/aho-corasick v0.0.0-20250424160509-463d218d4745
 	github.com/sigstore/sigstore-go v1.2.2
@@ -17,7 +18,6 @@ require (
 
 require (
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 // indirect

--- a/internal/packagecheck/yarn_alias_test.go
+++ b/internal/packagecheck/yarn_alias_test.go
@@ -1,0 +1,83 @@
+package packagecheck
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestYarnClassicAliasIdentity(t *testing.T) {
+	for _, tc := range []struct{ header, name string }{
+		{`"safe@npm:real@^1.0.0"`, "real"},
+		{`"@local/safe@npm:real@next"`, "real"},
+		{`"safe@npm:@scope/real@*"`, "@scope/real"},
+		{`"@local/safe@npm:@scope/real@1"`, "@scope/real"},
+		{`"safe@npm:real"`, "real"},
+		{`"safe@npm:real@"`, "real"},
+		{`"safe@npm:@scope/real"`, "@scope/real"},
+		{`"a@npm:real@^1", "b@npm:real@~1", real@1.2.3`, "real"},
+		{`real@1.2.3, "a@npm:real@^1"`, "real"},
+		{`"@local/_safe@npm:real@^1"`, "real"},
+		{`"a@npm:@scope/_real@^1"`, "@scope/_real"},
+		{`"@scope/_real@^1"`, "@scope/_real"},
+		{`"real@>=1.0.0\t<2.0.0", "a@npm:real@^1"`, "real"},
+	} {
+		refs, err := ParseYarnLock(writeYarn(t, yarnHeader+tc.header+":\n  version \"1.2.3\"\n"))
+		require.NoError(t, err)
+		require.Equal(t, []string{tc.name + "@1.2.3"}, refSet(refs), tc.header)
+	}
+}
+
+func TestYarnClassicAliasRejectsAmbiguity(t *testing.T) {
+	for _, header := range []string{
+		`"a@npm:real@1", "b@npm:other@1"`,
+		`"b@npm:other@1", "a@npm:real@1"`,
+		`real@1, other@1`, `"a@npm:real@1", real@https://example.test/x`,
+		`"a@file:vendor@npm:real@1"`, `"a@npm:real@file:../x"`,
+		`"a@npm:real@jsr:thing"`, `"a@npm:real@npm:other@1"`,
+		`"a@npm:real@user/repo"`, `"a@npm:real@custom:thing"`,
+		`"a@npm:real@https://example.test/x"`, `"a@npm:"`,
+		`"a@npm:@scope"`, `"a@npm:@scope/"`, `"a@npm:real/extra@1"`,
+		`"a@npm:real@1",`, `"a@npm:real@1`, `""a@npm:real@1""`,
+		`"bad name@npm:real@1"`, `"a@npm:bad name@1"`,
+		`"a@npm:real@1", "b@npm:Real@1"`,
+	} {
+		refs, err := ParseYarnLock(writeYarn(t, yarnHeader+header+":\n  version \"1.2.3\"\n"))
+		require.NoError(t, err)
+		require.Empty(t, refs, header)
+	}
+}
+
+func TestYarnClassicAliasUsesBodyVersion(t *testing.T) {
+	for _, version := range []string{"latest", "1", "1.2", "1.2.x", "^1.2.3", "npm:real@1.2.3", "1.2.3+..", "1.2.3+a+b", "01.2.3", "1.2.3-01"} {
+		refs, err := ParseYarnLock(writeYarn(t, fmt.Sprintf("\"a@npm:real@1.2.3\":\n  version %q\n", version)))
+		require.NoError(t, err)
+		require.Empty(t, refs)
+	}
+	refs, err := ParseYarnLock(writeYarn(t, "\"a@npm:real@1.0.0\":\n  version \"2.0.0\"\n\nreal@2:\n  version \"2.0.0\"\n"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"real@2.0.0"}, refSet(refs))
+}
+
+func TestYarnClassicAliasResolutionSource(t *testing.T) {
+	for _, resolved := range []string{"git+https://example.test/other.git#abc", "git://example.test/other", "file:../local", "ssh://example.test/project", "custom:other"} {
+		refs, err := ParseYarnLock(writeYarn(t, fmt.Sprintf("\"a@npm:real@^1\":\n  version \"1.2.3\"\n  resolved %q\n", resolved)))
+		require.NoError(t, err)
+		require.Empty(t, refs, resolved)
+	}
+	refs, err := ParseYarnLock(writeYarn(t, "\"a@npm:real@^1\":\n  version \"1.2.3\"\n  resolved \"https://registry.yarnpkg.com/real/-/real-1.2.3.tgz#abc\"\n"))
+	require.NoError(t, err)
+	require.Equal(t, []string{"real@1.2.3"}, refSet(refs))
+}
+
+func TestYarnClassicAliasRunnerFindsRealPackage(t *testing.T) {
+	target := writeYarn(t, "\"safe@npm:fixture-malicious@^1\":\n  version \"1.2.3\"\n")
+	runner := Runner{Matcher: intel.NewMatcher(intel.Snapshot{Records: []intel.Record{{ID: "MAL-YARN-ALIAS-FIXTURE", Ecosystem: intel.EcosystemNPM, Name: "fixture-malicious", Kind: intel.KindMalicious, Versions: []string{"1.2.3"}}}})}
+	result, err := runner.Run([]Target{target})
+	require.NoError(t, err)
+	require.Len(t, result.Hits, 1)
+	require.Equal(t, "fixture-malicious", result.Hits[0].Record.Name)
+	require.Equal(t, 1, result.Ecosystems[0].PackagesRead)
+}

--- a/internal/packagecheck/yarnlock.go
+++ b/internal/packagecheck/yarnlock.go
@@ -1,12 +1,15 @@
 package packagecheck
 
 import (
+	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"regexp"
 	"sort"
 	"strings"
 
+	"github.com/blang/semver"
 	"github.com/garagon/aguara/internal/intel"
 )
 
@@ -17,9 +20,10 @@ import (
 // spaces, so a dependency literally named `version` with an exact range
 // cannot be mistaken for the block's own resolved version even when the
 // block has no top-level version line. yarn v1 always quotes the value;
-// yarn Berry uses `version: x.y.z` (no quotes) and is rejected before
-// this runs.
-var yarnVersionRe = regexp.MustCompile(`^  version\s+"([^"]+)"`)
+// yarn Berry is routed separately before this runs. Capture a complete JSON
+// string so escapes are decoded and trailing non-comment text cannot be ignored.
+var yarnVersionRe = regexp.MustCompile(`^  version[\t ]+("(?:[^"\\]|\\.)*")[\t ]*(?:#.*)?$`)
+var yarnResolvedRe = regexp.MustCompile(`^  resolved[\t ]+("(?:[^"\\]|\\.)*")[\t ]*(?:#.*)?$`)
 
 // yarnNonRegistryProtocols are descriptor range protocols that mark a
 // dependency as resolved from somewhere other than the public npm
@@ -28,18 +32,14 @@ var yarnVersionRe = regexp.MustCompile(`^  version\s+"([^"]+)"`)
 // cannot be mapped with confidence to a registry (npm, name, version)
 // tuple.
 //
-// npm: is included deliberately: in yarn v1 the `npm:` protocol only
-// appears on aliased installs (`alias@npm:real@range`), where the
-// directory key is the alias and the real package is embedded in the
-// range. Unlike package-lock.json (which records the real package in a
-// dedicated `name` field), yarn v1 offers no clean field for it, so
-// the conservative choice is to skip aliases rather than sub-parse the
-// range. Mapping yarn aliases to their real package is a possible
-// follow-up; under-reporting beats inventing a mapping.
+// npm: aliases are resolved separately before checking the target selector.
 var yarnNonRegistryProtocols = []string{
 	"npm:", "file:", "link:", "workspace:", "portal:", "patch:",
 	"git+", "git:", "ssh:", "http:", "https:", "github:", "exec:",
 }
+
+var yarnRegistryNameRe = regexp.MustCompile(`^(?:@[A-Za-z0-9.!~*'()_-]+/)?[A-Za-z0-9.!~*'()_-]+$`)
+var yarnRegistrySelectorRe = regexp.MustCompile(`^[A-Za-z0-9._*^~<>=|+\s -]+$`)
 
 // ParseYarnLock reads a yarn classic (v1) yarn.lock and returns the
 // declared npm packages. It is the yarn counterpart to ParsePackageLock
@@ -65,7 +65,7 @@ var yarnNonRegistryProtocols = []string{
 // Conservative by design, mirroring ParsePackageLock: an entry is
 // emitted only when it maps with confidence to a registry tuple. Any
 // descriptor with a non-registry protocol (see yarnNonRegistryProtocols,
-// which includes npm: aliases), a name that is not a usable npm
+// after resolving an npm: alias), a name that is not a usable npm
 // identifier, or a body without an exact resolved version is skipped.
 // Results dedupe on (name, version) and come out in deterministic order.
 func ParseYarnLock(target Target) ([]PackageRef, error) {
@@ -132,6 +132,7 @@ func ParseYarnLock(target Target) ([]PackageRef, error) {
 		// dependency range (even one for a dependency literally named
 		// "version").
 		version := ""
+		resolvedRegistry := true
 		j := i + 1
 		for j < len(lines) {
 			b := lines[j]
@@ -140,13 +141,19 @@ func ParseYarnLock(target Target) ([]PackageRef, error) {
 			}
 			if version == "" {
 				if m := yarnVersionRe.FindStringSubmatch(b); m != nil {
-					version = m[1]
+					_ = json.Unmarshal([]byte(m[1]), &version)
+				}
+			}
+			if m := yarnResolvedRe.FindStringSubmatch(b); m != nil {
+				var resolved string
+				if json.Unmarshal([]byte(m[1]), &resolved) != nil || !yarnRegistryResolution(resolved) {
+					resolvedRegistry = false
 				}
 			}
 			j++
 		}
 
-		if registry && name != "" && isExactYarnVersion(version) {
+		if registry && resolvedRegistry && name != "" && isExactYarnVersion(version) {
 			add(name, version)
 		}
 		i = j
@@ -162,26 +169,38 @@ func ParseYarnLock(target Target) ([]PackageRef, error) {
 // descriptor list, with the trailing ':' already removed) into the
 // package name and whether the block resolves to a registry package.
 //
-// The name comes from the first descriptor. registry is false when any
-// descriptor carries a non-registry protocol or fails to parse, or when
-// the first descriptor's name is not a usable npm identifier — the
-// conservative posture so a mixed or malformed block never emits.
+// All descriptors must agree on the real identity. Requested selectors never
+// supply a version; only the block's resolved version is used for matching.
 func yarnHeaderNameAndRegistry(header string) (name string, registry bool) {
 	descriptors := strings.Split(header, ",")
 	for idx, d := range descriptors {
 		n, rng, ok := yarnDescriptorParse(d)
-		if !ok {
+		if !ok || !yarnRegistryName(n) {
 			return "", false
 		}
-		if !yarnRegistryRange(rng) {
+		if spec, alias := strings.CutPrefix(rng, "npm:"); alias {
+			// Classic's registry resolver defaults an omitted/empty selector to
+			// latest. This differs from pnpm's exact resolved alias locator.
+			at := strings.IndexByte(strings.TrimPrefix(spec, "@"), '@')
+			if at < 0 {
+				n, rng = spec, "latest"
+			} else {
+				if strings.HasPrefix(spec, "@") {
+					at++
+				}
+				n, rng = spec[:at], spec[at+1:]
+				if rng == "" {
+					rng = "latest"
+				}
+			}
+		}
+		if !yarnRegistryName(n) || !yarnRegistryRange(rng) {
 			return "", false
 		}
 		if idx == 0 {
-			canonical, valid := validNPMName(n)
-			if !valid {
-				return "", false
-			}
-			name = canonical
+			name = n
+		} else if n != name {
+			return "", false
 		}
 	}
 	return name, name != ""
@@ -195,7 +214,15 @@ func yarnHeaderNameAndRegistry(header string) (name string, registry bool) {
 // must skip rather than treat as a registry package.
 func yarnDescriptorParse(desc string) (name, rng string, ok bool) {
 	desc = strings.TrimSpace(desc)
-	desc = strings.Trim(desc, `"`)
+	if strings.HasPrefix(desc, `"`) {
+		var decoded string
+		if json.Unmarshal([]byte(desc), &decoded) != nil {
+			return "", "", false
+		}
+		desc = decoded
+	} else if strings.Contains(desc, `"`) {
+		return "", "", false
+	}
 	if desc == "" {
 		return "", "", false
 	}
@@ -222,6 +249,9 @@ func yarnDescriptorParse(desc string) (name, rng string, ok bool) {
 // yarnRegistryRange reports whether a descriptor range resolves from the
 // public npm registry (a bare semver range with no protocol prefix).
 func yarnRegistryRange(rng string) bool {
+	if !yarnRegistrySelectorRe.MatchString(rng) || strings.TrimSpace(rng) == "" {
+		return false
+	}
 	for _, p := range yarnNonRegistryProtocols {
 		if strings.HasPrefix(rng, p) {
 			return false
@@ -235,10 +265,22 @@ func yarnRegistryRange(rng string) bool {
 // Guards against an accidental capture of a range from a misparsed
 // body line.
 func isExactYarnVersion(v string) bool {
-	if v == "" {
-		return false
+	_, err := semver.Parse(v)
+	return err == nil
+}
+
+func yarnRegistryName(name string) bool {
+	return !strings.HasPrefix(name, ".") && yarnRegistryNameRe.MatchString(name)
+}
+
+// A registry request cannot override explicit git/local resolution evidence.
+// HTTP tarballs may use configured registries; this does not authenticate hosts.
+func yarnRegistryResolution(resolved string) bool {
+	if resolved == "" {
+		return true
 	}
-	return !strings.ContainsAny(v, " \t^~*<>=|:/")
+	u, err := url.Parse(resolved)
+	return err == nil && (u.Scheme == "http" || u.Scheme == "https") && u.Host != ""
 }
 
 // hasYarnBerryMetadata reports whether content has a top-level

--- a/internal/packagecheck/yarnlock_test.go
+++ b/internal/packagecheck/yarnlock_test.go
@@ -63,8 +63,8 @@ func TestParseYarnLock_QuotedScopedMultiDescriptor(t *testing.T) {
 
 func TestParseYarnLock_SkipsNonRegistrySources(t *testing.T) {
 	// file: / link: / workspace: / portal: / patch: / git / and the
-	// npm: alias protocol are all non-registry and must be skipped;
-	// only the clean registry entry survives.
+	// other non-registry sources must be skipped; an npm: alias now
+	// resolves to its real registry package.
 	refs, err := ParseYarnLock(writeYarn(t, yarnHeader+`clean@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/clean/-/clean-1.0.0.tgz#abc"
@@ -89,7 +89,7 @@ func TestParseYarnLock_SkipsNonRegistrySources(t *testing.T) {
   version "1.0.0"
 `))
 	require.NoError(t, err)
-	require.Equal(t, []string{"clean@1.0.0"}, refSet(refs))
+	require.Equal(t, []string{"clean@1.0.0", "real-pkg@1.5.0"}, refSet(refs))
 }
 
 func TestParseYarnLock_DedupAndDistinctVersions(t *testing.T) {


### PR DESCRIPTION
Yarn classic can install a package under a different dependency name. Aguara
previously skipped those `npm:` alias entries, so a malicious package could be
absent from the dependency check even when its resolved version was in yarn.lock.

The Classic parser now takes the real package name from the alias target and
the installed version from the block's `version` field. Requested ranges and
tags never substitute for that resolved version. Scoped names, omitted alias
selectors and multiple descriptors for the same real package are supported.

A block is excluded when its descriptors disagree about the real package or
contain a malformed identity, a non-registry source or a non-exact body version.
An explicit Git or local `resolved` URL also excludes the block. Resolved
versions pass SemVer parsing, including prerelease and build identifiers.
Alias and direct entries for the same package/version are deduplicated. Yarn
Berry keeps its existing resolution-based parser; pnpm and Bun are unchanged.

Tests cover alias/direct equivalence, scopes, tags and ranges, conflicting
descriptors in either order, malformed quoting, source protocols, version
authority and a Runner lookup that reports the real malicious package rather
than the alias. The original alias miss and conflicting-name acceptance were
reproduced before the change. Focused race tests, vet and lint pass.

The version parser uses an existing dependency at its unchanged version. No
new registry lookup or package-manager invocation is added.

README coverage now includes Classic aliases. This resolves lockfile identity;
it does not authenticate a registry, fetch packages or execute install scripts.
