### PR TITLE
Avoid repeated prefix scans when locating pattern findings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Pattern scans no longer recount the entire preceding text to locate every
+  match. Line tracking advances with each pattern's matches, preserving finding
+  locations and original excerpts without limiting the number of results.
 - JavaScript GitHub-channel checks no longer rescan an entire string for every
   repeated mutation name. Rejected string interiors are visited once per name,
   without changing mutation matching or finding locations.

--- a/internal/engine/pattern/line_cursor_test.go
+++ b/internal/engine/pattern/line_cursor_test.go
@@ -1,0 +1,58 @@
+package pattern
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/garagon/aguara/internal/rules"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMatchPatternLinePositions(t *testing.T) {
+	for _, tc := range []struct {
+		name, content, value string
+		kind                 rules.PatternType
+		want                 []matchHit
+	}{
+		{"regex same line", "x x\nx", "x", rules.PatternRegex, []matchHit{{1, "x"}, {1, "x"}, {2, "x"}}},
+		{"regex blank lines and CRLF", "\r\nx\r\n\r\nx\n", "x", rules.PatternRegex, []matchHit{{2, "x"}, {4, "x"}}},
+		{"regex multiline", "x\ny\nx\ny", "x\ny", rules.PatternRegex, []matchHit{{1, "x\ny"}, {3, "x\ny"}}},
+		{"regex empty input", "", "^$", rules.PatternRegex, []matchHit{{1, ""}}},
+		{"regex zero width", "x\n\ny\n", "(?m)^", rules.PatternRegex, []matchHit{{1, ""}, {2, ""}, {3, ""}, {4, ""}}},
+		{"regex EOF", "x\n", "$", rules.PatternRegex, []matchHit{{2, ""}}},
+		{"contains same line", "X x\nx", "x", rules.PatternContains, []matchHit{{1, "X"}, {1, "x"}, {2, "x"}}},
+		{"contains multiline", "X\nY\nx\ny", "x\ny", rules.PatternContains, []matchHit{{1, "X\nY"}, {3, "x\ny"}}},
+		{"contains blank lines and CRLF", "\r\nX\r\n\r\nx\n", "x", rules.PatternContains, []matchHit{{2, "X"}, {4, "x"}}},
+		{"contains unicode contraction", "\u0130\n\n\u0130 \u0130", "i", rules.PatternContains, []matchHit{{1, "\u0130"}, {3, "\u0130"}, {3, "\u0130"}}},
+		{"contains unicode expansion", "\u023a\n\u023a \u023a", "\u2c65", rules.PatternContains, []matchHit{{1, "\u023a"}, {2, "\u023a"}, {2, "\u023a"}}},
+		{"contains no match", "normal\ntext", "marker", rules.PatternContains, nil},
+		{"contains empty pattern", "normal\ntext", "", rules.PatternContains, nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			pat := rules.CompiledPattern{Type: tc.kind, Value: tc.value}
+			if tc.kind == rules.PatternRegex {
+				pat.Regex = regexp.MustCompile(tc.value)
+			}
+			got := matchPattern(pat, tc.content, newLowercaseContent(tc.content), strings.Split(tc.content, "\n"))
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMatchPatternLineCursorResetsPerPattern(t *testing.T) {
+	content := "early\n\nlate"
+	lower := newLowercaseContent(content)
+	for _, kind := range []rules.PatternType{rules.PatternRegex, rules.PatternContains} {
+		for _, tc := range []struct {
+			value string
+			line  int
+		}{{"late", 3}, {"early", 1}, {"late", 3}} {
+			pat := rules.CompiledPattern{Type: kind, Value: tc.value}
+			if kind == rules.PatternRegex {
+				pat.Regex = regexp.MustCompile(tc.value)
+			}
+			require.Equal(t, []matchHit{{tc.line, tc.value}}, matchPattern(pat, content, lower, strings.Split(content, "\n")))
+		}
+	}
+}

--- a/internal/engine/pattern/matcher.go
+++ b/internal/engine/pattern/matcher.go
@@ -363,6 +363,13 @@ func isExcluded(excludes []rules.CompiledPattern, lines []string, lineNum int) b
 
 func matchPattern(pat rules.CompiledPattern, content string, lowerContent *lowercaseContent, lines []string) []matchHit {
 	var hits []matchHit
+	// Both matchers return ordered source offsets; count each prefix byte once.
+	previous, line := 0, 1
+	lineAt := func(start int) int {
+		line += strings.Count(content[previous:start], "\n")
+		previous = start
+		return line
+	}
 	switch pat.Type {
 	case rules.PatternRegex:
 		if pat.Regex == nil {
@@ -370,7 +377,7 @@ func matchPattern(pat rules.CompiledPattern, content string, lowerContent *lower
 		}
 		locs := pat.Regex.FindAllStringIndex(content, -1)
 		for _, loc := range locs {
-			line := lineNumberAtOffset(content, loc[0])
+			line := lineAt(loc[0])
 			matched := content[loc[0]:loc[1]]
 			if len(matched) > 200 {
 				matched = matched[:200] + "..."
@@ -391,7 +398,7 @@ func matchPattern(pat rules.CompiledPattern, content string, lowerContent *lower
 			absPos := idx + pos
 			start := lowerContent.originalOffset(absPos)
 			end := lowerContent.originalOffset(absPos + len(target))
-			line := lineNumberAtOffset(content, start)
+			line := lineAt(start)
 			matched := content[start:end]
 			hits = append(hits, matchHit{line: line, text: matched})
 			idx = absPos + len(target)


### PR DESCRIPTION
Files with many matches made the pattern matcher repeatedly count newlines from
the start of the file. That work grew quadratically even when all matches were
on one line and would later be deduplicated into one finding.

Line tracking now advances through the original text as each pattern finds its
matches. It does not cap results, skip matches or change detection rules.
Finding locations, original excerpts, confidence and deduplication keep their
existing behavior. Decoded content uses the same matcher without changing its
source-file anchors.

Small regression fixtures cover repeated same-line hits, blank lines, CRLF,
multiline patterns, empty and zero-width matches, EOF, Unicode case-conversion
offsets and independent cursors for successive patterns. Existing matcher,
decoder, exclusion, confidence and prefilter-equivalence tests pass under the
race detector; vet and lint also pass.

This removes repeated prefix work from line attribution. It does not claim to
bound all scanner CPU or memory use, add in-flight cancellation, or establish a
measured speedup for full scans.
