### PR TITLE
Prepare v0.28.0 for reviewing untrusted projects

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,14 +31,14 @@ version-matching limits.
 
 ## Trust Boundary
 
-On `main`, `audit` and CI scans ignore target-owned policy by default. A local
+From v0.28.0, `audit` and CI scans ignore target-owned policy by default. A local
 `scan` can still trust it. Use `--project-policy ignore` when inspecting unfamiliar
 content. The public Go scanning APIs ignore target-owned `.aguaraignore` and
 inline suppression directives by default. `WithTrustedTargetPolicy()` opts in
 when the caller owns that policy.
 
-These controls are development features until released. Older binaries may honor
-repository-owned exclusions. Check the version before relying on this boundary.
+Older binaries may honor repository-owned exclusions. Check the version before
+relying on this boundary.
 Caller-supplied exclusions, overrides and custom rules also affect coverage.
 
 A clean result means no matching finding in the analyzed input, not proof of
@@ -112,7 +112,7 @@ exported through public aliases, rather than copying a partial struct.
   state store, but rug-pull analysis needs one.
 
 `audit` has its own aggregate output, including triage and agent-handoff guidance
-on `main`. Do not assume it has the same schema as `ScanResult`. Severity,
+from v0.28.0. Do not assume it has the same schema as `ScanResult`. Severity,
 confidence, score and decision impact are distinct. Keep downstream identity,
 session policy and enforcement decisions outside Aguara's core.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,187 +5,106 @@ Format based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-09-10
+
+A project should not decide what its security review is allowed to see.
+Aguara now ignores repository-owned exclusions in audit, CI and embedded
+scanning by default, reports incomplete checks as errors, and gives reviewers
+clearer guidance on what to investigate before installing dependencies or
+handing the project to an agent.
+
+This release also improves package identity and policy parsing, refreshes
+offline intelligence from a verified September snapshot, and protects more
+sensitive material in reports. Analysis stays local and does not execute the
+code being inspected.
+
 ### Added
 
-- Skill posture now flags a whole-value `allowed-tools: '*'` declaration in
-  `SKILL.md`. The structural frontmatter check identifies a request to
-  pre-approve every tool while leaving explicit tool lists, scoped command
-  wildcards, body examples, and malformed metadata quiet.
-- Agent-skill scans now correlate mandatory execution instructions in
-  `SKILL.md` with the local helper they reference. A required or hidden helper
-  becomes a review finding only when that exact file contains a strong,
-  unexplained behavior such as an instruction-override payload, a network
-  command execution, or a direct VCS dependency install. Ordinary setup
-  commands, optional diagnostics, comments, and safe helpers remain quiet.
-- Local Python and shell scripts now contribute concrete behavior evidence:
-  decoded or character-constructed Python values reaching `exec`/`eval`,
-  remote Python response bodies flowing into execution, structured systemd
-  or cron persistence, and real pip/npm commands using unencrypted dependency
-  sources. Python files that read high-trust local context and then perform a
-  bound HTTP write, or that apply literal world-writable permissions through a
-  bound Python API or command, are also surfaced for review.
-  The existing `SC-EX-007` persistence rule keeps its ID while moving from a
-  flat pattern to the script analyzer, so saved policies remain compatible.
-
-### Fixed
-
-- Installed npm identities, package-lock entries and agent settings now use
-  exact JSON property names. Case variants cannot erase or invent package
-  versions, hook commands or permissions. Repeated properties use their final
-  value, and inline agent settings retain original JSON keys. Legacy nested
-  package-lock decoding fails with an error when its bounded work budget ends.
-- `init` now creates configuration, workflows and hooks without following leaf
-  symlinks or escaping the selected directory through a linked parent. Existing
-  regular files retain their content and permissions. The one-time PATH hint
-  uses the same non-overwriting creation boundary for its marker.
-- Embedded malicious-package intelligence now uses the signed September 7
-  snapshot, filtered through the current source-evidence policy. Offline checks
-  no longer depend on the June snapshot. The source date and eight ecosystems
-  are preserved; manually curated incident records are unchanged.
-- Lockfile and dependency-manifest checks now reject leaf symlinks and special
-  files, and limit each input to 50 MiB. Invalid linked candidates remain visible
-  to discovery and return an error instead of disappearing or selecting a
-  fallback. Go, Ruby and Gradle retain streaming reads with a total-byte budget.
-- Pattern scans no longer recount the entire preceding text to locate every
-  match. Line tracking advances with each pattern's matches, preserving finding
-  locations and original excerpts without limiting the number of results.
-- Saved `update` reports and `clean` JSON reports now reject symlink and special
-  file destinations. Failed rendering preserves the previous report, and
-  successful writes replace it with a private file rather than truncating links.
-- JavaScript GitHub-channel checks no longer rescan an entire string for every
-  repeated mutation name. Rejected string interiors are visited once per name,
-  without changing mutation matching or finding locations.
-- JavaScript destructive-cleanup checks read recursive deletion options from
-  actual object properties. Quoted delimiters no longer hide a recursive wipe,
-  and example strings, nested options or overwritten values do not enable it.
-- Python remote-code checks retain the fetched source when a variable is decoded
-  or read back into itself, including inside a helper that returns the payload.
-  Replacing that variable with local content still clears the remote evidence.
-- Yarn classic dependency checks now resolve `npm:` aliases to the real package
-  and the lockfile's resolved version. Conflicting package identities, malformed
-  descriptors, non-registry sources and non-exact body versions remain excluded.
-- npm manifest checks now distinguish exact JSON field names. Unrelated keys
-  such as `Scripts` or `DEPENDENCIES` can no longer erase or introduce lifecycle
-  and dependency evidence; the same correction applies to publish provenance.
-  Repeated exact keys use the final value instead of merging earlier objects.
-  Inline scans preserve original manifest bytes for this check while retaining
-  Unicode normalization for text detection.
-- Findings no longer expose username-only URL tokens, empty-password credentials,
-  or credential tails after a second `@`. Dependency and shell evidence keeps
-  the destination visible; default redaction also covers URLs in neighboring
-  finding context and descriptions.
-- Cargo dependency checks now parse TOML structure, so inline comments, quoted
-  keys and escaped strings cannot hide a locked crates.io package. Private
-  registries remain excluded. Invalid TOML syntax or package identity fields
-  return an error instead of a successful partial result, and reads are limited
-  to 50 MiB. Unrelated metadata is parsed without decoding a whole document.
-- pnpm policy checks now read the value referenced by a YAML alias, including
-  aliased build-approval mappings. Dangerous settings are no longer missed
-  behind anchors, and a safe value does not trigger a finding merely because
-  its anchor is named `true`, `off`, or `0`. Findings retain the policy key's
-  source line; rule IDs, severities, and merge precedence are unchanged.
-- Dependency checks no longer classify a package as malicious solely because a
-  vulnerability description or reference mentions malware. OSV imports require
-  source evidence or reviewed exact versions. The same policy filters older
-  embedded and cached intelligence, while retaining manual incident records,
-  MAL advisories and reviewed historical compromises. Generic vulnerability
-  reports are not treated as evidence that an installed package contains malware.
-- Intel downloaded with `--insecure-intel` is now labeled unverified and cannot
-  become trusted input to later default checks or `--allow-stale`. Unverified
-  saves clear previous verification markers. Older markers require a new signed
-  `aguara update` because they did not distinguish skipped signature checks.
-  Normal signed refreshes and verified offline fallback remain supported.
-- Terminal reports now display control characters in filenames, finding text,
-  and discovered MCP server fields as visible escapes instead of letting them
-  alter the terminal. This applies with or without color; structured report
-  values and detection behavior are unchanged.
-- Report, baseline, and monitor-state writes now reject linked or special-file
-  destinations and use unique sibling temporary files. A failed write leaves
-  the existing artifact intact instead of truncating it. On Unix, saved files
-  are private to the owner (mode 0600, subject to umask); stdout is unchanged.
-- Directory scans now report an incomplete scan when an eligible file exceeds
-  the size limit instead of silently omitting it. The error identifies the file
-  and limit; configured exclusions and binary-file exclusions remain unchanged.
-  Disk reads also enforce the limit if a file grows after inspection, without
-  analyzing a truncated prefix. In-memory scanning keeps its existing behavior.
-- NuGet dependency checks now reject linked and special-file manifests and
-  enforce a 50 MiB input limit for project files and `packages.lock.json`.
-  Rejected inputs return an error rather than a successful dependency report.
-  Reads remain bounded if a manifest grows after inspection.
-- WASM scans now release their per-call Promise executor callbacks. Completed
-  scans no longer remain referenced by those callback registrations in a
-  long-lived browser session; asynchronous results and errors are unchanged.
-- The bundled WebAssembly page now renders finding fields, summaries, and
-  errors as text instead of HTML. Match previews retain their 120-character
-  limit without shortening or splitting HTML entities during rendering.
-- Scans now return an error if a selected file cannot be read, an analyzer
-  reports a failure, or directory discovery cannot complete. Partial findings
-  are not presented as a successful report, including in `scan --auto`.
-  Error messages identify the affected file or analyzer without quoting parser
-  input. Configured exclusions and intentionally skipped files are unchanged.
-- Scanning an explicitly selected directory symlink now scans its destination
-  instead of returning an empty success. Symlinks inside that directory remain
-  excluded.
-- Scan reports now redact complete PEM private-key blocks from finding
-  evidence, including truncated blocks. Credential locations remain protected
-  when a severity filter removes the original credential finding, so nearby
-  findings cannot expose it through their context. Explicit unredacted output
-  remains available for local investigation.
-- Repositories being evaluated can no longer declare themselves clean in
-  `aguara audit`, `aguara scan --ci`, the GitHub Action, WASM, or the public
-  scanning API. These trust-boundary paths ignore target-owned
-  `.aguara.yml`, `.aguaraignore`, and inline suppression directives by default.
-  Local `aguara scan` keeps its existing policy behavior, with an explicit
-  `--project-policy trust|ignore` override for either workflow; Go callers
-  must opt in with `WithTrustedTargetPolicy` before target policy is honored.
-- Reusable Go-library scanners now expose analyzer-owned detections through
-  `Scanner.ListRules` and `Scanner.ExplainRule`, matching the global catalog.
-  Consumers can enumerate and explain rules such as `SC-EX-007` without
-  maintaining a separate metadata path. Disabled rule IDs are normalized
-  consistently so catalog output and scan behavior cannot disagree by case.
-- `aguara scan` no longer contacts GitHub Releases in the background to
-  check for a newer binary. Local scans now honor Aguara's offline-by-default
-  contract without requiring `--no-update-check`; threat-intel refresh remains
-  an explicit `aguara update` or `--fresh` operation.
+- Audit reports include `triage`, `agent_handoff` and `action_plan`: review
+  priorities, next steps and machine-readable guidance for install, execution,
+  CI and agent configuration. These fields guide consumers; they do not enforce
+  permissions or replace existing exit-code thresholds.
+- Skill checks flag blanket tool approval in `SKILL.md` and connect required
+  local helpers to suspicious behavior in the referenced file. Explicit tool
+  lists, optional diagnostics, comments and safe helpers remain quiet.
+- Python and shell checks cover decoded values reaching execution, remote
+  response bodies flowing into code execution, systemd/cron persistence,
+  unencrypted dependency sources and additional credential-access or permission
+  risks. The persistence detection `SC-EX-007` keeps its ID after moving into
+  the script analyzer.
 
 ### Changed
 
-- Remote MCP endpoint findings now distinguish dedicated MCP URL shapes from
-  ordinary JSON `url` fields. Package metadata, feeds, schemas, and other
-  unrelated URLs stay quiet; a real remote MCP endpoint remains visible as
-  trust context without forcing the default handoff into review by itself.
-- Approval/execution gap detection now requires explicit reuse of a previous
-  or cached approval. Instructions that ask the user to confirm the exact
-  action before it runs are treated as the expected safety control, not as a
-  TOCTOU finding.
-- Findings and rule metadata now expose a `decision_impact` of `review`
-  or `context`. Ordinary local shell-script execution, `pip install`, and
-  system package installation commands remain visible as supporting context,
-  but no longer force the default audit triage or agent handoff into
-  review-only mode by themselves. All other built-in and custom rules default
-  to review, and explicit `--fail-on` gates remain authoritative.
-- An accepted scan baseline now produces `triage.decision: proceed` when
-  no new or non-baselineable finding remains. Existing findings stay
-  visible in the report and baseline summary.
-- `aguara audit` JSON now includes an additive `triage` block with a
-  deterministic `proceed` / `review` / `stop` decision, reasons, and
-  next steps for humans, CI dashboards, and agent workflows. The
-  existing `verdict.status`, `threshold_exceeded`, and exit-code
-  behavior are unchanged.
-- `aguara audit` now also emits agent handoff guidance derived from
-  triage, with explicit `allowed`, `review_only`, or `blocked` status
-  plus allowed and blocked actions for agent workflows. This gives AI
-  coding tools a safer pre-execution contract without changing scan
-  findings, gates, or exit codes.
-- `aguara audit` JSON now includes an additive `action_plan` block with
-  machine-readable permissions for install, execution, CI, repo agent
-  config, editing, and finding explanation. It is derived from triage
-  and agent handoff so wrappers and MCP clients can apply the same
-  trust decision without parsing prose.
-- README positioning now leads with when to run Aguara - before
-  install, before CI, or before handing a repo to an AI coding agent -
-  and adds a short "When to Use Aguara" section mapping real trust
-  decisions to the corresponding commands.
+- Audit, CI scans, the GitHub Action, WASM and public scanning APIs ignore
+  target-owned exclusions and suppressions by default. Local `scan` retains
+  project-policy behavior; use `--project-policy ignore` for unfamiliar code.
+  Go consumers can explicitly opt in with `WithTrustedTargetPolicy()`.
+- Findings distinguish supporting `context` from `review` signals through
+  `decision_impact`. Ordinary installation or local shell commands no longer
+  force review by themselves. Explicit failure thresholds remain authoritative.
+  Accepted baselines can produce a `proceed` triage decision while keeping
+  existing findings visible.
+- Remote MCP checks distinguish actual endpoint shapes from unrelated JSON URLs.
+  Approval-reuse checks require explicit reuse of previous or cached approval;
+  requesting confirmation of the current action remains a valid control.
+- Embedded intelligence now uses the verified September 7 snapshot, filtered
+  through the current malicious-package admission policy: 35,774 record rows
+  and 203,639 all-version entries across eight ecosystems. These are separate
+  data structures, not a count of unique packages. Manual incident data remains.
+- The catalog exposes 258 detections: 192 pattern rules and 66 analyzer-owned
+  detections. Reusable scanners now enumerate and explain analyzer rules too;
+  `RulesLoaded` still counts compiled pattern rules, not the combined catalog.
+
+### Fixed
+
+- A failed discovery, unreadable selected file, analyzer failure or oversized
+  eligible file no longer becomes a successful clean scan. Lockfile and
+  dependency-manifest readers reject leaf symlinks and special files, enforce
+  a 50 MiB limit, and do not analyze truncated input. Go, Ruby and Gradle retain
+  streaming reads. An explicitly selected directory symlink is scanned rather
+  than silently returning an empty result.
+- Package identities and policy values are read more precisely. npm manifests,
+  installed-package metadata, package-lock entries and agent settings use exact
+  JSON keys and final duplicate values. Yarn classic aliases retain the real
+  package and resolved version. Cargo checks parse TOML structure; pnpm policy
+  checks resolve YAML aliases without confusing anchor names with values.
+  Legacy package-lock trees have a 128-level nesting limit and a 50 MiB
+  cumulative subtree-decoding budget; exceeding either returns an error.
+- Malware classification requires source evidence or reviewed exact versions,
+  not a word in an advisory description or URL. The same admission policy
+  filters old embedded, cached and refreshed data. Unverified intel cannot be
+  reused as verified input in later default checks or stale fallback.
+- Default report redaction covers full or truncated PEM private-key blocks and
+  additional credential-bearing URL forms, including neighboring context when
+  severity filters remove the original credential finding. Terminal reports
+  escape control characters. The bundled WASM page renders result fields as
+  text, not HTML, and releases completed Promise executor callbacks.
+- Report, baseline and monitor-state writes reject linked or special-file
+  destinations and preserve existing files when rendering fails. Saved reports
+  use private files on Unix. Initialization creates files without overwriting
+  existing ones or escaping the selected project through linked parents.
+- Python remote-code checks preserve fetched provenance through same-variable
+  decoding. JavaScript destructive-cleanup checks distinguish actual recursive
+  options from quoted, nested or overwritten values.
+- Pattern line attribution advances through matches instead of repeatedly
+  counting the entire preceding text. GitHub-channel checks avoid rescanning
+  string interiors for every repeated mutation name. Finding locations and
+  detection scope are preserved; these changes do not establish hard deadlines.
+- `scan` no longer checks GitHub Releases in the background. Intel refresh is
+  still an explicit `aguara update` or `--fresh` operation.
+
+### Upgrade Notes
+
+- Review CI expectations when upgrading: target-owned exclusions no longer hide
+  findings in the default untrusted-project paths. Caller-supplied policy remains
+  authoritative. Guidance fields do not change explicit failure thresholds.
+- Older intel cache verification markers are rejected. Run a normal signed
+  `aguara update` to restore verified cache reuse; offline checks can use the
+  new embedded snapshot. Do not use `--insecure-intel` to bypass this migration.
+- Input limits apply to disk-backed scan and dependency paths, not arbitrary
+  inline API content. Consumers must bound inline inputs and execution resources.
+  No aggregate memory budget, immediate parser cancellation or full shell
+  interpretation is promised.
 
 ## [0.27.0] - 2026-06-12
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Status
 
-Aguara v0.27.0 (2026-06-12; aggregates the terminal UX round #220 TTY detection + #221 shared style layer + `audit --verbose`, the native fuzz harness #223 with 22 targets + nightly workflow, and dependency bumps). Previous: v0.26.0 (2026-06-11; C3 range-matching round: #216 measurement, #217 all-versions advisory matching, #218 npm bounded ranges, snapshot 26,268 records + 202,526 all-versions entries). Current tree: 24 fuzz targets, 192 YAML rules + 66 analyzer-emitted (258 cataloged), 13 YAML categories (+ analyzer categories incl. agent-trust), 14 per-file scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, scriptrisk, rsbuild, npmpolicy, pnpmpolicy, agentpolicy, skillpolicy, NLP, toxicflow, rugpull) plus the skill-chain project correlation and the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic v1 / yarn.lock Berry v2+ / bun.lock text - all with `npm:` alias resolution to the real package - and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
+Aguara v0.28.0 (2026-09-10): untrusted-project defaults, audit triage and agent handoff, skill/helper and script checks, parser/report hardening, and verified September 7 embedded intelligence (35,774 record rows + 203,639 all-version entries; not unique package totals). Previous release: v0.27.0 (2026-06-12). Current tree: 24 fuzz targets, 192 YAML rules + 66 analyzer-emitted (258 cataloged), 13 YAML categories (+ analyzer categories incl. agent-trust), 14 per-file scan analyzers (pattern, ci-trust, pkgmeta, jsrisk, pyrisk, scriptrisk, rsbuild, npmpolicy, pnpmpolicy, agentpolicy, skillpolicy, NLP, toxicflow, rugpull) plus the skill-chain project correlation and the `aguara check` incident command (npm/PyPI installed trees + pre-install npm lockfiles pnpm-lock.yaml / package-lock.json / yarn.lock classic v1 / yarn.lock Berry v2+ / bun.lock text - all with `npm:` alias resolution to the real package - and Go/Rust/PHP/Ruby/Java/.NET lockfiles), 0 lint issues.
 
 Distribution: install.sh (mandatory checksum verification, bounded curl + retry), Homebrew tap, Docker (GHCR, multi-arch `linux/amd64+arm64`, runs as non-root UID 10001, base images digest-pinned, signed at digest with Cosign + SBOM + SLSA provenance attestations), GoReleaser (releases signed via Cosign keyless, SPDX SBOM per archive, `-trimpath` for reproducibility), GitHub Action, go install.
 
@@ -168,7 +168,7 @@ When any of these values change, update ALL references across the vault:
 - Coverage (currently 82% on the Codecov badge; badge scope excludes tools/ and benchmarks/)
 - Star/fork count (currently 48/6)
 - Watch skill count (currently 28,000+)
-- Version number (currently v0.27.0)
+- Version number (currently v0.28.0)
 
 Use `Grep` to find all occurrences before updating.
 

--- a/Makefile
+++ b/Makefile
@@ -117,7 +117,7 @@ verify-docker: bench-docker test-race-docker smoke-docker
 # archive + checksums from github.com), so this target is intentionally
 # NOT folded into `verify-docker` which runs offline.
 # Override INSTALL_SH_TEST_VERSION to pin to a different release.
-INSTALL_SH_TEST_VERSION ?= v0.27.0
+INSTALL_SH_TEST_VERSION ?= v0.28.0
 INSTALL_SH_TEST_IMAGE   ?= aguara-install-test:cap-drop
 
 test-install-sh-docker:

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Use it when evaluating a repository or skill, reviewing a change, or adding a se
 Install the published release:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/garagon/aguara/v0.27.0/install.sh \
-  | VERSION=v0.27.0 sh
+curl -fsSL https://raw.githubusercontent.com/garagon/aguara/v0.28.0/install.sh \
+  | VERSION=v0.28.0 sh
 ```
 
 The default location is `~/.local/bin`; add it to your `PATH` if needed. The installer verifies the archive checksum. See [signature verification](#verifying-signed-releases) for verifying its signing identity, or [other installation options](#installation).
@@ -40,11 +40,11 @@ aguara audit .
 
 This combines a malicious-package check with a content scan. It does not install dependencies or run the project's commands. Read the findings before taking the next step; a passing result is not a guarantee that the project is safe.
 
-**Release boundary:** these installation examples use **v0.27.0**. The [development section](#development-version) describes features on `main` that are not in that release. In particular, v0.27.0 can honor repository-owned exclusions and suppressions: review them when inspecting an unfamiliar project. The explicit untrusted-project policy controls are a development feature.
+**Trust boundary:** in v0.28.0, `audit`, CI scans and the public scanning API ignore target-owned exclusions and suppressions by default. Local `scan` can still honor them; use `--project-policy ignore` for unfamiliar projects. Older releases may trust repository-owned policy. See the [upgrade notes](CHANGELOG.md#0280---2026-09-10) before changing an existing integration.
 
 ### Reading a finding
 
-For example, a `.claude/settings.json` containing `"allow": ["Bash(*)"]` grants broad shell approval. Aguara reports that configuration for review. A shortened JSON finding from v0.27.0:
+For example, a `.claude/settings.json` containing `"allow": ["Bash(*)"]` grants broad shell approval. Aguara reports that configuration for review. A shortened JSON finding from v0.28.0:
 
 ```json
 {
@@ -142,7 +142,7 @@ and cannot be reused by default checks or `--allow-stale`. Older cache markers
 do not reliably establish that a signature was verified; run `aguara update`
 without `--insecure-intel` to restore verified offline use after upgrading.
 
-Release notices are separate from analysis: `aguara version` can check for a newer release, and v0.27.0 also does this during `scan`. Set `AGUARA_NO_UPDATE_CHECK=1` to disable those checks. For network-isolated use, set that variable and avoid `update` and `--fresh`; no online lookup is needed to analyze the content.
+Release notices are separate from analysis: `aguara version` can check for a newer release; `scan` does not. Set `AGUARA_NO_UPDATE_CHECK=1` to disable release notices. For network-isolated use, set that variable and avoid `update` and `--fresh`; no online lookup is needed to analyze the content.
 
 ## Adopting Aguara in CI
 
@@ -165,17 +165,17 @@ Baseline-matched content findings remain visible but do not fail the gate. New f
 
 ## Installation
 
-The following alternatives install the published version, not the development features below.
+The following alternatives install the published release:
 
 ```bash
 # Homebrew
 brew install garagon/tap/aguara
 
 # Docker: read-only project mount, non-root container
-docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.27.0 audit /repo
+docker run --rm -v "$PWD:/repo:ro" ghcr.io/garagon/aguara:0.28.0 audit /repo
 
-# Go: pinned release; requires Go 1.25.5 or later
-go install github.com/garagon/aguara/cmd/aguara@v0.27.0
+# Go: pinned release; requires Go 1.25.8 or later
+go install github.com/garagon/aguara/cmd/aguara@v0.28.0
 ```
 
 Release binaries are available for Linux, macOS, and Windows on the [Releases page](https://github.com/garagon/aguara/releases). The container supports Linux amd64 and arm64. Go installs do not inject release version metadata; use release artifacts when that metadata or signature verification is required.
@@ -185,11 +185,11 @@ Release binaries are available for Linux, macOS, and Windows on the [Releases pa
 The Action runs a content scan, not the combined package audit. Pin both the Action and its binary:
 
 ```yaml
-- uses: garagon/aguara@v0.27.0
+- uses: garagon/aguara@v0.28.0
   with:
     path: .
     fail-on: high
-    version: v0.27.0
+    version: v0.28.0
 ```
 
 The default SARIF upload needs `security-events: write`. See [`action.yml`](action.yml) for inputs; use the CLI audit in a separate CI step when you also need package-intelligence checks.
@@ -237,7 +237,7 @@ func main() {
 
 ## Development Version
 
-**The following capabilities are on `main`, not in v0.27.0.** See [Unreleased changes](CHANGELOG.md#unreleased). Building from source is not equivalent to installing a signed release.
+**v0.28.0 includes the capabilities below.** Later changes on `main` are listed under [Unreleased](CHANGELOG.md#unreleased). Building from source is not equivalent to installing a signed release.
 
 | Capability | What changes for the caller |
 |---|---|
@@ -254,11 +254,11 @@ For a development build, clone the repository, review and check out the commit y
 ./aguara audit . --format json
 ```
 
-The development catalog contains **258 detections: 192 YAML pattern rules and 66 analyzer-emitted detections**. The installed binary's `aguara list-rules` is the reference for its own catalog. This count is not the number of malicious-package records in the intelligence snapshot.
+The v0.28.0 catalog contains **258 detections: 192 YAML pattern rules and 66 analyzer-emitted detections**. The installed binary's `aguara list-rules` is the reference for its own catalog. This count is not the number of malicious-package records in the intelligence snapshot.
 
 ## Rules and Architecture
 
-Content analysis combines pattern matching and decoding, configuration parsers, language-specific checks, prompt-injection analysis, and bounded cross-file correlation. On `main`, thirteen per-file analyzers run by default; rug-pull tracking joins with `--monitor`. Skill-chain correlation runs separately across files.
+Content analysis combines pattern matching and decoding, configuration parsers, language-specific checks, prompt-injection analysis, and bounded cross-file correlation. Thirteen per-file analyzers run by default; rug-pull tracking joins with `--monitor`. Skill-chain correlation runs separately across files.
 
 Package-intelligence checking is a separate path used by `check` and combined with content analysis by `audit`. See [CONTRIBUTING.md](CONTRIBUTING.md) for the package layout and [RULES.md](RULES.md) for detection details.
 
@@ -278,14 +278,14 @@ aguara explain CRED_002
 aguara scan . --rules ./my-rules/
 ```
 
-Custom rules and local configuration can change coverage. Review `.aguara.yml`, `.aguaraignore`, custom rules, and inline suppressions before trusting a project's scan policy. Use `aguara init` to scaffold a local configuration. The `--project-policy` boundary described above applies only to development builds until it is released.
+Custom rules and local configuration can change coverage. Review `.aguara.yml`, `.aguaraignore`, custom rules, and inline suppressions before trusting a project's scan policy. Use `aguara init` to scaffold a local configuration. The `--project-policy` boundary described above is available from v0.28.0.
 
 ## Verifying Signed Releases
 
 Release archives have checksums signed with Cosign keyless and include SPDX SBOMs. Container images are signed at their digest with SBOM and SLSA provenance attestations. Verify the signing identity as well as the checksum:
 
 ```bash
-VERSION=v0.27.0
+VERSION=v0.28.0
 ARCHIVE=aguara_${VERSION#v}_linux_amd64.tar.gz
 
 curl -fsSLO https://github.com/garagon/aguara/releases/download/${VERSION}/${ARCHIVE}

--- a/action.yml
+++ b/action.yml
@@ -90,7 +90,7 @@ runs:
         # Anything that isn't a semver tag (vX.Y.Z) or a 40-char SHA is
         # rejected so we never fetch install.sh from a mutable branch
         # like `main`, `v1`, or `@branch-name`.
-        DEFAULT_REF="v0.27.0"
+        DEFAULT_REF="v0.28.0"
         INSTALL_REF="${INSTALL_SCRIPT_REF:-${ACTION_REF:-$DEFAULT_REF}}"
         if [[ ! "$INSTALL_REF" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] && \
            [[ ! "$INSTALL_REF" =~ ^[0-9a-f]{40}$ ]]; then

--- a/cmd/aguara/commands/init.go
+++ b/cmd/aguara/commands/init.go
@@ -215,7 +215,7 @@ exit $?
 //   - automatic version pinning matching whatever tag the user
 //     pins the `uses:` ref to.
 //
-// The action ref is pinned to the v0.27.0 tag rather than `@v1`
+// The action ref is pinned to the v0.28.0 tag rather than `@v1`
 // (which exists but lags significantly behind point releases). New
 // projects get a reproducible, dependabot-friendly pin; users who
 // want floating-major can edit the ref themselves.
@@ -244,7 +244,7 @@ jobs:
 
       - name: Run Aguara security scan
         id: scan
-        uses: garagon/aguara@v0.27.0
+        uses: garagon/aguara@v0.28.0
         with:
           path: .
           fail-on: high
@@ -253,7 +253,7 @@ jobs:
           # version override and fetches whatever release is
           # "latest" at run time -- so the scanner code can drift
           # away from the action ref above without notice.
-          version: v0.27.0
+          version: v0.28.0
           # SARIF results land at aguara-results.sarif and are
           # uploaded to GitHub Code Scanning automatically. Set
           # upload-sarif: 'false' to disable that upload.


### PR DESCRIPTION
A project should not decide what its security review is allowed to see. This release makes Aguara more useful when evaluating unfamiliar repositories, reviewing dependencies or preparing an agent to work on a project.

Audit, CI and embedded scans ignore repository-owned exclusions by default. Incomplete checks return errors instead of looking clean. Audit reports give reviewers priorities and next steps, while keeping enforcement in the hands of the caller.

The release also brings more precise package and policy parsing, skill/helper and script checks, stronger report redaction and file-write boundaries, and offline intelligence refreshed from a verified September snapshot. The catalog contains 258 detections; intelligence records are counted separately.

This PR prepares those already-merged changes for v0.28.0:

- Consolidates the changelog into a product release with explicit upgrade notes.
- Pins installation examples, the Action fallback, generated workflows and install acceptance to the same version, including the Docker tag.
- Updates the README and contributor/agent references so released features are no longer described as development-only.

Two upgrade details are called out: integrations should review the new untrusted-project defaults, and older intel caches need a normal signed `aguara update` to restore verified reuse. No detection logic or severity changes are introduced by this PR.

Validation: version-pin guardrail, focused race tests for generated files and public catalog APIs, vet and lint. Historical changelog entries remain unchanged. GoReleaser reports a valid configuration with the existing Homebrew `brews` deprecation; the formula-to-cask migration is outside this release. Full CI must pass before merge; the tag and signed-artifact acceptance follow afterward.
