### PR TITLE
Avoid repeated whole-string work in GitHub mutation checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- JavaScript GitHub-channel checks no longer rescan an entire string for every
+  repeated mutation name. Rejected string interiors are visited once per name,
+  without changing mutation matching or finding locations.
 - Python remote-code checks retain the fetched source when a variable is decoded
   or read back into itself, including inside a helper that returns the payload.
   Replacing that variable with local content still clears the remote evidence.

--- a/internal/engine/jsrisk/graphql_mutation_scan_test.go
+++ b/internal/engine/jsrisk/graphql_mutation_scan_test.go
@@ -1,0 +1,57 @@
+package jsrisk
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestGraphQLMutationScanEquivalence(t *testing.T) {
+	for _, src := range []string{
+		`const q = 'createGist createGist createGist';`,
+		`const a = 'createGist createGist'; const b = 'mutation { createGist }';`,
+		`const q = 'createGist mutation';`,
+		`const q = 'mutationName createGist';`,
+		`const q = 'mutation { createCommitOnBranch }';`,
+		`const mutation = 1; const q = 'createGist';`,
+		"const q = `mutation ${x} createGist`;",
+		"const q = `createGist ${'mutation { createGist }'}`;",
+		"const q = `mutation ${'createGist'} body`;",
+		`// mutation createGist
+const q = 'createGist';`,
+		`const re = /mutation createGist/;`,
+		`const q = 'mutation { createGist }'; const z = 'mutation { createCommitOnBranch }';`,
+		`const q = 'createGist`,
+	} {
+		view := newJSLexicalView([]byte(src))
+		lower := bytes.ToLower(view.Code)
+		for _, needle := range githubGraphQLMutationNeedles {
+			// Legacy occurrence walk is intentionally limited to these tiny
+			// fixtures. It establishes matching equivalence, not a timing gate.
+			want := -1
+			for from := 0; from < len(lower); {
+				i := bytes.Index(lower[from:], []byte(needle))
+				if i < 0 {
+					break
+				}
+				abs := from + i
+				if s, e, ok := stringRangeContaining(view, abs); ok && graphqlMutationKeywordRe.Match(lower[s:e]) {
+					want = abs
+					break
+				}
+				from = abs + 1
+			}
+			if got := graphqlMutationIndex(view, lower, needle); got != want {
+				t.Errorf("%s: got %d, want %d in %q", needle, got, want, src)
+			}
+		}
+	}
+}
+
+func TestGraphQLMutationScanPreservesPriority(t *testing.T) {
+	src := "client.graphql(q);\nconst a = 'mutation { createGist }';\nconst b = 'createCommitOnBranch createCommitOnBranch';\nconst c = 'mutation { createCommitOnBranch }';"
+	view := newJSLexicalView([]byte(src))
+	kind, line := findGitHubWriteChannel(view, bytes.ToLower(view.Code))
+	if kind != "graphql-write" || line != 4 {
+		t.Fatalf("channel = %q, line = %d; want graphql-write at line 4", kind, line)
+	}
+}

--- a/internal/engine/jsrisk/jsrisk.go
+++ b/internal/engine/jsrisk/jsrisk.go
@@ -1089,20 +1089,6 @@ func isJSIdentByte(b byte) bool {
 // with word boundaries, so `mutationName` / `commentMutation` do not match.
 var graphqlMutationKeywordRe = regexp.MustCompile(`(?i)\bmutation\b`)
 
-// graphqlMutationInSameString reports whether the word-bounded GraphQL
-// `mutation` keyword lives in the SAME string literal as the GitHub
-// mutation-name occurrence at idx, binding the name to an actual GraphQL
-// mutation body. This rejects free-text neighbours such as
-// `const mutationName = 'createGist'`, where the name sits in one string and
-// the substring `mutation` is an unrelated identifier outside it.
-func graphqlMutationInSameString(view jsLexicalView, lowerCode []byte, idx int) bool {
-	s, e, ok := stringRangeContaining(view, idx)
-	if !ok {
-		return false
-	}
-	return graphqlMutationKeywordRe.Match(lowerCode[s:e])
-}
-
 // graphqlMutationIndex returns the offset of the first occurrence of the
 // lowercase GitHub mutation needle that lies inside a string interior AND
 // has the GraphQL `mutation` keyword nearby (a real mutation body), or -1.
@@ -1116,8 +1102,14 @@ func graphqlMutationIndex(view jsLexicalView, lowerCode []byte, needle string) i
 			return -1
 		}
 		abs := from + i
-		if view.InString(abs) && graphqlMutationInSameString(view, lowerCode, abs) {
-			return abs
+		if s, e, ok := stringRangeContaining(view, abs); ok {
+			if graphqlMutationKeywordRe.Match(lowerCode[s:e]) {
+				return abs
+			}
+			// Every remaining name in this interior has the same rejected
+			// keyword predicate. Scan each interior at most once per needle.
+			from = e
+			continue
 		}
 		from = abs + 1
 	}


### PR DESCRIPTION
Repeated GraphQL mutation names could make Aguara search the same string over
and over, even when that string was not a mutation. A file containing many such
names could therefore consume disproportionate scan time without producing a
finding.

The JavaScript analyzer now skips the rest of a string interior once it has
established that the required `mutation` keyword is absent. Each rejected
interior is searched at most once per supported mutation name. Later strings,
including strings inside template interpolations, remain eligible.

Matching conditions, mutation-name priority, finding locations and metadata are
unchanged. The change removes this specific quadratic rescan; it does not claim
to make every analyzer loop interruptible or establish an overall latency SLO.

Small differential fixtures compare the new search with the previous algorithm
for repeated names, later valid mutations, keyword boundaries, comments, regex
literals and template segments. A channel-level test preserves priority and line
anchoring. Existing GitHub C2 controls, focused race tests, vet and lint pass.
No stress test or local fuzz run was used to validate this change.
