### PR TITLE
Distinguish recursive deletion options from quoted and overwritten values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- JavaScript destructive-cleanup checks read recursive deletion options from
+  actual object properties. Quoted delimiters no longer hide a recursive wipe,
+  and example strings, nested options or overwritten values do not enable it.
 - Python remote-code checks retain the fetched source when a variable is decoded
   or read back into itself, including inside a helper that returns the payload.
   Replacing that variable with local content still clears the remote evidence.

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -2070,29 +2070,106 @@ var fsDeleteMethodCaps = map[string]deleteMethodCap{
 	"emptydirsync": {mode: delModeRecursive, fsExtra: true},
 }
 
-// recursiveOptTrueRe matches a `recursive: true` (or `!0`) option, with an
-// optionally quoted key. A literal `recursive: false`, a variable, or the bare
-// key absent leaves recursion off, so `fs.rmSync(p, { recursive: false })`
-// cannot wipe a directory.
-var recursiveOptTrueRe = regexp.MustCompile(`\brecursive["']?\s*:\s*(?:true|!0)\b`)
+var staticOptionKeyRe = regexp.MustCompile(`^(?:(get|set|async)\s+)?([A-Za-z_$][\w$]*|[0-9][A-Za-z0-9_.]*|\.[0-9]+|'[^'\\]*'|"[^"\\]*")\s*([:(]|$)`)
+var optionIdentifierRe = regexp.MustCompile(`^[A-Za-z_$][\w$]*$`)
 
 // optsHaveTopLevelRecursiveTrue reports whether the options argument sets
 // `recursive: true` at the TOP level of the options object. A nested
 // `recursive: true` (`{ recursive: false, retry: { recursive: true } }`) does
 // not enable Node's recursive removal, so it must not grant the capability.
 func optsHaveTopLevelRecursiveTrue(opts []byte) bool {
-	for _, loc := range recursiveOptTrueRe.FindAllIndex(opts, -1) {
-		depth := 0
-		for i := 0; i < loc[0]; i++ {
-			switch opts[i] {
-			case '{', '[', '(':
-				depth++
-			case '}', ']', ')':
-				depth--
+	opts = bytes.TrimSpace(opts)
+	if len(opts) < 2 || opts[0] != '{' {
+		return false
+	}
+	view := newJSLexicalView(opts)
+	code := view.Code
+	recursive := false
+	member := func(raw []byte) {
+		raw = bytes.TrimSpace(raw)
+		if len(raw) == 0 {
+			return
+		}
+		m := staticOptionKeyRe.FindSubmatchIndex(raw)
+		if m == nil {
+			// Spreads, computed keys, accessors and shorthand may overwrite the
+			// option. A later explicit property can establish it again.
+			recursive = false
+			return
+		}
+		key := string(raw[m[4]:m[5]])
+		if key[0] == '\'' || key[0] == '"' {
+			key = key[1 : len(key)-1]
+		}
+		if key == "recursive" {
+			value := bytes.TrimSpace(raw[m[1]:])
+			recursive = m[2] < 0 && string(raw[m[6]:m[7]]) == ":" &&
+				(bytes.Equal(value, []byte("true")) || bytes.Equal(value, []byte("!0")))
+		}
+	}
+	start := 1
+	var stack []byte
+	for i := 1; i < len(code); i++ {
+		if view.InString(i) {
+			continue
+		}
+		switch code[i] {
+		case '{', '[', '(':
+			stack = append(stack, code[i])
+		case '}', ']', ')':
+			if len(stack) == 0 {
+				if code[i] != '}' {
+					return false
+				}
+				member(code[start:i])
+				return recursive && staticObjectFallback(code[i+1:])
+			}
+			open := stack[len(stack)-1]
+			if open == '{' && code[i] != '}' || open == '[' && code[i] != ']' || open == '(' && code[i] != ')' {
+				return false
+			}
+			stack = stack[:len(stack)-1]
+		case ',':
+			if len(stack) == 0 {
+				member(code[start:i])
+				start = i + 1
 			}
 		}
-		if depth == 1 { // directly inside the options object's braces
-			return true
+	}
+	return false
+}
+
+// A literal object is truthy and non-null. Only accept a single inert fallback
+// operand; a surrounding conditional could select a different options object.
+func staticObjectFallback(tail []byte) bool {
+	tail = bytes.TrimSpace(tail)
+	if len(tail) == 0 {
+		return true
+	}
+	if !bytes.HasPrefix(tail, []byte("||")) && !bytes.HasPrefix(tail, []byte("??")) {
+		return false
+	}
+	rhs := bytes.TrimSpace(tail[2:])
+	if optionIdentifierRe.Match(rhs) {
+		return true
+	}
+	if len(rhs) < 2 || rhs[0] != '{' || rhs[len(rhs)-1] != '}' {
+		return false
+	}
+	view := newJSLexicalView(rhs)
+	depth := 0
+	for i, b := range view.Code {
+		if view.InString(i) {
+			continue
+		}
+		switch b {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i == len(rhs)-1
+			}
 		}
 	}
 	return false

--- a/internal/engine/jsrisk/recursive_options_test.go
+++ b/internal/engine/jsrisk/recursive_options_test.go
@@ -1,0 +1,55 @@
+package jsrisk
+
+import "testing"
+
+func TestWiperRecursiveOptionStructure(t *testing.T) {
+	for _, tc := range []struct {
+		opts string
+		want bool
+	}{
+		{`{recursive:true}`, true},
+		{`{'recursive':true}`, true},
+		{`{"recursive":!0}`, true},
+		{`{note:'}',recursive:true}`, true},
+		{`{note:'{[(',recursive:true}`, true},
+		{`{note:"escaped \\\" }",recursive:true}`, true},
+		{"{note:`a } b`,recursive:true}", true},
+		{`{note:/[}]/,recursive:true}`, true},
+		{`{note:/* } */0,recursive:true}`, true},
+		{`{retry:{x:'}'},recursive:true}`, true},
+		{`{note:'recursive:true'}`, false},
+		{`{retry:{note:'}',recursive:true}}`, false},
+		{`{recursive:false,retry:{recursive:true}}`, false},
+		{`{'not-recursive':true}`, false},
+		{`{$recursive:true}`, false},
+		{`{recursive:true && false}`, false},
+		{`{recursive:true,recursive:false}`, false},
+		{`{recursive:false,recursive:true}`, true},
+		{`{recursive:true,recursive:enabled}`, false},
+		{`{recursive:true,...options}`, false},
+		{`{...options,recursive:true}`, true},
+		{`{recursive:true,[key]:false}`, false},
+		{`{['recursive']:true}`, false},
+		{`{recursive:true,get recursive(){return false}}`, false},
+		{`{recursive:true,recursive}`, false},
+		{`{recursive:true,force}`, true},
+		{`{recursive:true,0:false}`, true},
+		{`{recursive:true,get note(){return false}}`, true},
+		{`{recursive:true,"'recursive'":false}`, true},
+		{`{"'recursive'":true}`, false},
+		{`{recursive:true} || {recursive:false}`, true},
+		{`{recursive:false} || {recursive:true}`, false},
+		{`{recursive:true} ?? fallback`, true},
+		{`{recursive:true} && {recursive:false}`, false},
+		{`{recursive:true} || fallback ? {recursive:false} : {recursive:false}`, false},
+		{`{recursive:true} || {} ? {recursive:false} : {recursive:false}`, false},
+		{"{note:`x ${'}'} y`,recursive:true}", true},
+	} {
+		t.Run(tc.opts, func(t *testing.T) {
+			src := "const fs = require('fs'); fs.rmSync(process.env.HOME," + tc.opts + ");"
+			if got := hasRule(analyze(t, "cleanup.js", src), RuleWiperTripwire); got != tc.want {
+				t.Fatalf("wiper = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Aguara could miss a recursive home-directory deletion when an unrelated option
contained a quoted brace. The same option reader could also mistake an example
string or a nested setting for permission to delete recursively.

The wiper check now reads direct object properties using the analyzer's existing
lexical view. Braces and commas inside strings no longer change the structure.
The `recursive` key must be exact and its value must be the complete supported
boolean expression, not the beginning of a larger expression.

Repeated explicit properties follow their written order. An unknown overwrite,
such as a later spread or computed key, does not establish recursive deletion.
The existing filesystem bindings, sensitive-path checks, delete-method
capabilities and severities are unchanged. This does not evaluate arbitrary
JavaScript options or add shell parsing.

Regression tests cover the original miss alongside quoted keys, comments,
regex literals, nested objects, lookalike keys, overwritten values and ordinary
nonrecursive cleanup. The existing wiper matrix remains part of validation.
All deletion examples are scanned as text; no deletion command is executed.
