### PR TITLE
Bound dependency-file reads and reject linked lockfiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ### Fixed
 
+- Lockfile and dependency-manifest checks now reject leaf symlinks and special
+  files, and limit each input to 50 MiB. Invalid linked candidates remain visible
+  to discovery and return an error instead of disappearing or selecting a
+  fallback. Go, Ruby and Gradle retain streaming reads with a total-byte budget.
 - Pattern scans no longer recount the entire preceding text to locate every
   match. Line tracking advances with each pattern's matches, preserving finding
   locations and original excerpts without limiting the number of results.

--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Matching supports exact versions and advisories affecting every version of a pac
 
 Unambiguous `npm:` aliases resolve to the real package in package-lock, pnpm, Yarn classic, Yarn Berry, and Bun. Classic Yarn uses the alias target name and the block's resolved version; conflicting descriptors and ambiguous non-registry identities are skipped rather than assigned a guessed package identity. Binary `bun.lockb` is not parsed; a repository with only that file returns an error asking for text `bun.lock`.
 
+Lockfile and dependency-manifest inputs must be regular files no larger than 50 MiB. Leaf symlinks, including dangling links, return an error rather than being followed or silently skipped. This read boundary does not confine parent directories or guarantee that file contents remain unchanged during a check. Installed-package scanning is a separate path.
+
 ### Behavior and policy
 
 Aguara also inspects code for behaviors that do not depend on a package already being listed in an advisory: suspicious second-stage execution, credential transmission, host-file tampering, and destructive cleanup. It combines signatures, parsed configuration, bounded code analysis, and heuristic correlations. Binding checks to actual calls reduces noise, but it does not eliminate false positives or provide whole-program dataflow analysis.

--- a/internal/packagecheck/bunlock.go
+++ b/internal/packagecheck/bunlock.go
@@ -3,7 +3,6 @@ package packagecheck
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -56,7 +55,7 @@ var bunTrailingCommaRe = regexp.MustCompile(`,(\s*[}\]])`)
 // no findings (never a panic), and results dedupe on (name, version) in
 // deterministic order.
 func ParseBunLock(target Target) ([]PackageRef, error) {
-	data, err := os.ReadFile(target.Path)
+	data, err := readManifest(target.Path, "bun.lock")
 	if err != nil {
 		return nil, fmt.Errorf("open bun.lock: %w", err)
 	}

--- a/internal/packagecheck/cargo.go
+++ b/internal/packagecheck/cargo.go
@@ -2,7 +2,6 @@ package packagecheck
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/garagon/aguara/internal/intel"
 	"github.com/pelletier/go-toml/v2/unstable"
@@ -12,22 +11,7 @@ import (
 // public crates.io registries. Unknown tables and fields are not package data.
 // It does not execute Cargo, resolve dependencies, or access the network.
 func ParseCargo(target Target) ([]PackageRef, error) {
-	info, err := os.Stat(target.Path)
-	if err != nil {
-		return nil, fmt.Errorf("stat Cargo.lock: %w", err)
-	}
-	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("read Cargo.lock: input must be a regular file")
-	}
-	if info.Size() > maxManifestBytes {
-		return nil, fmt.Errorf("read Cargo.lock: input exceeds %d-byte limit", maxManifestBytes)
-	}
-	f, err := os.Open(target.Path)
-	if err != nil {
-		return nil, fmt.Errorf("open Cargo.lock: %w", err)
-	}
-	defer func() { _ = f.Close() }()
-	data, err := readBoundedManifestBytes(f, maxManifestBytes, "Cargo.lock")
+	data, err := readManifest(target.Path, "Cargo.lock")
 	if err != nil {
 		return nil, fmt.Errorf("read Cargo.lock: %w", err)
 	}

--- a/internal/packagecheck/composer.go
+++ b/internal/packagecheck/composer.go
@@ -3,7 +3,6 @@ package packagecheck
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/garagon/aguara/internal/intel"
@@ -26,7 +25,7 @@ import (
 // vendor/composer/ is intentionally NOT parsed in this first cut;
 // composer.lock is authoritative for what the project resolved.
 func ParseComposer(target Target) ([]PackageRef, error) {
-	data, err := os.ReadFile(target.Path)
+	data, err := readManifest(target.Path, "composer.lock")
 	if err != nil {
 		return nil, fmt.Errorf("open composer.lock: %w", err)
 	}

--- a/internal/packagecheck/discovery.go
+++ b/internal/packagecheck/discovery.go
@@ -126,14 +126,14 @@ func Discover(root string, ecosystems []string) ([]Target, error) {
 // `require` lines but no checked-in go.sum (libraries that delegate
 // locking to the downstream consumer).
 func pickGoTarget(dir string) []Target {
-	if statRegular(filepath.Join(dir, "go.sum")) {
+	if manifestCandidate(filepath.Join(dir, "go.sum")) {
 		return []Target{{
 			Ecosystem: intel.EcosystemGo,
 			Path:      filepath.Join(dir, "go.sum"),
 			Source:    "go.sum",
 		}}
 	}
-	if statRegular(filepath.Join(dir, "go.mod")) {
+	if manifestCandidate(filepath.Join(dir, "go.mod")) {
 		return []Target{{
 			Ecosystem: intel.EcosystemGo,
 			Path:      filepath.Join(dir, "go.mod"),
@@ -149,7 +149,7 @@ func pickGoTarget(dir string) []Target {
 // resolved version set is whatever `cargo update` would produce
 // today, which the offline parser cannot determine.
 func pickCargoTarget(dir string) []Target {
-	if statRegular(filepath.Join(dir, "Cargo.lock")) {
+	if manifestCandidate(filepath.Join(dir, "Cargo.lock")) {
 		return []Target{{
 			Ecosystem: intel.EcosystemCargo,
 			Path:      filepath.Join(dir, "Cargo.lock"),
@@ -164,7 +164,7 @@ func pickCargoTarget(dir string) []Target {
 // alone (no lockfile) is skipped for the same reason as Cargo.toml
 // without Cargo.lock.
 func pickComposerTarget(dir string) []Target {
-	if statRegular(filepath.Join(dir, "composer.lock")) {
+	if manifestCandidate(filepath.Join(dir, "composer.lock")) {
 		return []Target{{
 			Ecosystem: intel.EcosystemPackagist,
 			Path:      filepath.Join(dir, "composer.lock"),
@@ -177,7 +177,7 @@ func pickComposerTarget(dir string) []Target {
 // pickRubyTarget returns a Target for a Ruby/Bundler project
 // rooted at dir, or nil when no Gemfile.lock is present.
 func pickRubyTarget(dir string) []Target {
-	if statRegular(filepath.Join(dir, "Gemfile.lock")) {
+	if manifestCandidate(filepath.Join(dir, "Gemfile.lock")) {
 		return []Target{{
 			Ecosystem: intel.EcosystemRubyGems,
 			Path:      filepath.Join(dir, "Gemfile.lock"),
@@ -200,14 +200,14 @@ func pickRubyTarget(dir string) []Target {
 // "gradle.lockfile" for both Gradle modes (they share the parser).
 func pickMavenTargets(dir string) []Target {
 	var out []Target
-	if statRegular(filepath.Join(dir, "pom.xml")) {
+	if manifestCandidate(filepath.Join(dir, "pom.xml")) {
 		out = append(out, Target{
 			Ecosystem: intel.EcosystemMaven,
 			Path:      filepath.Join(dir, "pom.xml"),
 			Source:    "pom.xml",
 		})
 	}
-	if statRegular(filepath.Join(dir, "gradle.lockfile")) {
+	if manifestCandidate(filepath.Join(dir, "gradle.lockfile")) {
 		out = append(out, Target{
 			Ecosystem: intel.EcosystemMaven,
 			Path:      filepath.Join(dir, "gradle.lockfile"),
@@ -317,7 +317,7 @@ func pickPnpmTarget(dir string) []Target {
 	if hasNodeModulesAncestor(dir) {
 		return nil
 	}
-	if statRegular(filepath.Join(dir, "pnpm-lock.yaml")) {
+	if manifestCandidate(filepath.Join(dir, "pnpm-lock.yaml")) {
 		return []Target{{
 			Ecosystem: intel.EcosystemNPM,
 			Path:      filepath.Join(dir, "pnpm-lock.yaml"),
@@ -343,7 +343,7 @@ func pickPackageLockTarget(dir string) []Target {
 	if hasNodeModulesAncestor(dir) {
 		return nil
 	}
-	if statRegular(filepath.Join(dir, "package-lock.json")) {
+	if manifestCandidate(filepath.Join(dir, "package-lock.json")) {
 		return []Target{{
 			Ecosystem: intel.EcosystemNPM,
 			Path:      filepath.Join(dir, "package-lock.json"),
@@ -364,7 +364,7 @@ func pickYarnLockTarget(dir string) []Target {
 	if hasNodeModulesAncestor(dir) {
 		return nil
 	}
-	if statRegular(filepath.Join(dir, "yarn.lock")) {
+	if manifestCandidate(filepath.Join(dir, "yarn.lock")) {
 		return []Target{{
 			Ecosystem: intel.EcosystemNPM,
 			Path:      filepath.Join(dir, "yarn.lock"),
@@ -385,14 +385,14 @@ func pickBunLockTarget(dir string) []Target {
 	if hasNodeModulesAncestor(dir) {
 		return nil
 	}
-	if statRegular(filepath.Join(dir, "bun.lock")) {
+	if manifestCandidate(filepath.Join(dir, "bun.lock")) {
 		return []Target{{
 			Ecosystem: intel.EcosystemNPM,
 			Path:      filepath.Join(dir, "bun.lock"),
 			Source:    "bun.lock",
 		}}
 	}
-	if statRegular(filepath.Join(dir, "bun.lockb")) {
+	if manifestCandidate(filepath.Join(dir, "bun.lockb")) {
 		return []Target{{
 			Ecosystem: intel.EcosystemNPM,
 			Path:      filepath.Join(dir, "bun.lockb"),
@@ -419,7 +419,9 @@ func hasNodeModulesAncestor(dir string) bool {
 	}
 }
 
-func statRegular(path string) bool {
-	info, err := os.Stat(path)
-	return err == nil && info.Mode().IsRegular()
+// Retain unsafe leaf candidates so parsing reports an error instead of silently
+// skipping a manifest or choosing a lower-priority fallback.
+func manifestCandidate(path string) bool {
+	info, err := os.Lstat(path)
+	return err == nil && !info.IsDir()
 }

--- a/internal/packagecheck/go.go
+++ b/internal/packagecheck/go.go
@@ -3,7 +3,6 @@ package packagecheck
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/garagon/aguara/internal/intel"
@@ -39,7 +38,7 @@ func ParseGo(target Target) ([]PackageRef, error) {
 // stable format but stray blank lines / future suffixes should not
 // abort the parse.
 func parseGoSum(target Target) ([]PackageRef, error) {
-	f, err := os.Open(target.Path)
+	f, err := openManifest(target.Path, "go.sum")
 	if err != nil {
 		return nil, fmt.Errorf("open go.sum: %w", err)
 	}
@@ -49,7 +48,7 @@ func parseGoSum(target Target) ([]PackageRef, error) {
 	seen := make(map[key]bool)
 	var refs []PackageRef
 
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(boundedManifestReader(f, maxManifestBytes, "go.sum"))
 	// go.sum lines are short; the default Scanner buffer (64 KiB)
 	// is far more than enough for a single line.
 	for scanner.Scan() {
@@ -105,7 +104,7 @@ func parseGoSum(target Target) ([]PackageRef, error) {
 // `module` and `go` directives are also skipped; they declare the
 // CURRENT module, not a dependency.
 func parseGoMod(target Target) ([]PackageRef, error) {
-	f, err := os.Open(target.Path)
+	f, err := openManifest(target.Path, "go.mod")
 	if err != nil {
 		return nil, fmt.Errorf("open go.mod: %w", err)
 	}
@@ -114,7 +113,7 @@ func parseGoMod(target Target) ([]PackageRef, error) {
 	var refs []PackageRef
 	inRequire := false
 
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(boundedManifestReader(f, maxManifestBytes, "go.mod"))
 	for scanner.Scan() {
 		raw := scanner.Text()
 		// Strip an inline `// comment` so a require line

--- a/internal/packagecheck/lockfile_input_test.go
+++ b/internal/packagecheck/lockfile_input_test.go
@@ -1,0 +1,96 @@
+package packagecheck
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/garagon/aguara/internal/intel"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLockfileInputRejectsLinkedFiles(t *testing.T) {
+	for _, tc := range []struct{ ecosystem, source, content string }{
+		{intel.EcosystemGo, "go.sum", "example.com/pkg v1.0.0 h1:example\n"},
+		{intel.EcosystemGo, "go.mod", "module example.com/root\nrequire example.com/pkg v1.0.0\n"},
+		{intel.EcosystemCargo, "Cargo.lock", "[[package]]\nname = 'example'\nversion = '1.0.0'\nsource = 'registry+https://github.com/rust-lang/crates.io-index'\n"},
+		{intel.EcosystemPackagist, "composer.lock", `{"packages":[{"name":"vendor/example","version":"1.0.0"}]}`},
+		{intel.EcosystemRubyGems, "Gemfile.lock", "GEM\n  remote: https://rubygems.org/\n  specs:\n    example (1.0.0)\n"},
+		{intel.EcosystemMaven, "pom.xml", "<project><dependencies><dependency><groupId>example</groupId><artifactId>pkg</artifactId><version>1.0.0</version></dependency></dependencies></project>"},
+		{intel.EcosystemMaven, "gradle.lockfile", "example:pkg:1.0.0=runtime\n"},
+		{intel.EcosystemNPM, "pnpm-lock.yaml", "lockfileVersion: '9.0'\npackages:\n  example@1.0.0: {}\n"},
+		{intel.EcosystemNPM, "package-lock.json", `{"lockfileVersion":3,"packages":{"node_modules/example":{"version":"1.0.0"}}}`},
+		{intel.EcosystemNPM, "yarn.lock", "example@^1.0.0:\n  version \"1.0.0\"\n"},
+		{intel.EcosystemNPM, "bun.lock", `{"packages":{"example":["example@1.0.0","",{},"sha512-example"]}}`},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), tc.source)
+			require.NoError(t, os.WriteFile(path, []byte(tc.content), 0o600))
+			target := Target{Ecosystem: tc.ecosystem, Source: tc.source, Path: path}
+			refs, err := parseTarget(target)
+			require.NoError(t, err)
+			require.Len(t, refs, 1, "regular-file control")
+			for _, dangling := range []bool{false, true} {
+				dir := t.TempDir()
+				link := filepath.Join(dir, tc.source)
+				dest := path
+				if dangling {
+					dest += ".missing"
+				}
+				if err := os.Symlink(dest, link); err != nil {
+					t.Skipf("symlink unavailable: %v", err)
+				}
+				target.Path = link
+				refs, err := parseTarget(target)
+				require.Error(t, err)
+				require.Empty(t, refs)
+				targets, err := Discover(dir, []string{tc.ecosystem})
+				require.NoError(t, err)
+				require.Len(t, targets, 1, "unsafe candidates must not disappear")
+				result, err := (&Runner{Matcher: intel.NewMatcher(intel.Snapshot{})}).Run(targets)
+				require.Error(t, err)
+				require.Nil(t, result)
+			}
+		})
+	}
+}
+
+func TestLockfileInputInvalidPreferredDoesNotFallBack(t *testing.T) {
+	for _, tc := range []struct{ ecosystem, preferred, fallback string }{
+		{intel.EcosystemGo, "go.sum", "go.mod"},
+		{intel.EcosystemNPM, "bun.lock", "bun.lockb"},
+	} {
+		t.Run(tc.preferred, func(t *testing.T) {
+			dir := t.TempDir()
+			preferred := filepath.Join(dir, tc.preferred)
+			if err := os.Symlink(filepath.Join(dir, "missing"), preferred); err != nil {
+				t.Skipf("symlink unavailable: %v", err)
+			}
+			require.NoError(t, os.WriteFile(filepath.Join(dir, tc.fallback), []byte("module example.com/root\n"), 0o600))
+			targets, err := Discover(dir, []string{tc.ecosystem})
+			require.NoError(t, err)
+			require.Len(t, targets, 1)
+			require.Equal(t, preferred, targets[0].Path)
+			result, err := (&Runner{Matcher: intel.NewMatcher(intel.Snapshot{})}).Run(targets)
+			require.Error(t, err)
+			require.Nil(t, result)
+		})
+	}
+}
+
+func TestLockfileInputGradleLinkedPerConfiguration(t *testing.T) {
+	dir := t.TempDir()
+	locks := filepath.Join(dir, "gradle", "dependency-locks")
+	require.NoError(t, os.MkdirAll(locks, 0o700))
+	good := filepath.Join(locks, "a.lockfile")
+	require.NoError(t, os.WriteFile(good, []byte("example:pkg:1.0.0=runtime\n"), 0o600))
+	if err := os.Symlink(good, filepath.Join(locks, "z.lockfile")); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	targets, err := Discover(dir, []string{intel.EcosystemMaven})
+	require.NoError(t, err)
+	require.Len(t, targets, 2)
+	result, err := (&Runner{Matcher: intel.NewMatcher(intel.Snapshot{})}).Run(targets)
+	require.Error(t, err)
+	require.Nil(t, result, "do not return the preceding valid target as a complete check")
+}

--- a/internal/packagecheck/manifest_input.go
+++ b/internal/packagecheck/manifest_input.go
@@ -1,0 +1,71 @@
+package packagecheck
+
+import (
+	"fmt"
+	"io"
+	"os"
+)
+
+// Guard the leaf at open time on Unix and verify the opened identity everywhere.
+// Parent directories are not confined and the file contents are not a snapshot.
+func openManifest(path, label string) (*os.File, error) {
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s input must be a regular file, not a symlink or special file", label)
+	}
+	if info.Size() > maxManifestBytes {
+		return nil, fmt.Errorf("%s input exceeds %d-byte limit", label, maxManifestBytes)
+	}
+	f, err := os.OpenFile(path, os.O_RDONLY|manifestOpenFlags, 0)
+	if err != nil {
+		return nil, err
+	}
+	opened, err := f.Stat()
+	if err == nil && (!opened.Mode().IsRegular() || !os.SameFile(info, opened)) {
+		err = fmt.Errorf("%s input changed while opening", label)
+	}
+	if err == nil && opened.Size() > maxManifestBytes {
+		err = fmt.Errorf("%s input exceeds %d-byte limit", label, maxManifestBytes)
+	}
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	return f, nil
+}
+
+func readManifest(path, label string) ([]byte, error) {
+	f, err := openManifest(path, label)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = f.Close() }()
+	return readBoundedManifestBytes(f, maxManifestBytes, label)
+}
+
+// Streaming parsers must distinguish an actual EOF from the byte budget ending.
+// They retain their per-line limits and discard all refs on this reader's error.
+func boundedManifestReader(r io.Reader, limit int64, label string) io.Reader {
+	return &manifestLimitReader{reader: io.LimitReader(r, limit+1), remaining: limit, label: label}
+}
+
+type manifestLimitReader struct {
+	reader    io.Reader
+	remaining int64
+	label     string
+}
+
+func (r *manifestLimitReader) Read(p []byte) (int, error) {
+	if r.remaining < 0 {
+		return 0, fmt.Errorf("%s input exceeds byte limit", r.label)
+	}
+	n, err := r.reader.Read(p)
+	r.remaining -= int64(n)
+	if r.remaining < 0 {
+		return 0, fmt.Errorf("%s input exceeds byte limit", r.label)
+	}
+	return n, err
+}

--- a/internal/packagecheck/manifest_input_test.go
+++ b/internal/packagecheck/manifest_input_test.go
@@ -1,0 +1,73 @@
+package packagecheck
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBoundedManifestReader(t *testing.T) {
+	const limit = 64
+	for _, size := range []int{0, limit - 1, limit, limit + 1, limit * 4} {
+		t.Run(fmt.Sprint(size), func(t *testing.T) {
+			source := strings.NewReader(strings.Repeat("x", size))
+			reader := boundedManifestReader(source, limit, "fixture")
+			data, err := io.ReadAll(reader)
+			if size <= limit {
+				require.NoError(t, err)
+				require.Len(t, data, size)
+			} else {
+				require.ErrorContains(t, err, "fixture input exceeds")
+				consumed, err := source.Seek(0, io.SeekCurrent)
+				require.NoError(t, err)
+				require.EqualValues(t, limit+1, consumed)
+				_, err = reader.Read(make([]byte, 1))
+				require.Error(t, err, "overflow must remain an error")
+			}
+		})
+	}
+	t.Run("short lines cannot bypass total budget", func(t *testing.T) {
+		scanner := bufio.NewScanner(boundedManifestReader(strings.NewReader(strings.Repeat("x\n", 40)), limit, "fixture"))
+		for scanner.Scan() {
+		}
+		require.ErrorContains(t, scanner.Err(), "input exceeds")
+	})
+	t.Run("read errors survive", func(t *testing.T) {
+		want := errors.New("interrupted")
+		reader := io.MultiReader(strings.NewReader("x\n"), nugetFailingReader{err: want})
+		scanner := bufio.NewScanner(boundedManifestReader(reader, limit, "fixture"))
+		for scanner.Scan() {
+		}
+		require.ErrorIs(t, scanner.Err(), want)
+	})
+}
+
+func TestOpenManifestRegularBoundary(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "manifest")
+	require.NoError(t, os.WriteFile(path, []byte("small fixture"), 0o600))
+	data, err := readManifest(path, "fixture")
+	require.NoError(t, err)
+	require.Equal(t, "small fixture", string(data))
+	for _, invalid := range []string{dir, path + ".missing"} {
+		file, err := openManifest(invalid, "fixture")
+		require.Error(t, err)
+		require.Nil(t, file)
+	}
+	t.Run("hardlinks remain regular files", func(t *testing.T) {
+		link := filepath.Join(dir, "hardlink")
+		if err := os.Link(path, link); err != nil {
+			t.Skipf("hardlink unavailable: %v", err)
+		}
+		data, err := readManifest(link, "fixture")
+		require.NoError(t, err)
+		require.Equal(t, "small fixture", string(data))
+	})
+}

--- a/internal/packagecheck/maven.go
+++ b/internal/packagecheck/maven.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"encoding/xml"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/garagon/aguara/internal/intel"
@@ -16,9 +15,9 @@ import (
 //
 //   - "pom.xml"          -> parsePomXML  (Maven proper)
 //   - "gradle.lockfile"  -> parseGradleLockfile (both
-//                            single-lockfile mode at project root
-//                            and per-configuration mode under
-//                            gradle/dependency-locks/)
+//     single-lockfile mode at project root
+//     and per-configuration mode under
+//     gradle/dependency-locks/)
 //
 // No external commands (`mvn`, `gradle`). No network. Parent POMs,
 // BOMs, dependencyManagement-only declarations, profiles, and the
@@ -49,7 +48,7 @@ func ParseMaven(target Target) ([]PackageRef, error) {
 // dependency rather than emit a half-formed PackageRef the
 // matcher could mis-attribute.
 func parsePomXML(target Target) ([]PackageRef, error) {
-	data, err := os.ReadFile(target.Path)
+	data, err := readManifest(target.Path, "pom.xml")
 	if err != nil {
 		return nil, fmt.Errorf("open pom.xml: %w", err)
 	}
@@ -182,7 +181,7 @@ func resolveMavenProperty(version string, props map[string]string) (string, bool
 // (`group:name:version:classifier`) for a zero-FP guarantee on the
 // common case.
 func parseGradleLockfile(target Target) ([]PackageRef, error) {
-	f, err := os.Open(target.Path)
+	f, err := openManifest(target.Path, "gradle.lockfile")
 	if err != nil {
 		return nil, fmt.Errorf("open gradle.lockfile: %w", err)
 	}
@@ -190,7 +189,7 @@ func parseGradleLockfile(target Target) ([]PackageRef, error) {
 
 	var refs []PackageRef
 	seen := make(map[string]bool)
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(boundedManifestReader(f, maxManifestBytes, "gradle.lockfile"))
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {

--- a/internal/packagecheck/nuget_input.go
+++ b/internal/packagecheck/nuget_input.go
@@ -1,9 +1,7 @@
 package packagecheck
 
 import (
-	"fmt"
 	"io"
-	"os"
 )
 
 // Match the scanner's default per-file limit. NuGet parsing must also enforce
@@ -11,34 +9,7 @@ import (
 const maxNuGetManifestBytes int64 = maxManifestBytes
 
 func readNuGetManifest(path string) ([]byte, error) {
-	info, err := os.Lstat(path)
-	if err != nil {
-		return nil, err
-	}
-	if !info.Mode().IsRegular() {
-		return nil, fmt.Errorf("NuGet input must be a regular file, not a symlink or special file")
-	}
-	if info.Size() > maxNuGetManifestBytes {
-		return nil, fmt.Errorf("NuGet input exceeds %d-byte limit", maxNuGetManifestBytes)
-	}
-	// Reject leaf symlinks at open time on Unix and verify the opened identity
-	// before reading. This is not a snapshot of the discovery directory tree.
-	f, err := os.OpenFile(path, os.O_RDONLY|manifestOpenFlags, 0)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = f.Close() }()
-	opened, err := f.Stat()
-	if err != nil {
-		return nil, err
-	}
-	if !opened.Mode().IsRegular() || !os.SameFile(info, opened) {
-		return nil, fmt.Errorf("NuGet input changed while opening")
-	}
-	if opened.Size() > maxNuGetManifestBytes {
-		return nil, fmt.Errorf("NuGet input exceeds %d-byte limit", maxNuGetManifestBytes)
-	}
-	return readNuGetBytes(f, maxNuGetManifestBytes)
+	return readManifest(path, "NuGet")
 }
 
 func readNuGetBytes(r io.Reader, limit int64) ([]byte, error) {

--- a/internal/packagecheck/packagelock.go
+++ b/internal/packagecheck/packagelock.go
@@ -3,7 +3,6 @@ package packagecheck
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"sort"
 	"strings"
 
@@ -116,7 +115,7 @@ type packageLock struct {
 // false match against an npm advisory. Better to under-report than to
 // manufacture confidence.
 func ParsePackageLock(target Target) ([]PackageRef, error) {
-	data, err := os.ReadFile(target.Path)
+	data, err := readManifest(target.Path, "package-lock.json")
 	if err != nil {
 		return nil, fmt.Errorf("open package-lock.json: %w", err)
 	}

--- a/internal/packagecheck/pnpm.go
+++ b/internal/packagecheck/pnpm.go
@@ -2,7 +2,6 @@ package packagecheck
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -47,7 +46,7 @@ var exactNpmVersionRe = regexp.MustCompile(`^[0-9]+\.[0-9]+\.[0-9]+(?:[-+][0-9A-
 // the npm registry and matching them against npm advisories would
 // false-positive on name collisions.
 func ParsePNPMLock(target Target) ([]PackageRef, error) {
-	data, err := os.ReadFile(target.Path)
+	data, err := readManifest(target.Path, "pnpm-lock.yaml")
 	if err != nil {
 		return nil, fmt.Errorf("open pnpm-lock.yaml: %w", err)
 	}

--- a/internal/packagecheck/ruby.go
+++ b/internal/packagecheck/ruby.go
@@ -3,7 +3,6 @@ package packagecheck
 import (
 	"bufio"
 	"fmt"
-	"os"
 	"regexp"
 	"strings"
 
@@ -32,7 +31,7 @@ var gemSpecLine = regexp.MustCompile(`^(\S+)\s+\(([^)]+)\)$`)
 //
 // No external commands. No network.
 func ParseRuby(target Target) ([]PackageRef, error) {
-	f, err := os.Open(target.Path)
+	f, err := openManifest(target.Path, "Gemfile.lock")
 	if err != nil {
 		return nil, fmt.Errorf("open Gemfile.lock: %w", err)
 	}
@@ -42,7 +41,7 @@ func ParseRuby(target Target) ([]PackageRef, error) {
 	inGEM := false
 	inSpecs := false
 
-	scanner := bufio.NewScanner(f)
+	scanner := bufio.NewScanner(boundedManifestReader(f, maxManifestBytes, "Gemfile.lock"))
 	for scanner.Scan() {
 		raw := scanner.Text()
 		if raw == "" {

--- a/internal/packagecheck/yarnlock.go
+++ b/internal/packagecheck/yarnlock.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/url"
-	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -69,7 +68,7 @@ var yarnRegistrySelectorRe = regexp.MustCompile(`^[A-Za-z0-9._*^~<>=|+\s -]+$`)
 // identifier, or a body without an exact resolved version is skipped.
 // Results dedupe on (name, version) and come out in deterministic order.
 func ParseYarnLock(target Target) ([]PackageRef, error) {
-	data, err := os.ReadFile(target.Path)
+	data, err := readManifest(target.Path, "yarn.lock")
 	if err != nil {
 		return nil, fmt.Errorf("open yarn.lock: %w", err)
 	}


### PR DESCRIPTION
Dependency checks should not follow a lockfile link outside the selected file or read an input without a byte limit. This extends the existing NuGet read boundary to the other lockfile and dependency-manifest parsers.

Each parser now requires a regular file, verifies the opened file against the pre-open identity, and rejects inputs larger than 50 MiB. Go, Ruby and Gradle keep their streaming parsers with a total-byte budget; the other parsers use a bounded read. A parser error still aborts the check rather than returning a partial successful result.

Discovery retains linked and dangling manifest candidates so they produce an error instead of disappearing. An invalid preferred `go.sum` or `bun.lock` does not trigger fallback to another file. Ordinary regular files and hardlinks remain supported; leaf symlinks are intentionally no longer accepted.

Tests cover all eleven newly protected source formats, linked and dangling inputs, preferred-file selection, per-configuration Gradle files, small byte-budget boundaries, read errors, and existing alias-resolution examples. Focused race tests, package vet, lint and build pass locally. Full repository checks run in CI.

This is a file-read boundary, not a filesystem sandbox: parent directories are not confined and file contents are not a snapshot. Atomic leaf-symlink rejection at open time uses Unix flags; other platforms retain metadata and identity checks. Installed-package scanning and aggregate scan budgets are outside this change. No matching rules or severities change.
