### PR TITLE
Protect saved update and cleanup reports from linked destinations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Saved `update` reports and `clean` JSON reports now reject symlink and special
+  file destinations. Failed rendering preserves the previous report, and
+  successful writes replace it with a private file rather than truncating links.
 - JavaScript destructive-cleanup checks read recursive deletion options from
   actual object properties. Quoted delimiters no longer hide a recursive wipe,
   and example strings, nested options or overwritten values do not enable it.

--- a/cmd/aguara/commands/clean.go
+++ b/cmd/aguara/commands/clean.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -96,18 +97,11 @@ func runClean(cmd *cobra.Command, args []string) error {
 }
 
 func writeCleanJSON(result *incident.CleanResult) error {
-	w := os.Stdout
-	if flagOutput != "" {
-		f, err := os.Create(flagOutput)
-		if err != nil {
-			return err
-		}
-		defer func() { _ = f.Close() }()
-		w = f
-	}
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(result)
+	return writeReport(func(w io.Writer) error {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	})
 }
 
 func writeCleanTerminal(result *incident.CleanResult) error {

--- a/cmd/aguara/commands/maintenance_report_test.go
+++ b/cmd/aguara/commands/maintenance_report_test.go
@@ -1,0 +1,74 @@
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/garagon/aguara/internal/incident"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMaintenanceReportsReplaceFiles(t *testing.T) {
+	for name, write := range map[string]func() error{
+		"clean":           func() error { return writeCleanJSON(&incident.CleanResult{}) },
+		"update-json":     func() error { return writeUpdateJSON(updateOutput{}) },
+		"update-terminal": func() error { return writeUpdateTerminal(updateOutput{}) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			resetFlags()
+			t.Cleanup(resetFlags)
+			dir := t.TempDir()
+			flagOutput = filepath.Join(dir, "report")
+			want := captureStdoutBytes(t, func() {
+				flagOutput = ""
+				require.NoError(t, write())
+			})
+			flagOutput = filepath.Join(dir, "report")
+			require.NoError(t, os.WriteFile(flagOutput, []byte("old report"), 0o600))
+			linked := filepath.Join(t.TempDir(), "linked-report")
+			linkErr := os.Link(flagOutput, linked)
+			if runtime.GOOS != "windows" {
+				require.NoError(t, linkErr)
+			} else if linkErr != nil {
+				t.Logf("hardlink check unavailable: %v", linkErr)
+			}
+			stdout := captureStdoutBytes(t, func() { require.NoError(t, write()) })
+			require.Empty(t, stdout)
+			got, err := os.ReadFile(flagOutput)
+			require.NoError(t, err)
+			require.Equal(t, want, got)
+			if linkErr == nil {
+				old, err := os.ReadFile(linked)
+				require.NoError(t, err)
+				require.Equal(t, "old report", string(old))
+			}
+			if runtime.GOOS != "windows" {
+				info, err := os.Stat(flagOutput)
+				require.NoError(t, err)
+				require.Zero(t, info.Mode().Perm()&0o077)
+			}
+			entries, err := os.ReadDir(dir)
+			require.NoError(t, err)
+			require.Len(t, entries, 1)
+		})
+	}
+}
+
+func TestMaintenanceReportEncodingFailurePreservesFile(t *testing.T) {
+	resetFlags()
+	t.Cleanup(resetFlags)
+	dir := t.TempDir()
+	flagOutput = filepath.Join(dir, "report")
+	require.NoError(t, os.WriteFile(flagOutput, []byte("original"), 0o600))
+	err := writeUpdateJSON(updateOutput{GeneratedAt: time.Date(10000, 1, 1, 0, 0, 0, 0, time.UTC)})
+	require.Error(t, err)
+	data, err := os.ReadFile(flagOutput)
+	require.NoError(t, err)
+	require.Equal(t, "original", string(data))
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+}

--- a/cmd/aguara/commands/report_file_test.go
+++ b/cmd/aguara/commands/report_file_test.go
@@ -13,9 +13,12 @@ import (
 
 func TestReportWritersRejectSymlink(t *testing.T) {
 	writers := map[string]func() error{
-		"scan":  func() error { return writeOutput(&scanner.ScanResult{}) },
-		"check": func() error { return writeCheckJSON(&incident.CheckResult{}) },
-		"audit": func() error { return writeAuditJSON(&AuditResult{}) },
+		"scan":            func() error { return writeOutput(&scanner.ScanResult{}) },
+		"check":           func() error { return writeCheckJSON(&incident.CheckResult{}) },
+		"audit":           func() error { return writeAuditJSON(&AuditResult{}) },
+		"clean":           func() error { return writeCleanJSON(&incident.CleanResult{}) },
+		"update-json":     func() error { return writeUpdateJSON(updateOutput{}) },
+		"update-terminal": func() error { return writeUpdateTerminal(updateOutput{}) },
 	}
 	for name, write := range writers {
 		t.Run(name, func(t *testing.T) {

--- a/cmd/aguara/commands/update.go
+++ b/cmd/aguara/commands/update.go
@@ -155,40 +155,34 @@ func writeUpdateOutput(snap intel.Snapshot, storeDir string, verified bool) erro
 }
 
 func writeUpdateJSON(out updateOutput) error {
-	w := io.Writer(os.Stdout)
-	if flagOutput != "" {
-		f, err := os.Create(flagOutput)
-		if err != nil {
-			return fmt.Errorf("aguara update: write --output: %w", err)
-		}
-		defer func() { _ = f.Close() }()
-		w = f
+	err := writeReport(func(w io.Writer) error {
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		return enc.Encode(out)
+	})
+	if err != nil && flagOutput != "" {
+		return fmt.Errorf("aguara update: write --output: %w", err)
 	}
-	enc := json.NewEncoder(w)
-	enc.SetIndent("", "  ")
-	return enc.Encode(out)
+	return err
 }
 
 func writeUpdateTerminal(out updateOutput) error {
-	w := io.Writer(os.Stdout)
-	if flagOutput != "" {
-		f, err := os.Create(flagOutput)
-		if err != nil {
-			return fmt.Errorf("aguara update: write --output: %w", err)
+	err := writeReport(func(w io.Writer) error {
+		if out.Verified {
+			fmt.Fprintf(w, "Aguara threat intel updated (verified signed bundle)\n")
+		} else {
+			fmt.Fprintf(w, "Aguara threat intel updated (UNVERIFIED: signature verification skipped)\n")
+			fmt.Fprintf(w, "  Not eligible for default checks or --allow-stale; run aguara update without --insecure-intel to verify.\n")
 		}
-		defer func() { _ = f.Close() }()
-		w = f
+		fmt.Fprintf(w, "  records:    %d\n", out.Records)
+		fmt.Fprintf(w, "  ecosystems: %s\n", strings.Join(out.Ecosystems, ", "))
+		fmt.Fprintf(w, "  written:    %s\n", out.SnapshotPath)
+		return nil
+	})
+	if err != nil && flagOutput != "" {
+		return fmt.Errorf("aguara update: write --output: %w", err)
 	}
-	if out.Verified {
-		fmt.Fprintf(w, "Aguara threat intel updated (verified signed bundle)\n")
-	} else {
-		fmt.Fprintf(w, "Aguara threat intel updated (UNVERIFIED: signature verification skipped)\n")
-		fmt.Fprintf(w, "  Not eligible for default checks or --allow-stale; run aguara update without --insecure-intel to verify.\n")
-	}
-	fmt.Fprintf(w, "  records:    %d\n", out.Records)
-	fmt.Fprintf(w, "  ecosystems: %s\n", strings.Join(out.Ecosystems, ", "))
-	fmt.Fprintf(w, "  written:    %s\n", out.SnapshotPath)
-	return nil
+	return err
 }
 
 // assertOutputNotShadowingStore returns an error if flagOutput would


### PR DESCRIPTION
Saving an `aguara update` report or a `clean` JSON report could follow a
destination symlink and overwrite its target. Those writers also truncated an
existing report before rendering, leaving it empty if JSON encoding failed.

They now use the same file writer as scan, check and audit reports. Symlink and
special-file destinations are rejected. Rendering finishes in a private sibling
file before replacement, so an error preserves the previous report and an
existing hard link does not expose its other name to truncation.

Report contents, JSON formatting and stdout routing are unchanged. The update
guard that prevents choosing the intel snapshot as the output path remains in
place. This change does not alter snapshot storage or execute cleanup actions.

Tests reproduce the original symlink overwrite and encoding-failure truncation,
then verify target preservation, private replacement, hard-link isolation,
stdout/file equivalence and temporary-file cleanup. Existing update writer and
store-path guard tests also pass, along with focused race tests, vet and lint.

The shared writer protects the destination entry, not arbitrary symlinked parent
directories. Atomic replacement follows the existing platform-specific contract.
